### PR TITLE
fix(cli): bundle OpenCode artifacts with npm package

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -38,7 +38,8 @@
   "scripts": {
     "build": "bun build src/main.ts --outdir dist --target node",
     "build:web-ui": "cd web-ui && bun run build",
-    "build:all": "bun run build && bun run build:web-ui",
+    "build:opencode": "bun run src/main.ts build:opencode",
+    "build:all": "bun run build && bun run build:web-ui && bun run build:opencode",
     "dev": "bun run src/main.ts",
     "typecheck": "tsc --noEmit",
     "prepublishOnly": "bun run build:all"

--- a/cli/src/build/generator.ts
+++ b/cli/src/build/generator.ts
@@ -13,6 +13,21 @@ import type {
 } from "./models.js";
 
 /**
+ * Escape a string value for safe YAML output.
+ * Wraps in double quotes if the value contains special YAML characters.
+ */
+const escapeYamlValue = (value: string): string => {
+  // Characters that require quoting in YAML
+  const needsQuoting = /[\[\]{}:#>|*&!%@`'"\\,\n]|^[\s-]|^\s*$/.test(value);
+  if (needsQuoting) {
+    // Escape backslashes and double quotes, then wrap in double quotes
+    const escaped = value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+    return `"${escaped}"`;
+  }
+  return value;
+};
+
+/**
  * Generate OpenCode command markdown file with YAML frontmatter.
  */
 export const generateCommandFile = (
@@ -21,7 +36,7 @@ export const generateCommandFile = (
 ): E.Either<CLIError, { filename: string; content: string }> => {
   try {
     // Build YAML frontmatter (metadata only)
-    const frontmatterLines = ["---", `description: ${ocCmd.description}`];
+    const frontmatterLines = ["---", `description: ${escapeYamlValue(ocCmd.description)}`];
 
     // Add argument-hint if present (quote the value to handle brackets properly in YAML)
     if (ocCmd.argumentHint) {
@@ -71,7 +86,7 @@ export const generateAgentFile = (
     // Build YAML frontmatter
     const frontmatterLines = [
       "---",
-      `description: ${ocAgent.description}`,
+      `description: ${escapeYamlValue(ocAgent.description)}`,
       `mode: ${ocAgent.mode}`,
     ];
 
@@ -114,8 +129,8 @@ export const generateSkillFile = (
     // Anthropic Skills v1.0 format
     const frontmatterLines = [
       "---",
-      `name: ${ocSkill.name}`,
-      `description: ${ocSkill.description}`,
+      `name: ${escapeYamlValue(ocSkill.name)}`,
+      `description: ${escapeYamlValue(ocSkill.description)}`,
       "---",
       "",
       ocSkill.content,


### PR DESCRIPTION
## Summary

- Fix YAML escaping bug in OpenCode artifact generator that caused build failures when descriptions contain special characters like `[DEPRECATED]`
- Bundle pre-built OpenCode artifacts with the npm package so `install:opencode` works out of the box

## Changes

1. **YAML escaping fix** (`cli/src/build/generator.ts`):
   - Added `escapeYamlValue()` helper that properly quotes strings containing YAML special characters (`[`, `]`, `{`, `}`, `:`, `#`, etc.)
   - Applied to command, agent, and skill description fields

2. **Bundle artifacts** (`cli/package.json`):
   - Added `build:opencode` script
   - Updated `build:all` to include `build:opencode`
   - `prepublishOnly` now builds OpenCode artifacts so they're included in npm package

## Test plan

- [x] `bun run build:all` succeeds with all 9 base agents (was 8 before fix)
- [x] `npm pack --dry-run` shows `dist/opencode/` contents included
- [x] Generated YAML has properly quoted descriptions

Fixes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)