### PR TITLE
chore: add Lefthook for git hooks management

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -77,6 +77,37 @@ See [DEVELOPMENT.md](../DEVELOPMENT.md) for detailed project architecture and te
 4. Push and create PR: `git push origin feat/your-feature`
 5. After PR approval and merge, automation handles the release
 
+## Git Hooks (Optional)
+
+This project uses [Lefthook](https://github.com/evilmartians/lefthook) for local git hooks. Installing it is optional but recommended.
+
+### Setup
+
+```bash
+# macOS
+brew install lefthook
+
+# Or via npm
+npm install -g @evilmartians/lefthook
+
+# Then install hooks
+lefthook install
+```
+
+### What the hooks do
+
+- **pre-commit**: Runs lint and format checks on staged files (fast, parallel)
+- **pre-push**: Runs typecheck and tests (comprehensive, parallel)
+
+### Skipping hooks
+
+If you need to skip hooks temporarily:
+
+```bash
+git commit --no-verify -m "your message"
+git push --no-verify
+```
+
 ## Testing
 
 Before submitting a PR:

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,25 @@
+# Lefthook git hooks configuration
+# https://github.com/evilmartians/lefthook
+#
+# Install: brew install lefthook && lefthook install
+# Or: npm install -g @evilmartians/lefthook && lefthook install
+
+pre-commit:
+  parallel: true
+  commands:
+    lint:
+      glob: "cli/**/*.{ts,tsx,js,jsx}"
+      run: cd cli && bun run lint
+    format:
+      glob: "cli/**/*.{ts,tsx,js,jsx}"
+      run: cd cli && bun run format
+
+pre-push:
+  parallel: true
+  commands:
+    typecheck-cli:
+      run: cd cli && bun run typecheck
+    typecheck-webui:
+      run: cd cli/web-ui && npx tsc --noEmit
+    test:
+      run: cd cli && bun run test


### PR DESCRIPTION
## Summary

Add Lefthook for local git hooks management. This provides fast, parallel execution of lint/format/typecheck/tests on commit and push.

## Changes Made

- Added `lefthook.yml` configuration file
- Updated `.github/CONTRIBUTING.md` with setup instructions

## Hooks Configured

| Hook | Commands | Execution |
|------|----------|-----------|
| pre-commit | lint, format | parallel |
| pre-push | typecheck-cli, typecheck-webui, test | parallel |

## Benefits

- Fast (Go-based, parallel execution)
- Zero dependencies for contributors (optional install)
- Cross-platform
- Simple YAML config

## Test plan

- [x] Build passes (`just build`)
- [x] Lefthook config is valid YAML
- [x] Test `lefthook install` and verify hooks work

Closes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)