### PR TITLE
feat(dev): add comment check to /feature-verify

### DIFF
--- a/docs/reference/dev/feature-verify.md
+++ b/docs/reference/dev/feature-verify.md
@@ -20,7 +20,11 @@ Validates acceptance criteria and requirements mapping before merge.
 
 ## Description
 
-The `feature-verify` command performs comprehensive validation of a completed feature implementation. It checks acceptance criteria, verifies requirements coverage, runs tests, and produces a verification report.
+The `feature-verify` command performs comprehensive validation of a completed feature implementation. It runs three parallel checks:
+
+1. **Code Quality** - Linting, formatting, tests, and coverage
+2. **Feature Verification** - Acceptance criteria and requirements coverage
+3. **Comment Check** - Flags unnecessary comments added during implementation (advisory)
 
 ## Parameters
 
@@ -36,13 +40,20 @@ The `feature-verify` command performs comprehensive validation of a completed fe
 
 ## Output
 
-**Location:** `.rp1/work/features/<feature-id>/verification-report.md`
+**Reports Generated:**
+
+| Report | Description |
+|--------|-------------|
+| `code_check_report_N.md` | Lint, format, test, coverage results |
+| `feature_verify_report_N.md` | Acceptance criteria and requirements |
+| `comment_check_report_N.md` | Unnecessary comments flagged |
 
 **Contents:**
 
 - Requirements coverage matrix
 - Acceptance criteria status
 - Test results summary
+- Comment quality assessment (advisory)
 - Field notes review (intentional deviations)
 - Overall verdict
 
@@ -78,21 +89,32 @@ The `feature-verify` command performs comprehensive validation of a completed fe
 Feature: user-auth
 Status: READY FOR MERGE
 
+Code Quality: PASS
+- Linting: 0 errors
+- Tests: 45/45 passing
+- Coverage: 94%
+
 Requirements Coverage:
 - REQ-001: ✓ PASS
 - REQ-002: ✓ PASS
 - REQ-003: ✓ INTENTIONAL_DEVIATION (see field-notes.md)
 
-Acceptance Criteria: 12/12 passed
-Tests: 45/45 passing
-Coverage: 94%
+Comment Check: WARN (advisory)
+- 3 unnecessary comments flagged
+- Run /code-clean-comments to clean
 
-Report: .rp1/work/features/user-auth/verification-report.md
+Acceptance Criteria: 12/12 passed
+
+Reports:
+- .rp1/work/features/user-auth/code_check_report_1.md
+- .rp1/work/features/user-auth/feature_verify_report_1.md
+- .rp1/work/features/user-auth/comment_check_report_1.md
 ```
 
 ## Related Commands
 
 - [`feature-build`](feature-build.md) - Previous step
+- [`code-clean-comments`](code-clean-comments.md) - Clean flagged comments
 - [`feature-archive`](feature-archive.md) - Archive after merge
 
 ## See Also


### PR DESCRIPTION
## Summary

Adds comment checking as a parallel validation phase in `/feature-verify`:

- Added `MODE` parameter to `comment-cleaner` agent supporting `clean` (default) or `check` (report-only)
- Feature-verify now runs 3 parallel validation phases:
  1. Code Quality Check (linting, tests, coverage)
  2. Feature Verification (acceptance criteria)
  3. **Comment Check** (flags unnecessary comments) - NEW
- Comment check is advisory - WARN status doesn't block verification or archive
- Generates `comment_check_report_N.md` in feature directory

## Test plan

- [x] TypeScript typecheck passes
- [x] Manual test: Run `/feature-verify` on a feature with unnecessary comments
- [x] Verify comment check report is generated
- [x] Verify advisory warning doesn't block verification

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)