### PR TITLE
fix(base): use line-change threshold for incremental knowledge-build

### DIFF
--- a/docs/reference/base/knowledge-build.md
+++ b/docs/reference/base/knowledge-build.md
@@ -43,8 +43,11 @@ The command automatically detects the appropriate build mode:
 | Mode | Condition | Duration |
 |------|-----------|----------|
 | **Skip** | KB exists, no git changes | Instant |
-| **Full** | First build or >50 files changed | 10-15 min |
-| **Incremental** | <50 files changed since last build | 2-5 min |
+| **Full** | First build or >2000 lines changed | 10-15 min |
+| **Incremental** | ≤2000 lines changed since last build | 2-5 min |
+
+!!! note "Line-change threshold"
+    The threshold uses **lines changed** (insertions + deletions) rather than file count. This better reflects actual change significance—50 one-line config tweaks are less impactful than 5 large refactors. Generated files (lock files, vendor, dist, etc.) are excluded from the count.
 
 ## Output
 


### PR DESCRIPTION
## Summary
- Replaces the 50-file count threshold with ~2000 line-change threshold for determining incremental vs full KB rebuilds
- File count is a poor heuristic: 50 one-line changes are insignificant while 5 large refactors are significant
- Uses `git diff --stat` to calculate lines changed, excluding generated/vendored files

## Changes
| File | Description |
|------|-------------|
| `plugins/base/commands/knowledge-build.md` | Replace file-count check with line-change calculation |
| `docs/reference/base/knowledge-build.md` | Update documentation to reflect new threshold |

## Excluded files (from line count)
- Lock files: `*.lock`, `*-lock.json`, `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`, `bun.lock`
- Vendored: `vendor/`, `node_modules/`, `.git/`
- Minified: `*.min.js`, `*.min.css`, `*.map`
- Build outputs: `dist/`, `build/`, `.next/`, `out/`
- Generated: `*.generated.*`, `*.gen.*`
- Coverage: `coverage/`, `*.lcov`

## Test plan
- [x] Lint and format checks pass
- [x] Unit tests pass (1 unrelated flaky timeout in version.test.ts)
- [ ] Manual test: Run `/knowledge-build` on a repo with many small file changes (should stay incremental)
- [ ] Manual test: Run `/knowledge-build` on a repo with >2000 lines of actual code changes (should trigger full)

Closes #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)