### PR TITLE
fix: remove incorrect --slug option from worktree skill

### DIFF
--- a/plugins/dev/skills/worktree-workflow/SKILL.md
+++ b/plugins/dev/skills/worktree-workflow/SKILL.md
@@ -49,7 +49,7 @@ Record `original_cwd` in your working memory. You will need this value in Phase 
 Run the worktree creation command with the provided parameters:
 
 ```bash
-rp1 agent-tools worktree create --slug {task_slug} --prefix {agent_prefix}
+rp1 agent-tools worktree create {task_slug} --prefix {agent_prefix}
 ```
 
 The command returns JSON. Parse and extract these values:


### PR DESCRIPTION
The worktree skill incorrectly used `--slug {task_slug}` but the CLI expects the slug as a positional argument: `rp1 agent-tools worktree create <slug>`.

Closes #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)