### PR TITLE
feat(dev): add blueprint-archive command for PRD lifecycle management

### DIFF
--- a/docs/reference/dev/blueprint-archive.md
+++ b/docs/reference/dev/blueprint-archive.md
@@ -1,0 +1,96 @@
+# blueprint-archive
+
+Archives completed PRDs (Product Requirements Documents) to a dedicated archives directory with closure summary.
+
+---
+
+## Synopsis
+
+=== "Claude Code"
+
+    ```bash
+    /blueprint-archive <prd-name>
+    ```
+
+=== "OpenCode"
+
+    ```bash
+    /rp1-dev/blueprint-archive <prd-name>
+    ```
+
+## Description
+
+The `blueprint-archive` command moves completed PRD documentation from the active PRDs directory to the archives. It creates a closure summary documenting completion status and archives associated features that are complete.
+
+## Parameters
+
+| Parameter | Position | Required | Default | Description |
+|-----------|----------|----------|---------|-------------|
+| `PRD_NAME` | `$1` | Yes | - | PRD name to archive (without .md extension) |
+
+## Directory Structure
+
+**Before:**
+```
+.rp1/work/prds/mobile-app.md
+.rp1/work/features/mobile-auth/
+.rp1/work/features/mobile-dashboard/
+```
+
+**After:**
+```
+.rp1/work/archives/prds/mobile-app/
+├── prd.md
+└── closure_summary.md
+
+.rp1/work/archives/features/mobile-auth/
+.rp1/work/features/mobile-dashboard/  (kept if incomplete)
+```
+
+## Workflow
+
+1. **Status Confirmation**: Prompts whether objectives were met (Yes/Partial/No)
+2. **Feature Discovery**: Finds features that reference this PRD
+3. **Feature Archival**: Archives completed features, keeps in-progress ones active
+4. **Closure Summary**: Creates summary documenting status and archived items
+5. **KB Check**: Suggests `/knowledge-build` if learnings not captured
+
+## Examples
+
+### Archive a Completed PRD
+
+=== "Claude Code"
+
+    ```bash
+    /blueprint-archive mobile-app
+    ```
+
+=== "OpenCode"
+
+    ```bash
+    /rp1-dev/blueprint-archive mobile-app
+    ```
+
+**Example interaction:**
+```
+Were the PRD objectives met?
+> Yes - Objectives achieved
+
+PRD Archived Successfully
+
+PRD: mobile-app
+Status: yes
+Location: .rp1/work/archives/prds/mobile-app/
+
+Features:
+- Archived: 2 (mobile-auth, mobile-settings)
+- Active: 1 (mobile-dashboard)
+
+Knowledge Base: Missing - run `/knowledge-build` to capture learnings
+```
+
+## Related Commands
+
+- [`blueprint`](blueprint.md) - Create PRDs
+- [`feature-archive`](feature-archive.md) - Archive individual features
+- [`knowledge-build`](../base/knowledge-build.md) - Capture learnings into KB

--- a/docs/reference/dev/index.md
+++ b/docs/reference/dev/index.md
@@ -3,8 +3,8 @@
 The `rp1-dev` plugin provides development workflow capabilities for the complete feature lifecycle, code quality tools, and PR management.
 
 **Version**: 3.0.0
-**Commands**: 19
-**Agents**: 19
+**Commands**: 20
+**Agents**: 20
 **Dependencies**: rp1-base >= 2.0.0
 
 ---
@@ -18,6 +18,7 @@ Start projects and plan features with structured documentation.
 | Command | Description |
 |---------|-------------|
 | [`blueprint`](blueprint.md) | Create project charter and PRD documents |
+| [`blueprint-archive`](blueprint-archive.md) | Archive completed PRDs with closure summary |
 | [`feature-requirements`](feature-requirements.md) | Collect and document feature requirements |
 | [`feature-design`](feature-design.md) | Generate technical design specifications (auto-generates tasks) |
 | [`feature-tasks`](feature-tasks.md) | Regenerate tasks (optional - tasks auto-generate after design) |
@@ -84,6 +85,7 @@ Each step produces artifacts that feed into the next:
 **Optional Steps**:
 
 - `blueprint` - Create project charter and PRDs before starting features
+- `blueprint-archive` - Archive completed PRDs with closure summary
 - `validate-hypothesis` - Test design assumptions before building
 - `feature-tasks` - Manually regenerate or update tasks
 

--- a/plugins/dev/README.md
+++ b/plugins/dev/README.md
@@ -20,10 +20,11 @@ Then install dev plugin:
 /plugin install rp1-dev
 ```
 
-## Commands (20)
+## Commands (21)
 
-### Project Onboarding (2)
+### Project Onboarding (3)
 - `/blueprint [prd-name]` - Guided wizard to capture project vision via charter + PRDs
+- `/blueprint-archive <prd-name>` - Archive completed PRD with closure summary
 - `/bootstrap [project-name]` - Bootstrap a new project with charter discovery and tech stack scaffolding
 
 **Blueprint Flow** (for brownfield projects):
@@ -170,7 +171,7 @@ The `feature-build` command uses a **builder-reviewer architecture** for improve
 /feature-build my-feature 1 auto    # Build milestone 1, auto-handle failures
 ```
 
-## Agents (19)
+## Agents (20)
 
 This plugin provides specialized agents for development workflows:
 
@@ -180,6 +181,7 @@ This plugin provides specialized agents for development workflows:
 | task-reviewer | Verifies builder work across 4 dimensions, returns SUCCESS/FAILURE |
 | feature-tasker | Generates tasks from design, supports incremental updates |
 | blueprint-wizard | Captures project vision through charter and PRD documents |
+| blueprint-archiver | Archives PRDs with closure summary and associated features |
 | hypothesis-tester | Validates design assumptions through experiments |
 | feature-verifier | Verifies acceptance criteria before merge |
 | feature-editor | Propagates mid-stream changes across documentation |

--- a/plugins/dev/agents/blueprint-archiver.md
+++ b/plugins/dev/agents/blueprint-archiver.md
@@ -1,0 +1,188 @@
+---
+name: blueprint-archiver
+description: Archives PRDs to {RP1_ROOT}/work/archives/prds/ with closure summary and associated feature archival
+tools: Read, Glob, Bash, Edit, AskUserQuestion
+model: inherit
+author: cloud-on-prem/rp1
+---
+
+# Blueprint Archiver
+
+You are **PRDArchiverGPT** - archives completed PRDs to `{RP1_ROOT}/work/archives/prds/`.
+
+## S0 Parameters
+
+| Name | Pos | Default | Purpose |
+|------|-----|---------|---------|
+| PRD_NAME | $1 | (req) | PRD name to archive |
+| COMPLETION_STATUS | $2 | (none) | `yes`, `partial`, or `no` |
+| RP1_ROOT | Env | `.rp1/` | Root dir |
+
+## S1 Paths
+
+```
+PRD_FILE = {RP1_ROOT}/work/prds/{PRD_NAME}.md
+ARCHIVE_DIR = {RP1_ROOT}/work/archives/prds/{PRD_NAME}/
+FEATURES_DIR = {RP1_ROOT}/work/features/
+FEATURE_ARCHIVES = {RP1_ROOT}/work/archives/features/
+KB_DIR = {RP1_ROOT}/context/
+```
+
+## S2 Validation
+
+1. PRD_NAME non-empty -> else error + STOP
+2. PRD_FILE must exist -> else:
+```
+{"type":"error","message":"PRD '{PRD_NAME}' not found at {PRD_FILE}"}
+```
+
+## S3 Status Confirmation
+
+If COMPLETION_STATUS not provided, return:
+```json
+{
+  "type": "needs_status",
+  "prd_name": "{PRD_NAME}",
+  "message": "Confirm PRD completion status"
+}
+```
+
+If COMPLETION_STATUS is `no`, return:
+```json
+{
+  "type": "aborted",
+  "reason": "incomplete",
+  "message": "PRD not archived - objectives not met. Continue development or update scope."
+}
+```
+
+## S4 Find Associated Features
+
+Scan `{FEATURES_DIR}/*/requirements.md` for lines containing:
+- `**Parent PRD**:` with link to this PRD (`prds/{PRD_NAME}.md`)
+- OR `PRD: {PRD_NAME}`
+
+Collect list of feature IDs that reference this PRD.
+
+## S5 Feature Status Check
+
+For each associated feature:
+1. Check if `{FEATURES_DIR}/{feature_id}/tasks.md` exists
+2. If exists, count completed vs total tasks
+3. Classify: `completed` (all done), `in_progress` (some done), `not_started`
+
+Return for confirmation if any features in_progress:
+```json
+{
+  "type": "needs_feature_confirmation",
+  "prd_name": "{PRD_NAME}",
+  "features": [
+    {"id": "{feature_id}", "status": "in_progress", "progress": "3/5 tasks"}
+  ],
+  "message": "Some features are incomplete. Archive anyway?"
+}
+```
+
+## S6 Execute Archive
+
+### 6.1 Create Archive Dir
+```bash
+mkdir -p {ARCHIVE_DIR}
+```
+
+### 6.2 Move PRD
+```bash
+mv {PRD_FILE} {ARCHIVE_DIR}/prd.md
+```
+
+### 6.3 Archive Completed Features
+
+For each associated feature with status `completed`:
+```bash
+mkdir -p {FEATURE_ARCHIVES}
+mv {FEATURES_DIR}/{feature_id}/ {FEATURE_ARCHIVES}/{feature_id}/
+```
+
+Track archived feature IDs.
+
+### 6.4 Generate Closure Summary
+
+Write `{ARCHIVE_DIR}/closure_summary.md`:
+
+```markdown
+# Closure Summary: {PRD_NAME}
+
+**Archived**: {YYYY-MM-DD}
+**Status**: {COMPLETION_STATUS} (Yes/Partial)
+**Original Location**: {PRD_FILE}
+
+## Completion Assessment
+
+{Brief summary based on status - 1-2 sentences}
+
+## Associated Features
+
+| Feature | Status | Action |
+|---------|--------|--------|
+| {feature_id} | completed | Archived |
+| {feature_id} | in_progress | Left active |
+| {feature_id} | not_started | Left active |
+
+## Archived Items
+
+- PRD: `{ARCHIVE_DIR}/prd.md`
+{For each archived feature:}
+- Feature: `{FEATURE_ARCHIVES}/{feature_id}/`
+
+## Notes
+
+{Any relevant notes about partial completion or remaining work}
+```
+
+## S7 KB Check
+
+Check if PRD content exists in KB:
+1. Grep `{KB_DIR}/*.md` for PRD name or key terms
+2. If no matches found, set `kb_missing = true`
+
+## S8 Output
+
+### Success
+```json
+{
+  "type": "success",
+  "prd_name": "{PRD_NAME}",
+  "archive_path": "{ARCHIVE_DIR}",
+  "completion_status": "{COMPLETION_STATUS}",
+  "features_archived": ["{feature_id}", ...],
+  "features_active": ["{feature_id}", ...],
+  "kb_present": true|false,
+  "message": "PRD archived successfully"
+}
+```
+
+Display:
+```
+PRD Archived Successfully
+
+**PRD**: {PRD_NAME}
+**Status**: {COMPLETION_STATUS}
+**Location**: {ARCHIVE_DIR}
+
+**Features**:
+- Archived: {N} ({list})
+- Active: {N} ({list})
+
+**Knowledge Base**: {Present | Missing - run `/knowledge-build` to capture learnings}
+
+**Next Steps**:
+- View closure summary: `{ARCHIVE_DIR}/closure_summary.md`
+- Capture learnings: `/knowledge-build`
+```
+
+## DONT
+
+- Ask approval beyond status confirmation
+- Iterate/refine
+- Execute >1x
+- Archive features that are in_progress without confirmation

--- a/plugins/dev/commands/blueprint-archive.md
+++ b/plugins/dev/commands/blueprint-archive.md
@@ -1,0 +1,105 @@
+---
+name: blueprint-archive
+version: 1.0.0
+description: Archives a completed PRD to {RP1_ROOT}/work/archives/prds/ with closure summary
+argument-hint: "prd-name"
+tags: [blueprint, prd, archive, lifecycle]
+created: 2025-12-30
+author: cloud-on-prem/rp1
+---
+
+# Blueprint Archive
+
+Archives completed PRD docs from active -> archives dir with closure summary.
+
+## Usage
+
+```
+/rp1-dev:blueprint-archive <prd-name>
+```
+
+**Params**: `prd-name` (req) - PRD name to archive (without .md extension)
+
+## Behavior
+
+- Moves `{RP1_ROOT}/work/prds/<prd-name>.md` -> `{RP1_ROOT}/work/archives/prds/<prd-name>/prd.md`
+- Creates `closure_summary.md` with completion status and feature mapping
+- Archives completed associated features
+- Checks KB for captured learnings
+- Prompts for completion status (Yes/Partial/No)
+
+## Execution
+
+### Step 1: Invoke Agent (Status Check)
+
+Task tool:
+- `subagent_type`: `rp1-dev:blueprint-archiver`
+- `prompt`:
+```
+PRD_NAME: $1
+```
+
+### Step 2: Handle Status Response
+
+If agent returns `type: "needs_status"`:
+
+AskUserQuestion:
+```yaml
+questions:
+  - question: "Were the PRD objectives met?"
+    header: "Status"
+    options:
+      - label: "Yes - Objectives achieved"
+        description: "All or most goals were accomplished"
+      - label: "Partial - Some objectives met"
+        description: "Some goals achieved, others deferred or descoped"
+      - label: "No - Objectives not met"
+        description: "PRD abandoned or superseded"
+    multiSelect: false
+```
+
+Map response:
+- "Yes" -> `COMPLETION_STATUS: yes`
+- "Partial" -> `COMPLETION_STATUS: partial`
+- "No" -> `COMPLETION_STATUS: no`
+
+Re-invoke agent with status:
+```
+PRD_NAME: $1
+COMPLETION_STATUS: {mapped_status}
+```
+
+### Step 3: Handle Feature Confirmation
+
+If agent returns `type: "needs_feature_confirmation"`:
+
+AskUserQuestion:
+```yaml
+questions:
+  - question: "Some features are in progress. Archive PRD anyway?"
+    header: "Confirm"
+    options:
+      - label: "Yes - Archive PRD, leave features active"
+        description: "Archive the PRD but keep incomplete features in active directory"
+      - label: "No - Cancel archive"
+        description: "Abort the archive operation"
+    multiSelect: false
+```
+
+- **Yes**: Re-invoke with `SKIP_FEATURE_CHECK: true`
+- **No**: Output `Archive cancelled - features still in progress` + STOP
+
+### Step 4: Handle Aborted
+
+If agent returns `type: "aborted"`:
+- Output agent message
+- STOP
+
+### Step 5: Report Success
+
+Display agent success output directly.
+
+If `kb_present: false`:
+```
+Tip: Run `/knowledge-build` to capture learnings from this PRD into the knowledge base.
+```


### PR DESCRIPTION
## Summary

Closes #128 

- Adds `/blueprint-archive <prd-name>` command for archiving completed PRDs
- Archives PRDs to `.rp1/work/archives/prds/<prd-name>/` with closure summary
- Finds and archives associated completed features
- Prompts for completion status (Yes/Partial/No) before archiving
- Checks KB for captured learnings and suggests `/knowledge-build` if missing

## Changes

| File | Description |
|------|-------------|
| `plugins/dev/agents/blueprint-archiver.md` | New agent that handles PRD archival logic |
| `plugins/dev/commands/blueprint-archive.md` | New command that orchestrates the archival flow |
| `docs/reference/dev/blueprint-archive.md` | User documentation for the new command |
| `plugins/dev/README.md` | Updated command and agent counts |
| `docs/reference/dev/index.md` | Added to docs index |

## Archive Structure

```
.rp1/work/archives/prds/<prd-name>/
├── prd.md              # Original PRD content
└── closure_summary.md  # Completion status, feature mapping, notes
```

## Test plan

- [x] Build passes (`just build`)
- [x] Lint/type checks pass (`just check`)
- [ ] Manual test: `/blueprint-archive main` on a project with PRDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)