### PR TITLE
feat(web-ui): add file deep linking via query parameter

### DIFF
--- a/cli/web-ui/src/app/routes.tsx
+++ b/cli/web-ui/src/app/routes.tsx
@@ -1,10 +1,28 @@
 import { AlertCircle, FileText, Loader2, RefreshCw } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
-import { createBrowserRouter, Navigate, useParams } from "react-router-dom";
+import {
+	createBrowserRouter,
+	Navigate,
+	useParams,
+	useSearchParams,
+} from "react-router-dom";
 import { MarkdownViewer } from "@/components/MarkdownViewer";
 import { useFileContent } from "@/hooks/useFileContent";
 import { useWebSocket } from "@/providers/WebSocketProvider";
 import { Layout } from "./Layout";
+
+function IndexRedirect() {
+	const [searchParams] = useSearchParams();
+	const file = searchParams.get("file");
+
+	if (file) {
+		// Remove leading slash if present to normalize path
+		const normalizedPath = file.startsWith("/") ? file.slice(1) : file;
+		return <Navigate to={`/view/${normalizedPath}`} replace />;
+	}
+
+	return <Navigate to="/view/context/index.md" replace />;
+}
 
 export const router = createBrowserRouter([
 	{
@@ -13,7 +31,7 @@ export const router = createBrowserRouter([
 		children: [
 			{
 				index: true,
-				element: <Navigate to="/view/context/index.md" replace />,
+				element: <IndexRedirect />,
 			},
 			{
 				path: "view/*",


### PR DESCRIPTION
## Summary
- Add support for `?file=/path/to/file.md` query parameter for deep linking
- Enables external tools and links to open specific files directly in web-ui
- Normalizes paths (handles both `/path` and `path` formats)

## Test plan
- [ ] Open `http://localhost:7710/?file=context/index.md` - should navigate to index.md
- [ ] Open `http://localhost:7710/?file=/context/architecture.md` - should handle leading slash
- [ ] Open `http://localhost:7710/` - should redirect to default index.md

Closes #49