### PR TITLE
fix(web-ui): use directory name for project display instead of charter title

### DIFF
--- a/cli/web-ui/src/server/project.ts
+++ b/cli/web-ui/src/server/project.ts
@@ -87,24 +87,12 @@ export function getProjectMetadata(
 		chainTE(() =>
 			tryCatch(
 				async () => {
-					const projectName = basePath.split("/").pop() ?? "unknown";
+					// Always use directory name for project display
+					const name = basePath.split("/").pop() ?? "unknown";
 					const charterPath = join(basePath, ".rp1", "work", "charter.md");
 
-					let name = projectName;
 					const charterFile = Bun.file(charterPath);
 					const charterExists = await charterFile.exists();
-
-					if (charterExists) {
-						try {
-							const content = await charterFile.text();
-							const titleMatch = content.match(/^#\s+(.+)/m);
-							if (titleMatch) {
-								name = titleMatch[1].trim();
-							}
-						} catch {
-							/* use directory name */
-						}
-					}
 
 					const project: Project = {
 						path: basePath,

--- a/cli/web-ui/src/server/registry.ts
+++ b/cli/web-ui/src/server/registry.ts
@@ -110,28 +110,10 @@ export async function isValidProject(projectPath: string): Promise<boolean> {
 }
 
 /**
- * Extract project name from charter or use directory name.
+ * Get project display name from directory name.
+ * Always uses directory name for consistency and clarity.
  */
-export async function getProjectName(projectPath: string): Promise<string> {
-	try {
-		const charterPath = `${projectPath}/.rp1/work/charter.md`;
-		const content = await readFile(charterPath, "utf-8");
-
-		// Extract title from frontmatter
-		const titleMatch = content.match(
-			/^---[\s\S]*?title:\s*["']?([^"'\n]+)["']?/m,
-		);
-		if (titleMatch?.[1]) {
-			return titleMatch[1].trim();
-		}
-
-		// Extract first H1
-		const h1Match = content.match(/^#\s+(.+)$/m);
-		if (h1Match?.[1]) {
-			return h1Match[1].trim();
-		}
-	} catch {}
-
+export function getProjectName(projectPath: string): string {
 	return basename(projectPath);
 }
 
@@ -232,7 +214,7 @@ export async function registerProject(
 
 	// Create new entry
 	const id = generateProjectId(projectPath, existingIds);
-	const name = await getProjectName(projectPath);
+	const name = getProjectName(projectPath);
 
 	const entry: ProjectEntry = {
 		id,


### PR DESCRIPTION
Previously, when registering projects for the WebView, the code would extract
the first H1 heading from charter.md to use as the project name. This caused
confusing titles like "Project Charter: VS Code Goo..." instead of the actual
directory name (e.g., "goose").

This change simplifies project naming to always use the directory name,
which is more intuitive and consistent.

- project.ts: Remove charter.md title extraction logic
- registry.ts: Simplify getProjectName to sync function returning basename

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
