### PR TITLE
fix(release): guard xattr quarantine removal for macOS only

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -78,7 +78,7 @@ homebrew_casks:
     hooks:
       post:
         install: |
-          system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", staged_path]
+          system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", staged_path] if OS.mac?
 
 scoops:
   - name: rp1


### PR DESCRIPTION
The Homebrew cask post-install hook runs xattr to strip macOS quarantine
attributes, which fails on Linux where the binary doesn't exist.

Generated with AI

Co-Authored-By: rp1 <bot@rp1.run>
