### PR TITLE
fix: replace ${} shell expansion with rp1-root-dir CLI in all skills

### DIFF
--- a/plugins/base/skills/deep-research/SKILL.md
+++ b/plugins/base/skills/deep-research/SKILL.md
@@ -25,8 +25,7 @@ Extract these parameters from the user's input:
 |-----------|----------|---------|-------------|
 | `RESEARCH_TOPIC` | Yes | - | The user's research topic or questions (freeform text) |
 
-**Environment values** (resolve via shell):
-- `RP1_ROOT`: !`echo ${RP1_ROOT:-.rp1/}`
+**Resolve `RP1_ROOT`** by running: `rp1 agent-tools rp1-root-dir` — use the `root` value from the JSON response.
 
 You are executing the Deep Research workflow. You coordinate autonomous research through a map-reduce architecture: clarify intent, spawn parallel explorers, synthesize findings, and delegate report generation.
 

--- a/plugins/base/skills/generate-user-docs/SKILL.md
+++ b/plugins/base/skills/generate-user-docs/SKILL.md
@@ -21,8 +21,7 @@ metadata:
 
 This command takes no user parameters.
 
-**Environment values** (resolve via shell):
-- `RP1_ROOT`: !`echo ${RP1_ROOT:-.rp1/}`
+**Resolve `RP1_ROOT`** by running: `rp1 agent-tools rp1-root-dir` — use the `root` value from the JSON response.
 
 This command orchestrates user documentation synchronization with the auto-generated knowledge base using a two-phase map-reduce architecture.
 

--- a/plugins/base/skills/knowledge-build/SKILL.md
+++ b/plugins/base/skills/knowledge-build/SKILL.md
@@ -26,8 +26,7 @@ Extract these parameters from the user's input:
 |-----------|----------|---------|-------------|
 | `FEATURE_ID` | No | - | Feature ID to incorporate learnings from an archived feature into KB |
 
-**Environment values** (resolve via shell):
-- `RP1_ROOT`: !`echo ${RP1_ROOT:-.rp1/}`
+**Resolve `RP1_ROOT`** by running: `rp1 agent-tools rp1-root-dir` — use the `root` value from the JSON response.
 
 This command orchestrates parallel knowledge base generation using a map-reduce architecture
 

--- a/plugins/base/skills/knowledge-load/SKILL.md
+++ b/plugins/base/skills/knowledge-load/SKILL.md
@@ -26,8 +26,7 @@ Extract these parameters from the user's input:
 |-----------|----------|---------|-------------|
 | `LOAD_MODE` | No | `progressive` | Loading mode. Set `full` if user says "full", "all", or "everything"; otherwise `progressive` |
 
-**Environment values** (resolve via shell):
-- `RP1_ROOT`: !`echo ${RP1_ROOT:-.rp1/}`
+**Resolve `RP1_ROOT`** by running: `rp1 agent-tools rp1-root-dir` — use the `root` value from the JSON response.
 
 > **DEPRECATED**: This command is deprecated. All rp1 commands are now **self-contained**
 > and load KB context automatically via their agents. You no longer need to run `/knowledge-load`

--- a/plugins/base/skills/write-content/SKILL.md
+++ b/plugins/base/skills/write-content/SKILL.md
@@ -15,7 +15,7 @@ metadata:
 
 # /write-content - Content Writing Assistant
 
-$RP1_ROOT = !`echo ${RP1_ROOT:-.rp1/}`
+**Resolve `RP1_ROOT`** by running: `rp1 agent-tools rp1-root-dir` — use the `root` value from the JSON response.
 
 You are a professional technical writer helping users create high-quality markdown documents through structured collaboration. You will guide users through a specific workflow to produce polished, accurate content.
 

--- a/plugins/dev/skills/address-pr-feedback/SKILL.md
+++ b/plugins/dev/skills/address-pr-feedback/SKILL.md
@@ -29,8 +29,7 @@ Extract these parameters from the user's input:
 | `FEATURE_ID` | No | - | Feature ID (derived from PR if not provided) |
 | `AFK` | No | `false` | Non-interactive mode. Set `true` if user says "afk", "no prompts", or "unattended" |
 
-**Environment values** (resolve via shell):
-- `RP1_ROOT`: !`echo ${RP1_ROOT:-.rp1/}`
+**Resolve `RP1_ROOT`** by running: `rp1 agent-tools rp1-root-dir` — use the `root` value from the JSON response.
 
 ## Phase 1: Collection
 

--- a/plugins/dev/skills/blueprint-archive/SKILL.md
+++ b/plugins/dev/skills/blueprint-archive/SKILL.md
@@ -27,8 +27,7 @@ Extract these parameters from the user's input:
 |-----------|----------|---------|-------------|
 | `PRD_NAME` | Yes | - | PRD filename without extension (kebab-case) |
 
-**Environment values** (resolve via shell):
-- `RP1_ROOT`: !`echo ${RP1_ROOT:-.rp1/}`
+**Resolve `RP1_ROOT`** by running: `rp1 agent-tools rp1-root-dir` — use the `root` value from the JSON response.
 
 ## Usage
 

--- a/plugins/dev/skills/blueprint/SKILL.md
+++ b/plugins/dev/skills/blueprint/SKILL.md
@@ -28,8 +28,7 @@ Extract these parameters from the user's input:
 | `PRD_NAME` | No | - | PRD name to create (omit for default charter + main PRD flow) |
 | `EXTRA_CONTEXT` | No | `""` | Additional context provided by the user |
 
-**Environment values** (resolve via shell):
-- `RP1_ROOT`: !`echo ${RP1_ROOT:-.rp1/}`
+**Resolve `RP1_ROOT`** by running: `rp1 agent-tools rp1-root-dir` — use the `root` value from the JSON response.
 
 ## §STATE-MACHINE
 

--- a/plugins/dev/skills/bootstrap/SKILL.md
+++ b/plugins/dev/skills/bootstrap/SKILL.md
@@ -28,8 +28,7 @@ Extract these parameters from the user's input:
 |-----------|----------|---------|-------------|
 | `PROJECT_NAME` | No | (prompted) | New project directory name (lowercase, hyphens allowed) |
 
-**Environment values** (resolve via shell):
-- `RP1_ROOT`: !`echo ${RP1_ROOT:-.rp1/}`
+**Resolve `RP1_ROOT`** by running: `rp1 agent-tools rp1-root-dir` — use the `root` value from the JSON response.
 
 ## §1 Pre-Flight
 

--- a/plugins/dev/skills/build-express/SKILL.md
+++ b/plugins/dev/skills/build-express/SKILL.md
@@ -28,8 +28,7 @@ Extract these parameters from the user's input:
 |-----------|----------|---------|-------------|
 | `REQUEST` | No | `""` | Initial development request (may be empty; will prompt if missing) |
 
-**Environment values** (resolve via shell):
-- `RP1_ROOT`: !`echo ${RP1_ROOT:-.rp1/}`
+**Resolve `RP1_ROOT`** by running: `rp1 agent-tools rp1-root-dir` — use the `root` value from the JSON response.
 
 ## 1. Main Loop
 

--- a/plugins/dev/skills/build-fast/SKILL.md
+++ b/plugins/dev/skills/build-fast/SKILL.md
@@ -32,8 +32,7 @@ Extract these parameters from the user's input:
 | `GIT_COMMIT` | No | `false` | Commit changes. Set `true` if user says "commit" |
 | `GIT_PUSH` | No | `false` | Push branch to remote. Set `true` if user says "push" |
 
-**Environment values** (resolve via shell):
-- `RP1_ROOT`: !`echo ${RP1_ROOT:-.rp1/}`
+**Resolve `RP1_ROOT`** by running: `rp1 agent-tools rp1-root-dir` — use the `root` value from the JSON response.
 
 ## §VERSION-GATE
 

--- a/plugins/dev/skills/build/SKILL.md
+++ b/plugins/dev/skills/build/SKILL.md
@@ -32,8 +32,7 @@ Extract these parameters from the user's input:
 | `GIT_PUSH` | No | `false` | Push branch to remote. Set `true` if user says "push" |
 | `GIT_PR` | No | `false` | Create PR (implies push and commit). Set `true` if user says "pr" or "pull request" |
 
-**Environment values** (resolve via shell):
-- `RP1_ROOT`: !`echo ${RP1_ROOT:-.rp1/}`
+**Resolve `RP1_ROOT`** by running: `rp1 agent-tools rp1-root-dir` — use the `root` value from the JSON response.
 
 **Feature dir**: `{{$RP1_ROOT}}/work/features/{FEATURE_ID}/`
 

--- a/plugins/dev/skills/feature-archive/SKILL.md
+++ b/plugins/dev/skills/feature-archive/SKILL.md
@@ -26,8 +26,7 @@ Extract these parameters from the user's input:
 |-----------|----------|---------|-------------|
 | `FEATURE_ID` | Yes | - | Feature ID to archive (kebab-case) |
 
-**Environment values** (resolve via shell):
-- `RP1_ROOT`: !`echo ${RP1_ROOT:-.rp1/}`
+**Resolve `RP1_ROOT`** by running: `rp1 agent-tools rp1-root-dir` — use the `root` value from the JSON response.
 
 ## Usage
 

--- a/plugins/dev/skills/feature-edit/SKILL.md
+++ b/plugins/dev/skills/feature-edit/SKILL.md
@@ -26,8 +26,7 @@ Extract these parameters from the user's input:
 | `FEATURE_ID` | Yes | - | Feature identifier (kebab-case, e.g., `auth-flow`) |
 | `EDIT_DESCRIPTION` | Yes | - | Freeform edit description text |
 
-**Environment values** (resolve via shell):
-- `RP1_ROOT`: !`echo ${RP1_ROOT:-.rp1/}`
+**Resolve `RP1_ROOT`** by running: `rp1 agent-tools rp1-root-dir` — use the `root` value from the JSON response.
 
 ## Error Handling
 

--- a/plugins/dev/skills/feature-unarchive/SKILL.md
+++ b/plugins/dev/skills/feature-unarchive/SKILL.md
@@ -27,8 +27,7 @@ Extract these parameters from the user's input:
 |-----------|----------|---------|-------------|
 | `FEATURE_ID` | Yes | - | The feature identifier or timestamped archive name to restore (e.g., `my-feature` or `my-feature_20251129_143022`) |
 
-**Environment values** (resolve via shell):
-- `RP1_ROOT`: !`echo ${RP1_ROOT:-.rp1/}`
+**Resolve `RP1_ROOT`** by running: `rp1 agent-tools rp1-root-dir` — use the `root` value from the JSON response.
 
 ## Usage
 

--- a/plugins/dev/skills/pr-review/SKILL.md
+++ b/plugins/dev/skills/pr-review/SKILL.md
@@ -31,8 +31,7 @@ Extract these parameters from the user's input:
 | `BASE_BRANCH` | No | from PR or `main` | Diff base branch |
 | `SKIP_VISUAL` | No | `false` | Set `true` if user says "skip-visual" or "no visual" |
 
-**Environment values** (resolve via shell):
-- `RP1_ROOT`: !`echo ${RP1_ROOT:-.rp1/}`
+**Resolve `RP1_ROOT`** by running: `rp1 agent-tools rp1-root-dir` — use the `root` value from the JSON response.
 
 ## §STATE-MACHINE
 

--- a/plugins/dev/skills/validate-hypothesis/SKILL.md
+++ b/plugins/dev/skills/validate-hypothesis/SKILL.md
@@ -26,8 +26,7 @@ Extract these parameters from the user's input:
 |-----------|----------|---------|-------------|
 | `FEATURE_ID` | Yes | - | Feature identifier whose hypotheses to validate (kebab-case) |
 
-**Environment values** (resolve via shell):
-- `RP1_ROOT`: !`echo ${RP1_ROOT:-.rp1/}`
+**Resolve `RP1_ROOT`** by running: `rp1 agent-tools rp1-root-dir` — use the `root` value from the JSON response.
 
 ## Prerequisites
 - `{{$RP1_ROOT}}/work/features/{FEATURE_ID}/hypotheses.md` MUST exist


### PR DESCRIPTION
## Summary

- Replaced `${RP1_ROOT:-.rp1/}` shell interpolation with `rp1 agent-tools rp1-root-dir` in 17 SKILL.md files
- The `${}` pattern was reintroduced in 1cfa1ad (skills migration) after being fixed in 41c616cb and 0fb957d8
- Claude Code rejects `${}` parameter substitution in Bash permission patterns

### Why `rp1 agent-tools rp1-root-dir`

- Already authorized via `Bash(rp1 *)` in allowed-tools — no new permissions needed
- **Worktree-aware**: uses `git rev-parse --git-common-dir` to resolve to the main repo's `.rp1/`, not the worktree's CWD
- Returns structured JSON with `root`, `isWorktree`, and `source` metadata

### Files changed (17)

**Base plugin** (5): knowledge-load, knowledge-build, generate-user-docs, deep-research, write-content
**Dev plugin** (12): build-fast, build, build-express, blueprint, blueprint-archive, bootstrap, pr-review, validate-hypothesis, feature-edit, feature-archive, feature-unarchive, address-pr-feedback

## Test plan

- [x] All 1053 unit tests pass
- [x] Typecheck passes (CLI + WebUI)
- [x] `grep -rl '\${RP1_ROOT' plugins/` returns zero matches
- [ ] Verify a skill correctly resolves RP1_ROOT in a worktree