### PR TITLE
fix: skip nested worktrees in Arcade file trees

### DIFF
--- a/catalog/skills.yaml
+++ b/catalog/skills.yaml
@@ -283,8 +283,8 @@ skills:
     agents_that_use_me: []
     sub_agents_that_i_use: [rp1-dev:pr-comment-deduplicator,rp1-dev:pr-comment-poster,rp1-dev:pr-review-reporter,rp1-dev:pr-review-splitter,rp1-dev:pr-review-synthesizer,rp1-dev:pr-sub-reviewer,rp1-dev:pr-visualizer]
     skills_that_i_use: [rp1-dev:pr-visual]
-    last_update: "2026-04-03"
-    last_checksum: 8e94a437a168d9db530b875e8c273896fbeecbd5399d7d88371c33f3dbe20dff
+    last_update: "2026-04-08"
+    last_checksum: 6f7973b5b57fb86ee508eac13f0261170727c8125dbf336888d46ef32211f1ff
   - name: rp1-dev:pr-visual
     description: Transform pull request diffs into Mermaid diagrams for visual code review and change understanding.
     plugin: dev

--- a/cli/web-ui/src/__tests__/server/content-utils.test.ts
+++ b/cli/web-ui/src/__tests__/server/content-utils.test.ts
@@ -1,5 +1,17 @@
 import { describe, expect, test } from "bun:test";
-import { validateFilePath } from "../../server/routes/content-utils";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+	createInitialCommit,
+	createTestWorktree,
+	initTestRepo,
+	removeTestWorktree,
+} from "../../../../src/__tests__/helpers/git-helpers";
+import {
+	buildFileTree,
+	validateFilePath,
+} from "../../server/routes/content-utils";
 
 describe("content-utils", () => {
 	describe("validateFilePath", () => {
@@ -18,6 +30,38 @@ describe("content-utils", () => {
 			expect(validateFilePath("work/features/feat-1/tasks.md")).toBe(
 				"Access denied: path outside allowed directories",
 			);
+		});
+	});
+
+	describe("buildFileTree", () => {
+		test("skips nested git worktree directories", async () => {
+			const tempDir = await mkdtemp(join(tmpdir(), "rp1-content-utils-"));
+			const treeRoot = join(tempDir, "tree-root");
+			const repoRoot = join(tempDir, "repo-root");
+			const worktreePath = join(treeRoot, "pr-123");
+
+			try {
+				await mkdir(join(treeRoot, "visible"), { recursive: true });
+				await Bun.write(join(treeRoot, "visible", "notes.md"), "# visible");
+				await Bun.write(join(treeRoot, "top-level.md"), "# top-level");
+
+				await mkdir(repoRoot, { recursive: true });
+				await initTestRepo(repoRoot);
+				await createInitialCommit(repoRoot);
+				await createTestWorktree(repoRoot, worktreePath, "test-worktree");
+				await Bun.write(join(worktreePath, "worktree-only.md"), "# hidden");
+
+				const tree = await buildFileTree(treeRoot, ".rp1/work");
+
+				expect(tree).not.toBeNull();
+				expect(tree?.children?.map((child) => child.name)).toEqual([
+					"visible",
+					"top-level.md",
+				]);
+			} finally {
+				await removeTestWorktree(repoRoot, worktreePath, true).catch(() => {});
+				await rm(tempDir, { recursive: true, force: true });
+			}
 		});
 	});
 });

--- a/cli/web-ui/src/server/routes/content-utils.ts
+++ b/cli/web-ui/src/server/routes/content-utils.ts
@@ -1,4 +1,4 @@
-import { readdir, stat } from "node:fs/promises";
+import { readdir, readFile, stat } from "node:fs/promises";
 import { basename, extname, join, resolve } from "node:path";
 import type { FileWatcherPool } from "../file-watcher";
 import { parseCanonicalProjectSectionPath } from "../project-paths";
@@ -108,6 +108,9 @@ export async function buildFileTree(
 			const entryRelativePath = join(relativePath, entry.name);
 
 			if (entry.isDirectory()) {
+				if (await isGitWorktreeRoot(entryPath)) {
+					continue;
+				}
 				const subTree = await buildFileTree(entryPath, entryRelativePath);
 				if (subTree) {
 					children.push(subTree);
@@ -139,6 +142,30 @@ export async function buildFileTree(
 		};
 	} catch {
 		return null;
+	}
+}
+
+async function isGitWorktreeRoot(dirPath: string): Promise<boolean> {
+	try {
+		const gitPath = join(dirPath, ".git");
+		const gitStat = await stat(gitPath);
+
+		if (!gitStat.isFile()) {
+			return false;
+		}
+
+		const gitPointer = await readFile(gitPath, "utf-8");
+		if (!gitPointer.startsWith("gitdir:")) {
+			return false;
+		}
+
+		const gitDir = resolve(
+			dirPath,
+			gitPointer.slice("gitdir:".length).trim(),
+		).replaceAll("\\", "/");
+		return gitDir.includes("/.git/worktrees/");
+	} catch {
+		return false;
 	}
 }
 

--- a/docs/reference/dev/pr-review.md
+++ b/docs/reference/dev/pr-review.md
@@ -28,6 +28,9 @@ Thorough code review that understands what your PR is trying to accomplish and c
 
 The `pr-review` command performs comprehensive code review by first understanding what your PR is trying to accomplish (from the description or linked issues), then reviewing each changed file against that intent. Findings are synthesized into an overall assessment with specific, actionable feedback.
 
+!!! warning "Worktree Safety"
+    Do not create git worktrees under `.rp1/work/` while running PR reviews. Arcade treats `.rp1/work/` as artifact storage, and nested worktrees can make the project file browser unusable. If a separate checkout is unavoidable, place it outside `.rp1/`.
+
 ## Parameters
 
 | Parameter | Position | Required | Default | Description |

--- a/plugins/dev/skills/pr-review/SKILL.md
+++ b/plugins/dev/skills/pr-review/SKILL.md
@@ -12,7 +12,7 @@ metadata:
     - map-reduce
     - ci
   created: 2025-10-25
-  updated: 2026-02-26
+  updated: 2026-04-08
   author: cloud-on-prem/rp1
   arguments:
     - name: TARGET
@@ -45,6 +45,11 @@ metadata:
 
 §ROLE: Map-reduce PR review orchestrator. 6 phases, local + CI modes, comment deduplication.
 
+§GUARDRAILS
+
+- Never create git worktrees under `.rp1/work/` or anywhere inside the target project's `.rp1/` directory.
+- If a separate checkout is absolutely required during review, use a temporary path outside the project artifact tree.
+
 ## STATE-MACHINE
 
 ```mermaid
@@ -66,7 +71,7 @@ rp1 agent-tools emit \
 
 - Generate `RUN_ID` as a UUID at workflow start
 - Derive `RUN_NAME` from the resolved PR context: use `"PR #{pr_number}"` when a PR number is available, otherwise use `"PR: {branch_name}"` as fallback
-- On the **first** emit only, include `--name "{RUN_NAME}"` to label the run in the Arcade dashboard
+- On the **first** emit only, include `--name "{RUN_NAME}"` to label the run
 
 On session start, emit the status change:
 ```bash


### PR DESCRIPTION
## Summary
- skip nested git worktree roots when building Arcade project file trees
- add a regression test covering a copied worktree under `.rp1/work`
- add a `pr-review` guardrail and docs note to avoid creating worktrees inside `.rp1/`

## Verification
- bun test cli/web-ui/src/__tests__/server/content-utils.test.ts
- just catalog-check
- git push pre-push checks: no-artifactory, eval-verify, catalog, typecheck-cli, typecheck-webui