### PR TITLE
fix(cli): return init/migrate guidance for rp1-root-dir

### DIFF
--- a/cli/shared/directory-resolution.ts
+++ b/cli/shared/directory-resolution.ts
@@ -1,5 +1,6 @@
 import { execFileSync } from "node:child_process";
-import { existsSync, statSync } from "node:fs";
+import { existsSync, realpathSync, statSync } from "node:fs";
+import { homedir } from "node:os";
 import path from "node:path";
 import * as E from "fp-ts/lib/Either.js";
 import type { CLIError } from "./errors.js";
@@ -15,6 +16,11 @@ export interface ResolvedDirectorySet {
 	readonly workRoot: string;
 	readonly isWorktree: boolean;
 	readonly worktreeName?: string;
+}
+
+export interface DirectoryResolutionOptions {
+	readonly allowHomeProjectRoot?: boolean;
+	readonly requireProjectId?: boolean;
 }
 
 interface GitContext {
@@ -55,18 +61,45 @@ const hasProjectIdFile = (targetPath: string): boolean =>
 const hasRp1Directory = (targetPath: string): boolean =>
 	isDirectory(path.join(targetPath, ".rp1"));
 
+const canonicalizePathForComparison = (targetPath: string): string => {
+	const resolvedPath = path.resolve(targetPath);
+	try {
+		return realpathSync(resolvedPath);
+	} catch {
+		return resolvedPath;
+	}
+};
+
+const getUserHomeDirectory = (): string =>
+	canonicalizePathForComparison(process.env.HOME ?? homedir());
+
+const canAutoDiscoverProjectRoot = (
+	targetPath: string,
+	options: DirectoryResolutionOptions,
+): boolean =>
+	options.allowHomeProjectRoot === true ||
+	canonicalizePathForComparison(targetPath) !== getUserHomeDirectory();
+
 const walkUpToProjectRoot = (
 	startPath: string,
+	options: DirectoryResolutionOptions,
 ): { root: string; hasProjectId: boolean } | undefined => {
 	let current = path.resolve(startPath);
 	let fallbackRp1Dir: string | undefined;
 
 	while (true) {
-		if (hasProjectIdFile(current)) {
+		if (
+			hasProjectIdFile(current) &&
+			canAutoDiscoverProjectRoot(current, options)
+		) {
 			return { root: current, hasProjectId: true };
 		}
 
-		if (fallbackRp1Dir === undefined && hasRp1Directory(current)) {
+		if (
+			fallbackRp1Dir === undefined &&
+			hasRp1Directory(current) &&
+			canAutoDiscoverProjectRoot(current, options)
+		) {
 			fallbackRp1Dir = current;
 		}
 
@@ -86,6 +119,12 @@ const walkUpToProjectRoot = (
 
 	return undefined;
 };
+
+const missingProjectIdError = (projectRoot: string): CLIError =>
+	notFoundError(
+		".rp1/project_id",
+		`Found a legacy rp1 project at ${projectRoot}. Run 'rp1 migrate' from that project root to create .rp1/project_id.`,
+	);
 
 const execGit = (cwd: string, args: readonly string[]): string =>
 	execFileSync("git", [...args], {
@@ -154,6 +193,7 @@ const buildDirectorySet = (params: {
 
 export const resolveDirectorySet = (
 	startPath: string = process.cwd(),
+	options: DirectoryResolutionOptions = {},
 ): E.Either<CLIError, ResolvedDirectorySet> => {
 	const resolvedStartPath = path.resolve(startPath);
 
@@ -177,6 +217,13 @@ export const resolveDirectorySet = (
 				hasProjectIdFile(commonDirProjectRoot) ||
 				hasRp1Directory(commonDirProjectRoot)
 			) {
+				if (
+					options.requireProjectId === true &&
+					!hasProjectIdFile(commonDirProjectRoot)
+				) {
+					return E.left(missingProjectIdError(commonDirProjectRoot));
+				}
+
 				if (!hasProjectIdFile(commonDirProjectRoot)) {
 					console.warn(
 						`[rp1] Found .rp1/ directory at ${commonDirProjectRoot} without project_id. Run 'rp1 migrate' to create one.`,
@@ -197,8 +244,12 @@ export const resolveDirectorySet = (
 	// Phase 2: Walk up directory tree to find .rp1/project_id.
 	// Only reached for non-worktree contexts or worktrees whose main repo
 	// lacks an .rp1 directory.
-	const walkedResult = walkUpToProjectRoot(resolvedStartPath);
+	const walkedResult = walkUpToProjectRoot(resolvedStartPath, options);
 	if (walkedResult) {
+		if (options.requireProjectId === true && !walkedResult.hasProjectId) {
+			return E.left(missingProjectIdError(walkedResult.root));
+		}
+
 		return E.right(
 			buildDirectorySet({
 				projectRoot: walkedResult.root,

--- a/cli/src/__tests__/agent-tools/emit/validate.test.ts
+++ b/cli/src/__tests__/agent-tools/emit/validate.test.ts
@@ -4,21 +4,41 @@
  * and per-type payload shape validation.
  */
 
-import { describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, realpath, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { VALID_EVENT_TYPES } from "../../../../shared/events.js";
 import {
 	validateEmitOptions,
 	validatePayloadShape,
 } from "../../../agent-tools/emit/validate.js";
 import {
+	createInitialCommit,
+	createTestWorktree,
 	expectLeft,
 	expectRight,
+	expectTaskLeft,
 	expectTaskRight,
 	getErrorMessage,
+	initTestRepo,
 	withEnvOverride,
 } from "../../helpers/index.js";
 
 describe("emit validation", () => {
+	let tempDir: string;
+	let originalCwd: string;
+
+	beforeEach(async () => {
+		tempDir = await mkdtemp(join(tmpdir(), "emit-validate-test-"));
+		originalCwd = process.cwd();
+	});
+
+	afterEach(async () => {
+		process.chdir(originalCwd);
+		await rm(tempDir, { recursive: true, force: true });
+	});
+
 	describe("validatePayloadShape", () => {
 		describe("status_change", () => {
 			test("accepts valid status_change payload", () => {
@@ -284,6 +304,77 @@ describe("emit validation", () => {
 			// not necessarily cwd if cwd is a subdirectory
 			expect(result.projectPath).toBeTruthy();
 			expect(typeof result.projectPath).toBe("string");
+		});
+
+		test("fails with rp1 init guidance when --project is omitted outside an rp1 project", async () => {
+			const nonProjectDir = join(tempDir, "scratch");
+			await mkdir(nonProjectDir, { recursive: true });
+			process.chdir(nonProjectDir);
+
+			const error = await expectTaskLeft(
+				validateEmitOptions({
+					type: "status_change",
+					runId: "test-run-missing-project",
+					workflow: "build",
+					step: "plan",
+					data: '{"status": "running"}',
+				}),
+			);
+
+			expect(error._tag).toBe("NotFoundError");
+			if (error._tag !== "NotFoundError") return;
+
+			expect(error.suggestion).toContain("rp1 init");
+		});
+
+		test("fails with rp1 migrate guidance when --project is omitted inside a legacy project", async () => {
+			const legacyProjectRoot = join(tempDir, "legacy-project");
+			const nestedDir = join(legacyProjectRoot, "packages", "app");
+			await mkdir(join(legacyProjectRoot, ".rp1"), { recursive: true });
+			await mkdir(nestedDir, { recursive: true });
+			process.chdir(nestedDir);
+
+			const error = await expectTaskLeft(
+				validateEmitOptions({
+					type: "status_change",
+					runId: "test-run-legacy-project",
+					workflow: "build",
+					step: "plan",
+					data: '{"status": "running"}',
+				}),
+			);
+
+			expect(error._tag).toBe("NotFoundError");
+			if (error._tag !== "NotFoundError") return;
+
+			expect(error.suggestion).toContain("rp1 migrate");
+			expect(error.suggestion).toContain(legacyProjectRoot);
+		});
+
+		test("resolves the main repo root when --project is omitted from a worktree", async () => {
+			const mainRepoRoot = join(tempDir, "main-repo");
+			const worktreePath = join(tempDir, "linked-worktree");
+			await mkdir(join(mainRepoRoot, ".rp1"), { recursive: true });
+			await writeFile(join(mainRepoRoot, ".rp1", "project_id"), "project-123");
+			await initTestRepo(mainRepoRoot);
+			await createInitialCommit(mainRepoRoot);
+			await createTestWorktree(mainRepoRoot, worktreePath, "emit-test-branch");
+			const canonicalMainRepoRoot = await realpath(mainRepoRoot).catch(
+				() => mainRepoRoot,
+			);
+			process.chdir(worktreePath);
+
+			const result = await expectTaskRight(
+				validateEmitOptions({
+					type: "status_change",
+					runId: "test-run-worktree",
+					workflow: "build",
+					step: "plan",
+					data: '{"status": "running"}',
+				}),
+			);
+
+			expect(result.projectPath).toBe(canonicalMainRepoRoot);
 		});
 
 		test("explicit --project takes precedence over RP1_ROOT env var", async () => {

--- a/cli/src/__tests__/agent-tools/resolve-args/resolve-args.test.ts
+++ b/cli/src/__tests__/agent-tools/resolve-args/resolve-args.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { existsSync } from "node:fs";
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, realpath, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -15,7 +15,12 @@ import {
 	resolveSchemaFromNameOrPath,
 } from "../../../agent-tools/resolve-args/schema-lookup.js";
 import type { ArgumentDefinition } from "../../../build/models.js";
-import { writeFixture } from "../../helpers/index.js";
+import {
+	createInitialCommit,
+	createTestWorktree,
+	initTestRepo,
+	writeFixture,
+} from "../../helpers/index.js";
 
 /** True when dist/ bundle manifests exist (i.e. a build has been run). */
 // Test file is at cli/src/__tests__/agent-tools/resolve-args/ — 5 levels up to repo root
@@ -210,6 +215,15 @@ description: "A skill with no arguments for testing purposes"
 		expect(E.isRight(result)).toBe(true);
 		if (E.isRight(result)) {
 			expect(result.right.arguments).toEqual({});
+			expect(result.right.directories).toEqual({
+				projectRoot: tempDir,
+				projectId: undefined,
+				kbRoot: join(tempDir, ".rp1", "context"),
+				workRoot: join(tempDir, ".rp1", "work"),
+				isWorktree: false,
+				status: "uninitialized",
+				nextStepCommand: "rp1 init",
+			});
 			expect(result.right.environment).toEqual({});
 			expect(result.right.unresolved).toEqual([]);
 		}
@@ -571,6 +585,200 @@ metadata:
 		expect(E.isRight(result)).toBe(true);
 		if (E.isRight(result)) {
 			expect(result.right.arguments.FEATURE_ID).toBe("from-project-settings");
+			expect(result.right.directories).toEqual({
+				projectRoot: tempDir,
+				projectId: "project-123",
+				kbRoot: join(tempDir, ".rp1", "context"),
+				workRoot: join(tempDir, ".rp1", "work"),
+				isWorktree: false,
+				status: "initialized",
+			});
+		}
+	});
+
+	test("returns migrate guidance when project_root points at a legacy .rp1 directory", async () => {
+		const legacyProjectRoot = join(tempDir, "legacy-project");
+		const nestedDir = join(legacyProjectRoot, "packages", "app");
+
+		await mkdir(join(legacyProjectRoot, ".rp1"), { recursive: true });
+		await mkdir(nestedDir, { recursive: true });
+
+		const schemaPath = await createSkillFile(
+			tempDir,
+			`---
+name: test-skill
+description: "A test skill with structured arguments for validation"
+metadata:
+  arguments:
+    - name: FEATURE_ID
+      type: string
+      required: false
+      description: "Feature identifier"
+---
+# Test skill
+`,
+		);
+
+		const result = await resolveArgs({
+			schema_path: schemaPath,
+			raw_args: "",
+			project_root: nestedDir,
+		})();
+
+		expect(E.isRight(result)).toBe(true);
+		if (E.isRight(result)) {
+			expect(result.right.directories).toEqual({
+				projectRoot: legacyProjectRoot,
+				projectId: undefined,
+				kbRoot: join(legacyProjectRoot, ".rp1", "context"),
+				workRoot: join(legacyProjectRoot, ".rp1", "work"),
+				isWorktree: false,
+				status: "legacy",
+				nextStepCommand: "rp1 migrate",
+			});
+		}
+	});
+
+	test("returns init guidance when project_root is not an rp1 project", async () => {
+		const nestedDir = join(tempDir, "scratch", "app");
+		await mkdir(nestedDir, { recursive: true });
+
+		const schemaPath = await createSkillFile(
+			tempDir,
+			`---
+name: test-skill
+description: "A test skill with structured arguments for validation"
+metadata:
+  arguments:
+    - name: FEATURE_ID
+      type: string
+      required: false
+      description: "Feature identifier"
+---
+# Test skill
+`,
+		);
+
+		const result = await resolveArgs({
+			schema_path: schemaPath,
+			raw_args: "",
+			project_root: nestedDir,
+		})();
+
+		expect(E.isRight(result)).toBe(true);
+		if (E.isRight(result)) {
+			expect(result.right.directories).toEqual({
+				projectRoot: nestedDir,
+				projectId: undefined,
+				kbRoot: join(nestedDir, ".rp1", "context"),
+				workRoot: join(nestedDir, ".rp1", "work"),
+				isWorktree: false,
+				status: "uninitialized",
+				nextStepCommand: "rp1 init",
+			});
+		}
+	});
+
+	test("does not treat the home directory as an initialized project", async () => {
+		const fakeHome = join(tempDir, "fake-home");
+		const nestedPathUnderHome = join(fakeHome, "scratch", "app");
+		const originalHome = process.env.HOME;
+
+		await writeFixture(fakeHome, ".rp1/project_id", "project-123");
+		await mkdir(nestedPathUnderHome, { recursive: true });
+
+		const schemaPath = await createSkillFile(
+			tempDir,
+			`---
+name: test-skill
+description: "A test skill with structured arguments for validation"
+metadata:
+  arguments:
+    - name: FEATURE_ID
+      type: string
+      required: false
+      description: "Feature identifier"
+---
+# Test skill
+`,
+		);
+
+		process.env.HOME = fakeHome;
+
+		try {
+			const result = await resolveArgs({
+				schema_path: schemaPath,
+				raw_args: "",
+				project_root: nestedPathUnderHome,
+			})();
+
+			expect(E.isRight(result)).toBe(true);
+			if (E.isRight(result)) {
+				expect(result.right.directories).toEqual({
+					projectRoot: nestedPathUnderHome,
+					projectId: undefined,
+					kbRoot: join(nestedPathUnderHome, ".rp1", "context"),
+					workRoot: join(nestedPathUnderHome, ".rp1", "work"),
+					isWorktree: false,
+					status: "uninitialized",
+					nextStepCommand: "rp1 init",
+				});
+			}
+		} finally {
+			if (originalHome === undefined) {
+				delete process.env.HOME;
+			} else {
+				process.env.HOME = originalHome;
+			}
+		}
+	});
+
+	test("surfaces canonical worktree directories when project_root is a linked worktree", async () => {
+		const mainRepoRoot = join(tempDir, "worktree-main");
+		const linkedWorktreePath = join(tempDir, "linked-worktree");
+
+		await mkdir(join(mainRepoRoot, ".rp1"), { recursive: true });
+		await writeFile(join(mainRepoRoot, ".rp1", "project_id"), "project-123");
+		await initTestRepo(mainRepoRoot);
+		await createInitialCommit(mainRepoRoot);
+		await createTestWorktree(mainRepoRoot, linkedWorktreePath, "test-branch");
+		const canonicalMainRepoRoot = await realpath(mainRepoRoot).catch(
+			() => mainRepoRoot,
+		);
+
+		const schemaPath = await createSkillFile(
+			tempDir,
+			`---
+name: test-skill
+description: "A test skill with structured arguments for validation"
+metadata:
+  arguments:
+    - name: FEATURE_ID
+      type: string
+      required: false
+      description: "Feature identifier"
+---
+# Test skill
+`,
+		);
+
+		const result = await resolveArgs({
+			schema_path: schemaPath,
+			raw_args: "",
+			project_root: linkedWorktreePath,
+		})();
+
+		expect(E.isRight(result)).toBe(true);
+		if (E.isRight(result)) {
+			expect(result.right.directories).toEqual({
+				projectRoot: canonicalMainRepoRoot,
+				projectId: "project-123",
+				kbRoot: join(canonicalMainRepoRoot, ".rp1", "context"),
+				workRoot: join(canonicalMainRepoRoot, ".rp1", "work"),
+				isWorktree: true,
+				worktreeName: "test-branch",
+				status: "initialized",
+			});
 		}
 	});
 

--- a/cli/src/__tests__/agent-tools/rp1-root-dir/resolver.test.ts
+++ b/cli/src/__tests__/agent-tools/rp1-root-dir/resolver.test.ts
@@ -148,5 +148,67 @@ describe("rp1-root-dir resolver", () => {
 
 			expect(resolved._tag).toBe("Left");
 		});
+
+		test("does not treat HOME as the active project root", async () => {
+			const fakeHome = join(tempBase, "fake-home");
+			const nestedPathUnderHome = join(fakeHome, "scratch", "app");
+			const originalHome = process.env.HOME;
+
+			await mkdir(join(fakeHome, ".rp1"), { recursive: true });
+			writeFileSync(
+				join(fakeHome, ".rp1", "project_id"),
+				"990e8400-e29b-41d4-a716-446655440000",
+			);
+			await mkdir(nestedPathUnderHome, { recursive: true });
+
+			process.env.HOME = fakeHome;
+
+			try {
+				const result = resolveRp1Root(nestedPathUnderHome);
+				const resolved = await result();
+
+				expect(resolved._tag).toBe("Left");
+			} finally {
+				if (originalHome === undefined) {
+					delete process.env.HOME;
+				} else {
+					process.env.HOME = originalHome;
+				}
+			}
+		});
+	});
+
+	describe("strict project identity mode", () => {
+		test("suggests rp1 init when no rp1 project exists", async () => {
+			const result = resolveRp1Root(nonGitDir, { requireProjectId: true });
+			const resolved = await result();
+
+			expect(resolved._tag).toBe("Left");
+			if (resolved._tag !== "Left") return;
+
+			expect(resolved.left._tag).toBe("NotFoundError");
+			if (resolved.left._tag !== "NotFoundError") return;
+
+			expect(resolved.left.suggestion).toContain("rp1 init");
+		});
+
+		test("suggests rp1 migrate for legacy .rp1 directories without project_id", async () => {
+			const legacyProjectRoot = join(tempBase, "legacy-project");
+			await mkdir(join(legacyProjectRoot, ".rp1"), { recursive: true });
+
+			const result = resolveRp1Root(legacyProjectRoot, {
+				requireProjectId: true,
+			});
+			const resolved = await result();
+
+			expect(resolved._tag).toBe("Left");
+			if (resolved._tag !== "Left") return;
+
+			expect(resolved.left._tag).toBe("NotFoundError");
+			if (resolved.left._tag !== "NotFoundError") return;
+
+			expect(resolved.left.suggestion).toContain("rp1 migrate");
+			expect(resolved.left.suggestion).toContain(legacyProjectRoot);
+		});
 	});
 });

--- a/cli/src/__tests__/build/lint/legacy-arguments.test.ts
+++ b/cli/src/__tests__/build/lint/legacy-arguments.test.ts
@@ -1,5 +1,5 @@
 /**
- * Unit tests for L007-L012: source-level argument validation rules.
+ * Unit tests for L007-L014: source-level argument validation rules.
  */
 
 import { describe, expect, test } from "bun:test";
@@ -321,6 +321,39 @@ describe("L012: circular implies chain", () => {
 		expect(
 			diagnostics.filter((d) => d.rule === "L012").length,
 		).toBeGreaterThanOrEqual(1);
+	});
+});
+
+describe("L014: parameterized skills must use resolve-args directories", () => {
+	test("errors when a parameterized skill body calls rp1-root-dir", () => {
+		const metadata = makeMetadata({
+			arguments: [makeArg({ name: "FEATURE_ID", required: true })],
+		});
+		const body =
+			"## Step\n\nRun `rp1 agent-tools rp1-root-dir` and extract projectRoot.";
+		const diagnostics = lintSkillArguments(metadata, body, "test.md");
+		const l014 = diagnostics.filter((d) => d.rule === "L014");
+		expect(l014.length).toBe(1);
+		expect(l014[0].severity).toBe("error");
+		expect(l014[0].message).toContain("rp1-root-dir");
+		expect(l014[0].suggestion).toContain("projectRoot");
+	});
+
+	test("does not error when skill has no structured arguments", () => {
+		const metadata = makeMetadata({});
+		const body = "Run `rp1 agent-tools rp1-root-dir`.";
+		const diagnostics = lintSkillArguments(metadata, body, "test.md");
+		expect(diagnostics.filter((d) => d.rule === "L014").length).toBe(0);
+	});
+
+	test("does not error when parameterized skill uses generated directories only", () => {
+		const metadata = makeMetadata({
+			arguments: [makeArg({ name: "FEATURE_ID", required: true })],
+		});
+		const body =
+			"Use the pre-resolved `projectRoot`, `kbRoot`, and `workRoot` values.";
+		const diagnostics = lintSkillArguments(metadata, body, "test.md");
+		expect(diagnostics.filter((d) => d.rule === "L014").length).toBe(0);
 	});
 });
 

--- a/cli/src/__tests__/build/templates/template-rendering.test.ts
+++ b/cli/src/__tests__/build/templates/template-rendering.test.ts
@@ -189,6 +189,7 @@ describeWithLiquid("template rendering", () => {
 			const engine = createTestEngine();
 			const result = await engine.renderFile("opencode/skill", {
 				platform: "opencode",
+				namespacedPluginName: "rp1-base",
 				artifact: {
 					type: "skill",
 					namespacedName: "rp1-base-knowledge-build",
@@ -201,6 +202,41 @@ describeWithLiquid("template rendering", () => {
 				pluginName: "base",
 			});
 			expect(result.trim()).toBe(readGolden("opencode-skill.md").trim());
+		});
+
+		test("injects resolve-args directory guidance for parameterized skills", async () => {
+			const engine = createTestEngine();
+			const result = await engine.renderFile("opencode/skill", {
+				platform: "opencode",
+				namespacedPluginName: "rp1-base",
+				artifact: {
+					type: "skill",
+					name: "knowledge-build",
+					namespacedName: "rp1-base-knowledge-build",
+					description: "Build knowledge base artifacts",
+					allowedTools: "Bash, Read",
+					content: "Skill content.",
+					metadata: {
+						arguments: [
+							{
+								name: "FEATURE_ID",
+								type: "string",
+								required: false,
+								description: "Feature identifier",
+							},
+						],
+					},
+					supportingFiles: [],
+				},
+				pluginName: "base",
+			});
+			expect(result).toContain(
+				"Extract values from `data.arguments` and `data.directories`",
+			);
+			expect(result).toContain(
+				"| projectRoot | `data.directories.projectRoot` |",
+			);
+			expect(result).toContain("Do not call `rp1-root-dir`");
 		});
 
 		test("renders skill without allowed-tools", async () => {
@@ -263,6 +299,7 @@ describeWithLiquid("template rendering", () => {
 			const engine = createTestEngine();
 			const result = await engine.renderFile("codex/skill", {
 				platform: "codex",
+				namespacedPluginName: "rp1-dev",
 				artifact: {
 					type: "skill",
 					namespacedName: "rp1-dev-build",
@@ -282,6 +319,39 @@ describeWithLiquid("template rendering", () => {
 				pluginName: "dev",
 			});
 			expect(result.trim()).toBe(readGolden("codex-skill.md").trim());
+		});
+
+		test("injects resolve-args directory guidance for parameterized skills", async () => {
+			const engine = createTestEngine();
+			const result = await engine.renderFile("codex/skill", {
+				platform: "codex",
+				namespacedPluginName: "rp1-dev",
+				artifact: {
+					type: "skill",
+					name: "build",
+					namespacedName: "rp1-dev-build",
+					description: "Build plugin artifacts",
+					allowedTools: "Bash(echo *)",
+					content: "Codex skill content.",
+					metadata: {
+						arguments: [
+							{
+								name: "FEATURE_ID",
+								type: "string",
+								required: true,
+								description: "Feature identifier",
+							},
+						],
+					},
+					supportingFiles: [],
+				},
+				pluginName: "dev",
+			});
+			expect(result).toContain(
+				"Extract values from `data.arguments` and `data.directories`",
+			);
+			expect(result).toContain("| kbRoot | `data.directories.kbRoot` |");
+			expect(result).toContain("Do not call `rp1-root-dir`");
 		});
 	});
 
@@ -423,6 +493,7 @@ describeWithLiquid("template rendering", () => {
 			const engine = createTestEngine();
 			const result = await engine.renderFile("claude-code/skill", {
 				platform: "claude-code",
+				namespacedPluginName: "rp1-base",
 				artifact: {
 					type: "skill",
 					namespacedName: "rp1-base-knowledge-build",
@@ -443,6 +514,39 @@ describeWithLiquid("template rendering", () => {
 			expect(result).toContain("allowed-tools: Bash(echo *), Read, Edit");
 			expect(result).toContain("rp1-base:knowledge-load");
 			expect(result).toContain("version: 1.0.0");
+		});
+
+		test("injects resolve-args directory guidance for parameterized skills", async () => {
+			const engine = createTestEngine();
+			const result = await engine.renderFile("claude-code/skill", {
+				platform: "claude-code",
+				namespacedPluginName: "rp1-base",
+				artifact: {
+					type: "skill",
+					name: "knowledge-build",
+					namespacedName: "rp1-base-knowledge-build",
+					description: "Build knowledge base artifacts",
+					allowedTools: "Bash(echo *), Read, Edit",
+					content: "Skill content.",
+					metadata: {
+						arguments: [
+							{
+								name: "FEATURE_ID",
+								type: "string",
+								required: false,
+								description: "Feature identifier",
+							},
+						],
+					},
+					supportingFiles: [],
+				},
+				pluginName: "base",
+			});
+			expect(result).toContain(
+				"Extract values from `data.arguments` and `data.directories`",
+			);
+			expect(result).toContain("| workRoot | `data.directories.workRoot` |");
+			expect(result).toContain("Do not call `rp1-root-dir`");
 		});
 	});
 

--- a/cli/src/__tests__/init/directory-model.test.ts
+++ b/cli/src/__tests__/init/directory-model.test.ts
@@ -41,6 +41,32 @@ describe("init directory model", () => {
 		expect(directories.workDir).toBe(join(tempDir, ".rp1", "work"));
 	});
 
+	test("ignores a home-level project marker when initializing a nested directory", async () => {
+		const nestedDir = join(tempDir, "scratch", "app");
+		const originalHome = process.env.HOME;
+
+		await mkdir(join(tempDir, ".rp1"), { recursive: true });
+		await writeFile(join(tempDir, ".rp1", "project_id"), "project-123");
+		await mkdir(nestedDir, { recursive: true });
+
+		process.env.HOME = tempDir;
+
+		try {
+			const directories = resolveInitDirectoryModel(nestedDir);
+
+			expect(directories.projectRoot).toBe(nestedDir);
+			expect(directories.rp1Dir).toBe(join(nestedDir, ".rp1"));
+			expect(directories.contextDir).toBe(join(nestedDir, ".rp1", "context"));
+			expect(directories.workDir).toBe(join(nestedDir, ".rp1", "work"));
+		} finally {
+			if (originalHome === undefined) {
+				delete process.env.HOME;
+			} else {
+				process.env.HOME = originalHome;
+			}
+		}
+	});
+
 	test("detects work content from .rp1/work directory", async () => {
 		const workDir = join(tempDir, ".rp1", "work");
 

--- a/cli/src/__tests__/shared/directory-resolution.test.ts
+++ b/cli/src/__tests__/shared/directory-resolution.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { writeFileSync } from "node:fs";
-import { mkdir, realpath, rm } from "node:fs/promises";
+import { mkdir, realpath, rm, symlink } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import * as E from "fp-ts/lib/Either.js";
@@ -152,6 +152,66 @@ describe("directory resolution", () => {
 		if (E.isRight(result)) return;
 
 		expect(result.left._tag).toBe("NotFoundError");
+	});
+
+	test("does not auto-discover the home directory as a project root", async () => {
+		const fakeHome = join(tempBase, "fake-home");
+		const nestedPathUnderHome = join(fakeHome, "scratch", "app");
+		const originalHome = process.env.HOME;
+
+		await mkdir(join(fakeHome, ".rp1"), { recursive: true });
+		writeFileSync(
+			join(fakeHome, ".rp1", "project_id"),
+			"880e8400-e29b-41d4-a716-446655440000",
+		);
+		await mkdir(nestedPathUnderHome, { recursive: true });
+
+		process.env.HOME = fakeHome;
+
+		try {
+			const result = resolveDirectorySet(nestedPathUnderHome);
+			expect(E.isLeft(result)).toBe(true);
+			if (E.isRight(result)) return;
+
+			expect(result.left._tag).toBe("NotFoundError");
+		} finally {
+			if (originalHome === undefined) {
+				delete process.env.HOME;
+			} else {
+				process.env.HOME = originalHome;
+			}
+		}
+	});
+
+	test("does not auto-discover the home directory when HOME is a symlink alias", async () => {
+		const fakeHome = join(tempBase, "real-home");
+		const aliasedHome = join(tempBase, "alias-home");
+		const nestedPathUnderHome = join(fakeHome, "scratch", "app");
+		const originalHome = process.env.HOME;
+
+		await mkdir(join(fakeHome, ".rp1"), { recursive: true });
+		writeFileSync(
+			join(fakeHome, ".rp1", "project_id"),
+			"890e8400-e29b-41d4-a716-446655440000",
+		);
+		await mkdir(nestedPathUnderHome, { recursive: true });
+		await symlink(fakeHome, aliasedHome);
+
+		process.env.HOME = aliasedHome;
+
+		try {
+			const result = resolveDirectorySet(nestedPathUnderHome);
+			expect(E.isLeft(result)).toBe(true);
+			if (E.isRight(result)) return;
+
+			expect(result.left._tag).toBe("NotFoundError");
+		} finally {
+			if (originalHome === undefined) {
+				delete process.env.HOME;
+			} else {
+				process.env.HOME = originalHome;
+			}
+		}
 	});
 
 	test("RP1_PROJECT_ROOT env var is ignored", () => {

--- a/cli/src/agent-tools/command.ts
+++ b/cli/src/agent-tools/command.ts
@@ -247,7 +247,9 @@ Description:
 Resolution order:
   1. Walk up from current directory to find .rp1/project_id
   2. Git worktree detection via git-common-dir (maps to main repo)
-  3. Fall back to .rp1/ directory without project_id (with warning)
+  3. If a legacy .rp1/ directory exists without project_id, fail with a
+     suggestion to run 'rp1 migrate'
+  4. If no rp1 project exists, fail with a suggestion to run 'rp1 init'
 
 Output:
   JSON with resolved directories and detection metadata:

--- a/cli/src/agent-tools/command.ts
+++ b/cli/src/agent-tools/command.ts
@@ -506,7 +506,10 @@ const emitCommand = agentToolsCommand
 	)
 	.option("--unit <unit>", "Task/unit identifier")
 	.option("--data <json>", "JSON payload for the event")
-	.option("--project <path>", "Project path (defaults to cwd)")
+	.option(
+		"--project <path>",
+		"Absolute project path override (otherwise auto-resolved from the active rp1 project)",
+	)
 	.option("--name <name>", "Human-readable name for the run (set-once)")
 	.option(
 		"--harness <name>",
@@ -542,7 +545,12 @@ Arguments:
   --step <step>        Workflow step name (required for status_change, subflow_registered)
   --unit <unit>        Task/unit identifier (optional)
   --data <json>        JSON payload (optional, content depends on event type)
-  --project <path>     Absolute path to project root (optional, defaults to cwd)
+  --project <path>     Absolute path to project root (optional override)
+
+Project Resolution:
+  If --project is omitted, emit resolves the active rp1 project from the
+  current directory. If no project exists, run 'rp1 init'. If a legacy
+  .rp1/ directory exists without project_id, run 'rp1 migrate'.
 
 Output:
   JSON ToolResult with:

--- a/cli/src/agent-tools/command.ts
+++ b/cli/src/agent-tools/command.ts
@@ -309,7 +309,7 @@ agentToolsCommand
 	.option("-a, --args <args>", "Raw argument string from invocation")
 	.option(
 		"-p, --project-root <path>",
-		"Project root directory for settings lookup",
+		"Path used to anchor directory resolution and settings lookup",
 	)
 	.addHelpText(
 		"after",
@@ -334,11 +334,11 @@ Input (CLI flags or JSON via stdin/file):
   - name: Skill/agent namespace (e.g., "rp1-dev:build")
   - schema_path: Direct path to SKILL.md or agent .md file
   - raw_args: Raw argument string from invocation
-  - project_root: Project root directory (for settings lookup)
+  - project_root: Path used to anchor directory resolution and settings lookup
 
 Output:
-  JSON ToolResult with resolved arguments, an environment placeholder object,
-  and an unresolved list.
+  JSON ToolResult with resolved arguments, resolved directories, an
+  environment placeholder object, and an unresolved list.
 
 Examples:
   rp1 agent-tools resolve-args --name rp1-dev:build --args "my-feature --afk"

--- a/cli/src/agent-tools/emit/validate.ts
+++ b/cli/src/agent-tools/emit/validate.ts
@@ -293,10 +293,9 @@ export const validatePayloadShape = (
  * Resolve the project path for an emit event.
  *
  * When --project is explicitly provided, validates and resolves it via git
- * worktree normalization. When omitted, uses the same resolution chain as
- * `rp1 agent-tools rp1-root-dir`: project-root discovery → git common-dir → cwd.
- * This ensures emit records are attributed to the correct project regardless
- * of worktree context.
+ * worktree normalization. When omitted, requires the current directory to
+ * resolve to a real rp1 project with `.rp1/project_id`, matching
+ * `rp1 agent-tools rp1-root-dir`.
  */
 const validateProjectPath = (
 	project: string | undefined,
@@ -311,17 +310,11 @@ const validateProjectPath = (
 	}
 
 	return pipe(
-		resolveRp1Root(),
+		resolveRp1Root(process.cwd(), { requireProjectId: true }),
 		TE.map(
 			(result): ResolvedProjectPath => ({
 				projectPath: result.projectRoot,
 				worktreePath: result.isWorktree ? process.cwd() : undefined,
-			}),
-		),
-		TE.orElse(() =>
-			TE.right<CLIError, ResolvedProjectPath>({
-				projectPath: process.cwd(),
-				worktreePath: undefined,
 			}),
 		),
 	);

--- a/cli/src/agent-tools/resolve-args/index.ts
+++ b/cli/src/agent-tools/resolve-args/index.ts
@@ -1,7 +1,7 @@
 /**
  * resolve-args tool entry point.
- * Resolves structured arguments for skills and agents by merging
- * user input with settings files and schema defaults.
+ * Resolves structured arguments plus canonical project directories for skills
+ * and agents by merging user input with settings files and schema defaults.
  */
 
 import * as E from "fp-ts/lib/Either.js";
@@ -95,7 +95,7 @@ export const execute = (
 registerTool({
 	name: TOOL_NAME,
 	description:
-		"Resolve structured arguments for skills and agents from schema, settings, and user input",
+		"Resolve structured arguments and canonical project directories for skills and agents",
 	execute,
 });
 

--- a/cli/src/agent-tools/resolve-args/models.ts
+++ b/cli/src/agent-tools/resolve-args/models.ts
@@ -17,9 +17,28 @@ export type ResolvedArgumentValues = Readonly<Record<string, string | boolean>>;
 /** Reserved environment values keyed by parameter name. Currently emitted as {}. */
 export type ResolvedEnvironmentValues = Readonly<Record<string, string>>;
 
+/** Directory resolution status for the requested project root. */
+export type ResolvedDirectoryStatus =
+	| "initialized"
+	| "legacy"
+	| "uninitialized";
+
+/** Canonical project directories derived from project_root. */
+export interface ResolvedDirectories {
+	readonly projectRoot: string;
+	readonly projectId: string | undefined;
+	readonly kbRoot: string;
+	readonly workRoot: string;
+	readonly isWorktree: boolean;
+	readonly worktreeName?: string;
+	readonly status: ResolvedDirectoryStatus;
+	readonly nextStepCommand?: "rp1 init" | "rp1 migrate";
+}
+
 /** Output payload for the resolve-args tool. */
 export interface ResolvedArgs {
 	readonly arguments: ResolvedArgumentValues;
+	readonly directories: ResolvedDirectories;
 	readonly environment: ResolvedEnvironmentValues;
 	readonly unresolved: readonly string[];
 }

--- a/cli/src/agent-tools/resolve-args/resolver.ts
+++ b/cli/src/agent-tools/resolve-args/resolver.ts
@@ -3,6 +3,7 @@
  * Implements 5-layer merge, implies chain resolution, and unresolved detection.
  */
 
+import path from "node:path";
 import * as E from "fp-ts/lib/Either.js";
 import { pipe } from "fp-ts/lib/function.js";
 import * as TE from "fp-ts/lib/TaskEither.js";
@@ -11,7 +12,10 @@ import {
 	parseUserFacing,
 	toCanonicalString,
 } from "../../../shared/canonical-name.js";
-import { resolveDirectorySet } from "../../../shared/directory-resolution.js";
+import {
+	type ResolvedDirectorySet,
+	resolveDirectorySet,
+} from "../../../shared/directory-resolution.js";
 import type { CLIError } from "../../../shared/errors.js";
 import {
 	notFoundError,
@@ -27,6 +31,7 @@ import type {
 	ResolveArgsInput,
 	ResolvedArgs,
 	ResolvedArgumentValues,
+	ResolvedDirectories,
 } from "./models.js";
 import { resolveSchemaFromNameOrPath } from "./schema-lookup.js";
 
@@ -308,6 +313,44 @@ export const resolveImpliesChains = (
 	}
 };
 
+const buildFallbackDirectories = (projectRoot: string): ResolvedDirectories => {
+	const resolvedProjectRoot = path.resolve(projectRoot);
+
+	return {
+		projectRoot: resolvedProjectRoot,
+		projectId: undefined,
+		kbRoot: path.join(resolvedProjectRoot, ".rp1", "context"),
+		workRoot: path.join(resolvedProjectRoot, ".rp1", "work"),
+		isWorktree: false,
+		status: "uninitialized",
+		nextStepCommand: "rp1 init",
+	};
+};
+
+const mapResolvedDirectories = (
+	directories: ResolvedDirectorySet,
+): ResolvedDirectories => ({
+	projectRoot: directories.projectRoot,
+	projectId: directories.projectId,
+	kbRoot: directories.kbRoot,
+	workRoot: directories.workRoot,
+	isWorktree: directories.isWorktree,
+	worktreeName: directories.worktreeName,
+	status: directories.projectId === undefined ? "legacy" : "initialized",
+	...(directories.projectId === undefined && {
+		nextStepCommand: "rp1 migrate" as const,
+	}),
+});
+
+const resolveDirectories = (projectRoot: string): ResolvedDirectories =>
+	pipe(
+		resolveDirectorySet(projectRoot),
+		E.match(
+			() => buildFallbackDirectories(projectRoot),
+			(directories) => mapResolvedDirectories(directories),
+		),
+	);
+
 /**
  * Resolve arguments using the 5-layer merge precedence.
  *
@@ -331,6 +374,8 @@ export const resolveArgs = (
 			canonicalName = parsed.right;
 		}
 	}
+
+	const directories = resolveDirectories(input.project_root);
 
 	return pipe(
 		// Resolve schema file path from name or direct path
@@ -361,6 +406,7 @@ export const resolveArgs = (
 			if (schema.arguments.length === 0 && schema.environment.length === 0) {
 				return TE.right<CLIError, ResolvedArgs>({
 					arguments: {},
+					directories,
 					environment: {},
 					unresolved: [],
 				});
@@ -380,16 +426,9 @@ export const resolveArgs = (
 					const skillName = canonicalName
 						? toCanonicalString(canonicalName)
 						: extractNameFromPath(resolvedPath);
-					const settingsProjectRoot = pipe(
-						resolveDirectorySet(input.project_root),
-						E.match(
-							() => input.project_root,
-							(directories) => directories.projectRoot,
-						),
-					);
 					const settingsDefaults = await loadArgumentDefaultsForSkill(
 						skillName,
-						settingsProjectRoot,
+						directories.projectRoot,
 					);
 
 					// Merge all layers per argument
@@ -452,6 +491,7 @@ export const resolveArgs = (
 
 					return {
 						arguments: resolved as ResolvedArgumentValues,
+						directories,
 						environment: {},
 						unresolved,
 					};

--- a/cli/src/agent-tools/rp1-root-dir/index.ts
+++ b/cli/src/agent-tools/rp1-root-dir/index.ts
@@ -31,7 +31,7 @@ export const execute = (
 	_options: ToolOptions,
 ): TE.TaskEither<CLIError, ToolResult<Rp1RootResult>> =>
 	pipe(
-		resolveRp1Root(),
+		resolveRp1Root(process.cwd(), { requireProjectId: true }),
 		TE.map((data) => successResult(TOOL_NAME, data)),
 	);
 

--- a/cli/src/agent-tools/rp1-root-dir/resolver.ts
+++ b/cli/src/agent-tools/rp1-root-dir/resolver.ts
@@ -6,12 +6,19 @@ import { resolveDirectorySet } from "../../../shared/directory-resolution.js";
 import type { CLIError } from "../../../shared/errors.js";
 import type { Rp1RootResult } from "./models.js";
 
+export interface Rp1RootResolutionOptions {
+	readonly requireProjectId?: boolean;
+}
+
 export const resolveRp1Root = (
 	cwd: string = process.cwd(),
+	options: Rp1RootResolutionOptions = {},
 ): TE.TaskEither<CLIError, Rp1RootResult> =>
 	TE.fromEither(
 		pipe(
-			resolveDirectorySet(cwd),
+			resolveDirectorySet(cwd, {
+				requireProjectId: options.requireProjectId,
+			}),
 			E.map(
 				(directories: ResolvedDirectorySet): Rp1RootResult => ({
 					projectRoot: directories.projectRoot,

--- a/cli/src/build/lint/rules/legacy-arguments.ts
+++ b/cli/src/build/lint/rules/legacy-arguments.ts
@@ -11,6 +11,8 @@
  * L011: Implies references non-existent argument
  * L012: Circular implies chain
  * L013: Hand-written Resolve Arguments section alongside arguments (skill only)
+ * L014: Parameterized skill body manually calls rp1-root-dir instead of using
+ *       the generated Resolve Arguments directory values
  */
 
 import { validateImpliesChains } from "../../arguments.js";
@@ -19,6 +21,8 @@ import type { LintDiagnostic } from "../index.js";
 
 const PARAMETERS_HEADING_RE = /^#{1,3}\s+(?:0\.\s+)?Parameters\s*$/m;
 const RESOLVE_ARGS_HEADING_RE = /^#{1,3}\s+(?:0\.\s+)?Resolve\s+Arguments\s*$/m;
+const RP1_ROOT_DIR_RE =
+	/\brp1(?:\s+agent-tools)?\s+rp1-root-dir\b|\brp1-root-dir\b/m;
 
 /**
  * Validate argument definitions for enum/implies issues (L010-L012).
@@ -123,6 +127,32 @@ function lintResolveArgsHeading(
 }
 
 /**
+ * Check parameterized skill bodies for manual rp1-root-dir calls (L014).
+ * Parameterized skills already receive canonical directories from the
+ * generated Resolve Arguments section.
+ */
+function lintManualDirectoryResolution(
+	body: string,
+	hasArguments: boolean,
+	file: string,
+): LintDiagnostic[] {
+	if (!hasArguments) return [];
+	if (!RP1_ROOT_DIR_RE.test(body)) return [];
+
+	return [
+		{
+			rule: "L014",
+			severity: "error",
+			message:
+				"parameterized skill manually re-resolves directories via 'rp1-root-dir'. Use the generated Resolve Arguments directory values instead.",
+			file,
+			suggestion:
+				"Remove the 'rp1-root-dir' call and use the generated `projectRoot`, `kbRoot`, and `workRoot` values from the Resolve Arguments section.",
+		},
+	];
+}
+
+/**
  * Run source-level argument validation rules (L007-L013) on a parsed skill.
  *
  * @param metadata - Parsed SkillMetadata (may be undefined for skills without metadata)
@@ -166,6 +196,7 @@ export function lintSkillArguments(
 
 	diagnostics.push(...lintParametersHeading(body, hasArguments, file));
 	diagnostics.push(...lintResolveArgsHeading(body, hasArguments, file));
+	diagnostics.push(...lintManualDirectoryResolution(body, hasArguments, file));
 
 	if (hasArguments && metadata?.arguments) {
 		diagnostics.push(...lintArgumentDefinitions(metadata.arguments, file));

--- a/cli/src/build/templates/claude-code/skill.liquid
+++ b/cli/src/build/templates/claude-code/skill.liquid
@@ -44,17 +44,22 @@ Run the argument resolver to obtain all parameter values:
 rp1 agent-tools resolve-args --name {{ namespacedPluginName }}:{{ artifact.name }} --args "$ARGUMENTS"
 ```
 
-Parse the JSON response. Extract values from `data.arguments`:
+Parse the JSON response. Extract values from `data.arguments` and `data.directories`:
 
 | Variable | Source |
 |----------|--------|
 {%- for arg in artifact.metadata.arguments %}
 | {{ arg.name }} | `data.arguments.{{ arg.name }}` |
 {%- endfor %}
+| projectRoot | `data.directories.projectRoot` |
+| kbRoot | `data.directories.kbRoot` |
+| workRoot | `data.directories.workRoot` |
+| rp1DirectoryStatus | `data.directories.status` |
+| rp1NextStepCommand | `data.directories.nextStepCommand` |
 
 If `data.unresolved` is non-empty, warn the user about missing required arguments and stop.
 
-Use these resolved values for all subsequent steps. Do not re-derive or re-parse arguments.
+Use these resolved values for all subsequent steps. Do not call `rp1-root-dir`, re-derive project directories, or re-parse arguments.
 {%- endif %}
 
 {{ artifact.content | namespace_ref: platform | slash_commands: platform }}

--- a/cli/src/build/templates/codex/skill.liquid
+++ b/cli/src/build/templates/codex/skill.liquid
@@ -44,16 +44,21 @@ Run the argument resolver to obtain all parameter values:
 rp1 agent-tools resolve-args --name {{ namespacedPluginName }}:{{ artifact.name }} --args "the arguments provided by the user in their prompt"
 ```
 
-Parse the JSON response. Extract values from `data.arguments`:
+Parse the JSON response. Extract values from `data.arguments` and `data.directories`:
 
 | Variable | Source |
 |----------|--------|
 {%- for arg in artifact.metadata.arguments %}
 | {{ arg.name }} | `data.arguments.{{ arg.name }}` |
 {%- endfor %}
+| projectRoot | `data.directories.projectRoot` |
+| kbRoot | `data.directories.kbRoot` |
+| workRoot | `data.directories.workRoot` |
+| rp1DirectoryStatus | `data.directories.status` |
+| rp1NextStepCommand | `data.directories.nextStepCommand` |
 
 If `data.unresolved` is non-empty, warn the user about missing required arguments and stop.
 
-Use these resolved values for all subsequent steps. Do not re-derive or re-parse arguments.
+Use these resolved values for all subsequent steps. Do not call `rp1-root-dir`, re-derive project directories, or re-parse arguments.
 {% endif %}
 {{ artifact.content | namespace_ref: platform | slash_commands: platform | param_transform: platform | tool_prose: platform }}

--- a/cli/src/build/templates/opencode/skill.liquid
+++ b/cli/src/build/templates/opencode/skill.liquid
@@ -28,16 +28,21 @@ Run the argument resolver to obtain all parameter values:
 rp1 agent-tools resolve-args --name {{ namespacedPluginName }}:{{ artifact.name }} --args "$ARGUMENTS"
 ```
 
-Parse the JSON response. Extract values from `data.arguments`:
+Parse the JSON response. Extract values from `data.arguments` and `data.directories`:
 
 | Variable | Source |
 |----------|--------|
 {%- for arg in artifact.metadata.arguments %}
 | {{ arg.name }} | `data.arguments.{{ arg.name }}` |
 {%- endfor %}
+| projectRoot | `data.directories.projectRoot` |
+| kbRoot | `data.directories.kbRoot` |
+| workRoot | `data.directories.workRoot` |
+| rp1DirectoryStatus | `data.directories.status` |
+| rp1NextStepCommand | `data.directories.nextStepCommand` |
 
 If `data.unresolved` is non-empty, warn the user about missing required arguments and stop.
 
-Use these resolved values for all subsequent steps. Do not re-derive or re-parse arguments.
+Use these resolved values for all subsequent steps. Do not call `rp1-root-dir`, re-derive project directories, or re-parse arguments.
 {% endif %}
 {{ artifact.content | namespace_ref: platform | slash_commands: platform }}

--- a/docs/getting-started/rp1-directory.md
+++ b/docs/getting-started/rp1-directory.md
@@ -50,6 +50,8 @@ This file is:
 
 rp1 discovers your project by walking up the directory tree from the current working directory, looking for `.rp1/project_id`. This means you can run rp1 commands from any subdirectory within your project.
 
+rp1 does not auto-discover your home directory as a project root. If you want rp1 in a specific project, run `rp1 init` from that project directory rather than relying on a home-level `.rp1/` marker.
+
 If `.rp1/project_id` is not found but `.rp1/` exists (pre-migration project), rp1 still functions but logs a warning recommending `rp1 migrate`.
 
 For git worktrees, rp1 resolves back to the main worktree's `.rp1/` directory so all worktrees share the same project identity, knowledge base, and work artifacts.

--- a/docs/reference/cli/index.md
+++ b/docs/reference/cli/index.md
@@ -36,6 +36,8 @@ rp1 derives its directories from the project root:
 - Knowledge base: `.rp1/context/`
 - Work artifacts: `.rp1/work/`
 
+The home directory is not auto-discovered as a project root.
+
 ---
 
 ## Installation

--- a/plugins/base/skills/knowledge-build/SKILL.md
+++ b/plugins/base/skills/knowledge-build/SKILL.md
@@ -11,7 +11,7 @@ metadata:
     - core
     - parallel
   created: 2025-10-25
-  updated: 2026-04-03
+  updated: 2026-04-09
   author: cloud-on-prem/rp1
   arguments:
     - name: FEATURE_ID
@@ -33,7 +33,7 @@ metadata:
 
 ## §CTX
 
-- Run `rp1 agent-tools rp1-root-dir` once. Extract `projectRoot`, `kbRoot`, `workRoot`.
+- Use the pre-resolved `projectRoot`, `kbRoot`, and `workRoot` values from the generated Resolve Arguments step.
 - KB outputs live under `kbRoot`:
   - `index.md`
   - `concept_map.md`
@@ -68,7 +68,7 @@ metadata:
 
 ### 1. Detect Mode
 
-1. Resolve directories via `rp1-root-dir`. Create `kbRoot` if missing.
+1. Use the pre-resolved directories. Create `kbRoot` if missing.
 2. If `FEATURE_ID` is non-empty:
    - Set `MODE=FEATURE_LEARNING`.
    - Search, in order:


### PR DESCRIPTION
## Summary

- stop auto-discovering `$HOME` as an rp1 project root, including when `HOME` is reached through a symlink alias
- make `rp1 agent-tools rp1-root-dir` fail explicitly with `rp1 init` guidance when no project exists and `rp1 migrate` guidance when a legacy `.rp1/` directory is present without `.rp1/project_id`
- document the updated project discovery behavior

## Test Plan

- `bun test cli/src/__tests__/shared/directory-resolution.test.ts cli/src/__tests__/agent-tools/rp1-root-dir/resolver.test.ts cli/src/__tests__/init/directory-model.test.ts`
- exercised `bun /Users/prem/Development/rp1/cli/src/main.ts agent-tools rp1-root-dir` in isolated tmp directories for:
  - initialized project
  - empty directory
  - legacy `.rp1/` without `project_id`
  - HOME symlink alias case

## Related Issues

- Addresses the dir-resolution regression investigation
