### PR TITLE
Add Discord button to docs site and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
   <!-- x-release-please-end -->
   <a href="https://rp1.run"><img src="https://img.shields.io/badge/docs-rp1.run-blue" alt="Docs"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-green.svg" alt="License"></a>
+  <a href="https://discord.gg/cjmqWGb5q"><img src="https://img.shields.io/badge/Discord-Join%20us-5865F2?logo=discord&logoColor=white" alt="Discord"></a>
 </p>
 
 <p align="center">

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,6 +13,7 @@ Skip the iteration loops. Keep work attached to projects, artifacts, and feedbac
 
 [:fontawesome-solid-terminal: Get Started](getting-started/installation.md){ .md-button .md-button--primary }
 [:fontawesome-brands-github: View on GitHub](https://github.com/rp1-run/rp1){ .md-button .md-button--github }
+[:fontawesome-brands-discord: Discord](https://discord.gg/cjmqWGb5q){ .md-button .md-button--discord }
 
 <div class="carousel-container">
   <div class="splide" id="hero-carousel" aria-label="Product Screenshots">

--- a/docs/javascripts/analytics.js
+++ b/docs/javascripts/analytics.js
@@ -29,4 +29,11 @@
       trackEvent('github_click', { page: location.pathname, href: link.href });
     }
   });
+
+  document.addEventListener('click', function(e) {
+    var link = e.target.closest('a[href^="https://discord.gg"]');
+    if (link) {
+      trackEvent('discord_click', { page: location.pathname, href: link.href });
+    }
+  });
 })();

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -116,6 +116,31 @@
   color: var(--md-default-bg-color);
 }
 
+/* Discord button */
+.md-typeset .md-button--discord {
+  border-color: #5865F2;
+  color: #5865F2;
+  background-color: transparent;
+}
+
+.md-typeset .md-button--discord:hover {
+  border-color: #5865F2;
+  background-color: #5865F2;
+  color: #fff;
+}
+
+[data-md-color-scheme="slate"] .md-typeset .md-button--discord {
+  border-color: #7289da;
+  color: #7289da;
+  background-color: transparent;
+}
+
+[data-md-color-scheme="slate"] .md-typeset .md-button--discord:hover {
+  border-color: #5865F2;
+  background-color: #5865F2;
+  color: #fff;
+}
+
 /* Simple grid layout (Stripe-style) */
 .md-typeset .grid {
   display: grid;

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -150,6 +150,8 @@ extra:
   social:
     - icon: fontawesome/brands/github
       link: https://github.com/rp1-run/rp1
+    - icon: fontawesome/brands/discord
+      link: https://discord.gg/cjmqWGb5q
   generator: false
 
 extra_css:


### PR DESCRIPTION
## Summary
- Add Discord CTA button next to the GitHub button on the docs homepage
- Add Discord badge next to existing badges in README
- Add Discord to the footer social links in mkdocs.yml
- Add `discord_click` analytics event tracking
- Style the Discord button with brand colors for both light and dark modes

https://claude.ai/code/session_01RYFU52hCv2tzZQ95TbB9Ur