### PR TITLE
feat(web-ui): move notifications into dedicated sidebar

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -187,6 +187,13 @@ For the full pattern and command examples, see [docs/concepts/state-machines.md]
 - Use fp-ts pragmatically; prefer clear `match`, `map`, `flatMap`, and `isLeft` flows over overengineered abstractions.
 - For frontend work in `cli/web-ui/`, use `frontend-design` and `playwright-cli`; run `just serve-web-ui` before browser validation and use `/tmp` for temporary screenshots.
 
+## Commit discipline
+
+- When making commits, stage only the intended changes and verify the worktree state before committing.
+- Use Conventional Commits for every commit message: `<type>(<optional-scope>): <imperative summary>`.
+- Prefer scopes when they add clarity, such as `feat(web-ui): move notifications into dedicated sidebar` or `docs(agent): require conventional commits`.
+- Do not use vague commit messages like `updates`, `fix stuff`, or `wip` for final commits.
+
 ## Delivery checklist
 
 After changes:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,10 @@
 @AGENTS.md
 
+## Commit Discipline
+
+- Always use Conventional Commits for final commit messages: `<type>(<optional-scope>): <imperative summary>`.
+- Stage only the intended changes for each commit and avoid catch-all commit messages like `wip` or `updates`.
+
 <!-- rp1:start:v0.7.1 -->
 ## rp1 Knowledge Base
 

--- a/cli/web-ui/src/__tests__/app/V2Layout.test.tsx
+++ b/cli/web-ui/src/__tests__/app/V2Layout.test.tsx
@@ -1,0 +1,285 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+	cleanup,
+	fireEvent,
+	render,
+	screen,
+	waitFor,
+} from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+import { createMemoryRouter, RouterProvider } from "react-router-dom";
+
+let dismissNotificationMock = mock(async (_id: number) => {});
+let notificationsState = {
+	notifications: [
+		{
+			id: 1,
+			message: "Approval needed",
+			sourceType: "agent" as const,
+			sourceId: "run-1",
+			route: "/runs/run-1",
+			projectId: "proj-1",
+			createdAt: "2026-04-11T00:00:00.000Z",
+			harness: "codex" as const,
+			runCommand: "/build",
+			runName: "Sidebar Build",
+			projectName: "Alpha Project",
+			attentionLevel: "action_required" as const,
+		},
+	],
+	summary: {
+		totalCount: 1,
+		actionRequiredCount: 1,
+		attentionCount: 0,
+		informationalCount: 0,
+	},
+	isLoading: false,
+	error: null as Error | null,
+	refetch: () => {},
+	dismissNotification: async (id: number) => dismissNotificationMock(id),
+};
+let v2LayoutImportVersion = 0;
+
+function installLayoutMocks() {
+	mock.module("@/hooks/useNotifications", () => ({
+		useNotifications: () => notificationsState,
+	}));
+
+	mock.module("@/hooks/usePrefersReducedMotion", () => ({
+		usePrefersReducedMotion: () => true,
+	}));
+
+	mock.module("@/components/v2/CommandPalette", () => ({
+		CommandPalette: ({ open }: { open: boolean }) =>
+			open ? (
+				<div role="dialog" aria-label="Command Palette">
+					Command palette
+				</div>
+			) : null,
+	}));
+
+	mock.module("@/components/v2/NotificationToast", () => ({
+		NotificationContainer: () => null,
+	}));
+
+	mock.module("@/components/v2/ShortcutHelpOverlay", () => ({
+		ShortcutHelpOverlay: () => null,
+	}));
+
+	mock.module("@lobehub/icons", () => ({
+		Claude: () => <span data-testid="claude-icon" />,
+		OpenAI: () => <span data-testid="openai-icon" />,
+		OpenCode: () => <span data-testid="opencode-icon" />,
+	}));
+
+	mock.module("@/components/v2/IconRail", () => ({
+		IconRail: ({ className }: { className?: string }) => (
+			<div data-testid="icon-rail" className={className} />
+		),
+	}));
+
+	mock.module("@/components/ui/scroll-area", () => ({
+		ScrollArea: ({
+			children,
+			className,
+		}: {
+			children?: ReactNode;
+			className?: string;
+		}) => <div className={className}>{children}</div>,
+	}));
+
+	mock.module("@/components/v2/HarnessIcon", () => ({
+		HarnessIcon: () => <span data-testid="harness-icon" />,
+	}));
+
+	mock.module("framer-motion", () => ({
+		motion: new Proxy(
+			{},
+			{
+				get(_target: object, prop: string) {
+					return ({
+						children,
+						...props
+					}: Record<string, unknown> & { children?: ReactNode }) => {
+						const domProps: Record<string, unknown> = {};
+						const validProps = [
+							"aria-label",
+							"className",
+							"id",
+							"role",
+							"style",
+						];
+
+						for (const key of validProps) {
+							if (key in props) {
+								domProps[key] = props[key];
+							}
+						}
+
+						return createElement(prop, domProps, children);
+					};
+				},
+			},
+		),
+		AnimatePresence: ({ children }: { children?: ReactNode }) => children,
+	}));
+}
+
+async function renderLayout() {
+	installLayoutMocks();
+	const { AppLayout } = await import(
+		`../../app/V2Layout.tsx?v2-layout-test=${++v2LayoutImportVersion}`
+	);
+	const router = createMemoryRouter([
+		{
+			path: "/",
+			element: <AppLayout />,
+			children: [
+				{ index: true, element: <div>Activity page</div> },
+				{ path: "projects", element: <div>Projects page</div> },
+				{ path: "runs/:runId", element: <div>Run detail page</div> },
+			],
+		},
+	]);
+
+	return render(<RouterProvider router={router} />);
+}
+
+function getNotificationTriggers(): HTMLButtonElement[] {
+	return screen.getAllByRole("button", {
+		name: /^Open notifications\./i,
+	}) as HTMLButtonElement[];
+}
+
+describe("AppLayout notifications shell wiring", () => {
+	beforeEach(() => {
+		mock.restore();
+		document.body.innerHTML = "";
+		dismissNotificationMock = mock(async (_id: number) => {});
+		notificationsState = {
+			notifications: [
+				{
+					id: 1,
+					message: "Approval needed",
+					sourceType: "agent",
+					sourceId: "run-1",
+					route: "/runs/run-1",
+					projectId: "proj-1",
+					createdAt: "2026-04-11T00:00:00.000Z",
+					harness: "codex",
+					runCommand: "/build",
+					runName: "Sidebar Build",
+					projectName: "Alpha Project",
+					attentionLevel: "action_required",
+				},
+			],
+			summary: {
+				totalCount: 1,
+				actionRequiredCount: 1,
+				attentionCount: 0,
+				informationalCount: 0,
+			},
+			isLoading: false,
+			error: null,
+			refetch: () => {},
+			dismissNotification: async (id: number) => dismissNotificationMock(id),
+		};
+	});
+
+	afterEach(() => {
+		cleanup();
+		mock.restore();
+	});
+
+	test("shares one notifications drawer state across desktop and mobile triggers", async () => {
+		await renderLayout();
+
+		const [desktopTrigger, mobileTrigger] = getNotificationTriggers();
+		expect(desktopTrigger).toBeTruthy();
+		expect(mobileTrigger).toBeTruthy();
+
+		fireEvent.click(desktopTrigger);
+
+		await waitFor(() => {
+			for (const trigger of getNotificationTriggers()) {
+				expect(trigger.getAttribute("aria-pressed")).toBe("true");
+			}
+		});
+
+		fireEvent.click(getNotificationTriggers()[1]!);
+
+		await waitFor(() => {
+			for (const trigger of getNotificationTriggers()) {
+				expect(trigger.getAttribute("aria-pressed")).toBe("false");
+			}
+		});
+
+		fireEvent.click(getNotificationTriggers()[1]!);
+
+		await waitFor(() => {
+			for (const trigger of getNotificationTriggers()) {
+				expect(trigger.getAttribute("aria-pressed")).toBe("true");
+			}
+		});
+	});
+
+	test("supports keyboard toggle, restores focus on close, and keeps overlays exclusive", async () => {
+		await renderLayout();
+
+		const desktopTrigger = getNotificationTriggers()[0]!;
+		desktopTrigger.focus();
+		expect(document.activeElement).toBe(desktopTrigger);
+
+		fireEvent.keyDown(window, { key: "b", ctrlKey: true });
+
+		await waitFor(() => {
+			for (const trigger of getNotificationTriggers()) {
+				expect(trigger.getAttribute("aria-pressed")).toBe("true");
+			}
+		});
+		await waitFor(() => {
+			const closeButton = screen.getByRole("button", { name: "Close drawer" });
+			expect(document.activeElement).toBe(closeButton);
+		});
+
+		fireEvent.keyDown(window, { key: "k", ctrlKey: true });
+
+		await waitFor(() => {
+			expect(
+				screen.getByRole("dialog", { name: "Command Palette" }),
+			).toBeTruthy();
+			for (const trigger of getNotificationTriggers()) {
+				expect(trigger.getAttribute("aria-pressed")).toBe("false");
+			}
+		});
+
+		fireEvent.keyDown(window, { key: "k", ctrlKey: true });
+
+		await waitFor(() => {
+			expect(
+				screen.queryByRole("dialog", { name: "Command Palette" }),
+			).toBeNull();
+		});
+
+		fireEvent.keyDown(window, { key: "\\", ctrlKey: true });
+
+		await waitFor(() => {
+			for (const trigger of getNotificationTriggers()) {
+				expect(trigger.getAttribute("aria-pressed")).toBe("true");
+			}
+		});
+		await waitFor(() => {
+			const closeButton = screen.getByRole("button", { name: "Close drawer" });
+			expect(document.activeElement).toBe(closeButton);
+		});
+
+		fireEvent.keyDown(window, { key: "Escape" });
+
+		await waitFor(() => {
+			for (const trigger of getNotificationTriggers()) {
+				expect(trigger.getAttribute("aria-pressed")).toBe("false");
+			}
+			expect(document.activeElement).toBe(desktopTrigger);
+		});
+	});
+});

--- a/cli/web-ui/src/__tests__/components/ui/Drawer.test.tsx
+++ b/cli/web-ui/src/__tests__/components/ui/Drawer.test.tsx
@@ -1,0 +1,46 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { cleanup, render, screen } from "@testing-library/react";
+import { Drawer } from "../../../components/ui/drawer";
+
+describe("Drawer", () => {
+	beforeEach(() => {
+		document.body.innerHTML = "";
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+
+	test("keeps an open right-side drawer onscreen", () => {
+		render(
+			<Drawer open={true} onClose={() => {}} side="right" title="Notifications">
+				<div>Drawer content</div>
+			</Drawer>,
+		);
+
+		const dialog = screen.getByRole("dialog", {
+			name: "Notifications",
+		}) as HTMLDivElement;
+
+		expect(dialog.style.transform).toBe("translateX(0)");
+	});
+
+	test("moves a closed right-side drawer fully offscreen", () => {
+		render(
+			<Drawer
+				open={false}
+				onClose={() => {}}
+				side="right"
+				title="Notifications"
+			>
+				<div>Drawer content</div>
+			</Drawer>,
+		);
+
+		const dialog = screen.getByRole("dialog", {
+			name: "Notifications",
+		}) as HTMLDivElement;
+
+		expect(dialog.style.transform).toBe("translateX(100%)");
+	});
+});

--- a/cli/web-ui/src/__tests__/components/v2/NotificationToast.test.tsx
+++ b/cli/web-ui/src/__tests__/components/v2/NotificationToast.test.tsx
@@ -1,35 +1,70 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
-import { act, fireEvent, render, screen } from "@testing-library/react";
-import { createElement } from "react";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+	act,
+	cleanup,
+	fireEvent,
+	render,
+	screen,
+	waitFor,
+} from "@testing-library/react";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
 import type { NotificationMessage } from "@/types/websocket";
 
 type NotificationCallback = (msg: NotificationMessage) => void;
 
-let navigateMock: ReturnType<typeof mock>;
+let fetchMock: ReturnType<typeof mock>;
 let notificationListener: NotificationCallback | null = null;
+let notificationToastImportVersion = 0;
 
-mock.module("react-router-dom", () => ({
-	useNavigate: () => navigateMock,
-}));
+function LocationProbe() {
+	const location = useLocation();
+	return <span data-testid="location-probe">{location.pathname}</span>;
+}
 
-mock.module("@/hooks/usePrefersReducedMotion", () => ({
-	usePrefersReducedMotion: () => true,
-}));
+async function loadNotificationContainer() {
+	mock.module("@/hooks/usePrefersReducedMotion", () => ({
+		usePrefersReducedMotion: () => true,
+	}));
 
-mock.module("@/providers/WebSocketProvider", () => ({
-	useWebSocket: () => ({
-		onNotification: (callback: NotificationCallback) => {
-			notificationListener = callback;
-			return () => {
-				if (notificationListener === callback) {
-					notificationListener = null;
-				}
-			};
-		},
-	}),
-}));
+	mock.module("@/providers/WebSocketProvider", () => ({
+		useWebSocket: () => ({
+			onNotification: (callback: NotificationCallback) => {
+				notificationListener = callback;
+				return () => {
+					if (notificationListener === callback) {
+						notificationListener = null;
+					}
+				};
+			},
+		}),
+	}));
 
-import { NotificationContainer } from "../../../components/v2/NotificationToast";
+	const { NotificationContainer } = await import(
+		`../../../components/v2/NotificationToast.tsx?notification-toast-test=${++notificationToastImportVersion}`
+	);
+
+	return NotificationContainer;
+}
+
+async function renderNotificationContainer() {
+	const NotificationContainer = await loadNotificationContainer();
+
+	return render(
+		<MemoryRouter initialEntries={["/"]}>
+			<Routes>
+				<Route
+					path="*"
+					element={
+						<>
+							<LocationProbe />
+							<NotificationContainer />
+						</>
+					}
+				/>
+			</Routes>
+		</MemoryRouter>,
+	);
+}
 
 function emitNotification(message: NotificationMessage) {
 	if (!notificationListener) {
@@ -40,14 +75,36 @@ function emitNotification(message: NotificationMessage) {
 }
 
 beforeEach(() => {
+	mock.restore();
 	document.body.innerHTML = "";
-	navigateMock = mock(() => {});
+	fetchMock = mock((input: RequestInfo | URL, init?: RequestInit) => {
+		const url = String(input);
+		if (url.endsWith("/api/v2/notifications/3/dismiss")) {
+			return Promise.resolve({
+				ok: true,
+				status: 200,
+				statusText: "OK",
+				json: () => Promise.resolve({ dismissed: true }),
+			});
+		}
+
+		throw new Error(
+			`Unexpected fetch request: ${url} ${String(init?.method ?? "")}`,
+		);
+	});
+	globalThis.fetch = fetchMock as unknown as typeof fetch;
 	notificationListener = null;
 });
 
+afterEach(() => {
+	cleanup();
+	notificationListener = null;
+	mock.restore();
+});
+
 describe("NotificationContainer", () => {
-	test("renders separate action and dismiss buttons for a toast", () => {
-		render(createElement(NotificationContainer));
+	test("renders separate action and dismiss buttons for a toast", async () => {
+		await renderNotificationContainer();
 
 		act(() => {
 			emitNotification({
@@ -76,8 +133,8 @@ describe("NotificationContainer", () => {
 		expect(actionButton.contains(dismissButton)).toBe(false);
 	});
 
-	test("navigates from the action button and dismisses from the close button", () => {
-		render(createElement(NotificationContainer));
+	test("navigates from the action button and dismisses from the close button", async () => {
+		await renderNotificationContainer();
 
 		act(() => {
 			emitNotification({
@@ -100,8 +157,17 @@ describe("NotificationContainer", () => {
 			}),
 		);
 
-		expect(navigateMock).toHaveBeenCalledWith("/runs/run-2");
+		await waitFor(() => {
+			expect(screen.getByTestId("location-probe").textContent).toBe(
+				"/runs/run-2",
+			);
+		});
 		expect(screen.queryByText("Review ready")).toBeNull();
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	test("persists dismissals through the notifications endpoint", async () => {
+		await renderNotificationContainer();
 
 		act(() => {
 			emitNotification({
@@ -124,7 +190,45 @@ describe("NotificationContainer", () => {
 			}),
 		);
 
-		expect(navigateMock).toHaveBeenCalledTimes(1);
-		expect(screen.queryByText("Dismiss only")).toBeNull();
+		await waitFor(() => {
+			expect(fetchMock).toHaveBeenCalledWith(
+				"/api/v2/notifications/3/dismiss",
+				{
+					method: "POST",
+				},
+			);
+		});
+		await waitFor(() => {
+			expect(screen.queryByText("Dismiss only")).toBeNull();
+		});
+		expect(screen.getByTestId("location-probe").textContent).toBe("/");
+	});
+
+	test("removes visible toasts when a notification:dismissed event arrives", async () => {
+		await renderNotificationContainer();
+
+		act(() => {
+			emitNotification({
+				type: "notification:created",
+				notification: {
+					id: 4,
+					message: "Dismiss elsewhere",
+					sourceType: "run",
+					sourceId: "run-4",
+					route: "/runs/run-4",
+					projectId: "proj-1",
+					createdAt: "2026-04-10T00:00:00Z",
+				},
+			});
+		});
+
+		act(() => {
+			emitNotification({
+				type: "notification:dismissed",
+				notificationId: 4,
+			});
+		});
+
+		expect(screen.queryByText("Dismiss elsewhere")).toBeNull();
 	});
 });

--- a/cli/web-ui/src/__tests__/components/v2/NotificationTrigger.test.tsx
+++ b/cli/web-ui/src/__tests__/components/v2/NotificationTrigger.test.tsx
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import { render, screen } from "@testing-library/react";
+import { createElement } from "react";
+import { NotificationTrigger } from "../../../components/v2/NotificationTrigger";
+
+describe("NotificationTrigger", () => {
+	beforeEach(() => {
+		document.body.innerHTML = "";
+	});
+
+	test("surfaces actionable counts in the badge and accessible label", () => {
+		render(
+			createElement(NotificationTrigger, {
+				summary: {
+					totalCount: 3,
+					actionRequiredCount: 1,
+					attentionCount: 1,
+					informationalCount: 1,
+				},
+			}),
+		);
+
+		expect(
+			screen.getByRole("button", {
+				name: "Open notifications. 1 action required, 1 attention, 1 informational notifications.",
+			}),
+		).toBeTruthy();
+		expect(screen.getByText("2")).toBeTruthy();
+	});
+
+	test("shows a neutral informational dot without an actionable badge", () => {
+		render(
+			createElement(NotificationTrigger, {
+				summary: {
+					totalCount: 2,
+					actionRequiredCount: 0,
+					attentionCount: 0,
+					informationalCount: 2,
+				},
+			}),
+		);
+
+		expect(
+			screen.getByRole("button", {
+				name: "Open notifications. 0 action required, 0 attention, 2 informational notifications.",
+			}),
+		).toBeTruthy();
+		expect(screen.queryByText("2")).toBeNull();
+	});
+});

--- a/cli/web-ui/src/__tests__/components/v2/NotificationsSidebar.test.tsx
+++ b/cli/web-ui/src/__tests__/components/v2/NotificationsSidebar.test.tsx
@@ -1,0 +1,167 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+	act,
+	cleanup,
+	fireEvent,
+	render,
+	screen,
+	waitFor,
+} from "@testing-library/react";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
+
+let notificationsSidebarImportVersion = 0;
+
+async function loadNotificationsSidebar() {
+	mock.module("@lobehub/icons", () => ({
+		Claude: () => <span data-testid="claude-icon" />,
+		OpenAI: () => <span data-testid="openai-icon" />,
+		OpenCode: () => <span data-testid="opencode-icon" />,
+	}));
+
+	mock.module("@/components/v2/HarnessIcon", () => ({
+		HarnessIcon: () => <span data-testid="harness-icon" />,
+	}));
+
+	const { NotificationsSidebar } = await import(
+		`../../../components/v2/NotificationsSidebar.tsx?notifications-sidebar-test=${++notificationsSidebarImportVersion}`
+	);
+
+	return NotificationsSidebar;
+}
+
+describe("NotificationsSidebar", () => {
+	beforeEach(() => {
+		mock.restore();
+		document.body.innerHTML = "";
+	});
+
+	afterEach(() => {
+		cleanup();
+		mock.restore();
+	});
+
+	function LocationProbe() {
+		const location = useLocation();
+		return <span data-testid="location-probe">{location.pathname}</span>;
+	}
+
+	test("renders grouped notifications with separate open and dismiss controls", async () => {
+		const dismissMock = mock(() => Promise.resolve());
+		const closeMock = mock(() => {});
+		const NotificationsSidebar = await loadNotificationsSidebar();
+
+		render(
+			<MemoryRouter initialEntries={["/"]}>
+				<Routes>
+					<Route
+						path="*"
+						element={
+							<>
+								<LocationProbe />
+								<NotificationsSidebar
+									open={true}
+									onClose={closeMock}
+									onDismissNotification={dismissMock}
+									isLoading={false}
+									error={null}
+									notifications={[
+										{
+											id: 1,
+											message: "Approval needed",
+											sourceType: "agent",
+											sourceId: "run-1",
+											route: "/runs/run-1",
+											projectId: "proj-1",
+											createdAt: "2026-04-11T00:00:00.000Z",
+											harness: "codex",
+											runCommand: "/build",
+											runName: "Sidebar Build",
+											projectName: "Alpha Project",
+											attentionLevel: "action_required",
+										},
+										{
+											id: 2,
+											message: "Verify completed",
+											sourceType: "run",
+											sourceId: "run-2",
+											route: "/runs/run-2",
+											projectId: "proj-1",
+											createdAt: "2026-04-11T00:02:00.000Z",
+											harness: "claude-code",
+											runCommand: "/verify",
+											runName: "Sidebar Verify",
+											projectName: "Alpha Project",
+											attentionLevel: "info",
+										},
+									]}
+								/>
+							</>
+						}
+					/>
+				</Routes>
+			</MemoryRouter>,
+		);
+
+		expect(screen.getByRole("dialog", { name: "Notifications" })).toBeTruthy();
+		expect(screen.getByText("Action required")).toBeTruthy();
+		expect(screen.getByText("Informational")).toBeTruthy();
+
+		fireEvent.click(
+			screen.getByRole("button", {
+				name: "Open notification: Approval needed",
+			}),
+		);
+
+		await waitFor(() => {
+			expect(screen.getByTestId("location-probe").textContent).toBe(
+				"/runs/run-1",
+			);
+		});
+		expect(closeMock).toHaveBeenCalledTimes(1);
+
+		await act(async () => {
+			fireEvent.click(
+				screen.getByRole("button", {
+					name: "Dismiss notification: Approval needed",
+				}),
+			);
+		});
+
+		expect(dismissMock).toHaveBeenCalledWith(1);
+	});
+
+	test("shows loading and empty states inside the drawer", async () => {
+		const NotificationsSidebar = await loadNotificationsSidebar();
+
+		const { rerender } = render(
+			<MemoryRouter>
+				<NotificationsSidebar
+					open={true}
+					onClose={() => {}}
+					onDismissNotification={() => Promise.resolve()}
+					isLoading={true}
+					error={null}
+					notifications={[]}
+				/>
+			</MemoryRouter>,
+		);
+
+		expect(screen.getByRole("dialog", { name: "Notifications" })).toBeTruthy();
+		expect(screen.queryByText("No notifications right now.")).toBeNull();
+
+		rerender(
+			<MemoryRouter>
+				<NotificationsSidebar
+					open={true}
+					onClose={() => {}}
+					onDismissNotification={() => Promise.resolve()}
+					isLoading={false}
+					error={null}
+					notifications={[]}
+				/>
+			</MemoryRouter>,
+		);
+
+		expect(screen.getByText("No notifications right now.")).toBeTruthy();
+	});
+});

--- a/cli/web-ui/src/__tests__/components/v2/NotificationsSidebar.test.tsx
+++ b/cli/web-ui/src/__tests__/components/v2/NotificationsSidebar.test.tsx
@@ -164,4 +164,58 @@ describe("NotificationsSidebar", () => {
 
 		expect(screen.getByText("No notifications right now.")).toBeTruthy();
 	});
+
+	test("catches dismiss failures without leaking the rejection", async () => {
+		const warnMock = mock(() => {});
+		const originalWarn = console.warn;
+		console.warn = warnMock as typeof console.warn;
+
+		try {
+			const dismissMock = mock(() =>
+				Promise.reject(new Error("dismissal failed")),
+			);
+			const NotificationsSidebar = await loadNotificationsSidebar();
+
+			render(
+				<MemoryRouter>
+					<NotificationsSidebar
+						open={true}
+						onClose={() => {}}
+						onDismissNotification={dismissMock}
+						isLoading={false}
+						error={null}
+						notifications={[
+							{
+								id: 1,
+								message: "Approval needed",
+								sourceType: "agent",
+								sourceId: "run-1",
+								route: "/runs/run-1",
+								projectId: "proj-1",
+								createdAt: "2026-04-11T00:00:00.000Z",
+								harness: "codex",
+								runCommand: "/build",
+								runName: "Sidebar Build",
+								projectName: "Alpha Project",
+								attentionLevel: "action_required",
+							},
+						]}
+					/>
+				</MemoryRouter>,
+			);
+
+			fireEvent.click(
+				screen.getByRole("button", {
+					name: "Dismiss notification: Approval needed",
+				}),
+			);
+
+			await waitFor(() => {
+				expect(dismissMock).toHaveBeenCalledWith(1);
+				expect(warnMock).toHaveBeenCalledWith("Error: dismissal failed");
+			});
+		} finally {
+			console.warn = originalWarn;
+		}
+	});
 });

--- a/cli/web-ui/src/__tests__/hooks/useFeed.test.ts
+++ b/cli/web-ui/src/__tests__/hooks/useFeed.test.ts
@@ -1,0 +1,160 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { Run } from "@/types/runs";
+import type {
+	EventNotificationMessage,
+	NotificationMessage,
+} from "@/types/websocket";
+
+type AttentionCallback = () => void;
+type EventCallback = (msg: EventNotificationMessage) => void;
+type NotificationCallback = (msg: NotificationMessage) => void;
+type ReconnectCallback = () => void;
+
+let attentionListeners: AttentionCallback[] = [];
+let eventListeners: EventCallback[] = [];
+let notificationListeners: NotificationCallback[] = [];
+let reconnectListeners: ReconnectCallback[] = [];
+let fetchMock: ReturnType<typeof mock>;
+
+mock.module("@/providers/WebSocketProvider", () => ({
+	useWebSocket: () => ({
+		onEventNotification: (callback: EventCallback) => {
+			eventListeners.push(callback);
+			return () => {
+				eventListeners = eventListeners.filter(
+					(listener) => listener !== callback,
+				);
+			};
+		},
+		onNotification: (callback: NotificationCallback) => {
+			notificationListeners.push(callback);
+			return () => {
+				notificationListeners = notificationListeners.filter(
+					(listener) => listener !== callback,
+				);
+			};
+		},
+		subscribeToAttention: (callback: AttentionCallback) => {
+			attentionListeners.push(callback);
+			return () => {
+				attentionListeners = attentionListeners.filter(
+					(listener) => listener !== callback,
+				);
+			};
+		},
+		subscribeToReconnect: (callback: ReconnectCallback) => {
+			reconnectListeners.push(callback);
+			return () => {
+				reconnectListeners = reconnectListeners.filter(
+					(listener) => listener !== callback,
+				);
+			};
+		},
+	}),
+}));
+
+const baseRun: Run = {
+	id: "run-1",
+	projectId: "proj-1",
+	projectName: "Test Project",
+	featureId: "feat-1",
+	featureName: "Test Feature",
+	name: null,
+	command: "/build",
+	status: "running",
+	harness: "codex",
+	currentStep: null,
+	steps: [],
+	artifacts: [],
+	events: [],
+	startedAt: "2026-04-10T00:00:00.000Z",
+	lastEventAt: "2026-04-10T00:05:00.000Z",
+	completedAt: null,
+	error: null,
+	agentSteps: null,
+};
+
+beforeEach(() => {
+	attentionListeners = [];
+	eventListeners = [];
+	notificationListeners = [];
+	reconnectListeners = [];
+
+	fetchMock = mock(() =>
+		Promise.resolve({
+			ok: true,
+			json: () =>
+				Promise.resolve({
+					items: [
+						{
+							type: "run",
+							id: "run-1",
+							timestamp: "2026-04-10T00:05:00.000Z",
+							run: baseRun,
+						},
+					],
+					total: 1,
+				}),
+		}),
+	);
+
+	globalThis.fetch = fetchMock as unknown as typeof fetch;
+});
+
+describe("useFeed", () => {
+	test("refetches for attention updates but ignores notification websocket events", async () => {
+		const { useFeed } = await import("../../hooks/useFeed");
+		const { result } = renderHook(() => useFeed());
+
+		await waitFor(() => {
+			expect(result.current.isLoading).toBe(false);
+		});
+
+		expect(result.current.items).toHaveLength(1);
+		expect(result.current.items[0]?.type).toBe("run");
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+
+		act(() => {
+			for (const listener of eventListeners) {
+				listener({
+					type: "event:notification",
+					eventId: 1,
+					eventType: "status_change",
+					runId: "run-1",
+					projectId: "proj-1",
+					featureId: "feat-1",
+					step: "build",
+					data: { status: "running" },
+					createdAt: "2026-04-10T00:06:00.000Z",
+				});
+			}
+			for (const listener of notificationListeners) {
+				listener({
+					type: "notification:created",
+					notification: {
+						id: 7,
+						message: "Approval needed",
+						sourceType: "agent",
+						sourceId: "run-1",
+						route: "/runs/run-1",
+						projectId: "proj-1",
+						createdAt: "2026-04-10T00:06:00.000Z",
+					},
+				});
+			}
+		});
+
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+
+		act(() => {
+			for (const listener of attentionListeners) {
+				listener();
+			}
+		});
+
+		await waitFor(() => {
+			expect(fetchMock).toHaveBeenCalledTimes(2);
+		});
+	});
+});

--- a/cli/web-ui/src/__tests__/hooks/useNotifications.test.ts
+++ b/cli/web-ui/src/__tests__/hooks/useNotifications.test.ts
@@ -1,0 +1,340 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import type {
+	NotificationListItem,
+	NotificationsSummary,
+} from "@/hooks/useNotifications";
+import type { NotificationMessage } from "@/types/websocket";
+
+type NotificationCallback = (msg: NotificationMessage) => void;
+type ReconnectCallback = () => void;
+
+let notificationListeners: NotificationCallback[] = [];
+let reconnectListeners: ReconnectCallback[] = [];
+let notifications: NotificationListItem[] = [];
+let fetchMock: ReturnType<typeof mock>;
+let useNotificationsImportVersion = 0;
+
+function createNotification(
+	id: number,
+	overrides: Partial<NotificationListItem> = {},
+): NotificationListItem {
+	return {
+		id,
+		message: `Notification ${id}`,
+		sourceType: "run",
+		sourceId: `run-${id}`,
+		route: `/runs/run-${id}`,
+		projectId: "proj-1",
+		createdAt: `2026-04-11T00:${String(id).padStart(2, "0")}:00.000Z`,
+		harness: "codex",
+		runCommand: "/build",
+		runName: `Run ${id}`,
+		projectName: "Alpha Project",
+		attentionLevel: "info",
+		...overrides,
+	};
+}
+
+function summarizeNotifications(
+	items: NotificationListItem[],
+): NotificationsSummary {
+	let totalCount = 0;
+	let actionRequiredCount = 0;
+	let attentionCount = 0;
+	let informationalCount = 0;
+
+	for (const item of items) {
+		totalCount += 1;
+
+		if (item.attentionLevel === "action_required") {
+			actionRequiredCount += 1;
+			continue;
+		}
+
+		if (item.attentionLevel === "attention") {
+			attentionCount += 1;
+			continue;
+		}
+
+		informationalCount += 1;
+	}
+
+	return {
+		totalCount,
+		actionRequiredCount,
+		attentionCount,
+		informationalCount,
+	};
+}
+
+function createNotificationsPageResponse(page: NotificationListItem[]) {
+	return {
+		ok: true,
+		status: 200,
+		statusText: "OK",
+		json: () =>
+			Promise.resolve({
+				notifications: page,
+				total: notifications.length,
+				summary: summarizeNotifications(notifications),
+			}),
+	};
+}
+
+async function loadUseNotifications() {
+	mock.module("@/providers/WebSocketProvider", () => ({
+		useWebSocket: () => ({
+			onNotification: (callback: NotificationCallback) => {
+				notificationListeners.push(callback);
+				return () => {
+					notificationListeners = notificationListeners.filter(
+						(listener) => listener !== callback,
+					);
+				};
+			},
+			subscribeToReconnect: (callback: ReconnectCallback) => {
+				reconnectListeners.push(callback);
+				return () => {
+					reconnectListeners = reconnectListeners.filter(
+						(listener) => listener !== callback,
+					);
+				};
+			},
+		}),
+	}));
+
+	return import(
+		`../../hooks/useNotifications.ts?use-notifications-test=${++useNotificationsImportVersion}`
+	);
+}
+
+beforeEach(() => {
+	mock.restore();
+	notificationListeners = [];
+	reconnectListeners = [];
+	notifications = [
+		createNotification(7, {
+			message: "Approval needed",
+			sourceType: "agent",
+			sourceId: "run-1",
+			route: "/runs/run-1",
+			createdAt: "2026-04-11T00:00:00.000Z",
+			runName: "Sidebar Build",
+			attentionLevel: "action_required",
+		}),
+	];
+
+	fetchMock = mock((input: RequestInfo | URL, init?: RequestInit) => {
+		const url = new URL(String(input), "http://localhost");
+		if (url.pathname === "/api/v2/notifications/7/dismiss") {
+			return Promise.resolve({
+				ok: true,
+				status: 200,
+				statusText: "OK",
+				json: () => Promise.resolve({ dismissed: true }),
+			});
+		}
+
+		if (
+			url.pathname === "/api/v2/notifications" &&
+			init?.method === undefined
+		) {
+			const limit = Number.parseInt(url.searchParams.get("limit") ?? "50", 10);
+			const offset = Number.parseInt(url.searchParams.get("offset") ?? "0", 10);
+			const page = notifications.slice(offset, offset + limit);
+
+			return Promise.resolve(createNotificationsPageResponse(page));
+		}
+
+		throw new Error(`Unexpected fetch request: ${String(input)}`);
+	});
+
+	globalThis.fetch = fetchMock as unknown as typeof fetch;
+});
+
+afterEach(() => {
+	cleanup();
+	notificationListeners = [];
+	reconnectListeners = [];
+	mock.restore();
+});
+
+describe("useNotifications", () => {
+	test("loads the notifications contract and refetches for websocket and reconnect recovery events", async () => {
+		const { useNotifications } = await loadUseNotifications();
+		const { result } = renderHook(() => useNotifications());
+
+		await waitFor(() => {
+			expect(result.current.isLoading).toBe(false);
+		});
+
+		expect(result.current.notifications).toHaveLength(1);
+		expect(result.current.summary).toEqual({
+			totalCount: 1,
+			actionRequiredCount: 1,
+			attentionCount: 0,
+			informationalCount: 0,
+		});
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		expect(fetchMock).toHaveBeenNthCalledWith(
+			1,
+			"/api/v2/notifications?limit=50&offset=0",
+		);
+
+		act(() => {
+			for (const listener of notificationListeners) {
+				listener({
+					type: "notification:created",
+					notification: {
+						id: 8,
+						message: "Another notification",
+						sourceType: "run",
+						sourceId: "run-2",
+						route: "/runs/run-2",
+						projectId: "proj-1",
+						createdAt: "2026-04-11T00:01:00.000Z",
+					},
+				});
+			}
+		});
+
+		await waitFor(() => {
+			expect(fetchMock).toHaveBeenCalledTimes(2);
+		});
+
+		act(() => {
+			for (const listener of notificationListeners) {
+				listener({
+					type: "notification:dismissed",
+					notificationId: 7,
+				});
+			}
+		});
+
+		await waitFor(() => {
+			expect(fetchMock).toHaveBeenCalledTimes(3);
+		});
+
+		act(() => {
+			for (const listener of reconnectListeners) {
+				listener();
+			}
+		});
+
+		await waitFor(() => {
+			expect(fetchMock).toHaveBeenCalledTimes(4);
+		});
+	});
+
+	test("publishes the first-page summary before later pagination requests finish", async () => {
+		notifications = Array.from({ length: 55 }, (_, index) =>
+			createNotification(index + 1, {
+				attentionLevel: index === 0 ? "action_required" : "info",
+			}),
+		);
+		let resolveSecondPage!: (
+			value: ReturnType<typeof createNotificationsPageResponse>,
+		) => void;
+		const secondPageResponse = new Promise<
+			ReturnType<typeof createNotificationsPageResponse>
+		>((resolve) => {
+			resolveSecondPage = resolve;
+		});
+		fetchMock = mock((input: RequestInfo | URL, init?: RequestInit) => {
+			const url = new URL(String(input), "http://localhost");
+			if (
+				url.pathname === "/api/v2/notifications" &&
+				init?.method === undefined
+			) {
+				const limit = Number.parseInt(
+					url.searchParams.get("limit") ?? "50",
+					10,
+				);
+				const offset = Number.parseInt(
+					url.searchParams.get("offset") ?? "0",
+					10,
+				);
+				const page = notifications.slice(offset, offset + limit);
+
+				if (offset === 50) {
+					return secondPageResponse;
+				}
+
+				return Promise.resolve(createNotificationsPageResponse(page));
+			}
+
+			throw new Error(`Unexpected fetch request: ${String(input)}`);
+		});
+		globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+		const { useNotifications } = await loadUseNotifications();
+		const { result } = renderHook(() => useNotifications());
+
+		await waitFor(() => {
+			expect(fetchMock).toHaveBeenNthCalledWith(
+				2,
+				"/api/v2/notifications?limit=50&offset=50",
+			);
+		});
+
+		await waitFor(() => {
+			expect(result.current.summary).toEqual({
+				totalCount: 55,
+				actionRequiredCount: 1,
+				attentionCount: 0,
+				informationalCount: 54,
+			});
+		});
+		expect(result.current.isLoading).toBe(true);
+
+		await act(async () => {
+			resolveSecondPage(
+				createNotificationsPageResponse(notifications.slice(50)),
+			);
+		});
+
+		await waitFor(() => {
+			expect(result.current.isLoading).toBe(false);
+		});
+
+		expect(result.current.notifications).toHaveLength(55);
+		expect(result.current.notifications.at(0)?.id).toBe(1);
+		expect(result.current.notifications.at(-1)?.id).toBe(55);
+		expect(result.current.summary).toEqual({
+			totalCount: 55,
+			actionRequiredCount: 1,
+			attentionCount: 0,
+			informationalCount: 54,
+		});
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+		expect(fetchMock).toHaveBeenNthCalledWith(
+			1,
+			"/api/v2/notifications?limit=50&offset=0",
+		);
+		expect(fetchMock).toHaveBeenNthCalledWith(
+			2,
+			"/api/v2/notifications?limit=50&offset=50",
+		);
+	});
+
+	test("dismisses through the notifications endpoint and refreshes the list", async () => {
+		const { useNotifications } = await loadUseNotifications();
+		const { result } = renderHook(() => useNotifications());
+
+		await waitFor(() => {
+			expect(result.current.isLoading).toBe(false);
+		});
+
+		await act(async () => {
+			await result.current.dismissNotification(7);
+		});
+
+		expect(fetchMock).toHaveBeenNthCalledWith(
+			2,
+			"/api/v2/notifications/7/dismiss",
+			{ method: "POST" },
+		);
+		expect(fetchMock).toHaveBeenCalledTimes(3);
+	});
+});

--- a/cli/web-ui/src/__tests__/hooks/useNotifications.test.ts
+++ b/cli/web-ui/src/__tests__/hooks/useNotifications.test.ts
@@ -14,6 +14,7 @@ let reconnectListeners: ReconnectCallback[] = [];
 let notifications: NotificationListItem[] = [];
 let fetchMock: ReturnType<typeof mock>;
 let useNotificationsImportVersion = 0;
+let currentProjectId: string | null = null;
 
 function createNotification(
 	id: number,
@@ -68,7 +69,10 @@ function summarizeNotifications(
 	};
 }
 
-function createNotificationsPageResponse(page: NotificationListItem[]) {
+function createNotificationsPageResponse(
+	page: NotificationListItem[],
+	allItems: NotificationListItem[] = notifications,
+) {
 	return {
 		ok: true,
 		status: 200,
@@ -76,8 +80,8 @@ function createNotificationsPageResponse(page: NotificationListItem[]) {
 		json: () =>
 			Promise.resolve({
 				notifications: page,
-				total: notifications.length,
-				summary: summarizeNotifications(notifications),
+				total: allItems.length,
+				summary: summarizeNotifications(allItems),
 			}),
 	};
 }
@@ -101,6 +105,7 @@ async function loadUseNotifications() {
 					);
 				};
 			},
+			projectId: currentProjectId,
 		}),
 	}));
 
@@ -113,6 +118,7 @@ beforeEach(() => {
 	mock.restore();
 	notificationListeners = [];
 	reconnectListeners = [];
+	currentProjectId = null;
 	notifications = [
 		createNotification(7, {
 			message: "Approval needed",
@@ -140,11 +146,19 @@ beforeEach(() => {
 			url.pathname === "/api/v2/notifications" &&
 			init?.method === undefined
 		) {
+			const projectId = url.searchParams.get("projectId");
+			const matchingNotifications = projectId
+				? notifications.filter(
+						(notification) => notification.projectId === projectId,
+					)
+				: notifications;
 			const limit = Number.parseInt(url.searchParams.get("limit") ?? "50", 10);
 			const offset = Number.parseInt(url.searchParams.get("offset") ?? "0", 10);
-			const page = notifications.slice(offset, offset + limit);
+			const page = matchingNotifications.slice(offset, offset + limit);
 
-			return Promise.resolve(createNotificationsPageResponse(page));
+			return Promise.resolve(
+				createNotificationsPageResponse(page, matchingNotifications),
+			);
 		}
 
 		throw new Error(`Unexpected fetch request: ${String(input)}`);
@@ -336,5 +350,52 @@ describe("useNotifications", () => {
 			{ method: "POST" },
 		);
 		expect(fetchMock).toHaveBeenCalledTimes(3);
+	});
+
+	test("refetches notifications with the current websocket project scope", async () => {
+		notifications = [
+			createNotification(1, {
+				projectId: "proj-1",
+				projectName: "Alpha Project",
+			}),
+			createNotification(2, {
+				projectId: "proj-2",
+				projectName: "Beta Project",
+				message: "Scoped notification",
+			}),
+		];
+
+		const { useNotifications } = await loadUseNotifications();
+		const { result, rerender } = renderHook(() => useNotifications());
+
+		await waitFor(() => {
+			expect(result.current.isLoading).toBe(false);
+		});
+		expect(result.current.notifications).toHaveLength(2);
+
+		currentProjectId = "proj-2";
+		rerender();
+
+		await waitFor(() => {
+			expect(fetchMock).toHaveBeenNthCalledWith(
+				2,
+				"/api/v2/notifications?limit=50&offset=0&projectId=proj-2",
+			);
+		});
+		await waitFor(() => {
+			expect(result.current.notifications).toEqual([
+				expect.objectContaining({
+					id: 2,
+					projectId: "proj-2",
+					message: "Scoped notification",
+				}),
+			]);
+		});
+		expect(result.current.summary).toEqual({
+			totalCount: 1,
+			actionRequiredCount: 0,
+			attentionCount: 0,
+			informationalCount: 1,
+		});
 	});
 });

--- a/cli/web-ui/src/__tests__/hooks/useNotifications.test.ts
+++ b/cli/web-ui/src/__tests__/hooks/useNotifications.test.ts
@@ -398,4 +398,74 @@ describe("useNotifications", () => {
 			informationalCount: 1,
 		});
 	});
+
+	test("clears loading when a background refresh settles after an overlapping visible load", async () => {
+		notifications = [];
+		let resolveInitialRequest!: (
+			value: ReturnType<typeof createNotificationsPageResponse>,
+		) => void;
+		const initialRequest = new Promise<
+			ReturnType<typeof createNotificationsPageResponse>
+		>((resolve) => {
+			resolveInitialRequest = resolve;
+		});
+		let requestCount = 0;
+
+		fetchMock = mock((input: RequestInfo | URL, init?: RequestInit) => {
+			const url = new URL(String(input), "http://localhost");
+			if (
+				url.pathname === "/api/v2/notifications" &&
+				init?.method === undefined
+			) {
+				requestCount += 1;
+
+				if (requestCount === 1) {
+					return initialRequest;
+				}
+
+				return Promise.resolve(createNotificationsPageResponse([]));
+			}
+
+			throw new Error(`Unexpected fetch request: ${String(input)}`);
+		});
+		globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+		const { useNotifications } = await loadUseNotifications();
+		const { result } = renderHook(() => useNotifications());
+
+		await waitFor(() => {
+			expect(notificationListeners).toHaveLength(1);
+		});
+		expect(result.current.isLoading).toBe(true);
+
+		act(() => {
+			for (const listener of notificationListeners) {
+				listener({
+					type: "notification:dismissed",
+					notificationId: 7,
+				});
+			}
+		});
+
+		await waitFor(() => {
+			expect(fetchMock).toHaveBeenCalledTimes(2);
+		});
+
+		await waitFor(() => {
+			expect(result.current.isLoading).toBe(false);
+		});
+		expect(result.current.notifications).toEqual([]);
+		expect(result.current.summary).toEqual({
+			totalCount: 0,
+			actionRequiredCount: 0,
+			attentionCount: 0,
+			informationalCount: 0,
+		});
+
+		await act(async () => {
+			resolveInitialRequest(createNotificationsPageResponse([]));
+		});
+
+		expect(result.current.isLoading).toBe(false);
+	});
 });

--- a/cli/web-ui/src/__tests__/hooks/useRunDetail.test.ts
+++ b/cli/web-ui/src/__tests__/hooks/useRunDetail.test.ts
@@ -1,5 +1,5 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
-import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
 import type { Run, RunEvent } from "@/types/runs";
 import type { EventNotificationMessage } from "@/types/websocket";
 
@@ -9,18 +9,25 @@ let eventListeners: EventCallback[] = [];
 let mockWsStatus = "connected";
 let runResponse: Run;
 let fetchMock: ReturnType<typeof mock>;
+let useRunDetailImportVersion = 0;
 
-mock.module("@/providers/WebSocketProvider", () => ({
-	useWebSocket: () => ({
-		onEventNotification: (cb: EventCallback) => {
-			eventListeners.push(cb);
-			return () => {
-				eventListeners = eventListeners.filter((l) => l !== cb);
-			};
-		},
-		status: mockWsStatus,
-	}),
-}));
+async function loadUseRunDetail() {
+	mock.module("@/providers/WebSocketProvider", () => ({
+		useWebSocket: () => ({
+			onEventNotification: (cb: EventCallback) => {
+				eventListeners.push(cb);
+				return () => {
+					eventListeners = eventListeners.filter((l) => l !== cb);
+				};
+			},
+			status: mockWsStatus,
+		}),
+	}));
+
+	return import(
+		`../../hooks/useRunDetail.ts?use-run-detail-test=${++useRunDetailImportVersion}`
+	);
+}
 
 function emitEvent(msg: EventNotificationMessage) {
 	for (const listener of eventListeners) {
@@ -59,6 +66,7 @@ const baseRun: Run = {
 };
 
 beforeEach(() => {
+	mock.restore();
 	eventListeners = [];
 	mockWsStatus = "connected";
 	runResponse = { ...baseRun };
@@ -76,9 +84,15 @@ beforeEach(() => {
 	globalThis.fetch = fetchMock as unknown as typeof fetch;
 });
 
+afterEach(() => {
+	cleanup();
+	eventListeners = [];
+	mock.restore();
+});
+
 describe("useRunDetail", () => {
 	test("waiting_for_user event sets status to waiting and appends event", async () => {
-		const { useRunDetail } = await import("../../hooks/useRunDetail");
+		const { useRunDetail } = await loadUseRunDetail();
 		const { result } = renderHook(() => useRunDetail("run-1"));
 
 		await waitFor(() => {
@@ -113,7 +127,7 @@ describe("useRunDetail", () => {
 	});
 
 	test("btw_update event appends event without changing status", async () => {
-		const { useRunDetail } = await import("../../hooks/useRunDetail");
+		const { useRunDetail } = await loadUseRunDetail();
 		const { result } = renderHook(() => useRunDetail("run-1"));
 
 		await waitFor(() => {
@@ -146,7 +160,7 @@ describe("useRunDetail", () => {
 	});
 
 	test("subflow_registered event triggers refetch without inline handling", async () => {
-		const { useRunDetail } = await import("../../hooks/useRunDetail");
+		const { useRunDetail } = await loadUseRunDetail();
 		const { result } = renderHook(() => useRunDetail("run-1"));
 
 		await waitFor(() => {
@@ -174,7 +188,7 @@ describe("useRunDetail", () => {
 	});
 
 	test("annotation_updated event triggers refetch without inline handling", async () => {
-		const { useRunDetail } = await import("../../hooks/useRunDetail");
+		const { useRunDetail } = await loadUseRunDetail();
 		const { result } = renderHook(() => useRunDetail("run-1"));
 
 		await waitFor(() => {
@@ -202,7 +216,7 @@ describe("useRunDetail", () => {
 	});
 
 	test("ignores websocket events for a different run in the same project and feature", async () => {
-		const { useRunDetail } = await import("../../hooks/useRunDetail");
+		const { useRunDetail } = await loadUseRunDetail();
 		const { result } = renderHook(() => useRunDetail("run-1"));
 
 		await waitFor(() => {
@@ -243,7 +257,7 @@ describe("useRunDetail", () => {
 			],
 		};
 
-		const { useRunDetail } = await import("../../hooks/useRunDetail");
+		const { useRunDetail } = await loadUseRunDetail();
 		const { result } = renderHook(() => useRunDetail("run-1"));
 
 		await waitFor(() => {

--- a/cli/web-ui/src/__tests__/lib/time.test.ts
+++ b/cli/web-ui/src/__tests__/lib/time.test.ts
@@ -37,9 +37,9 @@ describe("formatRelativeTime", () => {
 		expect(formatRelativeTime(dateMinusHours(23))).toBe("23h ago");
 	});
 
-	test("returns 'yesterday' at the 24-hour boundary", () => {
-		expect(formatRelativeTime(dateMinusHours(24))).toBe("yesterday");
-		expect(formatRelativeTime(dateMinusDays(1))).toBe("yesterday");
+	test("returns '1d ago' at the 24-hour boundary", () => {
+		expect(formatRelativeTime(dateMinusHours(24))).toBe("1d ago");
+		expect(formatRelativeTime(dateMinusDays(1))).toBe("1d ago");
 	});
 
 	test("returns days ago for 2-6 days", () => {

--- a/cli/web-ui/src/__tests__/server/v2-api-feed.test.ts
+++ b/cli/web-ui/src/__tests__/server/v2-api-feed.test.ts
@@ -1,0 +1,243 @@
+import {
+	afterAll,
+	afterEach,
+	beforeAll,
+	describe,
+	expect,
+	test,
+} from "bun:test";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expectTaskRight } from "../../../../src/__tests__/helpers/index.js";
+import {
+	closeDatabase,
+	deriveRunStatus,
+	getEmitDatabase,
+	insertEvent,
+	insertRun,
+	resetInstance,
+} from "../../../../src/agent-tools/emit/database.js";
+import { insertNotification } from "../../../../src/agent-tools/emit/notification-database.js";
+import { saveRegistry } from "../../server/registry.js";
+import { handleV2FeedRequest } from "../../server/routes/v2-api.js";
+
+async function setupProject(tempDir: string, suffix: string) {
+	const homeDir = join(tempDir, `home-${suffix}`);
+	const projectRoot = join(tempDir, `project-${suffix}`);
+	const dbPath = join(tempDir, `feed-${suffix}.db`);
+	const now = "2026-04-11T00:00:00.000Z";
+
+	process.env.HOME = homeDir;
+	await mkdir(projectRoot, { recursive: true });
+	await saveRegistry({
+		version: 1,
+		lastInvoked: `project-${suffix}`,
+		projects: {
+			[`project-${suffix}`]: {
+				id: `project-${suffix}`,
+				projectId: `project-uuid-${suffix}`,
+				path: projectRoot,
+				name: `Project ${suffix}`,
+				addedAt: now,
+				lastAccessedAt: now,
+				available: true,
+			},
+		},
+	});
+
+	const db = await expectTaskRight(getEmitDatabase(dbPath));
+
+	return {
+		db,
+		projectId: `project-uuid-${suffix}`,
+		projectRoot,
+	};
+}
+
+describe("handleV2FeedRequest", () => {
+	let tempDir: string;
+	const originalHome = process.env.HOME;
+
+	beforeAll(async () => {
+		tempDir = await mkdtemp(join(tmpdir(), "rp1-v2-feed-"));
+	});
+
+	afterEach(() => {
+		closeDatabase();
+		resetInstance();
+		if (originalHome == null) {
+			delete process.env.HOME;
+		} else {
+			process.env.HOME = originalHome;
+		}
+	});
+
+	afterAll(async () => {
+		closeDatabase();
+		resetInstance();
+		if (originalHome == null) {
+			delete process.env.HOME;
+		} else {
+			process.env.HOME = originalHome;
+		}
+		await rm(tempDir, { recursive: true, force: true });
+	});
+
+	test("returns paginated run activity without standalone notifications", async () => {
+		const { db, projectId, projectRoot } = await setupProject(tempDir, "alpha");
+
+		insertRun(db, {
+			id: "run-earlier",
+			flow: "build",
+			featureId: "notifications-sidebar",
+			projectPath: projectRoot,
+			projectId,
+			name: "Earlier Run",
+			harness: "codex",
+		});
+		insertEvent(db, {
+			runId: "run-earlier",
+			type: "status_change",
+			step: "build",
+			data: JSON.stringify({ status: "running" }),
+			createdAt: "2026-04-10T01:00:00.000Z",
+		});
+		deriveRunStatus(db, "run-earlier");
+
+		insertRun(db, {
+			id: "run-latest",
+			flow: "verify",
+			featureId: "notifications-sidebar",
+			projectPath: projectRoot,
+			projectId,
+			name: "Latest Run",
+			harness: "claude-code",
+		});
+		insertEvent(db, {
+			runId: "run-latest",
+			type: "status_change",
+			step: "verify",
+			data: JSON.stringify({ status: "completed" }),
+			createdAt: "2026-04-10T03:00:00.000Z",
+		});
+		deriveRunStatus(db, "run-latest");
+
+		insertNotification(db, {
+			message: "build: Approval needed",
+			sourceType: "agent",
+			sourceId: "run-earlier",
+			route: "/runs/run-earlier",
+			projectId,
+		});
+
+		const response = await handleV2FeedRequest(
+			new Request("http://localhost/api/v2/feed?limit=1"),
+		);
+
+		expect(response.status).toBe(200);
+
+		const body = (await response.json()) as {
+			items: Array<{
+				type: "run";
+				id: string;
+				timestamp: string;
+				run: {
+					id: string;
+					command: string;
+					status: string;
+				};
+			}>;
+			total: number;
+		};
+
+		expect(body.total).toBe(2);
+		expect(body.items).toHaveLength(1);
+		expect(body.items[0]).toMatchObject({
+			type: "run",
+			id: "run-latest",
+			run: {
+				id: "run-latest",
+				command: "/verify",
+				status: "completed",
+			},
+		});
+	});
+
+	test("keeps run status filters intact after removing notifications", async () => {
+		const { db, projectId, projectRoot } = await setupProject(tempDir, "beta");
+
+		insertRun(db, {
+			id: "run-failed",
+			flow: "build",
+			featureId: "notifications-sidebar",
+			projectPath: projectRoot,
+			projectId,
+			name: "Failed Run",
+			harness: "codex",
+		});
+		insertEvent(db, {
+			runId: "run-failed",
+			type: "status_change",
+			step: "build",
+			data: JSON.stringify({ status: "failed" }),
+			createdAt: "2026-04-10T04:00:00.000Z",
+		});
+		deriveRunStatus(db, "run-failed");
+
+		insertRun(db, {
+			id: "run-running",
+			flow: "verify",
+			featureId: "notifications-sidebar",
+			projectPath: projectRoot,
+			projectId,
+			name: "Running Run",
+			harness: "claude-code",
+		});
+		insertEvent(db, {
+			runId: "run-running",
+			type: "status_change",
+			step: "verify",
+			data: JSON.stringify({ status: "running" }),
+			createdAt: "2026-04-10T05:00:00.000Z",
+		});
+		deriveRunStatus(db, "run-running");
+
+		insertNotification(db, {
+			message: "verify completed",
+			sourceType: "run",
+			sourceId: "run-running",
+			route: "/runs/run-running",
+			projectId,
+		});
+
+		const response = await handleV2FeedRequest(
+			new Request("http://localhost/api/v2/feed?status=failed"),
+		);
+
+		expect(response.status).toBe(200);
+
+		const body = (await response.json()) as {
+			items: Array<{
+				type: "run";
+				id: string;
+				timestamp: string;
+				run: {
+					status: string;
+				};
+			}>;
+			total: number;
+		};
+
+		expect(body.total).toBe(1);
+		expect(body.items).toHaveLength(1);
+		expect(body.items[0]).toMatchObject({
+			type: "run",
+			id: "run-failed",
+			run: {
+				status: "failed",
+			},
+		});
+		expect(body.items[0]?.run.status).toBe("failed");
+	});
+});

--- a/cli/web-ui/src/__tests__/server/v2-api-notifications.test.ts
+++ b/cli/web-ui/src/__tests__/server/v2-api-notifications.test.ts
@@ -1,0 +1,244 @@
+import {
+	afterAll,
+	afterEach,
+	beforeAll,
+	describe,
+	expect,
+	test,
+} from "bun:test";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expectTaskRight } from "../../../../src/__tests__/helpers/index.js";
+import {
+	closeDatabase,
+	getEmitDatabase,
+	insertRun,
+	resetInstance,
+} from "../../../../src/agent-tools/emit/database.js";
+import { insertNotification } from "../../../../src/agent-tools/emit/notification-database.js";
+import { saveRegistry } from "../../server/registry.js";
+import { handleV2NotificationsListRequest } from "../../server/routes/v2-api.js";
+
+describe("handleV2NotificationsListRequest", () => {
+	let tempDir: string;
+	const originalHome = process.env.HOME;
+
+	beforeAll(async () => {
+		tempDir = await mkdtemp(join(tmpdir(), "rp1-v2-notifications-"));
+	});
+
+	afterEach(() => {
+		closeDatabase();
+		resetInstance();
+		if (originalHome == null) {
+			delete process.env.HOME;
+		} else {
+			process.env.HOME = originalHome;
+		}
+	});
+
+	afterAll(async () => {
+		closeDatabase();
+		resetInstance();
+		if (originalHome == null) {
+			delete process.env.HOME;
+		} else {
+			process.env.HOME = originalHome;
+		}
+		await rm(tempDir, { recursive: true, force: true });
+	});
+
+	test("returns enriched notification rows and global summary counts", async () => {
+		const homeDir = join(tempDir, "home");
+		const projectRoot = join(tempDir, "project-alpha");
+		const dbPath = join(tempDir, "notifications.db");
+		const now = "2026-04-11T00:00:00.000Z";
+
+		process.env.HOME = homeDir;
+		await mkdir(projectRoot, { recursive: true });
+		await saveRegistry({
+			version: 1,
+			lastInvoked: "project-alpha",
+			projects: {
+				"project-alpha": {
+					id: "project-alpha",
+					projectId: "project-uuid-1",
+					path: projectRoot,
+					name: "Alpha Project",
+					addedAt: now,
+					lastAccessedAt: now,
+					available: true,
+				},
+			},
+		});
+
+		const db = await expectTaskRight(getEmitDatabase(dbPath));
+
+		insertRun(db, {
+			id: "run-failed",
+			flow: "build",
+			featureId: "notifications-sidebar",
+			projectPath: projectRoot,
+			projectId: "project-uuid-1",
+			name: "Sidebar Build",
+			harness: "codex",
+		});
+		insertRun(db, {
+			id: "run-completed",
+			flow: "verify",
+			featureId: "notifications-sidebar",
+			projectPath: projectRoot,
+			projectId: "project-uuid-1",
+			name: "Sidebar Verify",
+			harness: "claude-code",
+		});
+
+		insertNotification(db, {
+			message: "verify completed",
+			sourceType: "run",
+			sourceId: "run-completed",
+			route: "/runs/run-completed",
+			projectId: "project-uuid-1",
+		});
+		insertNotification(db, {
+			message: "Maintenance window later today",
+			sourceType: "system",
+			projectId: "project-uuid-1",
+		});
+		insertNotification(db, {
+			message: "build failed",
+			sourceType: "run",
+			sourceId: "run-failed",
+			route: "/runs/run-failed",
+			projectId: "project-uuid-1",
+		});
+		insertNotification(db, {
+			message: "build: Approval needed",
+			sourceType: "agent",
+			sourceId: "run-failed",
+			route: "/runs/run-failed",
+			projectId: "project-uuid-1",
+		});
+
+		const response = await handleV2NotificationsListRequest(
+			new Request("http://localhost/api/v2/notifications?limit=3"),
+		);
+
+		expect(response.status).toBe(200);
+
+		const body = (await response.json()) as {
+			notifications: Array<{
+				id: number;
+				message: string;
+				sourceType: string;
+				sourceId: string | null;
+				route: string | null;
+				projectId: string | null;
+				createdAt: string;
+				harness: string | null;
+				runCommand: string | null;
+				runName: string | null;
+				projectName: string | null;
+				attentionLevel: string;
+			}>;
+			total: number;
+			summary: {
+				totalCount: number;
+				actionRequiredCount: number;
+				attentionCount: number;
+				informationalCount: number;
+			};
+		};
+
+		expect(body.total).toBe(4);
+		expect(body.notifications).toHaveLength(3);
+		expect(body.summary).toEqual({
+			totalCount: 4,
+			actionRequiredCount: 1,
+			attentionCount: 1,
+			informationalCount: 2,
+		});
+
+		const agentNotification = body.notifications.find(
+			(notification) => notification.message === "build: Approval needed",
+		);
+		expect(agentNotification?.attentionLevel).toBe("action_required");
+
+		const failedNotification = body.notifications.find(
+			(notification) => notification.message === "build failed",
+		);
+		expect(failedNotification).toMatchObject({
+			sourceType: "run",
+			sourceId: "run-failed",
+			route: "/runs/run-failed",
+			projectId: "project-uuid-1",
+			harness: "codex",
+			runCommand: "/build",
+			runName: "Sidebar Build",
+			projectName: "Alpha Project",
+			attentionLevel: "attention",
+		});
+
+		const systemNotification = body.notifications.find(
+			(notification) =>
+				notification.message === "Maintenance window later today",
+		);
+		expect(systemNotification).toMatchObject({
+			harness: null,
+			runCommand: null,
+			runName: null,
+			projectName: "Alpha Project",
+			attentionLevel: "info",
+		});
+	});
+
+	test("keeps global summary counts when the default route page caps the first response at 50 rows", async () => {
+		const homeDir = join(tempDir, "home-pagination");
+		const dbPath = join(tempDir, "notifications-pagination.db");
+
+		process.env.HOME = homeDir;
+		await mkdir(homeDir, { recursive: true });
+
+		const db = await expectTaskRight(getEmitDatabase(dbPath));
+
+		for (let index = 1; index <= 55; index += 1) {
+			insertNotification(db, {
+				message: `Notification ${index}`,
+				sourceType: "system",
+			});
+		}
+
+		const response = await handleV2NotificationsListRequest(
+			new Request("http://localhost/api/v2/notifications"),
+		);
+
+		expect(response.status).toBe(200);
+
+		const body = (await response.json()) as {
+			notifications: Array<{
+				id: number;
+				message: string;
+				attentionLevel: string;
+			}>;
+			total: number;
+			summary: {
+				totalCount: number;
+				actionRequiredCount: number;
+				attentionCount: number;
+				informationalCount: number;
+			};
+		};
+
+		expect(body.total).toBe(55);
+		expect(body.notifications).toHaveLength(50);
+		expect(body.notifications[0]?.message).toBe("Notification 55");
+		expect(body.notifications.at(-1)?.message).toBe("Notification 6");
+		expect(body.summary).toEqual({
+			totalCount: 55,
+			actionRequiredCount: 0,
+			attentionCount: 0,
+			informationalCount: 55,
+		});
+	});
+});

--- a/cli/web-ui/src/__tests__/server/v2-api-workflows.test.ts
+++ b/cli/web-ui/src/__tests__/server/v2-api-workflows.test.ts
@@ -669,7 +669,7 @@ describe("handleV2WorkflowsListRequest", () => {
 
 		const prReviewWorkflow = body.workflows.find((w) => w.name === "pr-review");
 		expect(prReviewWorkflow).toBeDefined();
-		expect(prReviewWorkflow?.stateCount).toBe(4);
+		expect(prReviewWorkflow?.stateCount).toBe(2);
 	});
 
 	test("each workflow entry has the expected shape", async () => {
@@ -788,12 +788,10 @@ describe("handleV2WorkflowDetailRequest", () => {
 		};
 
 		expect(body.name).toBe("pr-review");
-		expect(body.states).toHaveLength(4);
+		expect(body.states).toHaveLength(2);
 		expect(body.orderedSteps.map((s) => s.id)).toEqual([
-			"split",
-			"review",
-			"synthesize",
-			"post",
+			"reviewing",
+			"posting",
 		]);
 	});
 

--- a/cli/web-ui/src/app/V2Layout.tsx
+++ b/cli/web-ui/src/app/V2Layout.tsx
@@ -5,11 +5,14 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { CommandPalette } from "@/components/v2/CommandPalette";
 import { IconRail } from "@/components/v2/IconRail";
 import { MobileTabBar } from "@/components/v2/MobileTabBar";
+import { NotificationsSidebar } from "@/components/v2/NotificationsSidebar";
 import { NotificationContainer } from "@/components/v2/NotificationToast";
+import { NotificationTrigger } from "@/components/v2/NotificationTrigger";
 import { ShortcutHelpOverlay } from "@/components/v2/ShortcutHelpOverlay";
 import { TerminalBreadcrumb } from "@/components/v2/TerminalBreadcrumb";
 import { BreadcrumbProvider } from "@/hooks/useBreadcrumbContext";
 import { useGlobalShortcuts } from "@/hooks/useGlobalShortcuts";
+import { useNotifications } from "@/hooks/useNotifications";
 import { usePrefersReducedMotion } from "@/hooks/usePrefersReducedMotion";
 import {
 	pageTransition,
@@ -33,12 +36,16 @@ function isFullHeightRoute(pathname: string): boolean {
 	return false;
 }
 
+type ActiveOverlay = "none" | "command-palette" | "notifications";
+
 export function AppLayout() {
-	const [commandPaletteOpen, setCommandPaletteOpen] = useState(false);
+	const [activeOverlay, setActiveOverlay] = useState<ActiveOverlay>("none");
 	const shortcutHelpOpen = false;
 	const location = useLocation();
 	const navigate = useNavigate();
 	const isFullHeight = isFullHeightRoute(location.pathname);
+	const { notifications, summary, isLoading, error, dismissNotification } =
+		useNotifications();
 
 	const animationKey =
 		location.pathname.match(/^\/runs\/[^/]+/)?.[0] ??
@@ -48,14 +55,14 @@ export function AppLayout() {
 	const reducedMotion = usePrefersReducedMotion();
 	const variants = reducedMotion ? pageVariantsReduced : pageVariants;
 	const transition = reducedMotion ? pageTransitionReduced : pageTransition;
-	const isOverlayOpen = commandPaletteOpen || shortcutHelpOpen;
+	const isOverlayOpen = activeOverlay !== "none" || shortcutHelpOpen;
 
 	const handleOpenCommandPalette = useCallback(() => {
-		setCommandPaletteOpen(true);
+		setActiveOverlay("command-palette");
 	}, []);
 
-	const handleCloseCommandPalette = useCallback(() => {
-		setCommandPaletteOpen(false);
+	const handleCloseActiveOverlay = useCallback(() => {
+		setActiveOverlay("none");
 	}, []);
 
 	const handleToggleShortcutHelp = useCallback(() => {}, []);
@@ -64,13 +71,18 @@ export function AppLayout() {
 		window.dispatchEvent(new CustomEvent("rp1:focus-search"));
 	}, []);
 
-	const handleToggleSidebar = useCallback(() => {}, []);
+	const handleToggleNotifications = useCallback(() => {
+		setActiveOverlay((current) =>
+			current === "notifications" ? "none" : "notifications",
+		);
+	}, []);
 
 	useGlobalShortcuts({
+		activeOverlay,
 		onOpenCommandPalette: handleOpenCommandPalette,
-		onCloseCommandPalette: handleCloseCommandPalette,
+		onCloseOverlay: handleCloseActiveOverlay,
 		onToggleShortcutHelp: handleToggleShortcutHelp,
-		onToggleSidebar: handleToggleSidebar,
+		onToggleSidebar: handleToggleNotifications,
 		onFocusSearch: handleFocusSearch,
 		isOverlayOpen,
 		navigate,
@@ -83,7 +95,15 @@ export function AppLayout() {
 					<IconRail className="hidden md:flex" />
 
 					<div className="flex flex-1 flex-col overflow-hidden">
-						<TerminalBreadcrumb />
+						<TerminalBreadcrumb
+							action={
+								<NotificationTrigger
+									summary={summary}
+									open={activeOverlay === "notifications"}
+									onClick={handleToggleNotifications}
+								/>
+							}
+						/>
 						{isFullHeight ? (
 							<main className="flex-1 overflow-hidden">
 								<AnimatePresence mode="wait">
@@ -124,11 +144,35 @@ export function AppLayout() {
 					<MobileTabBar
 						className="fixed inset-x-0 bottom-0 md:hidden"
 						onOpenCommandPalette={handleOpenCommandPalette}
+						notificationAction={
+							<NotificationTrigger
+								summary={summary}
+								open={activeOverlay === "notifications"}
+								onClick={handleToggleNotifications}
+								className="h-11 w-11"
+							/>
+						}
 					/>
 
 					<CommandPalette
-						open={commandPaletteOpen}
-						onOpenChange={setCommandPaletteOpen}
+						open={activeOverlay === "command-palette"}
+						onOpenChange={(open) => {
+							setActiveOverlay((current) => {
+								if (open) {
+									return "command-palette";
+								}
+
+								return current === "command-palette" ? "none" : current;
+							});
+						}}
+					/>
+					<NotificationsSidebar
+						open={activeOverlay === "notifications"}
+						onClose={handleCloseActiveOverlay}
+						notifications={notifications}
+						isLoading={isLoading}
+						error={error}
+						onDismissNotification={dismissNotification}
 					/>
 				</div>
 				<ShortcutHelpOverlay />

--- a/cli/web-ui/src/components/ui/drawer.tsx
+++ b/cli/web-ui/src/components/ui/drawer.tsx
@@ -24,6 +24,11 @@ export function Drawer({
 	const drawerRef = useRef<HTMLDivElement>(null);
 	const previousActiveElement = useRef<HTMLElement | null>(null);
 	const titleId = useId();
+	const transform = open
+		? "translateX(0)"
+		: side === "left"
+			? "translateX(-100%)"
+			: "translateX(100%)";
 
 	// Handle escape key
 	useEffect(() => {
@@ -111,15 +116,11 @@ export function Drawer({
 				aria-labelledby={title ? titleId : undefined}
 				aria-label={title ? undefined : "Drawer"}
 				onKeyDown={handleKeyDown}
+				style={{ transform }}
 				className={cn(
 					"fixed z-50 flex flex-col bg-background shadow-lg transition-transform duration-200 ease-in-out",
 					side === "left" && "inset-y-0 left-0 w-80 max-w-[85vw]",
 					side === "right" && "inset-y-0 right-0 w-80 max-w-[85vw]",
-					open
-						? "translate-x-0"
-						: side === "left"
-							? "-translate-x-full"
-							: "translate-x-full",
 					className,
 				)}
 			>

--- a/cli/web-ui/src/components/v2/MobileTabBar.tsx
+++ b/cli/web-ui/src/components/v2/MobileTabBar.tsx
@@ -1,4 +1,5 @@
 import { Activity, Command, SquareKanban } from "lucide-react";
+import type { ReactNode } from "react";
 import { NavLink, useLocation } from "react-router-dom";
 import { cn } from "@/lib/utils";
 
@@ -17,11 +18,13 @@ const TAB_ITEMS: readonly TabItem[] = [
 export interface MobileTabBarProps {
 	className?: string;
 	onOpenCommandPalette: () => void;
+	notificationAction?: ReactNode;
 }
 
 export function MobileTabBar({
 	className,
 	onOpenCommandPalette,
+	notificationAction,
 }: MobileTabBarProps) {
 	const location = useLocation();
 
@@ -54,6 +57,7 @@ export function MobileTabBar({
 					</NavLink>
 				);
 			})}
+			{notificationAction ? notificationAction : null}
 			<button
 				type="button"
 				onClick={onOpenCommandPalette}

--- a/cli/web-ui/src/components/v2/NotificationToast.tsx
+++ b/cli/web-ui/src/components/v2/NotificationToast.tsx
@@ -14,6 +14,10 @@ interface Toast {
 const AUTO_DISMISS_MS = 6000;
 const EXIT_ANIMATION_MS = 200;
 
+function getDismissErrorMessage(response: Response): string {
+	return `Failed to dismiss notification: ${response.statusText || `HTTP ${response.status}`}`;
+}
+
 export function NotificationContainer() {
 	const [toasts, setToasts] = useState<readonly Toast[]>([]);
 	const timersRef = useRef<Map<number, ReturnType<typeof setTimeout>>>(
@@ -36,9 +40,20 @@ export function NotificationContainer() {
 				return;
 			}
 
-			setToasts((prev) =>
-				prev.map((t) => (t.id === id ? { ...t, exiting: true } : t)),
-			);
+			let shouldAnimateExit = false;
+			setToasts((prev) => {
+				const toast = prev.find((candidate) => candidate.id === id);
+				if (!toast || toast.exiting) {
+					return prev;
+				}
+
+				shouldAnimateExit = true;
+				return prev.map((t) => (t.id === id ? { ...t, exiting: true } : t));
+			});
+
+			if (!shouldAnimateExit) {
+				return;
+			}
 
 			setTimeout(() => {
 				setToasts((prev) => prev.filter((t) => t.id !== id));
@@ -60,22 +75,27 @@ export function NotificationContainer() {
 
 	useEffect(() => {
 		const unsubscribe = onNotification((msg: NotificationMessage) => {
-			if (msg.type !== "notification:created") return;
+			if (msg.type === "notification:created") {
+				const notification = msg.notification;
+				const toast: Toast = {
+					id: notification.id,
+					message: notification.message,
+					route: notification.route,
+					exiting: false,
+				};
 
-			const notification = msg.notification;
-			const toast: Toast = {
-				id: notification.id,
-				message: notification.message,
-				route: notification.route,
-				exiting: false,
-			};
+				setToasts((prev) => [...prev, toast]);
+				scheduleAutoDismiss(notification.id);
+				return;
+			}
 
-			setToasts((prev) => [...prev, toast]);
-			scheduleAutoDismiss(notification.id);
+			if (msg.type === "notification:dismissed") {
+				removeToast(msg.notificationId);
+			}
 		});
 
 		return unsubscribe;
-	}, [onNotification, scheduleAutoDismiss]);
+	}, [onNotification, removeToast, scheduleAutoDismiss]);
 
 	useEffect(() => {
 		const currentTimers = timersRef.current;
@@ -98,8 +118,20 @@ export function NotificationContainer() {
 	);
 
 	const handleDismiss = useCallback(
-		(id: number) => {
-			removeToast(id);
+		async (id: number) => {
+			try {
+				const response = await fetch(`/api/v2/notifications/${id}/dismiss`, {
+					method: "POST",
+				});
+
+				if (!response.ok) {
+					throw new Error(getDismissErrorMessage(response));
+				}
+
+				removeToast(id);
+			} catch (error) {
+				console.warn(String(error));
+			}
 		},
 		[removeToast],
 	);
@@ -119,26 +151,38 @@ export function NotificationContainer() {
 					}}
 				>
 					<div className="rp1-notification-accent" />
-					<button
-						type="button"
-						className="rp1-notification-action"
-						onClick={() => handleClick(toast)}
-						aria-label={
-							toast.route
-								? `${toast.message}. Click to navigate.`
-								: `${toast.message}. Dismiss notification.`
-						}
-					>
-						<div className="rp1-notification-body">
-							<div className="rp1-notification-header">
-								<span className="rp1-notification-title">{toast.message}</span>
+					{toast.route ? (
+						<button
+							type="button"
+							className="rp1-notification-action"
+							onClick={() => handleClick(toast)}
+							aria-label={`${toast.message}. Click to navigate.`}
+						>
+							<div className="rp1-notification-body">
+								<div className="rp1-notification-header">
+									<span className="rp1-notification-title">
+										{toast.message}
+									</span>
+								</div>
+							</div>
+						</button>
+					) : (
+						<div className="rp1-notification-action">
+							<div className="rp1-notification-body">
+								<div className="rp1-notification-header">
+									<span className="rp1-notification-title">
+										{toast.message}
+									</span>
+								</div>
 							</div>
 						</div>
-					</button>
+					)}
 					<button
 						type="button"
 						className="rp1-notification-close"
-						onClick={() => handleDismiss(toast.id)}
+						onClick={() => {
+							void handleDismiss(toast.id);
+						}}
 						aria-label="Dismiss notification"
 					>
 						&times;

--- a/cli/web-ui/src/components/v2/NotificationTrigger.tsx
+++ b/cli/web-ui/src/components/v2/NotificationTrigger.tsx
@@ -1,0 +1,62 @@
+import { Bell } from "lucide-react";
+import type { NotificationsSummary } from "@/hooks/useNotifications";
+import { cn } from "@/lib/utils";
+
+export interface NotificationTriggerProps {
+	readonly summary: NotificationsSummary;
+	readonly open?: boolean;
+	readonly onClick?: () => void;
+	readonly className?: string;
+}
+
+function buildAriaLabel(summary: NotificationsSummary): string {
+	if (summary.totalCount === 0) {
+		return "Open notifications. No active notifications.";
+	}
+
+	return `Open notifications. ${summary.actionRequiredCount} action required, ${summary.attentionCount} attention, ${summary.informationalCount} informational notifications.`;
+}
+
+export function NotificationTrigger({
+	summary,
+	open = false,
+	onClick,
+	className,
+}: NotificationTriggerProps) {
+	const actionableCount = summary.actionRequiredCount + summary.attentionCount;
+	const hasInformationalOnly = summary.totalCount > 0 && actionableCount === 0;
+	const badgeLabel = actionableCount > 99 ? "99+" : String(actionableCount);
+
+	return (
+		<button
+			type="button"
+			onClick={onClick}
+			className={cn(
+				"relative inline-flex h-8 w-8 shrink-0 items-center justify-center rounded transition-colors duration-150",
+				"focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-border",
+				open
+					? "bg-surface text-fg"
+					: "text-fg-ghost hover:bg-surface/60 hover:text-fg",
+				className,
+			)}
+			aria-label={buildAriaLabel(summary)}
+			aria-pressed={open}
+		>
+			<Bell size={16} strokeWidth={1.5} aria-hidden="true" />
+
+			{actionableCount > 0 ? (
+				<span
+					className="absolute -right-1 -top-1 flex h-4 min-w-4 items-center justify-center rounded-full bg-accent-amber px-1 text-[10px] font-medium text-background"
+					aria-hidden="true"
+				>
+					{badgeLabel}
+				</span>
+			) : hasInformationalOnly ? (
+				<span
+					className="absolute right-1 top-1 h-2 w-2 rounded-full bg-fg-ghost/80"
+					aria-hidden="true"
+				/>
+			) : null}
+		</button>
+	);
+}

--- a/cli/web-ui/src/components/v2/NotificationsSidebar.tsx
+++ b/cli/web-ui/src/components/v2/NotificationsSidebar.tsx
@@ -1,0 +1,279 @@
+import { Bell, Loader2, SquareKanban, X } from "lucide-react";
+import { useCallback, useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { Drawer } from "@/components/ui/drawer";
+import type {
+	NotificationAttentionLevel,
+	NotificationListItem,
+} from "@/hooks/useNotifications";
+import { formatRelativeTime } from "@/lib/time";
+import { cn } from "@/lib/utils";
+import { HarnessIcon } from "./HarnessIcon";
+
+export interface NotificationsSidebarProps {
+	readonly open: boolean;
+	readonly onClose: () => void;
+	readonly notifications: readonly NotificationListItem[];
+	readonly isLoading: boolean;
+	readonly error: Error | null;
+	readonly onDismissNotification: (id: number) => Promise<void>;
+	readonly className?: string;
+}
+
+interface NotificationGroup {
+	readonly level: NotificationAttentionLevel;
+	readonly label: string;
+	readonly items: readonly NotificationListItem[];
+}
+
+const GROUP_ORDER: ReadonlyArray<{
+	level: NotificationAttentionLevel;
+	label: string;
+}> = [
+	{ level: "action_required", label: "Action required" },
+	{ level: "attention", label: "Attention" },
+	{ level: "info", label: "Informational" },
+];
+
+function buildNotificationGroups(
+	notifications: readonly NotificationListItem[],
+): NotificationGroup[] {
+	return GROUP_ORDER.map(({ level, label }) => ({
+		level,
+		label,
+		items: notifications.filter(
+			(notification) => notification.attentionLevel === level,
+		),
+	})).filter((group) => group.items.length > 0);
+}
+
+function accentClassForLevel(level: NotificationAttentionLevel): string {
+	switch (level) {
+		case "action_required":
+			return "bg-accent-amber animate-status-pulse";
+		case "attention":
+			return "bg-accent-amber";
+		case "info":
+			return "bg-fg-ghost";
+	}
+}
+
+function headingClassForLevel(level: NotificationAttentionLevel): string {
+	switch (level) {
+		case "action_required":
+			return "text-accent-amber";
+		case "attention":
+			return "text-fg";
+		case "info":
+			return "text-fg-ghost";
+	}
+}
+
+export function NotificationsSidebar({
+	open,
+	onClose,
+	notifications,
+	isLoading,
+	error,
+	onDismissNotification,
+	className,
+}: NotificationsSidebarProps) {
+	const navigate = useNavigate();
+	const [dismissingIds, setDismissingIds] = useState<readonly number[]>([]);
+	const groups = useMemo(
+		() => buildNotificationGroups(notifications),
+		[notifications],
+	);
+
+	const handleOpenRoute = useCallback(
+		(notification: NotificationListItem) => {
+			if (!notification.route) {
+				return;
+			}
+
+			navigate(notification.route);
+			onClose();
+		},
+		[navigate, onClose],
+	);
+
+	const handleOpenProject = useCallback(
+		(projectId: string) => {
+			navigate(`/projects/${projectId}`);
+			onClose();
+		},
+		[navigate, onClose],
+	);
+
+	const handleDismiss = useCallback(
+		async (notificationId: number) => {
+			setDismissingIds((current) =>
+				current.includes(notificationId)
+					? current
+					: [...current, notificationId],
+			);
+
+			try {
+				await onDismissNotification(notificationId);
+			} finally {
+				setDismissingIds((current) =>
+					current.filter((id) => id !== notificationId),
+				);
+			}
+		},
+		[onDismissNotification],
+	);
+
+	return (
+		<Drawer
+			open={open}
+			onClose={onClose}
+			side="right"
+			title="Notifications"
+			className={cn("w-full max-w-[420px]", className)}
+		>
+			{isLoading && notifications.length === 0 ? (
+				<div className="flex h-full items-center justify-center px-6 py-16">
+					<Loader2 className="h-4 w-4 animate-spin text-fg-ghost" />
+				</div>
+			) : error && notifications.length === 0 ? (
+				<div className="flex h-full flex-col items-center justify-center px-6 py-16 text-center">
+					<p className="type-body text-failure">
+						Failed to load notifications.
+					</p>
+					<p className="mt-2 type-secondary text-fg-ghost">{error.message}</p>
+				</div>
+			) : notifications.length === 0 ? (
+				<div className="flex h-full flex-col items-center justify-center px-6 py-16 text-center">
+					<Bell
+						className="mb-4 h-5 w-5 text-fg-ghost"
+						strokeWidth={1.5}
+						aria-hidden="true"
+					/>
+					<p className="type-body text-fg-ghost">No notifications right now.</p>
+					<p className="mt-2 max-w-[240px] type-secondary text-fg-ghost">
+						New approvals, failures, and status updates will appear here.
+					</p>
+				</div>
+			) : (
+				<div className="flex flex-col gap-6 px-4 py-4">
+					{groups.map((group) => (
+						<section
+							key={group.level}
+							aria-labelledby={`notifications-group-${group.level}`}
+							className="flex flex-col gap-3"
+						>
+							<div className="flex items-center justify-between">
+								<h3
+									id={`notifications-group-${group.level}`}
+									className={cn(
+										"type-caption uppercase tracking-[0.08em]",
+										headingClassForLevel(group.level),
+									)}
+								>
+									{group.label}
+								</h3>
+								<span className="type-secondary tabular-nums text-fg-ghost">
+									{group.items.length}
+								</span>
+							</div>
+
+							<div className="flex flex-col gap-3">
+								{group.items.map((notification) => {
+									const isDismissing = dismissingIds.includes(notification.id);
+									return (
+										<div
+											key={notification.id}
+											className="flex items-start gap-3 rounded-[var(--radius)] border border-border/70 bg-background px-3 py-3"
+										>
+											<span
+												className={cn(
+													"mt-2 h-2 w-2 shrink-0 rounded-full",
+													accentClassForLevel(notification.attentionLevel),
+												)}
+												aria-hidden="true"
+											/>
+
+											<div className="min-w-0 flex-1">
+												<div className="mb-2 flex min-w-0 items-center gap-2 text-fg-ghost">
+													<span className="type-secondary tabular-nums">
+														{formatRelativeTime(notification.createdAt)}
+													</span>
+													{notification.harness ? (
+														<HarnessIcon
+															harness={notification.harness}
+															size={14}
+														/>
+													) : null}
+													{notification.runCommand ? (
+														<span className="type-secondary font-medium text-fg">
+															{notification.runCommand}
+														</span>
+													) : null}
+													{notification.runName ? (
+														<span className="truncate type-secondary text-fg-muted">
+															{notification.runName}
+														</span>
+													) : null}
+												</div>
+
+												{notification.route ? (
+													<button
+														type="button"
+														onClick={() => handleOpenRoute(notification)}
+														className="w-full text-left transition-colors duration-150 hover:text-fg-muted focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-border"
+														aria-label={`Open notification: ${notification.message}`}
+													>
+														<p className="type-body text-fg">
+															{notification.message}
+														</p>
+													</button>
+												) : (
+													<p className="type-body text-fg">
+														{notification.message}
+													</p>
+												)}
+
+												{notification.projectId && notification.projectName ? (
+													<button
+														type="button"
+														onClick={() =>
+															handleOpenProject(notification.projectId!)
+														}
+														className="mt-3 inline-flex items-center gap-1 type-secondary italic text-fg-ghost transition-colors duration-150 hover:text-fg-muted focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-border"
+														aria-label={`Open project ${notification.projectName}`}
+													>
+														<SquareKanban
+															className="h-3 w-3"
+															strokeWidth={1.5}
+															aria-hidden="true"
+														/>
+														{notification.projectName}
+													</button>
+												) : null}
+											</div>
+
+											<button
+												type="button"
+												onClick={() => void handleDismiss(notification.id)}
+												className="shrink-0 rounded p-1 text-fg-ghost transition-colors duration-150 hover:text-fg focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-border disabled:cursor-not-allowed disabled:opacity-50"
+												aria-label={`Dismiss notification: ${notification.message}`}
+												disabled={isDismissing}
+											>
+												<X
+													className="h-4 w-4"
+													strokeWidth={1.5}
+													aria-hidden="true"
+												/>
+											</button>
+										</div>
+									);
+								})}
+							</div>
+						</section>
+					))}
+				</div>
+			)}
+		</Drawer>
+	);
+}

--- a/cli/web-ui/src/components/v2/NotificationsSidebar.tsx
+++ b/cli/web-ui/src/components/v2/NotificationsSidebar.tsx
@@ -115,6 +115,8 @@ export function NotificationsSidebar({
 
 			try {
 				await onDismissNotification(notificationId);
+			} catch (dismissError) {
+				console.warn(String(dismissError));
 			} finally {
 				setDismissingIds((current) =>
 					current.filter((id) => id !== notificationId),

--- a/cli/web-ui/src/components/v2/TerminalBreadcrumb.tsx
+++ b/cli/web-ui/src/components/v2/TerminalBreadcrumb.tsx
@@ -1,4 +1,5 @@
 import { SquareKanban } from "lucide-react";
+import type { ReactNode } from "react";
 import { Link, useLocation, useNavigate } from "react-router-dom";
 import { HarnessIcon } from "@/components/v2/HarnessIcon";
 import { useBreadcrumbContext } from "@/hooks/useBreadcrumbContext";
@@ -7,6 +8,7 @@ import { cn } from "@/lib/utils";
 
 export interface TerminalBreadcrumbProps {
 	className?: string;
+	action?: ReactNode;
 }
 
 export interface BreadcrumbSegment {
@@ -22,7 +24,10 @@ export function buildSegments(pathname: string): BreadcrumbSegment[] {
 	}));
 }
 
-export function TerminalBreadcrumb({ className }: TerminalBreadcrumbProps) {
+export function TerminalBreadcrumb({
+	className,
+	action,
+}: TerminalBreadcrumbProps) {
 	const { pathname } = useLocation();
 	const navigate = useNavigate();
 	const { projectName, projectId, runInfo } = useBreadcrumbContext();
@@ -32,13 +37,13 @@ export function TerminalBreadcrumb({ className }: TerminalBreadcrumbProps) {
 			<nav
 				aria-label="Run info"
 				className={cn(
-					"flex items-center justify-center border-b px-4 py-1.5 min-h-8 type-body",
+					"grid min-h-8 grid-cols-[1fr_auto_1fr] items-center border-b px-4 py-1.5 type-body",
 					"border-border",
 					"text-fg-ghost",
 					className,
 				)}
 			>
-				<div className="flex items-center gap-3">
+				<div className="col-start-2 flex items-center gap-3">
 					<span className="type-secondary tabular-nums text-fg-ghost">
 						{formatRelativeTime(runInfo.startedAt)}
 					</span>
@@ -64,6 +69,9 @@ export function TerminalBreadcrumb({ className }: TerminalBreadcrumbProps) {
 						{runInfo.projectName}
 					</span>
 				</div>
+				{action ? (
+					<div className="col-start-3 justify-self-end">{action}</div>
+				) : null}
 			</nav>
 		);
 	}
@@ -73,7 +81,7 @@ export function TerminalBreadcrumb({ className }: TerminalBreadcrumbProps) {
 			<nav
 				aria-label="Breadcrumb"
 				className={cn(
-					"flex items-center border-b px-4 py-1.5 min-h-8 type-body",
+					"flex min-h-8 items-center justify-between border-b px-4 py-1.5 type-body",
 					"border-border",
 					"text-fg-ghost",
 					className,
@@ -86,6 +94,7 @@ export function TerminalBreadcrumb({ className }: TerminalBreadcrumbProps) {
 					<SquareKanban className="h-3 w-3" strokeWidth={1.5} />
 					{projectName}
 				</Link>
+				{action ? <div className="flex items-center">{action}</div> : null}
 			</nav>
 		);
 	}
@@ -103,7 +112,7 @@ export function TerminalBreadcrumb({ className }: TerminalBreadcrumbProps) {
 		<nav
 			aria-label="Breadcrumb"
 			className={cn(
-				"flex items-center border-b px-4 py-1.5 min-h-8 type-body",
+				"flex min-h-8 items-center justify-between border-b px-4 py-1.5 type-body",
 				"border-border",
 				"text-fg-ghost",
 				className,
@@ -114,6 +123,7 @@ export function TerminalBreadcrumb({ className }: TerminalBreadcrumbProps) {
 					{pageLabel}
 				</span>
 			)}
+			{action ? <div className="flex items-center">{action}</div> : null}
 		</nav>
 	);
 }

--- a/cli/web-ui/src/components/v2/index.ts
+++ b/cli/web-ui/src/components/v2/index.ts
@@ -60,6 +60,14 @@ export {
 	type MobileTabBarProps,
 } from "./MobileTabBar";
 export { NewUpdatesChip, type NewUpdatesChipProps } from "./NewUpdatesChip";
+export {
+	NotificationsSidebar,
+	type NotificationsSidebarProps,
+} from "./NotificationsSidebar";
+export {
+	NotificationTrigger,
+	type NotificationTriggerProps,
+} from "./NotificationTrigger";
 export { RunCard, type RunCardProps } from "./RunCard";
 export { Select, type SelectProps } from "./Select";
 export {

--- a/cli/web-ui/src/hooks/useFeed.ts
+++ b/cli/web-ui/src/hooks/useFeed.ts
@@ -3,20 +3,6 @@ import { useWebSocket } from "@/providers/WebSocketProvider";
 import type { Run, RunsFilter } from "@/types/runs";
 import { useReconnectRecovery } from "./useReconnectRecovery";
 
-interface NotificationFeedRecord {
-	readonly id: number;
-	readonly message: string;
-	readonly sourceType: string;
-	readonly sourceId: string | null;
-	readonly route: string | null;
-	readonly projectId: string | null;
-	readonly createdAt: string;
-	readonly harness: string | null;
-	readonly runCommand: string | null;
-	readonly runName: string | null;
-	readonly projectName: string | null;
-}
-
 export interface RunFeedItem {
 	readonly type: "run";
 	readonly id: string;
@@ -24,14 +10,7 @@ export interface RunFeedItem {
 	readonly run: Run;
 }
 
-export interface NotificationFeedItem {
-	readonly type: "notification";
-	readonly id: number;
-	readonly timestamp: string;
-	readonly notification: NotificationFeedRecord;
-}
-
-export type FeedItem = RunFeedItem | NotificationFeedItem;
+export type FeedItem = RunFeedItem;
 
 interface FeedResponse {
 	items: FeedItem[];
@@ -82,8 +61,7 @@ export function useFeed(options: UseFeedOptions = {}): UseFeedResult {
 	const [total, setTotal] = useState(0);
 	const [isLoading, setIsLoading] = useState(true);
 	const [error, setError] = useState<Error | null>(null);
-	const { onEventNotification, onNotification, subscribeToAttention } =
-		useWebSocket();
+	const { subscribeToAttention } = useWebSocket();
 
 	const { status, projectId, dateRange, limit, offset } = options;
 
@@ -125,18 +103,6 @@ export function useFeed(options: UseFeedOptions = {}): UseFeedResult {
 		});
 		return unsubscribe;
 	}, [subscribeToAttention, fetchFeed]);
-
-	useEffect(() => {
-		return onEventNotification(() => {
-			fetchFeed();
-		});
-	}, [onEventNotification, fetchFeed]);
-
-	useEffect(() => {
-		return onNotification(() => {
-			fetchFeed();
-		});
-	}, [onNotification, fetchFeed]);
 
 	useReconnectRecovery(fetchFeed);
 

--- a/cli/web-ui/src/hooks/useGlobalShortcuts.ts
+++ b/cli/web-ui/src/hooks/useGlobalShortcuts.ts
@@ -3,8 +3,9 @@ import type { NavigateFunction } from "react-router-dom";
 import { isTextInputElement } from "@/lib/keyboard";
 
 export interface UseGlobalShortcutsOptions {
+	activeOverlay: "none" | "command-palette" | "notifications";
 	onOpenCommandPalette: () => void;
-	onCloseCommandPalette: () => void;
+	onCloseOverlay: () => void;
 	onToggleShortcutHelp: () => void;
 	onToggleSidebar: () => void;
 	onFocusSearch: () => void;
@@ -21,8 +22,9 @@ const CHORD_TARGETS: Record<string, string> = {
 };
 
 export function useGlobalShortcuts({
+	activeOverlay,
 	onOpenCommandPalette,
-	onCloseCommandPalette,
+	onCloseOverlay,
 	onToggleShortcutHelp,
 	onToggleSidebar,
 	onFocusSearch,
@@ -47,18 +49,10 @@ export function useGlobalShortcuts({
 
 			if (isMod && e.key === "k") {
 				e.preventDefault();
-				if (isOverlayOpen) {
-					onCloseCommandPalette();
+				if (activeOverlay === "command-palette") {
+					onCloseOverlay();
 				} else {
 					onOpenCommandPalette();
-				}
-				return;
-			}
-
-			if (isOverlayOpen) {
-				if (e.key === "Escape") {
-					e.preventDefault();
-					onCloseCommandPalette();
 				}
 				return;
 			}
@@ -66,6 +60,14 @@ export function useGlobalShortcuts({
 			if (isMod && (e.key === "\\" || e.key === "b")) {
 				e.preventDefault();
 				onToggleSidebar();
+				return;
+			}
+
+			if (isOverlayOpen) {
+				if (e.key === "Escape") {
+					e.preventDefault();
+					onCloseOverlay();
+				}
 				return;
 			}
 
@@ -121,9 +123,10 @@ export function useGlobalShortcuts({
 			}
 		};
 	}, [
+		activeOverlay,
 		isOverlayOpen,
 		onOpenCommandPalette,
-		onCloseCommandPalette,
+		onCloseOverlay,
 		onToggleShortcutHelp,
 		onToggleSidebar,
 		onFocusSearch,

--- a/cli/web-ui/src/hooks/useNotifications.ts
+++ b/cli/web-ui/src/hooks/useNotifications.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useWebSocket } from "@/providers/WebSocketProvider";
 import { useReconnectRecovery } from "./useReconnectRecovery";
 
@@ -57,11 +57,17 @@ function getResponseErrorMessage(response: Response, prefix: string): string {
 	return `${prefix}: ${response.statusText || `HTTP ${response.status}`}`;
 }
 
-function buildNotificationsUrl(offset: number): string {
+function buildNotificationsUrl(
+	offset: number,
+	projectId: string | null,
+): string {
 	const params = new URLSearchParams({
 		limit: String(NOTIFICATIONS_PAGE_SIZE),
 		offset: String(offset),
 	});
+	if (projectId) {
+		params.set("projectId", projectId);
+	}
 
 	return `/api/v2/notifications?${params.toString()}`;
 }
@@ -75,10 +81,14 @@ export function useNotifications(): UseNotificationsResult {
 	);
 	const [isLoading, setIsLoading] = useState(true);
 	const [error, setError] = useState<Error | null>(null);
-	const { onNotification } = useWebSocket();
+	const latestRequestIdRef = useRef(0);
+	const { onNotification, projectId } = useWebSocket();
 
 	const fetchNotifications = useCallback(
 		async ({ showLoading = false }: { showLoading?: boolean } = {}) => {
+			const requestId = ++latestRequestIdRef.current;
+			const currentProjectId = projectId;
+
 			if (showLoading) {
 				setIsLoading(true);
 			}
@@ -90,7 +100,9 @@ export function useNotifications(): UseNotificationsResult {
 				let nextSummary = EMPTY_NOTIFICATIONS_SUMMARY;
 
 				do {
-					const response = await fetch(buildNotificationsUrl(offset));
+					const response = await fetch(
+						buildNotificationsUrl(offset, currentProjectId),
+					);
 					if (!response.ok) {
 						throw new Error(
 							getResponseErrorMessage(
@@ -104,6 +116,9 @@ export function useNotifications(): UseNotificationsResult {
 					if (offset === 0) {
 						total = data.total;
 						nextSummary = data.summary;
+						if (requestId !== latestRequestIdRef.current) {
+							return;
+						}
 						setSummary(data.summary);
 					}
 
@@ -121,22 +136,28 @@ export function useNotifications(): UseNotificationsResult {
 					);
 				}
 
+				if (requestId !== latestRequestIdRef.current) {
+					return;
+				}
 				setNotifications(allNotifications);
 				setSummary(nextSummary);
 				setError(null);
 			} catch (fetchError) {
+				if (requestId !== latestRequestIdRef.current) {
+					return;
+				}
 				setError(
 					fetchError instanceof Error
 						? fetchError
 						: new Error(String(fetchError)),
 				);
 			} finally {
-				if (showLoading) {
+				if (showLoading && requestId === latestRequestIdRef.current) {
 					setIsLoading(false);
 				}
 			}
 		},
-		[],
+		[projectId],
 	);
 
 	useEffect(() => {

--- a/cli/web-ui/src/hooks/useNotifications.ts
+++ b/cli/web-ui/src/hooks/useNotifications.ts
@@ -81,6 +81,7 @@ export function useNotifications(): UseNotificationsResult {
 	);
 	const [isLoading, setIsLoading] = useState(true);
 	const [error, setError] = useState<Error | null>(null);
+	const loadingRequestIdRef = useRef<number | null>(null);
 	const latestRequestIdRef = useRef(0);
 	const { onNotification, projectId } = useWebSocket();
 
@@ -90,6 +91,7 @@ export function useNotifications(): UseNotificationsResult {
 			const currentProjectId = projectId;
 
 			if (showLoading) {
+				loadingRequestIdRef.current = requestId;
 				setIsLoading(true);
 			}
 
@@ -152,7 +154,13 @@ export function useNotifications(): UseNotificationsResult {
 						: new Error(String(fetchError)),
 				);
 			} finally {
-				if (showLoading && requestId === latestRequestIdRef.current) {
+				const loadingRequestId = loadingRequestIdRef.current;
+				if (
+					loadingRequestId !== null &&
+					requestId >= loadingRequestId &&
+					requestId === latestRequestIdRef.current
+				) {
+					loadingRequestIdRef.current = null;
 					setIsLoading(false);
 				}
 			}

--- a/cli/web-ui/src/hooks/useNotifications.ts
+++ b/cli/web-ui/src/hooks/useNotifications.ts
@@ -1,0 +1,198 @@
+import { useCallback, useEffect, useState } from "react";
+import { useWebSocket } from "@/providers/WebSocketProvider";
+import { useReconnectRecovery } from "./useReconnectRecovery";
+
+export type NotificationAttentionLevel =
+	| "action_required"
+	| "attention"
+	| "info";
+
+export interface NotificationListItem {
+	readonly id: number;
+	readonly message: string;
+	readonly sourceType: "run" | "agent" | "system";
+	readonly sourceId: string | null;
+	readonly route: string | null;
+	readonly projectId: string | null;
+	readonly createdAt: string;
+	readonly harness: string | null;
+	readonly runCommand: string | null;
+	readonly runName: string | null;
+	readonly projectName: string | null;
+	readonly attentionLevel: NotificationAttentionLevel;
+}
+
+export interface NotificationsSummary {
+	readonly totalCount: number;
+	readonly actionRequiredCount: number;
+	readonly attentionCount: number;
+	readonly informationalCount: number;
+}
+
+interface NotificationsListResponse {
+	notifications: NotificationListItem[];
+	total: number;
+	summary: NotificationsSummary;
+}
+
+const NOTIFICATIONS_PAGE_SIZE = 50;
+
+export interface UseNotificationsResult {
+	notifications: NotificationListItem[];
+	summary: NotificationsSummary;
+	isLoading: boolean;
+	error: Error | null;
+	refetch: () => void;
+	dismissNotification: (id: number) => Promise<void>;
+}
+
+export const EMPTY_NOTIFICATIONS_SUMMARY: NotificationsSummary = {
+	totalCount: 0,
+	actionRequiredCount: 0,
+	attentionCount: 0,
+	informationalCount: 0,
+};
+
+function getResponseErrorMessage(response: Response, prefix: string): string {
+	return `${prefix}: ${response.statusText || `HTTP ${response.status}`}`;
+}
+
+function buildNotificationsUrl(offset: number): string {
+	const params = new URLSearchParams({
+		limit: String(NOTIFICATIONS_PAGE_SIZE),
+		offset: String(offset),
+	});
+
+	return `/api/v2/notifications?${params.toString()}`;
+}
+
+export function useNotifications(): UseNotificationsResult {
+	const [notifications, setNotifications] = useState<NotificationListItem[]>(
+		[],
+	);
+	const [summary, setSummary] = useState<NotificationsSummary>(
+		EMPTY_NOTIFICATIONS_SUMMARY,
+	);
+	const [isLoading, setIsLoading] = useState(true);
+	const [error, setError] = useState<Error | null>(null);
+	const { onNotification } = useWebSocket();
+
+	const fetchNotifications = useCallback(
+		async ({ showLoading = false }: { showLoading?: boolean } = {}) => {
+			if (showLoading) {
+				setIsLoading(true);
+			}
+
+			try {
+				const allNotifications: NotificationListItem[] = [];
+				let total = 0;
+				let offset = 0;
+				let nextSummary = EMPTY_NOTIFICATIONS_SUMMARY;
+
+				do {
+					const response = await fetch(buildNotificationsUrl(offset));
+					if (!response.ok) {
+						throw new Error(
+							getResponseErrorMessage(
+								response,
+								"Failed to fetch notifications",
+							),
+						);
+					}
+
+					const data = (await response.json()) as NotificationsListResponse;
+					if (offset === 0) {
+						total = data.total;
+						nextSummary = data.summary;
+						setSummary(data.summary);
+					}
+
+					allNotifications.push(...data.notifications);
+					offset += data.notifications.length;
+
+					if (data.notifications.length === 0) {
+						break;
+					}
+				} while (allNotifications.length < total);
+
+				if (allNotifications.length < total) {
+					throw new Error(
+						"Failed to fetch notifications: incomplete paginated response",
+					);
+				}
+
+				setNotifications(allNotifications);
+				setSummary(nextSummary);
+				setError(null);
+			} catch (fetchError) {
+				setError(
+					fetchError instanceof Error
+						? fetchError
+						: new Error(String(fetchError)),
+				);
+			} finally {
+				if (showLoading) {
+					setIsLoading(false);
+				}
+			}
+		},
+		[],
+	);
+
+	useEffect(() => {
+		void fetchNotifications({ showLoading: true });
+	}, [fetchNotifications]);
+
+	useEffect(() => {
+		return onNotification((message) => {
+			if (
+				message.type === "notification:created" ||
+				message.type === "notification:dismissed"
+			) {
+				void fetchNotifications();
+			}
+		});
+	}, [fetchNotifications, onNotification]);
+
+	useReconnectRecovery(fetchNotifications);
+
+	const refetch = useCallback(() => {
+		void fetchNotifications({ showLoading: true });
+	}, [fetchNotifications]);
+
+	const dismissNotification = useCallback(
+		async (id: number) => {
+			try {
+				const response = await fetch(`/api/v2/notifications/${id}/dismiss`, {
+					method: "POST",
+				});
+
+				if (!response.ok) {
+					throw new Error(
+						getResponseErrorMessage(response, "Failed to dismiss notification"),
+					);
+				}
+
+				setError(null);
+				await fetchNotifications();
+			} catch (dismissError) {
+				const nextError =
+					dismissError instanceof Error
+						? dismissError
+						: new Error(String(dismissError));
+				setError(nextError);
+				throw nextError;
+			}
+		},
+		[fetchNotifications],
+	);
+
+	return {
+		notifications,
+		summary,
+		isLoading,
+		error,
+		refetch,
+		dismissNotification,
+	};
+}

--- a/cli/web-ui/src/pages/v2/HomePage.tsx
+++ b/cli/web-ui/src/pages/v2/HomePage.tsx
@@ -1,10 +1,10 @@
 import { AnimatePresence, motion } from "framer-motion";
-import { Activity, SlidersHorizontal, SquareKanban, X } from "lucide-react";
+import { Activity, SlidersHorizontal, SquareKanban } from "lucide-react";
 import { useCallback, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { FilterBar } from "@/components/v2/FilterBar";
 import { HarnessIcon } from "@/components/v2/HarnessIcon";
-import type { FeedItem, NotificationFeedItem } from "@/hooks/useFeed";
+import type { FeedItem } from "@/hooks/useFeed";
 import { useFeed } from "@/hooks/useFeed";
 import { usePrefersReducedMotion } from "@/hooks/usePrefersReducedMotion";
 import { resolveRunDisplayName } from "@/lib/run-display";
@@ -147,131 +147,6 @@ function FeedEntry({
 	);
 }
 
-function NotificationFeedEntry({
-	item,
-	onClick,
-	onDismiss,
-	onProjectClick,
-	reducedMotion,
-}: {
-	item: NotificationFeedItem;
-	onClick: () => void;
-	onDismiss: (id: number) => void;
-	onProjectClick: (projectId: string) => void;
-	reducedMotion: boolean;
-}) {
-	const notification = item.notification;
-	const hasRoute = !!notification.route;
-
-	return (
-		<motion.div
-			role={hasRoute ? "button" : undefined}
-			tabIndex={hasRoute ? 0 : undefined}
-			onClick={hasRoute ? onClick : undefined}
-			onKeyDown={
-				hasRoute
-					? (e) => {
-							if (e.key === "Enter" || e.key === " ") {
-								e.preventDefault();
-								onClick();
-							}
-						}
-					: undefined
-			}
-			variants={reducedMotion ? feedItemVariantsReduced : feedItemVariants}
-			transition={reducedMotion ? { duration: 0 } : feedItemTransition}
-			className={cn(
-				"group flex w-full items-center gap-3 px-3 py-2.5 text-left rounded-[var(--radius)]",
-				"transition-colors duration-150",
-				hasRoute && "hover:bg-surface cursor-pointer",
-				"focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-border",
-			)}
-		>
-			<span
-				className="inline-block w-[6px] shrink-0 text-fg-ghost/50 leading-none"
-				style={{ fontSize: "8px" }}
-				aria-hidden="true"
-			>
-				▲
-			</span>
-
-			<span className="w-[5.5em] shrink-0 text-right type-secondary tabular-nums text-fg-ghost">
-				{formatRelativeTime(notification.createdAt)}
-			</span>
-
-			<span className="inline-flex w-[14px] shrink-0 items-center justify-center">
-				{notification.harness ? (
-					<HarnessIcon harness={notification.harness} size={14} />
-				) : (
-					<span className="inline-block w-[14px]" />
-				)}
-			</span>
-
-			{notification.runCommand && (
-				<span className="shrink-0 type-body font-medium text-fg">
-					{notification.runCommand}
-				</span>
-			)}
-
-			<span
-				className={cn(
-					"truncate type-secondary",
-					hasRoute ? "text-fg-muted" : "text-fg-ghost",
-				)}
-			>
-				{notification.message}
-			</span>
-
-			{notification.projectName && notification.projectId && (
-				<button
-					type="button"
-					onClick={(e) => {
-						e.stopPropagation();
-						onProjectClick(notification.projectId!);
-					}}
-					onKeyDown={(e) => {
-						if (e.key === "Enter" || e.key === " ") {
-							e.stopPropagation();
-							onProjectClick(notification.projectId!);
-						}
-					}}
-					className="ml-auto shrink-0 flex items-center gap-1 pl-4 type-secondary italic text-fg-ghost hover:text-fg-muted transition-colors duration-150 cursor-pointer bg-transparent border-none p-0"
-					aria-label={`Open project ${notification.projectName}`}
-				>
-					<SquareKanban className="h-3 w-3" strokeWidth={1.5} />
-					{notification.projectName}
-				</button>
-			)}
-
-			<button
-				type="button"
-				onClick={(e) => {
-					e.stopPropagation();
-					onDismiss(notification.id);
-				}}
-				onKeyDown={(e) => {
-					if (e.key === "Enter" || e.key === " ") {
-						e.stopPropagation();
-						onDismiss(notification.id);
-					}
-				}}
-				className={cn(
-					"shrink-0 inline-flex items-center justify-center",
-					"h-5 w-5 rounded transition-colors duration-150",
-					"text-fg-ghost/0 group-hover:text-fg-ghost",
-					"hover:!text-fg-muted hover:bg-surface/50",
-					"bg-transparent border-none p-0 cursor-pointer",
-					"focus-visible:text-fg-ghost focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-border",
-					!notification.projectName && "ml-auto",
-				)}
-				aria-label="Dismiss notification"
-			>
-				<X className="h-3 w-3" strokeWidth={1.5} />
-			</button>
-		</motion.div>
-	);
-}
-
 export function HomePage() {
 	const navigate = useNavigate();
 	const [searchParams, setSearchParams] = useSearchParams();
@@ -286,7 +161,7 @@ export function HomePage() {
 	});
 	const [pageSize, setPageSize] = useState(PAGE_SIZE);
 
-	const { items, total, isLoading, refetch } = useFeed({
+	const { items, total, isLoading } = useFeed({
 		...filters,
 		limit: pageSize,
 	});
@@ -330,64 +205,19 @@ export function HomePage() {
 		[navigate],
 	);
 
-	const handleNotificationClick = useCallback(
-		(route: string) => {
-			navigate(route);
-		},
-		[navigate],
-	);
-
-	const handleDismiss = useCallback(
-		async (id: number) => {
-			try {
-				const response = await fetch(`/api/v2/notifications/${id}/dismiss`, {
-					method: "POST",
-				});
-				if (response.ok) {
-					refetch();
-				}
-			} catch {}
-		},
-		[refetch],
-	);
-
 	const renderFeedItem = useCallback(
 		(item: FeedItem) => {
-			if (item.type === "run" && item.run) {
-				return (
-					<FeedEntry
-						key={`run-${item.id}`}
-						run={item.run}
-						onClick={() => handleRunClick(item.id as string)}
-						onProjectClick={handleProjectClick}
-						reducedMotion={reducedMotion}
-					/>
-				);
-			}
-			if (item.type === "notification" && item.notification) {
-				return (
-					<NotificationFeedEntry
-						key={`notif-${item.id}`}
-						item={item as NotificationFeedItem}
-						onClick={() => {
-							const route = (item as NotificationFeedItem).notification.route;
-							if (route) handleNotificationClick(route);
-						}}
-						onDismiss={handleDismiss}
-						onProjectClick={handleProjectClick}
-						reducedMotion={reducedMotion}
-					/>
-				);
-			}
-			return null;
+			return (
+				<FeedEntry
+					key={`run-${item.id}`}
+					run={item.run}
+					onClick={() => handleRunClick(item.id)}
+					onProjectClick={handleProjectClick}
+					reducedMotion={reducedMotion}
+				/>
+			);
 		},
-		[
-			handleRunClick,
-			handleProjectClick,
-			handleNotificationClick,
-			handleDismiss,
-			reducedMotion,
-		],
+		[handleRunClick, handleProjectClick, reducedMotion],
 	);
 
 	return (

--- a/cli/web-ui/src/providers/ShortcutRegistryProvider.tsx
+++ b/cli/web-ui/src/providers/ShortcutRegistryProvider.tsx
@@ -45,14 +45,14 @@ const GLOBAL_SHORTCUTS: ShortcutDefinition[] = [
 	},
 	{
 		key: "Cmd+B",
-		label: "Toggle Sidebar",
-		description: "Show or hide the sidebar",
+		label: "Notifications",
+		description: "Show or hide the notifications drawer",
 		action: () => {},
 	},
 	{
 		key: "Cmd+\\",
-		label: "Toggle Sidebar",
-		description: "Show or hide the sidebar (alternate)",
+		label: "Notifications",
+		description: "Show or hide the notifications drawer (alternate)",
 		action: () => {},
 	},
 	{

--- a/cli/web-ui/src/server/routes/v2-api.ts
+++ b/cli/web-ui/src/server/routes/v2-api.ts
@@ -670,6 +670,135 @@ function runRecordToListRun(
 	};
 }
 
+type NotificationAttentionLevel = "action_required" | "attention" | "info";
+
+interface NotificationListItem {
+	readonly id: number;
+	readonly message: string;
+	readonly sourceType: NotificationRecord["sourceType"];
+	readonly sourceId: string | null;
+	readonly route: string | null;
+	readonly projectId: string | null;
+	readonly createdAt: string;
+	readonly harness: string | null;
+	readonly runCommand: string | null;
+	readonly runName: string | null;
+	readonly projectName: string | null;
+	readonly attentionLevel: NotificationAttentionLevel;
+}
+
+interface NotificationsSummary {
+	readonly totalCount: number;
+	readonly actionRequiredCount: number;
+	readonly attentionCount: number;
+	readonly informationalCount: number;
+}
+
+interface NotificationsListResponse {
+	readonly notifications: readonly NotificationListItem[];
+	readonly total: number;
+	readonly summary: NotificationsSummary;
+}
+
+function deriveNotificationAttentionLevel(
+	notification: Pick<NotificationRecord, "sourceType" | "message">,
+): NotificationAttentionLevel {
+	if (notification.sourceType === "agent") {
+		return "action_required";
+	}
+
+	if (
+		notification.sourceType === "run" &&
+		notification.message.endsWith(" failed")
+	) {
+		return "attention";
+	}
+
+	return "info";
+}
+
+function resolveNotificationProjectName(
+	projectLookup: ReturnType<typeof buildProjectLookup>,
+	projectId: string | null,
+): string | null {
+	if (!projectId) {
+		return null;
+	}
+
+	return projectLookup.byId.get(projectId)?.name ?? null;
+}
+
+function notificationRecordToListItem(
+	db: Database,
+	projectLookup: ReturnType<typeof buildProjectLookup>,
+	notification: NotificationRecord,
+): NotificationListItem {
+	let harness: string | null = null;
+	let runCommand: string | null = null;
+	let runName: string | null = null;
+	let projectName: string | null = resolveNotificationProjectName(
+		projectLookup,
+		notification.projectId,
+	);
+
+	if (notification.sourceId) {
+		const run = getRunById(db, notification.sourceId);
+		if (run) {
+			harness = run.harness;
+			runCommand = `/${run.flow}`;
+			runName = run.name ?? null;
+			const project =
+				findProjectByIdentity(projectLookup, run) ??
+				fallbackProjectFromRun(run);
+			projectName = project.name;
+		}
+	}
+
+	return {
+		id: notification.id,
+		message: notification.message,
+		sourceType: notification.sourceType,
+		sourceId: notification.sourceId,
+		route: notification.route,
+		projectId: notification.projectId,
+		createdAt: notification.createdAt,
+		harness,
+		runCommand,
+		runName,
+		projectName,
+		attentionLevel: deriveNotificationAttentionLevel(notification),
+	};
+}
+
+function summarizeNotifications(
+	notifications: readonly Pick<NotificationRecord, "sourceType" | "message">[],
+): NotificationsSummary {
+	let actionRequiredCount = 0;
+	let attentionCount = 0;
+	let informationalCount = 0;
+
+	for (const notification of notifications) {
+		switch (deriveNotificationAttentionLevel(notification)) {
+			case "action_required":
+				actionRequiredCount += 1;
+				break;
+			case "attention":
+				attentionCount += 1;
+				break;
+			case "info":
+				informationalCount += 1;
+				break;
+		}
+	}
+
+	return {
+		totalCount: notifications.length,
+		actionRequiredCount,
+		attentionCount,
+		informationalCount,
+	};
+}
+
 /**
  * Build a fully-populated Run object for the detail view.
  * Derives steps from status_change events, includes artifacts with docId,
@@ -1563,18 +1692,27 @@ export async function handleV2NotificationsListRequest(
 
 		const db = await getDb();
 		const result = listNotifications(db, { projectId, limit, offset });
+		const projects = await getAllProjects();
+		const projectLookup = buildProjectLookup(projects);
 
-		const notifications = result.notifications.map((n) => ({
-			id: n.id,
-			message: n.message,
-			sourceType: n.sourceType,
-			sourceId: n.sourceId,
-			route: n.route,
-			projectId: n.projectId,
-			createdAt: n.createdAt,
-		}));
+		const summaryRecords =
+			offset > 0 || result.notifications.length < result.total
+				? listNotifications(db, {
+						projectId,
+						limit: Math.max(result.total, 1),
+						offset: 0,
+					}).notifications
+				: result.notifications;
 
-		return jsonResponse({ notifications, total: result.total });
+		const response: NotificationsListResponse = {
+			notifications: result.notifications.map((notification) =>
+				notificationRecordToListItem(db, projectLookup, notification),
+			),
+			total: result.total,
+			summary: summarizeNotifications(summaryRecords),
+		};
+
+		return jsonResponse(response);
 	} catch (error) {
 		return errorResponse(`Failed to fetch notifications: ${String(error)}`);
 	}
@@ -1655,9 +1793,8 @@ export async function handleV2NotificationNotifyRequest(
 }
 
 /**
- * GET /api/v2/feed - unified activity feed (runs + notifications, chronologically interleaved).
- * Queries both tables, merges by timestamp, and applies pagination to the combined result.
- * When a status filter is active, notifications are still included alongside filtered runs.
+ * GET /api/v2/feed - run activity feed only.
+ * Returns runs ordered by latest activity time with filtering and pagination.
  */
 export async function handleV2FeedRequest(req: Request): Promise<Response> {
 	try {
@@ -1725,69 +1862,6 @@ export async function handleV2FeedRequest(req: Request): Promise<Response> {
 			});
 		}
 
-		const notifProjectId = dbProjectIdFilter ?? undefined;
-		const notifResult = listNotifications(db, {
-			projectId: notifProjectId,
-			limit: 200,
-			offset: 0,
-		});
-
-		let notifItems: Array<{
-			type: "notification";
-			id: number;
-			timestamp: string;
-			notification: Omit<NotificationRecord, "dismissed"> & {
-				harness: string | null;
-				runCommand: string | null;
-				runName: string | null;
-				projectName: string | null;
-			};
-		}> = notifResult.notifications.map((n) => {
-			let harness: string | null = null;
-			let runCommand: string | null = null;
-			let runName: string | null = null;
-			let projectName: string | null = null;
-
-			if (n.sourceId) {
-				const run = getRunById(db, n.sourceId);
-				if (run) {
-					harness = run.harness;
-					runCommand = `/${run.flow}`;
-					runName = run.name ?? null;
-					const project =
-						findProjectByIdentity(projectLookup, run) ??
-						fallbackProjectFromRun(run);
-					projectName = project.name;
-				}
-			} else if (n.projectId) {
-				for (const [, project] of projectLookup.byId) {
-					if (project.id === n.projectId) {
-						projectName = project.name;
-						break;
-					}
-				}
-			}
-
-			return {
-				type: "notification" as const,
-				id: n.id,
-				timestamp: n.createdAt,
-				notification: {
-					id: n.id,
-					message: n.message,
-					sourceType: n.sourceType,
-					sourceId: n.sourceId,
-					route: n.route,
-					projectId: n.projectId,
-					createdAt: n.createdAt,
-					harness,
-					runCommand,
-					runName,
-					projectName,
-				},
-			};
-		});
-
 		if (dateRange !== "all") {
 			const now = Date.now();
 			const ranges: Record<string, number> = {
@@ -1800,22 +1874,16 @@ export async function handleV2FeedRequest(req: Request): Promise<Response> {
 				runItems = runItems.filter(
 					(item) => now - new Date(item.timestamp).getTime() <= range,
 				);
-				notifItems = notifItems.filter(
-					(item) => now - new Date(item.timestamp).getTime() <= range,
-				);
 			}
 		}
 
-		type FeedItem = (typeof runItems)[number] | (typeof notifItems)[number];
-
-		const allItems: FeedItem[] = [...runItems, ...notifItems];
-		allItems.sort(
+		runItems.sort(
 			(a, b) =>
 				new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime(),
 		);
 
-		const total = allItems.length;
-		const paged = allItems.slice(offset, offset + limit);
+		const total = runItems.length;
+		const paged = runItems.slice(offset, offset + limit);
 
 		return jsonResponse({ items: paged, total });
 	} catch (error) {

--- a/docs/arcade/dashboard.md
+++ b/docs/arcade/dashboard.md
@@ -2,6 +2,8 @@
 
 The dashboard provides a glanceable status view for monitoring AI agent runs
 across all your projects. Access it at `/` when Arcade is running.
+Persistent notifications now live in a dedicated shell drawer instead of being
+mixed into the main activity page.
 
 **Time to orient**: Under 30 seconds to understand what needs attention.
 
@@ -64,9 +66,12 @@ If your dashboard shows no runs, ensure that:
 
 ---
 
-## Home Dashboard (Now View)
+## Activity Dashboard (`/`)
 
-The home dashboard (`/`) shows what needs your attention across all projects. Runs are grouped into four sections displayed in priority order:
+The activity dashboard (`/`) shows what needs your attention across all
+projects. It keeps the main page focused on run state, while approvals,
+failures, and other persistent notification records live in the notifications
+drawer. Runs are grouped into four sections displayed in priority order:
 
 | Section | Description | Default State |
 |---------|-------------|---------------|
@@ -190,27 +195,35 @@ Task-batch events show a summary like "12 tasks completed in Build step" rather 
 
 ## Navigation
 
-### Sidebar
+Arcade keeps run navigation and persistent notifications separate so you can
+stay on the current page while checking what needs attention.
 
-The left sidebar provides navigation between views:
+### Desktop shell
 
-| Item | Route | Description |
-|------|-------|-------------|
-| Home | `/` | Attention dashboard |
-| Runs | `/runs` | All runs list |
-| Projects | `/projects` | Project list |
+| Surface | Behavior |
+|---------|----------|
+| Left icon rail | Navigate between Activity (`/`) and Projects (`/projects`) |
+| Breadcrumb bar | Shows the current page, project, or run context |
+| Top-right bell trigger | Opens or closes the notifications drawer without navigating away |
 
-The sidebar can collapse to icon-only mode for more content space.
+### Narrow layouts
 
-### Header
+| Surface | Behavior |
+|---------|----------|
+| Bottom activity button | Opens the activity dashboard |
+| Bottom projects button | Opens the projects view |
+| Bottom bell trigger | Opens or closes the notifications drawer |
+| Bottom command button | Opens the command palette |
 
-The header displays:
+### Notifications drawer behavior
 
-- Logo and branding
-- Project switcher dropdown
-- WebSocket connection status indicator
-- Theme toggle (dark/light)
-- Help button (links to documentation)
+- Opens as a right-side drawer over the current page.
+- Groups active notifications into **Action required**, **Attention**, and
+  **Informational**.
+- Opens linked runs or projects, then closes the drawer when a notification has
+  a destination.
+- Lets you dismiss persistent notifications directly from the drawer.
+- Closes with `Escape`, `Cmd/Ctrl+B`, or `Cmd/Ctrl+\`.
 
 ---
 
@@ -222,18 +235,19 @@ The dashboard supports a comprehensive keyboard-first interaction model. See [Ke
 
 | Shortcut | Action |
 |----------|--------|
-| `Cmd/Ctrl + K` | Open command palette |
+| `Cmd/Ctrl + K` | Open or close command palette |
+| `Cmd/Ctrl + B` | Open or close the notifications drawer |
+| `Cmd/Ctrl + \` | Open or close the notifications drawer (alternate) |
 | `?` | Toggle shortcut help overlay |
 | `/` | Focus search input |
-| `Escape` | Dismiss overlay or blur focus |
-| `Cmd/Ctrl + \` | Toggle sidebar collapse |
+| `Escape` | Close the active overlay, or blur the focused element if no overlay is open |
 
 ### Go-To Chords
 
 | Chord | Destination |
 |-------|-------------|
-| `g` then `h` | Home |
-| `g` then `r` | Runs |
+| `g` then `h` | Activity dashboard |
+| `g` then `r` | Activity dashboard (alternate alias) |
 | `g` then `p` | Projects |
 
 ### List Navigation
@@ -248,12 +262,6 @@ The dashboard supports a comprehensive keyboard-first interaction model. See [Ke
 | `Escape` | Clear selection |
 
 Keyboard navigation uses the roving tabindex pattern for accessibility.
-
-### Run Detail
-
-| Key | Action |
-|-----|--------|
-| `Escape` | Return to runs list |
 
 ---
 

--- a/docs/arcade/index.md
+++ b/docs/arcade/index.md
@@ -1,7 +1,8 @@
 # Arcade
 
-Arcade is rp1's browser UI for monitoring runs, opening artifacts, and working
-through feedback without losing the surrounding workflow context.
+Arcade is rp1's browser UI for monitoring runs, checking notifications,
+opening artifacts, and working through feedback without losing the surrounding
+workflow context.
 
 ![Arcade annotations view showing comments attached to an artifact with surrounding workflow context](../assets/screens/arcade/annotations.png)
 
@@ -21,9 +22,10 @@ your browser.
 
 ## Main Surfaces
 
-### Home dashboard
+### Activity dashboard
 
-The home dashboard shows what needs attention across your projects.
+The activity dashboard keeps run monitoring separate from persistent
+notifications so the main page stays easy to scan.
 
 Typical sections:
 
@@ -31,6 +33,21 @@ Typical sections:
 - **Needs review** - completed work that needs a decision
 - **Failed** - workflows that need intervention
 - **Running** - active workflows still progressing
+
+Persistent notifications no longer appear as standalone items on this page.
+Open the notifications drawer from the shell when you need approvals, failures,
+or other notification records.
+
+### Notifications drawer
+
+The notifications drawer gives you a dedicated inbox without forcing a page
+change.
+
+- On desktop, open it from the bell trigger in the top-right breadcrumb bar.
+- On narrow layouts, use the matching bell action in the bottom navigation.
+- The drawer stays on top of the current page, groups items by urgency, lets
+  you follow linked runs or projects, and lets you dismiss notifications in
+  place.
 
 ### Runs list
 

--- a/docs/arcade/keyboard-shortcuts.md
+++ b/docs/arcade/keyboard-shortcuts.md
@@ -1,7 +1,9 @@
 # Keyboard Shortcuts
 
-Arcade supports keyboard navigation for efficient workflow management.
-Vim-style keys operate in parallel with arrow keys, requiring no mode toggle.
+Arcade supports keyboard navigation for efficient workflow management,
+including shell-level shortcuts for opening and closing the notifications
+drawer. Vim-style keys operate in parallel with arrow keys, requiring no mode
+toggle.
 
 For an overview of Arcade surfaces, see [Arcade](index.md).
 
@@ -28,12 +30,29 @@ The palette includes navigation items (Home, Runs, Projects) and actions (Toggle
 | Shortcut | Action |
 |----------|--------|
 | Cmd+K / Ctrl+K | Open command palette |
+| Cmd+B / Ctrl+B | Open or close the notifications drawer |
+| Cmd+\\ / Ctrl+\\ | Open or close the notifications drawer (alternate) |
 | ? | Toggle shortcut help overlay |
 | / | Focus search input on current view |
 | Escape | Dismiss topmost overlay or blur focus |
-| Cmd+\\ / Ctrl+\\ | Toggle sidebar collapse |
 
-Modifier-key shortcuts (Cmd+K, Cmd+\\) fire regardless of whether a text input is focused. Single-key shortcuts (?, /, g) are suppressed when a text input is focused.
+Modifier-key shortcuts (Cmd+K, Cmd+B, Cmd+\\) fire regardless of whether a
+text input is focused. Single-key shortcuts (?, /, g) are suppressed when a
+text input is focused.
+
+---
+
+## Notifications Drawer
+
+Press **Cmd+B** (macOS) or **Ctrl+B** (other platforms) to open the
+notifications drawer from the current page. **Cmd+\\** / **Ctrl+\\** provides
+the same behavior as an alternate shortcut.
+
+- The drawer opens on top of the current page instead of navigating away.
+- The same shortcut closes the drawer if it is already open.
+- **Escape** also closes the drawer.
+- On desktop, the drawer matches the bell trigger in the top-right breadcrumb
+  bar. On narrow layouts, it matches the bell action in the bottom navigation.
 
 ---
 
@@ -43,11 +62,12 @@ Press **g** followed by a second key within 500ms to jump to a section.
 
 | Chord | Destination |
 |-------|-------------|
-| g then h | Home (/) |
-| g then r | Runs (/runs) |
+| g then h | Activity (/) |
+| g then r | Activity (alternate alias) |
 | g then p | Projects (/projects) |
 
-Chords always navigate to the index route. Waiting longer than 500ms cancels the chord.
+Each chord jumps directly to its mapped section. Waiting longer than 500ms
+cancels the chord.
 
 ---
 
@@ -106,7 +126,8 @@ Vim keys and single-key shortcuts are automatically disabled when focus is in a 
 - Textareas
 - Contenteditable elements
 
-Arrow keys continue to work normally in text fields. Modifier-key shortcuts (Cmd+K, Cmd+\\) always fire regardless of focus.
+Arrow keys continue to work normally in text fields. Modifier-key shortcuts
+(Cmd+K, Cmd+B, Cmd+\\) always fire regardless of focus.
 
 ### Virtualized Lists
 
@@ -120,20 +141,23 @@ Keyboard navigation automatically scrolls virtualized lists to keep the selected
 
 ## Context-Specific Shortcuts
 
-### Run Detail View
-
-| Key | Action |
-|-----|--------|
-| Escape | Return to runs list |
-| `h` or Arrow Left | Return to runs list |
-
 ### Artifact Viewer
 
 | Shortcut | Action |
 |----------|--------|
-| Cmd+\\ / Ctrl+\\ | Toggle navigation sidebar |
-| Cmd+Enter / Ctrl+Enter | Submit annotation (when input focused) |
-| Escape | Close popover |
+| `e` | Toggle table of contents |
+| `c` | Copy artifact content |
+| `[` | Previous artifact |
+| `]` | Next artifact |
+| `h` or Arrow Left | Return to run detail |
+
+### File Browser
+
+| Shortcut | Action |
+|----------|--------|
+| `e` | Toggle table of contents |
+| `c` | Copy file content |
+| `h` or Arrow Left | Return to project view |
 
 ---
 


### PR DESCRIPTION
## Summary
- move notifications out of the activity feed into a dedicated shell sidebar with desktop and mobile entry points
- add notification trigger, sidebar, hook, drawer geometry fixes, pagination handling, and regression coverage across the web UI
- update Arcade docs for the new notifications surface and add agent-guide instructions to keep commits in Conventional Commit format

## Verification
- `cd cli/web-ui && bun test`
- `just check-web-ui`
- `git push -u origin ui-fixes` pre-push hooks
- Playwright browser validation for desktop and narrow-layout drawer behavior