### PR TITLE
feat: add Discord button to docs site

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -13,6 +13,7 @@ Skip the iteration loops. Keep work attached to projects, artifacts, and feedbac
 
 [:fontawesome-solid-terminal: Get Started](getting-started/installation.md){ .md-button .md-button--primary }
 [:fontawesome-brands-github: View on GitHub](https://github.com/rp1-run/rp1){ .md-button .md-button--github }
+[:fontawesome-brands-discord: Join Discord](https://discord.gg/XUqc4zcX26){ .md-button .md-button--discord }
 
 <div class="carousel-container">
   <div class="splide" id="hero-carousel" aria-label="Product Screenshots">

--- a/docs/overrides/partials/source.html
+++ b/docs/overrides/partials/source.html
@@ -1,0 +1,17 @@
+<a href="https://discord.gg/XUqc4zcX26" title="Join our Discord" class="md-source md-source--discord" target="_blank" rel="noopener">
+  <div class="md-source__icon md-icon">
+    {% include ".icons/fontawesome/brands/discord.svg" %}
+  </div>
+  <div class="md-source__repository">
+    <span class="md-source__repository__label">Discord</span>
+  </div>
+</a>
+<a href="{{ config.repo_url }}" title="{{ lang.t('source') }}" class="md-source" data-md-component="source">
+  <div class="md-source__icon md-icon">
+    {% set icon = config.theme.icon.repo or "fontawesome/brands/git-alt" %}
+    {% include ".icons/" ~ icon ~ ".svg" %}
+  </div>
+  <div class="md-source__repository">
+    {{ config.repo_name }}
+  </div>
+</a>

--- a/docs/overrides/partials/source.html
+++ b/docs/overrides/partials/source.html
@@ -2,9 +2,6 @@
   <div class="md-source__icon md-icon">
     {% include ".icons/fontawesome/brands/discord.svg" %}
   </div>
-  <div class="md-source__repository">
-    <span class="md-source__repository__label">Discord</span>
-  </div>
 </a>
 <a href="{{ config.repo_url }}" title="{{ lang.t('source') }}" class="md-source" data-md-component="source">
   <div class="md-source__icon md-icon">

--- a/docs/overrides/partials/source.html
+++ b/docs/overrides/partials/source.html
@@ -1,7 +1,5 @@
-<a href="https://discord.gg/XUqc4zcX26" title="Join our Discord" class="md-source md-source--discord" target="_blank" rel="noopener">
-  <div class="md-source__icon md-icon">
-    {% include ".icons/fontawesome/brands/discord.svg" %}
-  </div>
+<a href="https://discord.gg/XUqc4zcX26" title="Join our Discord" class="rp1-discord-badge" target="_blank" rel="noopener">
+  <img src="https://img.shields.io/badge/Discord-Join-5865F2?logo=discord&logoColor=white&style=flat" alt="Discord" loading="lazy" />
 </a>
 <a href="{{ config.repo_url }}" title="{{ lang.t('source') }}" class="md-source" data-md-component="source">
   <div class="md-source__icon md-icon">

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -330,17 +330,16 @@
 }
 
 .md-source--discord {
-  font-size: 0.65rem;
+  min-width: 0;
+  width: 2.4rem;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
-.md-source--discord .md-source__repository__label {
-  display: inline;
-}
-
-@media (max-width: 768px) {
-  .md-source--discord .md-source__repository__label {
-    display: none;
-  }
+.md-source--discord .md-source__icon {
+  margin: 0;
 }
 
 /* Discord CTA button */

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -322,6 +322,52 @@
   margin: 0 0.45rem;
 }
 
+/* Discord header link */
+.md-header__source {
+  display: flex;
+  gap: 0.4rem;
+  align-items: center;
+}
+
+.md-source--discord {
+  font-size: 0.65rem;
+}
+
+.md-source--discord .md-source__repository__label {
+  display: inline;
+}
+
+@media (max-width: 768px) {
+  .md-source--discord .md-source__repository__label {
+    display: none;
+  }
+}
+
+/* Discord CTA button */
+.md-typeset .md-button--discord {
+  border-color: #5865F2;
+  color: #5865F2;
+  background-color: transparent;
+}
+
+.md-typeset .md-button--discord:hover {
+  border-color: #5865F2;
+  background-color: #5865F2;
+  color: #ffffff;
+}
+
+[data-md-color-scheme="slate"] .md-typeset .md-button--discord {
+  border-color: #7289DA;
+  color: #7289DA;
+  background-color: transparent;
+}
+
+[data-md-color-scheme="slate"] .md-typeset .md-button--discord:hover {
+  border-color: #7289DA;
+  background-color: #7289DA;
+  color: #ffffff;
+}
+
 /* Mermaid diagram centering */
 .md-typeset .mermaid {
   text-align: center;

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -329,17 +329,14 @@
   align-items: center;
 }
 
-.md-source--discord {
-  min-width: 0;
-  width: 2.4rem;
-  padding: 0;
+.rp1-discord-badge {
   display: flex;
   align-items: center;
-  justify-content: center;
 }
 
-.md-source--discord .md-source__icon {
-  margin: 0;
+.rp1-discord-badge img {
+  height: 20px;
+  border-radius: 3px;
 }
 
 /* Discord CTA button */

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -150,6 +150,8 @@ extra:
   social:
     - icon: fontawesome/brands/github
       link: https://github.com/rp1-run/rp1
+    - icon: fontawesome/brands/discord
+      link: https://discord.gg/XUqc4zcX26
   generator: false
 
 extra_css:


### PR DESCRIPTION
## Summary
- Add Discord link to docs site header as a shields.io badge ("Discord | Join") next to the GitHub source badge
- Add Discord CTA button on the home page alongside Get Started and GitHub buttons
- Add Discord to footer social links in mkdocs.yml
- Responsive: badge scales naturally, home page CTA button wraps on mobile

## Test plan
- [x] Verify Discord badge renders in header next to GitHub source
- [x] Click badge → opens `https://discord.gg/XUqc4zcX26` in new tab
- [x] Verify home page Discord CTA button renders with correct styling in light and dark modes
- [x] Check footer shows Discord social link
- [ ] Test mobile viewport — header badge and CTA button remain usable