### PR TITLE
fix(cli): prevent eval runs from polluting Arcade UI

### DIFF
--- a/cli/src/agent-tools/emit/index.ts
+++ b/cli/src/agent-tools/emit/index.ts
@@ -373,8 +373,19 @@ const notifyDaemonNotification = async (
  */
 export const executeEmit = (
 	input: EmitInput,
-): TE.TaskEither<CLIError, ToolResult<EmitResult>> =>
-	pipe(
+): TE.TaskEither<CLIError, ToolResult<EmitResult>> => {
+	if (process.env.RP1_EVAL_MODE === "true") {
+		return TE.right(
+			successResult(TOOL_NAME, {
+				eventId: 0,
+				runId: input.runId,
+				type: input.type,
+				runStatus: "running" as const,
+			}),
+		);
+	}
+
+	return pipe(
 		getEmitDatabase(),
 		TE.chain((db) => {
 			const directories = resolveDirectorySet(input.projectPath);
@@ -506,6 +517,7 @@ export const executeEmit = (
 			);
 		}),
 	);
+};
 
 /**
  * Main execute function for tool registration.

--- a/cli/web-ui/src/daemon/manager.ts
+++ b/cli/web-ui/src/daemon/manager.ts
@@ -246,11 +246,12 @@ function getRp1Executable(): string {
 async function spawnDaemon(port: number): Promise<number> {
 	const rp1Path = getRp1Executable();
 
+	const { RP1_DB: _db, RP1_EVAL_MODE: _eval, ...cleanEnv } = process.env;
 	const proc = spawn(rp1Path, ["_daemon-server", "--port", String(port)], {
 		detached: true,
 		stdio: "ignore",
 		env: {
-			...process.env,
+			...cleanEnv,
 			RP1_DAEMON_MODE: "true",
 		},
 	});

--- a/cli/web-ui/src/server/routes/v2-api.ts
+++ b/cli/web-ui/src/server/routes/v2-api.ts
@@ -997,6 +997,7 @@ export async function handleV2RunsAttentionRequest(): Promise<Response> {
 		const toRuns = (records: readonly RunRecordWithLastEvent[]): Run[] => {
 			const runs: Run[] = [];
 			for (const record of records) {
+				if (isEvalRunRecord(record)) continue;
 				const project =
 					findProjectByIdentity(projectLookup, record) ??
 					fallbackProjectFromRun(record);


### PR DESCRIPTION
## Summary

- Short-circuit `executeEmit` when `RP1_EVAL_MODE=true` — returns synthetic success before any DB access, making emit a complete no-op during evals
- Add `isEvalRunRecord()` filter to the attention endpoint (`/api/v2/runs/attention`), which was the only endpoint missing it
- Strip `RP1_DB` and `RP1_EVAL_MODE` from daemon spawn env so a daemon restart during evals doesn't redirect it to the eval database

## Test plan

- [x] `just check-cli` — lint, typecheck, format all pass
- [x] `bun test cli/web-ui/src/__tests__/server/` — 157 tests pass
- [x] `bun test cli/src/__tests__/daemon/` — 9 tests pass
- [ ] Run `just eval-run rp1-dev/build-fast` and verify Arcade UI is unaffected
- [ ] Verify `rp1 arcade open` still works after eval run completes