### PR TITLE
fix(web-ui): preserve Milkdown cursor across refreshes

### DIFF
--- a/cli/web-ui/src/components/MilkdownEditor/MilkdownEditor.tsx
+++ b/cli/web-ui/src/components/MilkdownEditor/MilkdownEditor.tsx
@@ -1,9 +1,22 @@
-import { defaultValueCtx, Editor, rootCtx } from "@milkdown/kit/core";
+import { parserCtx } from "@milkdown/core";
+import {
+	defaultValueCtx,
+	Editor,
+	editorViewCtx,
+	rootCtx,
+} from "@milkdown/kit/core";
 import { history } from "@milkdown/kit/plugin/history";
 import { listener, listenerCtx } from "@milkdown/kit/plugin/listener";
 import { commonmark } from "@milkdown/kit/preset/commonmark";
 import { gfm } from "@milkdown/kit/preset/gfm";
+import { type Node as ProseNode, Slice } from "@milkdown/kit/prose/model";
+import {
+	type Selection as ProseSelection,
+	Selection,
+	TextSelection,
+} from "@milkdown/kit/prose/state";
 import type { EditorView } from "@milkdown/kit/prose/view";
+import { getMarkdown } from "@milkdown/kit/utils";
 import { highlight, highlightPluginConfig } from "@milkdown/plugin-highlight";
 import { createParser } from "@milkdown/plugin-highlight/shiki";
 import { Milkdown, MilkdownProvider, useEditor } from "@milkdown/react";
@@ -33,6 +46,42 @@ export interface MilkdownEditorProps {
 	readonly onContentChange?: (markdown: string) => void;
 }
 
+function clampSelectionPosition(doc: ProseNode, position: number): number {
+	return Math.max(0, Math.min(position, doc.content.size));
+}
+
+function createPreservedSelection(
+	doc: ProseNode,
+	selection: ProseSelection,
+): ProseSelection {
+	const anchor = clampSelectionPosition(doc, selection.anchor);
+	const head = clampSelectionPosition(doc, selection.head);
+
+	if (selection.empty) {
+		const bias = head === 0 ? 1 : -1;
+		return Selection.near(doc.resolve(head), bias);
+	}
+
+	return TextSelection.between(doc.resolve(anchor), doc.resolve(head));
+}
+
+function replaceContentWithPreservedSelection(
+	view: EditorView,
+	content: ProseNode,
+	selection: ProseSelection,
+): void {
+	const transaction = view.state.tr.replace(
+		0,
+		view.state.doc.content.size,
+		new Slice(content.content, 0, 0),
+	);
+	const preservedSelection = createPreservedSelection(
+		transaction.doc,
+		selection,
+	);
+	view.dispatch(transaction.setSelection(preservedSelection));
+}
+
 function MilkdownEditorInner({
 	content,
 	onContentChange,
@@ -41,6 +90,9 @@ function MilkdownEditorInner({
 	editorRef: React.Ref<MilkdownEditorHandle>;
 }) {
 	const viewRef = useRef<EditorView | undefined>(undefined);
+	const latestMarkdownRef = useRef(content);
+	const isApplyingExternalUpdateRef = useRef(false);
+	const onContentChangeRef = useRef(onContentChange);
 
 	const [highlightConfig, setHighlightConfig] = useState<{
 		parser: ReturnType<typeof createParser>;
@@ -67,22 +119,35 @@ function MilkdownEditorInner({
 		};
 	}, []);
 
+	useEffect(() => {
+		onContentChangeRef.current = onContentChange;
+	}, [onContentChange]);
+
 	const onChange = useCallback(
 		(_ctx: unknown, markdown: string, prevMarkdown: string) => {
-			if (markdown !== prevMarkdown) {
-				onContentChange?.(markdown);
-			}
+			if (markdown === prevMarkdown) return;
+			latestMarkdownRef.current = markdown;
+			if (isApplyingExternalUpdateRef.current) return;
+			onContentChangeRef.current?.(markdown);
 		},
-		[onContentChange],
+		[],
 	);
 
-	useEditor(
+	const { get: getEditor, loading } = useEditor(
 		(root) => {
 			const editor = Editor.make()
 				.config((ctx) => {
 					ctx.set(rootCtx, root);
 					ctx.set(defaultValueCtx, content);
-					ctx.get(listenerCtx).markdownUpdated(onChange);
+					ctx
+						.get(listenerCtx)
+						.markdownUpdated(onChange)
+						.mounted((listenerContext) => {
+							viewRef.current = listenerContext.get(editorViewCtx);
+						})
+						.destroy(() => {
+							viewRef.current = undefined;
+						});
 					if (highlightConfig) {
 						ctx.set(highlightPluginConfig.key, highlightConfig);
 					}
@@ -103,6 +168,52 @@ function MilkdownEditorInner({
 		},
 		[highlightConfig],
 	);
+
+	useEffect(() => {
+		if (loading) return;
+		const editor = getEditor();
+		if (!editor) return;
+		if (content === latestMarkdownRef.current) return;
+
+		const currentMarkdown = editor.action(getMarkdown());
+		if (currentMarkdown === content) {
+			latestMarkdownRef.current = content;
+			return;
+		}
+
+		const view = viewRef.current;
+		if (!view) return;
+
+		isApplyingExternalUpdateRef.current = true;
+		try {
+			const previousSelection = view.state.selection;
+			const hadFocus = view.hasFocus();
+			editor.action((ctx) => {
+				const viewFromContext = ctx.get(editorViewCtx);
+				const parser = ctx.get(parserCtx);
+				const nextDocument = parser(content);
+				if (!nextDocument) return;
+
+				replaceContentWithPreservedSelection(
+					viewFromContext,
+					nextDocument,
+					previousSelection,
+				);
+
+				if (hadFocus) {
+					viewFromContext.focus();
+					queueMicrotask(() => {
+						if (!viewFromContext.hasFocus()) {
+							viewFromContext.focus();
+						}
+					});
+				}
+			});
+			latestMarkdownRef.current = content;
+		} finally {
+			isApplyingExternalUpdateRef.current = false;
+		}
+	}, [content, getEditor, loading]);
 
 	useImperativeHandle(
 		editorRef,

--- a/cli/web-ui/src/components/MilkdownEditor/MilkdownEditor.tsx
+++ b/cli/web-ui/src/components/MilkdownEditor/MilkdownEditor.tsx
@@ -70,11 +70,9 @@ function replaceContentWithPreservedSelection(
 	content: ProseNode,
 	selection: ProseSelection,
 ): void {
-	const transaction = view.state.tr.replace(
-		0,
-		view.state.doc.content.size,
-		new Slice(content.content, 0, 0),
-	);
+	const transaction = view.state.tr
+		.replace(0, view.state.doc.content.size, new Slice(content.content, 0, 0))
+		.setMeta("addToHistory", false);
 	const preservedSelection = createPreservedSelection(
 		transaction.doc,
 		selection,
@@ -92,6 +90,7 @@ function MilkdownEditorInner({
 	const viewRef = useRef<EditorView | undefined>(undefined);
 	const latestMarkdownRef = useRef(content);
 	const isApplyingExternalUpdateRef = useRef(false);
+	const externalUpdateFrameRef = useRef<number | null>(null);
 	const onContentChangeRef = useRef(onContentChange);
 
 	const [highlightConfig, setHighlightConfig] = useState<{
@@ -122,6 +121,14 @@ function MilkdownEditorInner({
 	useEffect(() => {
 		onContentChangeRef.current = onContentChange;
 	}, [onContentChange]);
+
+	useEffect(() => {
+		return () => {
+			if (externalUpdateFrameRef.current !== null) {
+				cancelAnimationFrame(externalUpdateFrameRef.current);
+			}
+		};
+	}, []);
 
 	const onChange = useCallback(
 		(_ctx: unknown, markdown: string, prevMarkdown: string) => {
@@ -184,6 +191,11 @@ function MilkdownEditorInner({
 		const view = viewRef.current;
 		if (!view) return;
 
+		if (externalUpdateFrameRef.current !== null) {
+			cancelAnimationFrame(externalUpdateFrameRef.current);
+			externalUpdateFrameRef.current = null;
+		}
+
 		isApplyingExternalUpdateRef.current = true;
 		try {
 			const previousSelection = view.state.selection;
@@ -211,7 +223,10 @@ function MilkdownEditorInner({
 			});
 			latestMarkdownRef.current = content;
 		} finally {
-			isApplyingExternalUpdateRef.current = false;
+			externalUpdateFrameRef.current = requestAnimationFrame(() => {
+				externalUpdateFrameRef.current = null;
+				isApplyingExternalUpdateRef.current = false;
+			});
 		}
 	}, [content, getEditor, loading]);
 

--- a/cli/web-ui/src/components/v2/ArtifactViewerPanel.tsx
+++ b/cli/web-ui/src/components/v2/ArtifactViewerPanel.tsx
@@ -38,12 +38,7 @@ function ArtifactViewerInner({
 	runId,
 	subflowDiagram,
 }: ArtifactViewerPanelProps) {
-	const [content, setContentRaw] = useState<string | null>(null);
-	const [contentRevision, setContentRevision] = useState(0);
-	const setContent = useCallback((c: string | null) => {
-		setContentRaw(c);
-		setContentRevision((r) => r + 1);
-	}, []);
+	const [content, setContent] = useState<string | null>(null);
 	const [contentLoading, setContentLoading] = useState(false);
 	const [contentError, setContentError] = useState<string | null>(null);
 	const [headings, setHeadings] = useState<readonly HeadingEntry[]>([]);
@@ -101,7 +96,9 @@ function ArtifactViewerInner({
 					throw new Error(errorMessage);
 				}
 				const data = (await response.json()) as { content: string };
-				setContent(data.content);
+				setContent((current) =>
+					current === data.content ? current : data.content,
+				);
 			} catch (err) {
 				setContentError(err instanceof Error ? err.message : String(err));
 				setContent(null);
@@ -111,7 +108,7 @@ function ArtifactViewerInner({
 				}
 			}
 		},
-		[artifactPath, runId, setContent],
+		[artifactPath, runId],
 	);
 
 	useEffect(() => {
@@ -286,7 +283,6 @@ function ArtifactViewerInner({
 						viewportRef={scrollViewportRef}
 					>
 						<ContentPanel
-							key={contentRevision}
 							content={content}
 							path={selectedArtifact?.path ?? null}
 							isLoading={contentLoading}

--- a/cli/web-ui/src/components/v2/UnifiedContentRenderer.tsx
+++ b/cli/web-ui/src/components/v2/UnifiedContentRenderer.tsx
@@ -20,6 +20,7 @@ type SaveStatus = "idle" | "saving" | "saved" | "error";
 
 const SAVE_DEBOUNCE_MS = 1000;
 const SAVE_INDICATOR_DURATION_MS = 2000;
+const LOCAL_SAVE_ECHO_TTL_MS = 10000;
 
 interface UnifiedContentRendererProps {
 	readonly content: string;
@@ -114,6 +115,7 @@ function MarkdownEditorWithSave({
 	readonly onSaveStatusChange?: (status: SaveStatus) => void;
 }) {
 	const [_saveStatus, setSaveStatusRaw] = useState<SaveStatus>("idle");
+	const [resolvedContent, setResolvedContent] = useState(content);
 	const setSaveStatus = useCallback(
 		(status: SaveStatus) => {
 			setSaveStatusRaw(status);
@@ -123,10 +125,63 @@ function MarkdownEditorWithSave({
 	);
 	const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 	const indicatorTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+	const latestEditorContentRef = useRef(content);
+	const pendingLocalSavesRef = useRef<Map<string, number>>(new Map());
+	const contentIdentity = [
+		runId ?? "",
+		projectId ?? "",
+		filePath ?? "",
+		path,
+		docId ?? "",
+	].join("::");
+
+	useEffect(() => {
+		void contentIdentity;
+		if (saveTimerRef.current) {
+			clearTimeout(saveTimerRef.current);
+			saveTimerRef.current = null;
+		}
+		if (indicatorTimerRef.current) {
+			clearTimeout(indicatorTimerRef.current);
+			indicatorTimerRef.current = null;
+		}
+		setSaveStatus("idle");
+		latestEditorContentRef.current = content;
+		pendingLocalSavesRef.current.clear();
+		setResolvedContent(content);
+	}, [content, contentIdentity, setSaveStatus]);
+
+	useEffect(() => {
+		setResolvedContent((currentResolvedContent) => {
+			if (content === currentResolvedContent) {
+				pendingLocalSavesRef.current.delete(content);
+				return currentResolvedContent;
+			}
+
+			const cutoff = Date.now() - LOCAL_SAVE_ECHO_TTL_MS;
+			for (const [pendingContent, startedAt] of pendingLocalSavesRef.current) {
+				if (startedAt < cutoff) {
+					pendingLocalSavesRef.current.delete(pendingContent);
+				}
+			}
+
+			if (pendingLocalSavesRef.current.has(content)) {
+				pendingLocalSavesRef.current.delete(content);
+				return currentResolvedContent;
+			}
+
+			if (content === latestEditorContentRef.current) {
+				return content;
+			}
+
+			latestEditorContentRef.current = content;
+			return content;
+		});
+	}, [content]);
 
 	const { body: editorContent, frontmatter } = useMemo(
-		() => stripFrontmatter(content),
-		[content],
+		() => stripFrontmatter(resolvedContent),
+		[resolvedContent],
 	);
 	const editorContainerRef = useRef<HTMLElement>(null);
 	const gutterRef = useRef<HTMLDivElement>(null);
@@ -138,14 +193,20 @@ function MarkdownEditorWithSave({
 		(markdown: string) => {
 			if (!canSave) return;
 
+			const fullContent = restoreFrontmatter(frontmatter, markdown);
+			latestEditorContentRef.current = fullContent;
+
 			if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
 			if (indicatorTimerRef.current) clearTimeout(indicatorTimerRef.current);
 
 			saveTimerRef.current = setTimeout(async () => {
+				pendingLocalSavesRef.current.set(fullContent, Date.now());
+				setResolvedContent((current) =>
+					current === fullContent ? current : fullContent,
+				);
 				setSaveStatus("saving");
 				try {
 					let response: Response;
-					const fullContent = restoreFrontmatter(frontmatter, markdown);
 
 					if (runId) {
 						response = await fetch(`/api/v2/runs/${runId}/artifacts/save`, {
@@ -165,11 +226,13 @@ function MarkdownEditorWithSave({
 					}
 
 					if (!response.ok) {
+						pendingLocalSavesRef.current.delete(fullContent);
 						setSaveStatus("error");
 					} else {
 						setSaveStatus("saved");
 					}
 				} catch {
+					pendingLocalSavesRef.current.delete(fullContent);
 					setSaveStatus("error");
 				}
 

--- a/cli/web-ui/src/components/v2/UnifiedContentRenderer.tsx
+++ b/cli/web-ui/src/components/v2/UnifiedContentRenderer.tsx
@@ -134,9 +134,14 @@ function MarkdownEditorWithSave({
 		path,
 		docId ?? "",
 	].join("::");
+	const previousContentIdentityRef = useRef(contentIdentity);
 
 	useEffect(() => {
-		void contentIdentity;
+		if (previousContentIdentityRef.current === contentIdentity) {
+			return;
+		}
+
+		previousContentIdentityRef.current = contentIdentity;
 		if (saveTimerRef.current) {
 			clearTimeout(saveTimerRef.current);
 			saveTimerRef.current = null;

--- a/cli/web-ui/src/pages/v2/ArtifactViewerPage.tsx
+++ b/cli/web-ui/src/pages/v2/ArtifactViewerPage.tsx
@@ -58,6 +58,19 @@ interface ArtifactContent {
 	docId?: string;
 }
 
+function isSameArtifactContent(
+	left: ArtifactContent | null,
+	right: ArtifactContent | null,
+): boolean {
+	if (left === right) return true;
+	if (!left || !right) return false;
+	return (
+		left.path === right.path &&
+		left.content === right.content &&
+		left.docId === right.docId
+	);
+}
+
 /**
  * Annotation toggle button component (must be inside AnnotationProvider).
  * Only shows when sidebar is closed - provides a way to open it.
@@ -326,11 +339,14 @@ export function ArtifactViewerPage() {
 					throw new Error(errorMessage);
 				}
 				const data = (await response.json()) as { content: string };
-				setArtifactContent({
-					path: selectedArtifactPath,
+				const nextContent = {
+					path: selectedArtifact.path,
 					content: data.content,
 					docId: selectedArtifact.docId,
-				});
+				};
+				setArtifactContent((current) =>
+					isSameArtifactContent(current, nextContent) ? current : nextContent,
+				);
 			} catch (err) {
 				setContentError(err instanceof Error ? err.message : String(err));
 				setArtifactContent(null);
@@ -368,14 +384,14 @@ export function ArtifactViewerPage() {
 	}, [artifactContent]);
 
 	useEffect(() => {
-		if (!selectedArtifactPath || !run) return;
+		if (!selectedArtifact) return;
 
-		const normalizedPath = selectedArtifactPath.replace(/^\.rp1\//, "");
+		const normalizedPath = selectedArtifact.path.replace(/^\.rp1\//, "");
 
 		const unsubscribe = onFileChange((msg) => {
 			if (
 				msg.changeType === "modify" &&
-				(msg.path === selectedArtifactPath || msg.path === normalizedPath)
+				(msg.path === selectedArtifact.path || msg.path === normalizedPath)
 			) {
 				fetchArtifactContentWithScrollPreservation(true);
 			}
@@ -383,8 +399,7 @@ export function ArtifactViewerPage() {
 
 		return unsubscribe;
 	}, [
-		selectedArtifactPath,
-		run,
+		selectedArtifact,
 		onFileChange,
 		fetchArtifactContentWithScrollPreservation,
 	]);

--- a/cli/web-ui/src/pages/v2/ArtifactViewerPage.tsx
+++ b/cli/web-ui/src/pages/v2/ArtifactViewerPage.tsx
@@ -296,10 +296,12 @@ export function ArtifactViewerPage() {
 	const fetchArtifactContentWithScrollPreservation = useCallback(
 		async (preserveScroll: boolean) => {
 			if (!run || !selectedArtifactPath) {
+				savedScrollState.current = null;
 				setArtifactContent(null);
 				return;
 			}
 			if (!selectedArtifact) {
+				savedScrollState.current = null;
 				setContentError("Artifact not found");
 				setArtifactContent(null);
 				return;
@@ -313,6 +315,7 @@ export function ArtifactViewerPage() {
 			}
 
 			if (!preserveScroll) {
+				savedScrollState.current = null;
 				setContentLoading(true);
 				// Clear headings when loading new artifact (they'll be repopulated by MarkdownViewer if applicable)
 				setHeadings([]);
@@ -344,10 +347,18 @@ export function ArtifactViewerPage() {
 					content: data.content,
 					docId: selectedArtifact.docId,
 				};
-				setArtifactContent((current) =>
-					isSameArtifactContent(current, nextContent) ? current : nextContent,
-				);
+				setArtifactContent((current) => {
+					if (isSameArtifactContent(current, nextContent)) {
+						if (preserveScroll) {
+							savedScrollState.current = null;
+						}
+						return current;
+					}
+
+					return nextContent;
+				});
 			} catch (err) {
+				savedScrollState.current = null;
 				setContentError(err instanceof Error ? err.message : String(err));
 				setArtifactContent(null);
 			} finally {

--- a/cli/web-ui/src/pages/v2/FileBrowserPage.tsx
+++ b/cli/web-ui/src/pages/v2/FileBrowserPage.tsx
@@ -37,6 +37,19 @@ import type { FileContent } from "../../server/routes/content-utils";
 
 const STORAGE_KEY_TOC_COLLAPSED = "rp1-file-browser-toc-collapsed";
 
+function isSameFileContent(
+	left: FileContent | null,
+	right: FileContent | null,
+): boolean {
+	if (left === right) return true;
+	if (!left || !right) return false;
+	return (
+		left.path === right.path &&
+		left.content === right.content &&
+		left.mimeType === right.mimeType
+	);
+}
+
 export function FileBrowserPage() {
 	const { projectId, "*": filePath } = useParams<{
 		projectId: string;
@@ -54,12 +67,7 @@ export function FileBrowserPage() {
 	} = useProjectFileTree(projectId);
 	const { setProjectId, onTreeChange, onFileChange } = useWebSocket();
 
-	const [content, setContentRaw] = useState<FileContent | null>(null);
-	const [contentRevision, setContentRevision] = useState(0);
-	const setContent = useCallback((c: FileContent | null) => {
-		setContentRaw(c);
-		if (c !== null) setContentRevision((r) => r + 1);
-	}, []);
+	const [content, setContent] = useState<FileContent | null>(null);
 	const [contentLoading, setContentLoading] = useState(false);
 	const [contentError, setContentError] = useState<string | null>(null);
 	const [isRefreshing, setIsRefreshing] = useState(false);
@@ -154,7 +162,9 @@ export function FileBrowserPage() {
 					throw new Error(`Failed to fetch content: ${response.statusText}`);
 				}
 				const data = (await response.json()) as FileContent;
-				setContent(data);
+				setContent((current) =>
+					isSameFileContent(current, data) ? current : data,
+				);
 			} catch (err) {
 				setContentError(err instanceof Error ? err.message : String(err));
 				setContent(null);
@@ -163,7 +173,7 @@ export function FileBrowserPage() {
 				setIsRefreshing(false);
 			}
 		},
-		[selectedPath, projectId, setContent],
+		[selectedPath, projectId],
 	);
 
 	useEffect(() => {
@@ -434,7 +444,6 @@ export function FileBrowserPage() {
 
 					<ScrollArea className="flex-1" viewportRef={scrollViewportRef}>
 						<ContentPanel
-							key={contentRevision}
 							content={content?.content ?? null}
 							path={selectedPath ?? null}
 							isLoading={contentLoading}
@@ -557,7 +566,6 @@ export function FileBrowserPage() {
 							viewportRef={scrollViewportRef}
 						>
 							<ContentPanel
-								key={contentRevision}
 								content={content?.content ?? null}
 								path={selectedPath ?? null}
 								isLoading={contentLoading}

--- a/cli/web-ui/src/pages/v2/FileBrowserPage.tsx
+++ b/cli/web-ui/src/pages/v2/FileBrowserPage.tsx
@@ -128,6 +128,7 @@ export function FileBrowserPage() {
 	const fetchContent = useCallback(
 		async (preserveScroll = false) => {
 			if (!selectedPath || !projectId) {
+				savedScrollState.current = null;
 				setContent(null);
 				setContentLoading(false);
 				setContentError(null);
@@ -142,6 +143,7 @@ export function FileBrowserPage() {
 			}
 
 			if (!preserveScroll) {
+				savedScrollState.current = null;
 				setContentLoading(true);
 				setHeadings([]);
 				setActiveHeadingId(null);
@@ -162,10 +164,18 @@ export function FileBrowserPage() {
 					throw new Error(`Failed to fetch content: ${response.statusText}`);
 				}
 				const data = (await response.json()) as FileContent;
-				setContent((current) =>
-					isSameFileContent(current, data) ? current : data,
-				);
+				setContent((current) => {
+					if (isSameFileContent(current, data)) {
+						if (preserveScroll) {
+							savedScrollState.current = null;
+						}
+						return current;
+					}
+
+					return data;
+				});
 			} catch (err) {
+				savedScrollState.current = null;
 				setContentError(err instanceof Error ? err.message : String(err));
 				setContent(null);
 			} finally {


### PR DESCRIPTION
## Summary
- keep the Milkdown editor mounted and reconcile external markdown updates in place while preserving focus and selection
- suppress self-save echo refreshes in the shared renderer so watcher-driven autosave roundtrips do not recreate editor state
- remove the `contentRevision` remount workaround from file and artifact viewers and skip no-op content updates on refresh

## Testing
- `just check-web-ui`
- `bun run build` in `cli/web-ui`
- manual Playwright CLI repro for autosave echo cursor preservation
- manual Playwright CLI repro for true external file edit while preserving editor focus/selection