### PR TITLE
feat(web-ui): add workspace tabs shell

### DIFF
--- a/.rp1/context/architecture.md
+++ b/.rp1/context/architecture.md
@@ -4,7 +4,20 @@
 **Architecture Pattern**: Plugin-based CLI with tracked workflow state, artifact-backed handoffs, and multi-platform prompt compilation
 **Last Updated**: 2026-04-12
 
-## High-Level Architecture
+## System Layers
+
+```text
+Interaction          CLI commands (cli/src/commands/)
+Workflow Definition  Plugin skills & agents (plugins/*)
+Runtime Services     Agent tools, emit, bootstrap (cli/src/agent-tools/)
+Build & Distribution Build pipeline, catalog (cli/src/build/, cli/src/catalog/)
+Presentation         Arcade SPA + HTTP/WS server (cli/web-ui/)
+Persistence          SQLite (~/.rp1/rp1.db), KB files (.rp1/context/), work artifacts (.rp1/work/)
+Evaluation           Dockerized eval execution (evals/)
+Quality Gates        Lefthook, Biome, catalog checks
+```
+
+## Architecture Diagram
 
 ```mermaid
 flowchart TB
@@ -16,118 +29,74 @@ flowchart TB
     AgentTools --> EventDB[("~/.rp1/rp1.db")]
     AgentTools --> Daemon["Arcade Daemon\nHTTP + WS"]
     Daemon --> Browser["Web Browser"]
+    Daemon --> Registry["Project Registry\nprojects.json + async mutex"]
+    Daemon --> Diagnostics["Diagnostics\ndaemon.log"]
     Skills --> KB["Knowledge Base\n.rp1/context/*.md"]
-    Skills --> DocFlows["Doc Workflows\nwrite-content + generate-user-docs"]
-    DocFlows --> Scribe["scribe scan/process batches"]
-    DocFlows --> Work[".rp1/work\nbrief.md + scan_results.json"]
-    Skills --> PromptWriter["prompt-writer"]
-    PromptWriter --> Refs["Companion refs\nPATTERNS / TEMPLATES / RP1-AUTHORING"]
-    Skills --> Guide["/guide meta-skill\nCATALOG.md + WORKFLOWS.md"]
+    Skills --> Work[".rp1/work/\nbrief.md + scan_results.json"]
     Build --> Pipeline["LiquidJS build pipeline"]
     Pipeline --> Artifacts["Platform artifacts + compiled binary"]
-    Catalog --> Guide
+    Catalog --> Guide["/guide meta-skill\nCATALOG.md + WORKFLOWS.md"]
 ```
 
 ## Architectural Patterns
 
-| Pattern | Meaning | Current Evidence |
-|---------|---------|------------------|
-| Plugin Architecture | The repo stays organized as plugin-scoped capability packs, with base owning end-user workflows, dev owning development lifecycle, and utils owning reusable authoring tooling. | `write-content` and `generate-user-docs` remain in `plugins/base`; prompt authoring assets remain in `plugins/utils`; `/guide` meta-skill introduced in base to expose distributable catalog. |
-| Event-Sourced Runtime State | Runtime progress is tracked as events, while larger phase payloads live in durable files outside the event stream. RunRecord now carries `runPolicy`, `workIdentity`, and `bootstrapContext` for deterministic run selection. | Frontier workflows still standardize on `rp1 agent-tools emit` with `status_change`, `waiting_for_user`, and `artifact_registered`. |
-| Cross-Platform Build Pipeline | Markdown workflow specs remain the source of truth and compile into host-specific artifacts through the shared build pipeline. Platform-hint routing now lets `resolve-args` and schema lookup prefer the active harness. | `cli/src/main.ts` exposes `buildCommand`; platform definitions provide hook-driven extensibility via `PlatformDefinition` with lifecycle hooks (`preparePlugin`, `enrichAgentContext`, `postSkillWrite`, `postPluginBuild`). |
-| State-Machine-Driven Workflows | Long-running skills are modeled as explicit state machines with named phases, user gates, and terminal status emission. | `write-content`, `generate-user-docs`, and `prompt-writer` each declare `stateDiagram-v2` phases and emit explicit step transitions. |
-| Map-Reduce Agent Orchestration | Heavy analysis and editing work fans out to narrow workers and rejoins through a parent orchestrator. | `generate-user-docs` batches docs in groups of five, dispatches background `scribe` workers, and aggregates JSON responses. |
-| Artifact-Backed Workflow Handoffs | Multi-phase workflows bridge context through durable files in `.rp1/work/` and then register those files for dashboard visibility. | `write-content` persists `brief.md`; `generate-user-docs` persists `scan_results.json`; prompt-authoring rules codify `artifact_registered` and `storageRoot`. |
-| Progressive-Disclosure Reference Packs | Some skills pair a thin executable prompt with local reference packs so deeper guidance is loaded only when needed. | `prompt-writer` loads `PATTERNS.md`, `TEMPLATES.md`, and `RP1-AUTHORING.md` on demand; `/guide` loads `CATALOG.md` and `WORKFLOWS.md`. |
-| Deterministic Workflow Bootstrap | `workflow-bootstrap` resolves canonical directories, arguments, and run identity in one atomic call before any workflow emits progress. Skills declare `runPolicy` (fresh/resumable) and `identityArgs` in frontmatter metadata to drive deterministic run creation or resumption. | `cli/src/agent-tools/workflow-bootstrap/` implements bootstrap; `WorkflowRunPolicy` type added to `events.ts` and `build/models.ts`; RunRecord schema extended with `run_policy`, `work_identity`, `bootstrap_context`. |
-| Catalog-as-Code with Registry-Backed Discovery | Catalog generation migrated from shell scripts to a TypeScript registry (`cli/src/catalog/`) that parses frontmatter, groups by category, and renders distributable discovery views. The `/guide` meta-skill consumes `CATALOG.md` generated from this registry. | `cli/src/catalog/registry.ts` and `cli/src/catalog/maintenance.ts` replace `scripts/generate-catalog.sh`; `catalog/skills.yaml` removed. |
-| Build-Time Asset Embedding | Platform artifacts and configuration assets remain embedded into the compiled binary for single-executable distribution. | No contradicting evidence appeared in the frontier. |
-| Git Worktree-Aware Project Resolution | Project resolution derives shared KB and work paths from repository identity rather than session-local env vars. Home-directory guard prevents accidental adoption of `~/.rp1` as a project root. `requireProjectId` option now fails with actionable error for legacy projects. | `directory-resolution.ts` added `DirectoryResolutionOptions` with `allowHomeProjectRoot` and `requireProjectId`; `resolve-args` now returns `ResolvedDirectories` alongside arguments. |
-| Prompt Attestation with Content-Addressable Hashing | Prompt quality validation and freshness enforcement remain part of the architecture. | No contradicting evidence appeared in the frontier. |
-| Session Hooks with Platform Adaptation | Host-specific hooks still sit at the session boundary to start supporting services and adapt behavior per platform. | `plugins/base/hooks/hooks.json` starts the Arcade daemon and runs update checks on `SessionStart`. |
-| fp-ts Functional Pipelines | The CLI functional core remains organized around fp-ts-style error and task pipelines. | No contradicting evidence appeared in the frontier. |
-| Versioned Stanza Markers | Instruction-file stanzas now carry version stamps (`<!-- rp1:start:vX.Y.Z -->`) so the migrate command can detect and upgrade stale injections. | `cli/src/init/comment-fence.ts` parses versioned markers; `rp1 migrate` can backfill run metadata and upgrade stanzas. |
-| Dockerized Eval Execution | Prompt evaluations run inside the `rp1-dev` Docker container via `docker/eval-run.sh`, isolating harness CLIs and eval dependencies from the host. Attestation results are committed on the host after the container exits. | `docker/eval-run.sh` new; `Justfile` `eval-run` delegates to Docker; CI attestation job builds platform artifacts then verifies inside the same container. |
+| Pattern | Description |
+|---------|-------------|
+| Plugin Architecture | Three plugin packs (base, dev, utils) with scoped capabilities and enforced dependency direction |
+| Event-Sourced Runtime State | Workflow progress tracked as events via `rp1 agent-tools emit` with status_change, waiting_for_user, artifact_registered, subflow_registered |
+| Cross-Platform Build Pipeline | Markdown specs compile into host-specific artifacts through shared LiquidJS pipeline. All 3 platform templates emit `arcade_tracked` field |
+| State-Machine-Driven Workflows | Skills declare `stateDiagram-v2` phases with explicit step transitions and validation |
+| Map-Reduce Agent Orchestration | Heavy analysis fans out to narrow workers and rejoins through parent orchestrator |
+| Artifact-Backed Workflow Handoffs | Multi-phase workflows bridge context through durable files in `.rp1/work/` |
+| Deterministic Workflow Bootstrap | `workflow-bootstrap` resolves directories, arguments, and run identity atomically. Skills declare `runPolicy` and `identityArgs` |
+| Catalog-as-Code | TypeScript catalog registry parses frontmatter, groups by category, renders CATALOG.md and init skill-awareness blocks |
+| Session Hooks | Host-specific hooks start services at session boundary using `--format hook-json` for structured output |
+| Cross-Process Registry Serialization | `withRegistryLock` async mutex serializes all registry mutations preventing race conditions |
+| Daemon Diagnostics Logging | Structured NDJSON log entries to `daemon.log` for post-mortem debugging |
+| Git Worktree-Aware Project Resolution | Project resolution derives paths from repo identity; guards against home-directory adoption |
+| Versioned Stanza Markers | Instruction-file stanzas carry version stamps for staleness detection and `rp1 migrate` upgrades |
+| Dockerized Eval Execution | Prompt evals run inside Docker containers isolating harness CLIs and dependencies |
 
-## Layers
-
-| Layer | Purpose | Components |
-|-------|---------|------------|
-| Interaction | Host-tool entry points and user-visible CLI commands | `cli/src/main.ts`, `cli/src/commands/` |
-| Workflow Definition | Markdown-defined skills, agents, skill-local reference packs, and catalog discovery views | `plugins/base/`, `plugins/dev/`, `plugins/utils/`, `plugins/base/skills/guide/` |
-| Runtime Services | Event emission, state validation, directory resolution, workflow bootstrap, and agent-tool primitives | `cli/src/agent-tools/`, `cli/src/lib/`, `cli/shared/` |
-| Build & Distribution | Compile workflow specs into host-specific artifacts and shipped binaries; generate catalog artifacts | `cli/src/build/`, `cli/src/catalog/`, `cli/scripts/`, `scripts/` |
-| Presentation | Arcade dashboard SPA with notification sidebar, REST APIs, and WebSocket updates | `cli/web-ui/src/app/`, `cli/web-ui/src/server/` |
-| Persistence | Store event history, KB snapshots, and durable workflow artifacts | `~/.rp1/rp1.db`, `.rp1/context/`, `.rp1/work/` |
-| Evaluation | Prompt attestation, Dockerized eval execution, and eval suite management | `evals/`, `docker/eval-run.sh`, `docker/Dockerfile` |
-| Quality Gates | Catalog freshness, lint, format, typecheck, and attestation enforcement | `lefthook.yml`, `cli/src/catalog/maintenance.ts`, `cli/biome.json` |
-
-## Key Interaction Flows
+## Key Data Flows
 
 ### Event Pipeline
-Skill or agent emits a workflow event, state-machine validation checks the step transition, the runtime persists the event to SQLite, and the daemon broadcasts updates to Arcade via HTTP and WebSocket surfaces.
+Skill/agent emits workflow event -> State machine validation -> SQLite persistence -> HTTP notify daemon -> WebSocket broadcast to Arcade
 
 ### Workflow Bootstrap
-A tracked skill invokes `rp1 agent-tools workflow-bootstrap` which resolves canonical directories via `resolve-args`, validates the workflow target contract (runPolicy, identityArgs), then deterministically creates a fresh run or resumes an existing one based on project identity and work identity. The result provides `runId`, `directories`, and `arguments` as a single atomic context before any progress emission.
+Tracked skill invokes `workflow-bootstrap` -> Resolves canonical directories -> Validates workflow contract -> Creates/resumes run -> Returns runId + directories + arguments
 
 ### KB Generation
-The KB orchestrator selects `FULL`, `INCREMENTAL`, or `FEATURE_LEARNING`, runs spatial analysis, fans out specialist KB agents, reconciles each section against prior context, and writes `.rp1/context/*.md` plus `state.json`.
+Orchestrator selects mode (FULL/INCREMENTAL/FEATURE_LEARNING) -> Spatial analysis -> Parallel specialist agents -> Reconcile each section -> Write `.rp1/context/*.md` + `state.json`
 
-### Documentation Sync
-`generate-user-docs` discovers user-facing docs, infers style, validates KB freshness, scans files in parallel via `scribe`, persists `scan_results.json`, asks once for approval, then processes updates in bounded batches.
+### Startup Recovery
+Server reads `daemon-state.json` high-water mark -> Queries SQLite for missed events -> Replays via WebSocket hub -> Prunes stale projects from registry
 
-### Content Writing
-`write-content` normalizes the request, creates `.rp1/work/content/.../brief.md`, asks only blocking clarification questions, drafts and self-reviews against the brief, then registers final artifacts.
-
-### Prompt Authoring
-`prompt-writer` classifies the target, loads companion references only when needed, composes or rewrites the prompt using templates and reusable patterns, validates rp1 conventions, and emits completion state.
-
-### Plugin Build Pipeline
-The top-level build command parses prompt sources, applies LiquidJS preprocessing and semantic tag rendering, generates host-specific artifacts for Claude Code, OpenCode, and Codex via data-driven `PlatformDefinition` configs with lifecycle hooks, and bundles assets into the compiled binary.
-
-### Catalog Generation
-The TypeScript catalog registry (`cli/src/catalog/registry.ts`) scans plugin frontmatter, collects entries with category/workflow metadata, and renders `CATALOG.md` for the `/guide` meta-skill. `catalog/agents.yaml` is regenerated as a transitional freshness artifact via `cli/src/catalog/maintenance.ts`.
-
-### Feedback Lifecycle
-Users annotate artifacts in Arcade, the runtime persists the feedback in SQLite, WebSocket broadcasts update connected clients, and agents reply, resolve, or accept edits through feedback tooling.
-
-### Project Discovery
-`rp1-root-dir` walks up from the current working directory, resolves project identity from `.rp1/project_id`, checks worktree metadata when needed, guards against home-directory adoption, and returns project, KB, and work roots. `resolve-args` now co-returns `ResolvedDirectories` alongside argument values.
-
-### Eval Execution
-`just eval-run` builds the `rp1-dev` Docker image and runs `eval-run-local` inside the container with forwarded API keys. Passing `--attest --commit` attests passing suites inside the container and commits attestation changes on the host after the container exits.
+### Project Registry
+Registration/access from CLI/hooks -> Worktree normalization -> UUID-keyed entry -> Async-mutex-serialized read-modify-write -> Atomic temp-file + rename
 
 ## Integrations
 
 | Service | Purpose | Type |
 |---------|---------|------|
-| Bun | CLI runtime, HTTP/WS server, binary compilation, and tests | Runtime |
-| `bun:sqlite` | Persist events, runs, artifacts, annotations, and tasks | Embedded DB |
-| Git CLI | Detect KB staleness, compute diffs, and resolve repo context | Version control |
-| GitHub API (`@octokit/rest`) | PR review, comments, and reactions | REST API |
+| Bun | CLI runtime, HTTP/WS server, binary compilation, tests | Runtime |
+| bun:sqlite | Persist events, runs, artifacts, annotations, notifications | Embedded DB |
+| Git CLI | KB staleness, diffs, repo context, worktree resolution | Version control |
+| GitHub API | PR review, comments, reactions | REST API |
 | React + Vite | Arcade dashboard SPA | Frontend |
-| LiquidJS | Render platform-specific prompt artifacts | Build |
+| LiquidJS | Multi-platform prompt artifact rendering | Build |
 | chokidar | Watch `.rp1/work` and `.rp1/context` for live updates | Runtime |
-| promptfoo | Run prompt quality evaluations | Testing |
-| Release Please | Drive semver and release automation | CI/CD |
-| GitHub Actions | Run CI, release, and automation jobs | CI/CD |
-| Lefthook | Enforce local quality gates | Dev tooling |
+| promptfoo | Prompt quality evaluations | Testing |
+| Release Please | Semver and release automation | CI/CD |
+| GitHub Actions | CI, release, and automation jobs | CI/CD |
+| Lefthook | Local quality gates (lint, format, catalog check) | Dev tooling |
 | Biome | Linting and formatting for TS/TSX | Dev tooling |
 | MkDocs Material | Publish docs at `rp1.run` | Documentation |
-| Docker | Provide cross-platform testing and Dockerized eval execution environments | Dev tooling |
+| Docker | Cross-platform testing and eval execution | Dev tooling |
 
 ## Deployment
 
-- **Type**: Single-executable CLI with embedded assets plus a background daemon
-- **Targets**: `darwin-arm64`, `darwin-x64`, `linux-arm64`, `linux-x64`, `windows-x64`
-- **Distribution**: GitHub releases via GoReleaser plus marketplace artifacts; beta releases via `just beta-release` workflow
-- **Daemon**: Background Bun HTTP+WS server on port `7710` with PID-file lifecycle and version-aware restart
-- **Local Build Surface**: Top-level `rp1 build` entrypoint now exposes the build pipeline directly
-- **Docker Environments**: Multi-stage Dockerfile (`base` -> `target-repo` -> `stable` | `dev`) providing isolated testing and eval execution
-
-## Cross-References
-
-- **Surface behavior**: See [interaction-model.md](interaction-model.md)
-- **Component inventory**: See [modules.md](modules.md)
-- **Code conventions**: See [patterns.md](patterns.md)
-- **Domain terminology**: See [concept_map.md](concept_map.md)
+- **Distribution**: Single-executable CLI with embedded assets plus background daemon
+- **Targets**: darwin-arm64, darwin-x64, linux-arm64, linux-x64, windows-x64
+- **Daemon**: Background Bun HTTP+WS server on port 7710 with PID-file lifecycle, version-aware restart, SIGTERM->SIGKILL escalation, diagnostic logging
+- **Config directory**: macOS `~/Library/Application Support/rp1/`, Linux `$XDG_CONFIG_HOME/rp1/`, Windows `%APPDATA%\rp1\`
+- **Docker**: Multi-stage Dockerfile (base -> target-repo -> stable | dev) for isolated testing and eval execution

--- a/.rp1/context/concept_map.md
+++ b/.rp1/context/concept_map.md
@@ -5,138 +5,109 @@
 
 ## Core Concepts
 
-| Concept | Type | Meaning |
-|---------|------|---------|
-| Plugin | entity | Capability pack such as `rp1-base`, `rp1-dev`, or `rp1-utils` that groups skills and agents under a namespace and enforces dependency direction. |
-| Skill | entity | User-facing workflow entry point defined by `SKILL.md` with typed arguments, optional state machine, event emission, and platform-tagged behavior. Each skill declares `metadata.category` and `metadata.is_workflow` for discovery registry enrollment. |
-| Agent | entity | Focused worker that receives pre-resolved parameters from a parent skill and performs bounded execution in a single pass. |
-| Run | entity | Tracked workflow execution identified by `run-id`, governed by a `run_policy` (fresh or resumable), and advanced through explicit step and status events. Resumable runs carry `workIdentity` and `bootstrapContext` for identity-based matching. |
-| Event | entity | Typed record emitted against a run to drive workflow state, waiting gates, artifact registration, and dashboard updates. Six event types: `status_change`, `artifact_registered`, `annotation_updated`, `waiting_for_user`, `btw_update`, `subflow_registered`. |
-| Artifact | artifact | Registered output file with explicit `storageRoot` routing for project, work, or absolute paths. Classified by type: markdown, code, diagram, diff, report, or other. |
-| Annotation | entity | Threaded inline feedback attached to an artifact for review, reply, and resolution workflows. |
-| State Machine | entity | `stateDiagram-v2` workflow graph whose state IDs must align with emitted step names. Parsed into states, transitions, initial states, and terminal states for validation. |
-| Knowledge Base | resource | Structured project documentation under `.rp1/context/`, loaded progressively and treated as the repo knowledge source for KB-aware workflows. |
-| Platform Tag | entity | Semantic Liquid tag such as `dispatch_agent`, `ask_user`, `edit_model`, or `plan_tool` that the build pipeline renders per host. |
-| CanonicalName | entity | Normalized `plugin:artifact` identity used to translate namespaces across Claude Code, OpenCode, and Codex. Expressed as both canonical (`base:guide`) and user-facing (`rp1-base:guide`) forms. |
-| Project | entity | Registered workspace identified by `project_id`, resolved via directory walk-up or git worktree common-dir, that defines project, KB, and work roots. |
-| Task Queue | entity | Persistent work queue for cross-agent coordination with pending, in-progress, completed, failed, and cancelled states. |
-| PR Review | workflow | Map-reduce pull request analysis workflow with CI awareness (GitHub Actions, Buildkite, GitLab), configurable verdict modes, confidence gating, and GitHub integration. |
-| Attestation | artifact | Content-addressable evaluation record linking prompt and dependency hashes to pass/fail results per platform (claude-code, opencode, codex). |
-| Spatial Analyzer | workflow | KB discovery agent that ranks files and maps repository areas to downstream KB sections. |
-| Content Workflow | workflow | Tracked writing workflow that normalizes a request, persists a brief, asks only blocking questions, drafts, reviews, and finalizes a document. |
-| Content Brief | artifact | Durable brief artifact that separates verified facts, editorial decisions, open questions, and Q&A history for a writing run. |
-| Documentation Synchronization | workflow | Two-pass workflow that discovers user docs, validates KB currency, scans sections, requests one approval gate, and processes updates against KB-backed facts. |
-| Scan Results | artifact | Intermediate artifact bridging documentation scan and process phases with KB status, inferred style, per-file section classifications, and errors. |
-| Scribe | agent | File-level documentation worker that executes scan or process batches and returns strict JSON-only results. |
-| Prompt Authoring Workflow | workflow | Tracked workflow that authors or rewrites prompts, classifies the target, loads companion references, and validates rp1 conventions before review. |
-| Prompt Authoring Corpus | resource | On-demand reference set of patterns, templates, and rp1-specific authoring rules used to synthesize terse prompts. |
-| Workflow Bootstrap | entity | Auto-injected initialization step for tracked workflows that resolves arguments, resolves or resumes a run, and returns a composite result with arguments, directories, workflow metadata, run identity, and trace context. |
-| Discovery Registry | entity | Canonical skill catalog built from frontmatter metadata at build time. Drives `guide/CATALOG.md`, init skill-awareness blocks, `rp1 list --json` enrichment, and ambient suggestion tables from a single source of truth. |
-| Guide | skill | Interactive skill-discovery entry point that loads companion catalog and workflow docs, classifies user intent, validates installed skills per host, and offers to invoke recommended skills. |
-| Fence Versioning | mechanism | Versioned markers (`<!-- rp1:start v=X.Y.Z -->` / `# rp1:start v=X.Y.Z`) embedded in instruction files (CLAUDE.md, AGENTS.md, .gitignore) that enable staleness detection and guided `rp1 migrate` upgrades. |
-| Builder-Reviewer | pattern | Adversarial cooperation architecture where a builder agent implements code and a separate reviewer agent verifies it, with one retry cycle and fail-safe escalation to the user. |
-| Stateless Agent | pattern | Interview-style agent whose accumulated state lives in a visible file-based scratch pad rather than conversation context, enabling session-independent resumability. |
+| Concept | Type | Description |
+|---------|------|-------------|
+| Plugin | entity | Capability pack (`rp1-base`, `rp1-dev`, `rp1-utils`) grouping skills and agents under a namespace with enforced dependency direction |
+| Skill | entity | User-facing workflow entry point defined by `SKILL.md` with typed arguments, optional state machine, event emission, and platform-tagged behavior. Declares `metadata.category` and `metadata.is_workflow` for discovery registry enrollment |
+| Agent | entity | Focused worker receiving pre-resolved parameters from a parent skill for bounded single-pass execution |
+| Run | entity | Tracked workflow execution identified by `run-id`, governed by `run_policy` (fresh/resumable), advanced through explicit step and status events. Resumable runs carry `workIdentity` for identity-based matching |
+| Event | entity | Typed record emitted against a run: `status_change`, `artifact_registered`, `annotation_updated`, `waiting_for_user`, `btw_update`, `subflow_registered` |
+| Artifact | artifact | Registered output file with explicit `storageRoot` routing (project, work_dir, absolute). Types: markdown, code, diagram, diff, report, other |
+| Annotation | entity | Threaded inline feedback on an artifact for review, reply, and resolution. Anchored by text-selection, hidden-anchor, or line-based positions |
+| State Machine | entity | Mermaid `stateDiagram-v2` workflow graph whose state IDs must align with emitted step names. Parsed for validation |
+| Knowledge Base | resource | Structured project docs under `.rp1/context/`, loaded progressively as the repo knowledge source for KB-aware workflows |
+| Platform Tag | entity | Semantic Liquid tag (`dispatch_agent`, `ask_user`, `edit_model`, `plan_tool`) rendered per host by the build pipeline |
+| CanonicalName | entity | Normalized `plugin:artifact` identity translating namespaces across Claude Code, OpenCode, and Codex |
+| Project | entity | Registered workspace identified by `project_id`, resolved via directory walk-up or git worktree common-dir |
+| Task Queue | entity | Persistent work queue for cross-agent coordination with pending, in-progress, completed, failed, and cancelled states |
+| Notification | entity | System-generated message surfaced in Arcade, triggered by run status changes (completed/failed) or `waiting_for_user` events. Deduplicated per source |
+| Workflow Bootstrap | entity | Auto-injected initialization step resolving arguments, directories, and run identity in one atomic call |
+| Discovery Registry | entity | Canonical skill catalog built from frontmatter at build time. Drives CATALOG.md, init awareness blocks, `rp1 list --json`, and ambient suggestions |
+| Arcade Tracked | mechanism | Optional `metadata.arcade_tracked` boolean controlling Activity feed visibility without disabling workflow mechanics |
+| Platform Definition | entity | Data-driven build configuration capturing platform-varying behavior: registry, templates, naming, lifecycle hooks |
+| Subflow | entity | Nested workflow registered within a parent run via `subflow_registered` event type |
 
-## Terminology Glossary
+## Key Terminology
 
-| Term | Meaning |
-|------|---------|
-| `run-id` | UUID that identifies a workflow execution across status changes, gates, artifacts, and dashboard views. |
-| `storageRoot` | Explicit artifact root selector: `work_dir`, `project`, or `absolute`. |
-| Namespaced Step | Sub-agent step name prefixed with `agent-name:` to avoid collisions with parent workflow states. Logical step keys collapse the namespace for Arcade grouping. |
-| `SKILL.md` | Canonical skill file format with YAML frontmatter and workflow body. |
-| Resolve Args | Auto-injected argument-resolution step that merges user input, settings, env fallbacks, and schema defaults for `metadata.arguments`. Returns resolved arguments, canonical directories, and environment. |
-| Progressive Disclosure | Load `index.md` first, then widen only to the KB or reference files needed for the current task. |
-| Bayesian Reconciliation | KB update method that treats existing documentation as prior hypotheses and revises only where new evidence justifies it. |
-| Novelty Scan | Explicit post-reconciliation search for materially new concepts not already modeled in the prior KB. |
-| Diff Frontier | Changed-file frontier used to bias incremental KB analysis toward recently edited areas before widening locally. |
-| Document Kind | Requested or inferred document shape that selects the default structure, such as `auto`, `blog-post`, `technical-proposal`, or `feedback`. |
-| Source Hierarchy | Writing evidence order: user input, existing target doc, local project sources and KB, then external sources only when explicitly requested. |
-| Section Scenario | Doc-sync classification for a section: `verify`, `add`, or `fix`. |
-| `kb_match` | Reference from a user-doc section to a KB section, encoded as `file:line` or `file:start-end`. |
-| `scan_results.json` | Bridge artifact that carries KB status, inferred style, per-file section classifications, and scan errors into the process phase. |
-| Stale KB Gate | Explicit pre-scan decision when the KB is behind `HEAD` but still structurally readable. |
-| Review Marker | Inline HTML comment inserted when doc verification cannot confidently resolve a claim. |
-| `list_marker` | Canonical unordered-list style field; `list_style` is retained only as a compatibility alias. |
-| Companion Files | Prompt-writer support docs loaded on demand: `PATTERNS.md`, `TEMPLATES.md`, and `RP1-AUTHORING.md`. |
-| Prompt Complexity Band | Simple, moderate, or complex size bucket that guides template selection in prompt authoring. |
-| Shell-Safe Formatting | Prompt-authoring rule set that avoids shell-expansion hazards before text reaches the target host. |
-| `run_policy` | Workflow lifecycle selector: `fresh` always creates a new run; `resumable` matches an existing non-terminal run by `identity_args` values. |
-| `identity_args` | Subset of declared skill arguments whose values form the `workIdentity` key for resumable run matching. |
-| `workIdentity` | Composite key derived from `identity_args` values, stored on the run record and used to match subsequent invocations to an existing non-terminal run. |
-| Skill Category | Nine-value enum (`development`, `investigation`, `quality`, `review`, `documentation`, `knowledge`, `strategy`, `planning`, `prompt`) that classifies skills for catalog grouping and ambient awareness. |
-| `is_workflow` | Boolean frontmatter flag distinguishing workflow-orchestrating skills from single-purpose skills. Flows into catalog views and runtime listing. |
-| Run Invocation Context | Dashboard-surfaced metadata showing how a run was created: workflow name, run policy, decision (`created_new_run`, `matched_non_terminal_run`, `legacy_backfill_resume`), project identity, and worktree state. |
-| Logical Step Key | Collapsed step identifier for dashboard grouping: non-namespaced steps keep their ID; namespaced lifecycle steps collapse to the namespace prefix, optionally suffixed with `::unit`. |
-| Fence Marker | Versioned delimiter (HTML comment or shell comment) that brackets rp1-managed content in instruction files for staleness detection and safe upgrade. |
-| `LATEST_FENCE_VERSION` | Semver constant shipped with the CLI build; instruction file fence markers are stale when their version is older. |
-| Distribution Scope | Catalog classification: `distributable` (base, dev plugins, visible to end users) or `internal` (utils plugin, not in public catalog). |
-| ToolResult Envelope | Standard `{ success, tool, data, errors? }` JSON structure wrapping all agent-tool outputs for consistent AI-agent parsing. |
-| Confidence Gating | PR review threshold: 65%+ includes a finding; 40-64% triggers investigation for critical/high findings; below 40% excludes. |
-| Verdict Mode | PR review submission strategy: `auto` (severity-derived), `approve`, `request_changes`, or `comment`. |
+| Term | Definition |
+|------|------------|
+| run-id | UUID identifying a workflow execution across status changes, gates, artifacts, and dashboard views |
+| storageRoot | Artifact root selector: `work_dir`, `project`, or `absolute` |
+| Namespaced Step | Sub-agent step name prefixed with `agent-name:` to avoid collisions with parent workflow states |
+| run_policy | Workflow lifecycle selector: `fresh` always creates a new run; `resumable` matches existing non-terminal run by `identity_args` |
+| identity_args | Subset of declared skill arguments whose values form the `workIdentity` key for resumable run matching |
+| workIdentity | Composite key from `identity_args` values, stored on the run record for subsequent invocation matching |
+| Skill Category | Nine-value enum (`development`, `investigation`, `quality`, `review`, `documentation`, `knowledge`, `strategy`, `planning`, `prompt`) for catalog grouping |
+| is_workflow | Boolean frontmatter flag distinguishing workflow-orchestrating skills from single-purpose skills |
+| arcade_tracked | Optional boolean metadata field controlling Arcade Activity feed visibility. Defaults to true |
+| Resolve Args | Auto-injected argument-resolution step merging user input, settings, env fallbacks, and schema defaults |
+| Progressive Disclosure | Load `index.md` first, then only the KB files needed for the current task |
+| Bayesian Reconciliation | KB update method treating existing docs as prior hypotheses, revising only where new evidence justifies it |
+| Fence Marker | Versioned delimiter bracketing rp1-managed content in instruction files for staleness detection and upgrade |
+| Distribution Scope | Catalog classification: `distributable` (base, dev) or `internal` (utils) |
+| ToolResult Envelope | Standard `{ success, tool, data, errors? }` JSON structure wrapping all agent-tool outputs |
+| Confidence Gating | PR review threshold: 65%+ includes; 40-64% investigates critical/high; below 40% excludes |
+| Anchor | Position binding for an annotation: `text-selection`, `hidden-anchor`, or `line` |
+| Document Kind | Requested or inferred document shape selecting default structure (auto, blog-post, technical-proposal, feedback) |
+| Section Scenario | Doc-sync classification for a section: `verify`, `add`, or `fix` |
+| Logical Step Key | Collapsed step identifier for dashboard grouping: non-namespaced steps keep their ID; namespaced lifecycle steps collapse to namespace prefix |
 
-## Key Relationships
+## Relationships
 
-| From | Relation | To | Meaning |
-|------|----------|----|---------|
-| Plugin | contains | Skill | Plugins package user-facing workflows under a namespace. |
-| Plugin | contains | Agent | Plugins package focused workers alongside skills. |
-| Skill | delegates to | Agent | Skills orchestrate work and hand bounded tasks to agents. |
-| Skill | embeds | State Machine | Tracked skills declare workflow states in Mermaid and mirror them with emitted steps. |
-| Skill | enrolls in | Discovery Registry | Every skill with `category` and `is_workflow` metadata is collected into the canonical catalog. |
-| State Machine | governs | Run | Run progression is validated against declared states and transitions. |
-| Run | contains | Event | Runs are materialized through emitted workflow events. |
-| Run | produces | Artifact | Workflows register generated files as run artifacts. |
-| Run | carries | Run Invocation Context | Dashboard displays how each run was created, resumed, or matched. |
-| Artifact | anchors | Annotation | Feedback threads attach to specific artifact locations. |
-| Knowledge Base | grounds | Documentation Synchronization | User-doc reconciliation treats the KB as the fact source for scan and fix decisions. |
-| Knowledge Base | informs | Content Workflow | Repo-specific writing loads `index.md` first and then only the KB slices needed for the draft. |
-| Documentation Synchronization | dispatches | Scribe | The orchestrator delegates scan and process batches to scribe workers. |
-| Documentation Synchronization | produces | Scan Results | The scan phase persists an intermediate artifact that bridges into processing. |
-| Content Workflow | produces | Content Brief | Each writing run creates and maintains a durable brief as workflow state. |
-| Prompt Authoring Workflow | loads | Prompt Authoring Corpus | Prompt-writer pulls in templates, patterns, and rp1 authoring rules on demand. |
-| Platform Tag | transforms | Skill | Build-time rendering converts semantic tags into host-specific instructions. |
-| Spatial Analyzer | maps for | Knowledge Base | Spatial analysis routes repository evidence into downstream KB sections. |
-| Attestation | validates | Skill | Attestations tie prompt content hashes to evaluation outcomes for release gating. |
-| Task Queue | coordinates | Agent | Persistent tasks provide a shared handoff mechanism for agents. |
-| Discovery Registry | generates | Guide | The guide skill loads auto-generated `CATALOG.md` and `WORKFLOWS.md` from registry data. |
-| Discovery Registry | generates | Init Templates | The init workflow injects a registry-derived skill-awareness table into instruction files. |
-| Workflow Bootstrap | initializes | Run | Bootstrap resolves arguments, resolves directories, and creates or resumes a run in one step. |
-| Fence Versioning | gates | Project Migration | Stale fence markers trigger `rp1 migrate` to upgrade instruction file content. |
-| Builder-Reviewer | quality-gates | Agent | Builder implements, reviewer verifies, with one retry and user escalation. |
+```text
+Plugin ──contains──> Skill, Agent
+Skill ──delegates to──> Agent
+Skill ──embeds──> State Machine
+Skill ──enrolls in──> Discovery Registry
+Skill ──declares──> Arcade Tracked
+State Machine ──governs──> Run
+Run ──contains──> Event
+Run ──produces──> Artifact
+Run ──triggers──> Notification
+Artifact ──anchors──> Annotation
+Knowledge Base ──grounds──> Documentation Synchronization
+Knowledge Base ──informs──> Content Workflow
+Workflow Bootstrap ──initializes──> Run
+Platform Definition ──configures──> Build Template Context
+Discovery Registry ──generates──> Guide, Init Wizard
+Arcade Tracked ──filters──> Run (Activity feed visibility)
+Attestation ──validates──> Skill
+```
+
+## Agent Patterns
+
+| Pattern | Context | Application |
+|---------|---------|-------------|
+| Constitutional Prompting | All agent execution | Expert knowledge, codebase context, anti-loop directives, and output contracts in structured markdown |
+| Map-Reduce | KB generation, PR review | Spatial analyzer maps work to parallel units; orchestrator reduces results |
+| Skill-Agent Delegation | All workflow entry points | Skill interprets request, loads context, delegates bounded work to agents |
+| Builder-Reviewer | Feature implementation | Builder implements, reviewer verifies; one retry cycle with user escalation |
+| Stateless Agent | Blueprint charter creation | State persisted in visible file-based scratch pad for session-independent resumability |
+| Data-Driven Platform Build | Multi-platform artifacts | PlatformDefinition entries capture all platform-varying behavior |
+| Notification Auto-Generation | Emit pipeline | Status changes and waiting_for_user events auto-generate deduplicated notifications |
 
 ## Bounded Contexts
 
-| Context | Scope | Key Concepts | Boundary |
-|---------|-------|--------------|----------|
-| Knowledge Management | `rp1-base` | Knowledge Base, Spatial Analyzer, Progressive Disclosure, Bayesian Reconciliation | Owns `.rp1/context` generation and freshness signals; does not directly edit user-facing docs. |
-| Documentation Production | `rp1-base` | Content Workflow, Content Brief, Documentation Synchronization, Scan Results, Scribe | Owns user-facing doc creation and KB-backed reconciliation, persisting workflow state in `.rp1/work/`. |
-| Prompt Tooling | `rp1-utils` | Prompt Authoring Workflow, Prompt Authoring Corpus, Shell-Safe Formatting | Owns prompt synthesis, rewrite guidance, rp1 authoring conventions, and reusable prompt templates and patterns. |
-| Feature Delivery | `rp1-dev` | PR Review, Task Queue, Builder-Reviewer | Owns implementation and review workflows for product changes. |
-| Runtime Services | `cli/src` | Project, Run, Event, Workflow Bootstrap, Resolve Args, CLI entrypoints | Owns command registration, runtime detection, agent-tools plumbing, install/update/init flows, and top-level CLI execution. |
-| Dashboard | `cli/web-ui` | Arcade, Run, Artifact, Annotation, Run Invocation Context, Notifications | Owns live visualization, feedback threads, run invocation tracing, and waiting-gate visibility for active workflows. |
-| Quality Assurance | `evals/` | Attestation | Owns prompt verification and release-gating evidence. |
-| Platform Abstraction | build pipeline | Platform Tag, CanonicalName | Owns host-specific rendering and namespace translation so one prompt source can target multiple agent hosts. |
-| Discovery | `cli/src/catalog`, `guide` skill | Discovery Registry, Guide, Skill Category, Distribution Scope | Owns the single-source-of-truth skill catalog derived from frontmatter metadata, plus generated catalog views, init awareness blocks, and the interactive guide skill. |
-| Project Lifecycle | `cli/src/init`, `cli/src/migrate` | Fence Versioning, Init Wizard, Project Migration | Owns project initialization, instruction-file fencing, staleness detection, and guided migration upgrades. |
+| Context | Scope | Key Concepts |
+|---------|-------|-------------|
+| Knowledge Management | rp1-base | Knowledge Base, Spatial Analyzer, Progressive Disclosure |
+| Documentation Production | rp1-base | Content Workflow, Documentation Synchronization, Scribe |
+| Prompt Tooling | rp1-utils | Prompt Authoring Workflow, Shell-Safe Formatting |
+| Feature Delivery | rp1-dev | PR Review, Task Queue, Builder-Reviewer |
+| Runtime Services | cli/src | Project, Run, Event, Workflow Bootstrap, Notification |
+| Dashboard | cli/web-ui | Arcade, Artifact, Annotation, Run Invocation Context |
+| Platform Abstraction | build pipeline | Platform Tag, CanonicalName, Platform Definition |
+| Discovery | cli/catalog | Discovery Registry, Guide, Skill Category, Arcade Tracked |
+| Project Lifecycle | cli/init, cli/migrate | Fence Versioning, Init Wizard, Project Migration |
+| Quality Assurance | evals/ | Attestation |
 
 ## Cross-Cutting Concerns
 
-- **Fact grounding**: Writing workflows use a source hierarchy, treat the KB as the truth source for doc reconciliation, and insert review markers instead of inventing unsupported claims.
-- **Explicit human gates**: `waiting_for_user` is emitted before clarification, approval, or stale-KB decisions so pauses are visible in both the host tool and Arcade.
-- **Traceable intermediate state**: Resumable intermediates such as `brief.md` and `scan_results.json` persist under `.rp1/work/` instead of living only in prompt context.
-- **Style normalization**: Doc-sync infers dominant style once, normalizes to canonical fields such as `list_marker`, and applies them consistently during edits.
-- **State and step discipline**: Mermaid states, emitted step names, namespaced sub-agent steps, logical step keys, and terminal completion semantics stay aligned.
-- **Configuration resolution**: Typed `metadata.arguments` plus auto-injected `resolve-args` replace manual parameter parsing in tracked skills. Workflow bootstrap unifies argument resolution, directory resolution, and run creation into a single atomic step.
-- **Shell-safe prompt rendering**: Prompt-authoring guidance avoids text patterns that would be expanded or misparsed by the shell.
-- **Platform portability**: Semantic platform tags and canonical naming let one authored workflow target Claude Code, OpenCode, and Codex without duplicating prompt sources.
-- **Single-source discovery**: Skill category, workflow flag, and argument metadata in frontmatter drive all downstream catalog views, avoiding hand-maintained inventory tables that drift.
-- **Fence-versioned instruction files**: rp1-managed stanzas in CLAUDE.md, AGENTS.md, and .gitignore carry version markers so the CLI can detect staleness and offer guided upgrades.
-- **Standard tool envelope**: All agent-tools return a `ToolResult<T>` JSON envelope (`success`, `tool`, `data`, optional `errors`) for predictable AI-agent parsing.
-
-## Cross-References
-
-- **System topology**: See [architecture.md](architecture.md)
-- **Component inventory**: See [modules.md](modules.md)
-- **Implementation idioms**: See [patterns.md](patterns.md)
-- **Surface behavior**: See [interaction-model.md](interaction-model.md)
+- **Fact grounding**: Writing workflows use source hierarchy with KB as truth source
+- **Human gates**: `waiting_for_user` emitted before prompts, visible in host tool and Arcade
+- **Traceable state**: Intermediates (`brief.md`, `scan_results.json`) persist under `.rp1/work/`
+- **State discipline**: Mermaid states, emitted steps, namespaced sub-agent steps, and logical step keys stay aligned
+- **Configuration resolution**: `resolve-args` + `workflow-bootstrap` unify argument, directory, and run creation
+- **Platform portability**: Semantic tags and data-driven definitions let one prompt target multiple hosts
+- **Single-source discovery**: Frontmatter metadata drives all catalog views, avoiding drift
+- **Standard tool envelope**: All agent-tools return `ToolResult<T>` JSON for predictable AI-agent parsing

--- a/.rp1/context/index.md
+++ b/.rp1/context/index.md
@@ -7,7 +7,7 @@
 
 ## Project Summary
 
-rp1 is a Bun/TypeScript CLI and plugin monorepo for authoring, building, and running AI agent workflows across Claude Code, OpenCode, and Codex. It combines markdown-defined skills and agents, tracked runtime state with deterministic workflow bootstrap, the Arcade dashboard with notifications, a multi-platform build pipeline, catalog-driven skill discovery, and a progressively loaded knowledge base.
+rp1 is a Bun/TypeScript CLI and plugin monorepo for authoring, building, and running AI agent workflows across Claude Code, OpenCode, and Codex. It combines markdown-defined skills and agents, tracked runtime state with deterministic workflow bootstrap, the Arcade dashboard with notifications and contextual commands, a multi-platform build pipeline with arcade tracking controls, catalog-driven skill discovery, and a progressively loaded knowledge base.
 
 ## Quick Reference
 
@@ -23,11 +23,11 @@ rp1 is a Bun/TypeScript CLI and plugin monorepo for authoring, building, and run
 
 | File | Lines | Load For |
 |------|-------|----------|
-| architecture.md | 133 | System design, layers, data flow, integrations |
-| interaction-model.md | 154 | Cross-surface semantics, workflow states, notifications, accessibility |
-| modules.md | 119 | Module boundaries, responsibilities, dependency highlights |
+| architecture.md | 102 | System design, layers, data flow, integrations |
+| interaction-model.md | 89 | Cross-surface semantics, workflow states, notifications, accessibility |
+| modules.md | 87 | Module boundaries, responsibilities, dependency highlights |
 | patterns.md | 81 | Code conventions, workflow idioms, extension patterns |
-| concept_map.md | 142 | Domain concepts, terminology, bounded contexts |
+| concept_map.md | 113 | Domain concepts, terminology, bounded contexts |
 
 ## Task-Based Loading
 
@@ -52,13 +52,13 @@ cli/
 ├── src/               # CLI commands, agent-tools, build pipeline, init/install flows
 │   ├── commands/      # User-facing CLI commands including build, migrate, and arcade
 │   ├── agent-tools/   # Workflow protocol tools (emit, workflow-bootstrap, resolve-args, feedback, root-dir, etc.)
-│   ├── build/         # Multi-platform artifact build pipeline
+│   ├── build/         # Multi-platform artifact build pipeline with arcade tracking
 │   ├── catalog/       # Skill/agent catalog registry with distribution scoping
 │   ├── install/       # Host-tool installation and verification
 │   ├── migrate/       # Project migration with stanza upgrades and DB backfill
 │   └── init/          # Project initialization with versioned fence markers and Ink UI
 ├── shared/            # Errors, fp-ts helpers, events, logging, directory resolution
-└── web-ui/            # Arcade dashboard SPA with notifications sidebar, and Bun HTTP/WS server
+└── web-ui/            # Arcade dashboard SPA with notifications, contextual commands, and Bun HTTP/WS server
 plugins/
 ├── base/              # KB, docs sync, writing, research, strategy, security, guide meta-skill
 ├── dev/               # Build workflows, blueprinting, PR review, feature delivery

--- a/.rp1/context/interaction-model.md
+++ b/.rp1/context/interaction-model.md
@@ -6,149 +6,84 @@
 
 ## Experience Principles
 
-- **Keyboard-first monitoring**: Arcade remains keyboard-first and mouse-optional for run navigation, dialogs, command palette usage, dense list movement, and notification management.
-- **Observable workflows**: Long-running skills expose named runs, explicit phase transitions, gate pauses, and registered artifacts so progress is legible across host tools and Arcade.
-- **Evidence before questions**: Interactive workflows should read repo or KB material first and ask only for facts or decisions that materially change the output.
-- **Durable handoffs**: Intermediate artifacts are source-of-truth handoffs rather than disposable scratchpads; workflows preserve them across review, block, and cancel paths.
-- **Outcome-first documentation**: User-facing docs should start from the reader's outcome, prefer one clear path, and use concrete commands, paths, defaults, and examples while matching repo style.
-- **Automation-aware CLI**: CLI commands stay human-usable but expose explicit machine-friendly modes such as JSON output, lint-only checks, and lazy-loaded agent tooling.
-- **Attention-proportional notification**: Notifications are categorized by attention level (action required, attention, informational) so high-priority items surface prominently while low-priority items remain accessible without interrupting flow.
-- **Exclusive overlay model**: Only one overlay (command palette, notifications sidebar) is active at a time, preventing state confusion and ensuring keyboard shortcuts always have unambiguous targets.
+| Principle | Description |
+|-----------|-------------|
+| Keyboard-first monitoring | Arcade is keyboard-first and mouse-optional for run navigation, dialogs, command palette, and notification management |
+| Observable workflows | Long-running skills expose named runs, explicit phase transitions, gate pauses, and registered artifacts |
+| Evidence before questions | Interactive workflows read repo or KB material first and ask only for material-changing facts or decisions |
+| Durable handoffs | Intermediate artifacts are source-of-truth handoffs preserved across review, block, and cancel paths |
+| Automation-aware CLI | CLI commands expose machine-friendly modes: JSON output, lint-only checks, hook-json format, daemon-only startup |
+| Attention-proportional notification | Notifications categorized by attention level (action_required, attention, info). Bulk dismiss via "Read all" enables efficient triage |
+| Exclusive overlay model | Only one overlay active at a time. Side panels (ToC, annotations) are mutually exclusive within artifact viewer |
+| Progressive detail disclosure | Secondary metadata (frontmatter, run invocation context) hidden by default, surfaced via contextual commands. State persists in sessionStorage |
 
-## Actors & Surfaces
+## Surfaces
 
-| Actor | Surfaces | Goals | Entry Points |
-|-------|----------|-------|--------------|
-| Developer | CLI, Init Wizard, Reference Docs | Set up rp1, install or build artifacts, launch monitoring, migrate projects, learn command and workflow entry points | `rp1 init`, `rp1 install`, `rp1 arcade`, `rp1 build`, `rp1 migrate`, `docs/reference/index.md` |
-| Collaborating Developer | Host Tool Integration, Arcade Web UI | Invoke tracked workflows, answer gates, review drafts or docs updates, manage notifications, browse project files, decide whether to accept, revise, rebuild, or stop | `/write-content`, `/generate-user-docs`, `/prompt-writer`, `/build`, `/knowledge-build`, `/runs/:runId`, `/projects/:projectId/files` |
-| AI Agent | Agent Tools CLI, Host Tool Integration, Arcade Web UI | Execute structured workflows, emit state and artifact events, process file batches, keep parent runs coherent | `rp1 agent-tools emit`, `rp1 agent-tools resolve-args`, `rp1 agent-tools rp1-root-dir` |
-
-## Surface Detail
-
-### CLI
-**Role**: Project setup, maintenance, artifact build, daemon launch, project migration, and agent-tool entrypoint.
-**Primary actions**: Initialize and configure rp1, install plugins to supported hosts (with scope options for Claude Code), launch Arcade, build artifacts, migrate existing projects to the project-local directory model, list installed skills with optional JSON output, and use JSON or lint-only build modes for automation.
-
-### Host Tool Integration
-**Role**: Conversational execution surface for slash-command workflows inside supported assistants.
-**Primary actions**: Start tracked workflows, respond to `ask_user` gates, request revision or cancellation, and receive concise completion summaries with artifact paths.
-
-### Arcade Web UI
-**Role**: Live observability, artifact review, notification, file browsing, and feedback surface for workflow runs.
-**Primary actions**: Watch named runs and phase timelines via the Activity feed, filter runs by status, project, and date range, see waiting gates and completion states, open registered artifacts with table-of-contents navigation and follow mode, browse project file trees, manage notifications grouped by attention level in a slide-out sidebar, view run invocation context (workflow, run policy, worktree state), annotate or resolve feedback, and use the command palette for navigation and actions.
-
-### Agent Tools CLI
-**Role**: Protocol surface for workflow state, path resolution, artifact registration, and feedback operations.
-**Primary actions**: Emit `status_change`, `waiting_for_user`, and `artifact_registered` events, validate state-machine alignment, resolve arguments and project roots, and bridge agent work into Arcade-visible state.
-
-### Reference Docs
-**Role**: Preflight discovery surface explaining harness-specific invocation, parameters, outputs, and phase models before a workflow starts.
-**Primary actions**: Compare Claude Code and OpenCode invocation syntax, inspect parameters and examples, and understand workflow phases and output paths.
-
-### Init Wizard
-**Role**: Interactive terminal UI for first-time or guided project initialization.
-**Primary actions**: Select git-root behavior, choose reinit behavior, pick gitignore preset, and review detected tools and next steps.
+| Surface | Role | Key Entry Points |
+|---------|------|------------------|
+| CLI | Project setup, maintenance, artifact build, daemon launch | `rp1 init`, `rp1 install`, `rp1 arcade`, `rp1 arcade --daemon-only`, `rp1 arcade --format hook-json`, `rp1 build` |
+| Host Tool Integration | Conversational execution for slash-command workflows | `/write-content`, `/generate-user-docs`, `/build`, `/knowledge-build` |
+| Arcade Web UI | Live observability, artifact review, notification, file browsing, feedback | `/`, `/projects`, `/runs/:runId`, `/runs/:runId/artifacts/:path`, `/projects/:projectId/files/:path` |
+| Agent Tools CLI | Protocol surface for workflow state, path resolution, artifact registration | `rp1 agent-tools emit`, `resolve-args`, `rp1-root-dir`, `feedback` |
+| Reference Docs | Preflight discovery for harness-specific invocation and parameters | `docs/reference/`, `docs/arcade/` |
+| Init Wizard | Interactive terminal UI for project initialization | `rp1 init` |
 
 ## User-Visible States
 
-| State | Meaning | Surface Signals |
-|-------|---------|-----------------|
-| `running` | A workflow phase is actively executing. | `status_change` with `running`, named phase in the dashboard timeline, pulsing amber status dot in Activity feed |
-| `waiting_for_user` | The workflow is intentionally paused for a user decision or missing input. | `waiting_for_user` emit before prompt, host-tool options, Arcade gate pause, amber status dot and "waiting" label in Activity feed, action-required notification |
-| `blocked` | The workflow cannot continue because required facts or decisions remain unresolved. | Concise gap report, failed terminal path, preserved brief or scan artifact |
-| `cancelled` | The user chose to stop or reject a gate, and the workflow exits without silently discarding work products. | `skipped`-style terminal path, explicit stop/no option, preserved intermediate artifacts |
-| `completed` | A workflow finished successfully and has surfaced its final outputs. | Final `completed` emit, artifact registration, short completion summary, ghost-colored status dot in Activity feed |
-| `failed` | A workflow phase or run terminated with an error. | Red status dot in Activity feed, error message in run detail, attention-level notification |
-| `kb_stale` | Docs sync detected that the KB is behind `HEAD` but still structurally readable. | Warning block with generated time, KB commit, `HEAD`, and a continue/rebuild/cancel gate |
-| `partial_update` | A docs-sync file was usefully updated, but some edits failed or review markers remain. | Per-file `partial` status and final report counts separating partial files |
-| `connection_status` | Arcade distinguishes live-update health from reconnecting or fallback behavior. | Terminal-green blinking cursor when connected, terminal-red cursor and reconnect tooltip when disconnected; reconnect recovery preserves scroll position |
-| `annotation_status` | Artifact feedback is visibly open or resolved. | Yellow indicator and gutter highlight for open feedback, green indicator for resolved feedback |
-| `notification_attention` | Each notification carries an attention level determining its visual priority. | Action-required: pulsing amber dot and amber badge count; Attention: amber dot; Informational: ghost dot |
+| State | Meaning | Surfaces |
+|-------|---------|----------|
+| running | A workflow phase is actively executing | Arcade, Agent Tools |
+| waiting_for_user | Workflow paused for user decision | Arcade, Host Tool, Agent Tools |
+| completed | Workflow finished with final outputs | Arcade, Host Tool, Agent Tools |
+| failed | Phase or run terminated with error | Arcade, Agent Tools |
+| blocked | Required facts or decisions unresolved | Host Tool |
+| cancelled | User chose to stop; work products preserved | Host Tool |
+| kb_stale | KB behind HEAD but still readable; continue/rebuild/cancel gate | Host Tool |
+| connection_status | Live-update health vs reconnecting/fallback | Arcade |
+| annotation_status | Artifact feedback open or resolved | Arcade |
+| notification_attention | Per-notification attention level (action_required, attention, info) | Arcade |
+| frontmatter_visibility | Artifact/file frontmatter shown/hidden per view (sessionStorage) | Arcade |
+| run_metadata_visibility | Run invocation metadata shown/hidden (sessionStorage) | Arcade |
 
 ## Feedback Loops
 
-- **Workflow gate loop**: A phase needs a user choice or missing information, the workflow emits `waiting_for_user`, Arcade shows the pause, the host tool asks the question, and the answer resumes, revises, rebuilds, or cancels the run.
-- **Content drafting loop**: `write-content` normalizes the request, writes `brief.md`, clarifies only blockers, drafts, self-reviews, opens a review gate, and preserves the brief on block or stop.
-- **Docs sync loop**: `generate-user-docs` discovers docs, infers style, validates KB freshness, runs a stale-KB gate if needed, scans in parallel, preserves `scan_results.json`, asks once for approval, then processes batches and reports totals.
-- **Prompt authoring loop**: `prompt-writer` analyzes the target, loads extra rp1 guidance when needed, writes or rewrites the prompt, validates it, and can cycle through revise until accepted or stopped.
-- **Artifact registration loop**: When a workflow creates a durable output, it emits `artifact_registered` with explicit `storageRoot` so Arcade can resolve and show the file while the host tool reports the final path.
-- **Annotation feedback cycle**: User comments or edits an artifact in Arcade, the runtime persists the change, agents read it through feedback tooling, and replies or resolutions update the UI in real time.
-- **Notification lifecycle loop**: Workflow events (gates, failures, completions) produce notifications delivered via WebSocket. Toasts auto-dismiss after 6 seconds or on user click. Persistent notifications appear in the sidebar grouped by attention level and can be individually dismissed via API. Clicking a notification with a route navigates to the relevant run or artifact.
-- **Activity feed refresh loop**: The Activity feed auto-refreshes when the WebSocket `attention` signal fires or when a reconnect recovery occurs, ensuring the run list stays current without manual polling.
+| Loop | Trigger | Behavior |
+|------|---------|----------|
+| Workflow gate | Phase needs user choice | Emit waiting_for_user -> Arcade shows pause -> Host tool asks -> Answer resumes/revises/cancels |
+| Artifact registration | Workflow creates durable output | Emit artifact_registered with storageRoot -> Arcade resolves and shows file |
+| Annotation feedback | User comments/edits artifact in Arcade | Runtime persists change -> Agents read via feedback read -> Replies update UI via WebSocket |
+| Notification lifecycle | Events produce notifications | WebSocket delivery -> Toast auto-dismiss (6s) with dedup guard -> Sidebar grouped by attention -> Individual dismiss via X, bulk via "Read all" |
+| Contextual command registration | View mounts with commands | ShortcutRegistryProvider stores view commands -> Command palette shows view-labeled group -> User executes -> Cleanup on unmount |
+| Activity feed refresh | WebSocket attention signal or reconnect | Auto-refresh without manual polling |
 
-## Keyboard Shortcuts
+## Keyboard & Command System
 
-### Global (all views)
-| Key | Action |
-|-----|--------|
-| `Cmd+K` | Toggle command palette |
-| `Cmd+B` / `Cmd+\` | Toggle notifications sidebar |
-| `Escape` | Close active overlay or blur focused element |
-| `?` | Show keyboard shortcut help |
-| `/` | Focus search |
+- **Global shortcuts**: `g h` (home), `g p` (projects), `Cmd+K` (command palette), `n` (notifications)
+- **Navigation shortcuts**: Arrow keys with roving tabindex, `Enter` to open, `Escape` to close
+- **Contextual shortcuts**: Views register `ShortcutDefinition[]` and `CommandDefinition[]` via `useContextualShortcuts`
+- **Command palette**: Navigation, actions, theme toggle, and per-view contextual commands with keyword search
+- **Chord timeout**: 500ms with visual `data-chordPending` indicator
+- **Text input guard**: Single-key shortcuts suppressed during text entry
 
-### Navigation chords
-| Chord | Destination |
-|-------|-------------|
-| `g h` | Home (Activity) |
-| `g r` | Activity (runs) |
-| `g p` | Projects |
+## Cross-Surface Behavior
 
-### List navigation
-| Key | Action |
-|-----|--------|
-| `j` | Move selection down |
-| `k` | Move selection up |
-| `l` | Open selected item |
-| `h` / ArrowLeft | Go back |
+| Behavior | Delta |
+|----------|-------|
+| Plugin installation | Claude Code uses MCP registration with scope; OpenCode copies filesystem artifacts; Codex uses its own path |
+| Skill invocation syntax | Claude Code uses short slash commands; OpenCode uses rp1-prefixed names |
+| Execution vs observability | Host tools do the work; Agent Tools carry protocol; Arcade shows passive status |
+| Responsive layout | Desktop: icon-rail sidebar + resizable panels. Mobile: bottom tab bar + drawers |
+| Notification delivery | Arcade: real-time toasts with dedup + dismissible sidebar. Host tools: inline gates |
+| Run invocation context | Hidden by default, toggled via contextual command; shows workflow, run policy, worktree state |
+| Daemon lifecycle modes | Full mode (register + browser), daemon-only (start without project), hook-json (structured output for hooks) |
 
-### Contextual (Artifact Viewer)
-| Key | Action |
-|-----|--------|
-| `e` | Toggle table of contents |
-| `c` | Copy artifact content |
-| `[` / `]` | Previous / next artifact |
-| `h` / ArrowLeft | Back to run detail |
+## Accessibility
 
-### Contextual (File Browser)
-| Key | Action |
-|-----|--------|
-| `e` | Toggle table of contents |
-| `c` | Copy file content |
-| `h` / ArrowLeft | Back to project |
-
-## Accessibility & Discoverability
-
-- **Roving tabindex** keeps dense run lists keyboard-navigable without trapping tab order inside every row.
-- **Single-key shortcut suppression** protects text entry while preserving keyboard navigation elsewhere.
-- **Chord timeout** (500ms) prevents accidental chord triggering and resets pending state visually via `data-chordPending`.
-- **Reduced-motion fallback** replaces animated page transitions, toast animations, feed item animations, and command palette stagger effects with instant or zero-duration equivalents when the user prefers reduced motion.
-- **Dialogs, focus rings, and status labels** remain screen-reader legible and should not rely on color alone.
-- **Live region announcements**: Table-of-contents section changes are announced via `aria-live="polite"` regions in both the Artifact Viewer and File Browser. Notification toasts use an `aria-live="polite"` container.
-- **`waiting_for_user` before any prompt** makes gate pauses visible in Arcade before the host tool asks the question.
-- **Named first emits and state-machine-aligned steps** keep dashboard labels meaningful and prevent hidden phase drift.
-- **Namespaced sub-agent steps** keep parent timelines readable and avoid collisions between parent and child workflow phases.
-- **Explicit `storageRoot` on artifact registration** ensures outputs resolve predictably in the dashboard across work, project, and absolute paths.
-- **Notification trigger badge**: The bell icon shows a numeric badge for actionable counts (action_required + attention) and a subtle dot for informational-only notifications, with a descriptive `aria-label` summarizing counts by category.
-- **Shortcut registry**: A centralized `ShortcutRegistryProvider` tracks global, navigation, and contextual shortcuts so the help overlay always reflects the currently available bindings for the active view.
-
-## Cross-Surface Deltas
-
-| Behavior | Surfaces | Delta | Reason |
-|----------|----------|-------|--------|
-| Plugin installation | CLI, Host Tool Integration | Claude Code uses MCP registration with scope (user, project, local), OpenCode copies filesystem artifacts, and Codex uses its own artifact path. | Each host has a different plugin architecture. |
-| Skill invocation syntax | Reference Docs, Host Tool Integration | Claude Code favors short slash commands with optional prefixes, while OpenCode uses rp1-prefixed slash names and `/skills` discovery. | Collision avoidance and host-specific browsing capabilities differ. |
-| Semantic prompt authoring vs rendered harness output | CLI, Host Tool Integration, Agent Tools CLI | Prompt authors write semantic Liquid tags such as `dispatch_agent`, `ask_user`, `edit_model`, and `plan_tool`, and the build pipeline renders harness-specific instructions from that source. | One authored prompt needs to preserve intent across multiple assistants. |
-| Execution vs observability | Host Tool Integration, Agent Tools CLI, Arcade Web UI | Host tools are the conversational work surface, Agent Tools carry the protocol events, and Arcade shows passive run status, gates, artifacts, and notifications. | rp1 separates doing the work from monitoring and intervening in it. |
-| Artifact path resolution | Host Tool Integration, Agent Tools CLI, Arcade Web UI | Outputs can live under `.rp1/work`, the project root, or an absolute path, but every artifact must declare its root explicitly. | Intermediate workflow files and final deliverables have different lifetimes and locations. |
-| Navigation model | Arcade Web UI, CLI, Host Tool Integration | Web UI uses spatial keyboard navigation, chord shortcuts, command palette, and contextual shortcut registry. CLI uses subcommands and flags. Host tools use slash commands and inline prompts. | Each surface follows its native interaction idiom. |
-| Responsive layout | Arcade Web UI | Desktop uses an icon-rail sidebar, resizable panels, and slide-out notification drawer. Mobile uses a bottom tab bar with notification trigger, drawer-based artifact/ToC/annotation panels, and horizontal step selectors. | Desktop and mobile require different density and reach tradeoffs. |
-| Notification delivery | Arcade Web UI, Agent Tools CLI | Agent Tools emit events that create notifications server-side. Arcade delivers them as real-time toasts (auto-dismiss 6s) and persists them in a dismissible sidebar grouped by attention level. Host tools receive gates inline. | Arcade is the passive monitoring surface; host tools handle active decisions. |
-| Run invocation context | Arcade Web UI, Agent Tools CLI | The Arcade run detail page shows a dedicated invocation card with workflow name, run policy, decision (new/resumed/legacy), canonical and requested roots, worktree state, and work identity. Sensitive identity values are redacted server-side. Agent Tools record this context during workflow bootstrap. | Gives operators full provenance for debugging run behavior without exposing secrets. |
-
-## Related KB Links
-
-- **System topology**: See [architecture.md](architecture.md)
-- **Component inventory**: See [modules.md](modules.md)
-- **Terminology**: See [concept_map.md](concept_map.md)
-- **Implementation details**: See [patterns.md](patterns.md)
+- Roving tabindex for dense lists without trapping tab order
+- Single-key shortcut suppression during text entry
+- Reduced-motion fallback for all animations
+- Screen-reader aria-labels on status dots, notification triggers, commands
+- Live region announcements for ToC navigation and notifications
+- Named emits and state-machine-aligned steps for meaningful dashboard labels
+- Namespaced sub-agent steps prevent timeline collisions
+- Notification items use attention-level-differentiated backgrounds for visual triage

--- a/.rp1/context/modules.md
+++ b/.rp1/context/modules.md
@@ -4,116 +4,84 @@
 **Analysis Date**: 2026-04-12
 **Modules Analyzed**: 22
 
-## Core Modules
+## Module Map
 
-| Module | Purpose | Notes |
+| Module | Purpose | Files |
 |--------|---------|-------|
-| `cli/commands` | User-facing CLI commands via Commander.js, including thin adapters into install, init, update, verify, arcade, and build workflows. | 27 files; wires `build:opencode` through `cli/src/main.ts` and `cli/src/commands/build.ts`. |
-| `cli/agent-tools` | Agent-tools CLI surface with tool registry and workflow-oriented subcommands for AI agent infrastructure. | 59 files; includes `emit`, `state-machine`, `resolve-args`, `task`, `feedback`, `github-pr`, `comment-extract`, `mmd-validate`, `rp1-root-dir`, and `workflow-bootstrap`. |
-| `cli/build` | Multi-platform artifact build pipeline for Claude Code, OpenCode, and Codex outputs. | 50 files; owns parsing, linting (7 rules), template transforms, preprocessor conditionals, catalog generation, platform definitions, and platform-specific emitters via LiquidJS. |
-| `cli/catalog` | Skill and agent catalog registry with distribution scoping, category ordering, and maintenance artifact generation. | 3 files; powers `CATALOG.md` generation, init skill-awareness blocks, and `catalog/agents.yaml` + `catalog/skills.yaml` maintenance. |
-| `cli/install` | Install plugin artifacts into host tools with staging, backup/rollback, and verification. | 22 files. |
-| `cli/init` | Project initialization with context detection, tool detection, plugin installation, versioned comment/shell fence markers, and generated instruction templates. | 23 files; supports `comment-fence` and `shell-fence` with version-stamped markers. |
-| `cli/shared` | Cross-cutting shared library for errors, fp-ts helpers, directory resolution, logging, events, canonical naming, logical-step collapsing, project-id, and prompts. | 15 files; leaf-style support layer reused across CLI and web UI. |
-| `cli/assets` | Bundled asset access for release builds, including plugin and web-ui extraction. | 5 files. |
-| `cli/settings` | Settings file loading and validation for project and global rp1 configuration. | 2 files. |
-| `cli/config` | Supported-tools registry defining host tool capabilities. | 3 files. |
-| `cli/lib` | Utility library for cache, colors, package-manager detection, version comparison, fence staleness checking, and fence version tracking. | 6 files; includes `fence-check.ts` and `fence-version.ts`. |
-| `cli/migrate` | Migration system for upgrading rp1 project structures across versions, including stanza upgrades and DB backfill. | 5 files; `stanza-upgrade.ts` replaces fenced content in CLAUDE.md, AGENTS.md, and .gitignore with latest templates. |
-| `cli/uninstall` | Removes rp1 injections from instruction files and gitignore, uninstalls Claude Code plugins, preserves `.rp1` directory. | 2 files. |
-| `cli/pr-review` | PR review configuration loading and CI environment detection. | 4 files. |
+| cli/commands | User-facing CLI commands including build, migrate, and arcade | 27 |
+| cli/agent-tools | Agent-tools CLI with emit, workflow-bootstrap, resolve-args, state-machine, task, feedback | 59 |
+| cli/build | Multi-platform artifact build pipeline for Claude Code, OpenCode, Codex | 50 |
+| cli/catalog | Skill/agent catalog registry with distribution scoping and arcade tracking | 3 |
+| cli/install | Install plugin artifacts into host tools with staging, backup/rollback, verification | 22 |
+| cli/init | Project initialization with context detection, fence markers, and Ink UI | 23 |
+| cli/shared | Cross-cutting library: errors, fp-ts helpers, events, logging, directory resolution | 15 |
+| cli/lib | Utility: cache, colors, package-manager detection, fence version tracking | 6 |
+| cli/settings | Settings file loading and validation | 2 |
+| cli/migrate | Migration system for project structure upgrades | 5 |
+| cli/pr-review | PR review config and CI environment detection | 4 |
+| web-ui/server | Bun HTTP/WS server with REST APIs, file watching, event broadcast, notifications | 16 |
+| web-ui/daemon | Daemon lifecycle manager with diagnostic logging and IPC | 4 |
+| web-ui/frontend | React SPA dashboard: pages, components, hooks, providers, motion | 190 |
+| plugins/base | KB, docs sync, writing, research, strategy, security, guide meta-skill | 53 |
+| plugins/dev | Build workflows, blueprinting, PR review, feature delivery | 53 |
+| plugins/utils | Prompt writing, tersification, eval helpers | 15 |
+| docs/reference | User-facing reference docs for CLI, plugins, web UI, platform tags | 36 |
+| evals | Prompt attestation with content-addressable hashing and dockerized execution | 26 |
 
-## Web UI Modules
+## Key Components
 
-| Module | Purpose | Notes |
-|--------|---------|-------|
-| `web-ui/server` | Bun HTTP and WebSocket server with REST APIs, file watching, event broadcast, annotation embedding, and notification endpoints. | 16 files; key routes include `v2-api` (runs, events, artifacts, annotations, notifications, projects), content serving, and project lookup. |
-| `web-ui/daemon` | Daemon lifecycle manager for the web UI server; relays notification events over WebSocket. | 4 files. |
-| `web-ui/frontend` | React SPA dashboard with pages, components, hooks, providers, motion transitions, and a dedicated notifications sidebar. | 190 files; major entrypoints are `main.tsx`, `App.tsx`, `V2Layout.tsx`, and `routes.tsx`. |
-
-## Plugin Modules
-
-| Module | Purpose | Notes |
-|--------|---------|-------|
-| `plugins/base` | Foundational plugin for KB generation/loading, documentation workflows and sync, Mermaid validation, deep research, strategy, security analysis, maintenance, and the `/guide` meta-skill. | 53 files; `/guide` uses `CATALOG.md` for skill discovery and routing. |
-| `plugins/dev` | Feature delivery plugin for build workflows, blueprinting, PR review, code audit, feature lifecycle automation, and dockerized eval execution. | 53 files. |
-| `plugins/utils` | Prompt authoring plugin for prompt writing and rewriting, tersification, eval assertion extraction, and prompt-eval helpers. | 15 files; `prompt-writer` ships a companion reference pack. |
-
-## Documentation & Packages
-
-| Module | Purpose | Notes |
-|--------|---------|-------|
-| `docs/reference` | Human-facing reference surface for CLI commands, agent-tools, platform tags, web UI, and plugin skills. | 36 files; has its own hub, sub-indexes, and topical pages. |
-| `evals` | Prompt attestation system with content-addressable hashing, dependency graphs, workspace isolation for parallel test execution, dockerized eval execution, and shared assertion library. | 26 files; suites cover `rp1-dev` skills (`build`, `build-fast`, `speedrun`) with shared assertions and fixtures. |
-
-## Highlighted Components
-
-### `workflow-bootstrap`
-Agent-tool subcommand that deterministically creates or resumes a tracked workflow run. It resolves canonical skill schemas, validates `run_policy` (`fresh`/`resumable`), derives work identity from `identity_args`, resolves arguments via the 5-layer merge, and initializes the backing run in the emit database. This is the entry point for tracked-workflow lifecycle management.
-
-### `notification system`
-Emit-pipeline extension spanning `notification-generator.ts` and `notification-database.ts` within `cli/agent-tools/emit`. Auto-generates notifications for completed/failed runs and `waiting_for_user` events, with deduplication, truncation, and daemon relay for WebSocket broadcast to the Arcade sidebar.
-
-### `catalog registry`
-`cli/catalog` module that provides a unified skill/agent catalog with distribution scoping (`distributable`/`internal`), category ordering and trigger descriptions, renderable markdown generation, init skill-awareness block generation, and YAML maintenance artifacts.
-
-### `fence version system`
-Versioning system for injected instruction stanzas spanning `cli/init/comment-fence.ts`, `cli/init/shell-fence.ts`, `cli/lib/fence-check.ts`, `cli/lib/fence-version.ts`, and `cli/migrate/stanza-upgrade.ts`. Stamps version markers into CLAUDE.md, AGENTS.md, and .gitignore, then detects staleness and auto-upgrades during `rp1 migrate`.
-
-### `build:opencode`
-Public CLI command that exposes the OpenCode artifact build pipeline. It translates Commander flags into build args and delegates the real work to `executeBuild()` in `cli/build`.
-
-### `generate-user-docs`
-Base skill that synchronizes user-facing documentation against the current KB through a `validate -> stale gate -> scan -> approval -> process` workflow, preserving `scan_results.json` and asking for approval exactly once.
-
-### `scribe`
-Dual-mode documentation worker for scan/process batches. It classifies sections as `verify`, `add`, or `fix`, applies KB-backed rewrites or review markers, and returns JSON only.
-
-### `write-content`
-Tracked content-writing workflow that turns rough notes into a grounded Markdown document, maintains `.rp1/work/content/.../brief.md`, and registers both brief and final document artifacts.
-
-### `prompt-writer`
-Prompt authoring workflow that supports new prompts and rewrites, emits workflow state, loads templates and patterns selectively, and applies rp1-specific validation rules.
-
-### `guide`
-Base meta-skill that routes users to available rp1 skills using the generated `CATALOG.md` from the catalog registry.
-
-### `reference hub`
-Top-level docs surface rooted at `docs/reference/index.md` that routes readers to CLI, base, dev, and web-ui references plus topical pages such as agent-tools and platform tags.
+| Component | Module | Purpose |
+|-----------|--------|---------|
+| workflow-bootstrap | agent-tools | Deterministic run creation/resumption with run_policy, identity_args, and 5-layer argument merge |
+| emit pipeline | agent-tools/emit | Records all 6 event types with status derivation, step validation, skipped-step detection, and notification generation |
+| notification system | agent-tools/emit | Auto-generates notifications for terminal run states and waiting_for_user events with deduplication |
+| state-machine | agent-tools | Parses Mermaid stateDiagram-v2, validates step transitions, provides graph queries |
+| resolve-args | agent-tools | 5-layer argument merge (user > project settings > user settings > ENV > schema default) with directory resolution |
+| build parser | build | Frontmatter parsing for skills/agents including arcadeTracked extraction and workflow metadata |
+| build validator | build | L1 (syntax) + L2 (schema) validation including arcade_tracked field |
+| catalog registry | catalog | Centralized skill catalog with distribution scoping, category ordering, and arcadeTracked propagation |
+| server registry | web-ui/server | Multi-project registry with async mutex (`withRegistryLock`), atomic file persistence, worktree normalization |
+| daemon diagnostics | web-ui/daemon | Structured NDJSON logging for daemon lifecycle events to daemon.log |
+| arcade command | commands | CLI entry point with start/stop/status/restart, --daemon-only, --format hook-json modes |
+| install verifier | install | Cross-platform installation health check and skill discovery with arcade_tracked metadata |
 
 ## Dependency Highlights
 
-- `cli/commands` depends directly on `cli/shared`, `cli/init`, `cli/install`, `cli/config`, and `cli/build`; it lazy-loads `cli/agent-tools` and the daemon server path.
-- `cli/build` depends on `cli/shared`, the state-machine parser for build-time validation of workflow prompts, and `cli/catalog` for `CATALOG.md` generation.
-- `cli/agent-tools/workflow-bootstrap` depends on `cli/agent-tools/emit/database`, `cli/agent-tools/resolve-args/resolver`, `cli/build/parser` (for schema parsing), and `cli/shared/directory-resolution`.
-- `cli/agent-tools/emit` depends on `cli/agent-tools/emit/notification-database` and `cli/agent-tools/emit/notification-generator` for auto-notification creation, plus the daemon connector for WebSocket relay.
-- `cli/catalog` depends on `cli/build/parser` for skill schema parsing and `cli/shared/canonical-name` for naming; `cli/catalog/maintenance` depends on `cli/init/templates/generator` for init template co-generation.
-- `cli/init` depends on `cli/shared`, `cli/config`, and uses versioned fence markers from `cli/lib/fence-version`.
-- `cli/migrate` depends on `cli/init/comment-fence`, `cli/init/shell-fence`, and `cli/lib/fence-version` for stanza upgrades.
-- `web-ui/server` depends on `cli/shared` and on agent-tool-backed event, artifact, and notification state; `web-ui/frontend` consumes the server over REST and WebSocket.
-- `plugins/base` depends on agent-tool conventions for emits, artifact registration, and path resolution; `generate-user-docs` also treats `docs/reference` as a maintained target surface; `/guide` consumes `CATALOG.md` from `cli/catalog`.
-- `plugins/utils` depends indirectly on agent-tools because `prompt-writer` and its companion guide teach `emit`, `resolve-args`, `rp1-root-dir`, and artifact-registration conventions.
-- `plugins/dev` depends on `plugins/base`; base does not depend on dev.
-- `evals` tracks prompt content from the base and dev plugins for attestation and verification; supports dockerized eval execution with workspace isolation.
+```text
+cli/commands --> cli/shared, cli/init, cli/install, cli/build, web-ui/daemon (lazy)
+cli/build --> cli/shared, cli/agent-tools/state-machine, cli/catalog
+cli/agent-tools/emit --> cli/agent-tools/state-machine, web-ui/daemon (lazy)
+cli/agent-tools/resolve-args --> cli/settings, cli/shared
+cli/catalog --> cli/build/parser, cli/shared/canonical-name
+cli/install/verifier --> cli/build/parser, cli/assets
+web-ui/server/registry --> web-ui/daemon/config-dir
+web-ui/daemon --> web-ui/daemon/diagnostics
+web-ui/frontend --> web-ui/server (REST + WebSocket)
+plugins/dev --> plugins/base (runtime)
+plugins/* --> cli/agent-tools (runtime conventions)
+```
 
 ## Cross-Module Patterns
 
-| Pattern | Meaning | Status |
-|---------|---------|--------|
-| Skill-Agent Delegation | High-level skills orchestrate while specialized agents perform bounded execution work. | Confirmed |
-| Tracked Workflow Bootstrap | `workflow-bootstrap` deterministically creates or resumes runs based on `run_policy` and `identity_args`, giving skills a single atomic entry point for lifecycle management. | New |
-| Documentation Scan/Process Orchestration | `generate-user-docs` splits doc reconciliation into discovery, scan, approval, and process phases, with `scribe` handling batched file-level work. | Confirmed |
-| Notification Auto-Generation | The emit pipeline automatically creates notifications for terminal run states and agent prompts, relayed through daemon WebSocket to the Arcade sidebar. | New |
-| Catalog Registry | A centralized skill/agent catalog with distribution scoping, category ordering, and renderable output drives `CATALOG.md`, init skill-awareness blocks, and the `/guide` meta-skill. | New |
-| Versioned Fence Markers | Injected instruction stanzas carry version stamps that enable staleness detection and automated in-place upgrades during migration. | New |
-| State-Machine + Emit Discipline | Workflow prompts declare Mermaid state machines and drive dashboard-visible progress through `rp1 agent-tools emit`. | Confirmed |
-| Progressive Disclosure Authoring Pack | A primary skill stays focused while companion docs hold patterns, templates, and repo-specific conventions. | Confirmed |
-| Thin Command Adapter | User-facing CLI commands remain small adapters that translate flags and delegate substantive work into deeper modules. | Confirmed |
-| Multi-Platform Build | Single Markdown prompt sources are transformed into multiple host-tool artifacts through a shared build pipeline. | Confirmed |
+| Pattern | Modules | Benefit |
+|---------|---------|---------|
+| Skill-Agent Delegation | plugins/*, cli/agent-tools | Separation: skills orchestrate, agents do bounded work |
+| Tracked Workflow Bootstrap | workflow-bootstrap, emit, resolve-args | Atomic run creation with identity-based deduplication |
+| State-Machine + Emit Discipline | state-machine, emit, plugins/* | Dashboard-visible progress through validated step emissions |
+| Arcade Tracked Visibility | parser, validator, catalog, verifier | Skills opt out of Activity feed via arcadeTracked without losing workflow mechanics |
+| Async Mutex Registry | web-ui/server/registry | Serializes concurrent registry mutations preventing race conditions |
+| Notification Auto-Generation | emit, daemon, frontend | Terminal events auto-create deduplicated notifications relayed via WebSocket |
+| Catalog Registry | catalog, build, base/guide | Single-source catalog drives CATALOG.md, init blocks, and /guide |
+| Versioned Fence Markers | init, lib, migrate | Instruction stanzas carry version stamps for staleness detection and auto-upgrade |
+| Thin Command Adapter | commands, build, install, init | CLI commands translate flags and delegate to deeper modules |
+| Multi-Platform Build | build | Single markdown sources transform into 3 platform artifacts via shared pipeline |
 
-## Cross-References
+## External Dependencies
 
-- **System topology**: See [architecture.md](architecture.md)
-- **Surface behavior**: See [interaction-model.md](interaction-model.md)
-- **Code conventions**: See [patterns.md](patterns.md)
-- **Domain terminology**: See [concept_map.md](concept_map.md)
+| Package | Purpose |
+|---------|---------|
+| fp-ts | Functional programming: Either, TaskEither, Option |
+| liquidjs | Template engine for multi-platform build pipeline |
+| commander | CLI command framework |
+| yaml | YAML parsing for frontmatter and settings |
+| bun:sqlite | SQLite for emit events, notifications, tasks |

--- a/.rp1/context/patterns.md
+++ b/.rp1/context/patterns.md
@@ -3,79 +3,79 @@
 **Project**: rp1
 **Last Updated**: 2026-04-12
 
-## Naming & Organization
+## Naming Conventions
 
-- **Files**: TypeScript stays feature-scoped under directories such as `cli/src/commands/`; prompt assets use kebab-case skill folders with `SKILL.md` plus companion docs when deeper guidance is needed.
-- **Functions**: CLI helpers use camelCase verbs; prompt parameters use `UPPER_SNAKE_CASE` in `metadata.arguments`, while agents keep top-level `arguments`.
-- **Imports**: Relative TS imports keep explicit `.js` suffixes; command registration stays centralized in `cli/src/main.ts`.
-- **Evidence**: `cli/src/main.ts`, `plugins/base/skills/write-content/SKILL.md`, `plugins/base/agents/scribe.md`
+- **Files**: Feature-scoped directories (`cli/src/commands/`, `cli/src/build/`); prompt assets use kebab-case skill folders with `SKILL.md`; React: PascalCase components, camelCase hooks
+- **Functions**: CLI camelCase verbs; React hooks prefix `use`; error factories match their `_tag` (usageError, runtimeError)
+- **Parameters**: UPPER_SNAKE_CASE enforced by `/^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$/`
+- **Imports**: Relative TS imports keep `.js` suffixes; web-ui uses `@/` path alias; CSS classes use `rp1-` prefix to avoid Tailwind collisions
 
-## Type & Data Modeling
+## Type Patterns
 
-- **Data modeling**: Runtime TS favors discriminated unions, readonly records, and `Either`/`TaskEither`; prompt workflows describe inputs and outputs declaratively in YAML frontmatter and JSON contracts.
-- **Strictness**: Tagged unions (`_tag`, status/event enums) and explicit allowed-value tables are preferred over loose objects or prose-only contracts. Build-time types enforce canonical enums: `SkillCategory`, `WorkflowRunPolicy`, `Status`, `EventType`, `ArtifactType`.
-- **Immutability**: TS models lean on `readonly` and `as const`; persisted artifacts such as `brief.md` and `scan_results.json` serve as source-of-truth snapshots.
-- **Evidence**: `cli/shared/errors.ts`, `cli/shared/events.ts`, `cli/src/build/models.ts`
+- **Discriminated unions**: `_tag` field on CLIError, `type` field on EventPayload
+- **Enum tables**: SkillCategory, WorkflowRunPolicy, Status, EventType as string literal unions with parallel `VALID_*` arrays
+- **Immutability**: `readonly` properties and `as const` assertions throughout; persisted artifacts as source-of-truth snapshots
+- **Template strictness**: LiquidJS uses `strictVariables` and `strictFilters`
 
 ## Error Handling
 
-- **Strategy**: TS code returns `Either` or `TaskEither<CLIError, A>` and formats errors once at the CLI boundary; prompt workers fail fast on invalid inputs and return structured JSON with `errors[]`.
-- **Propagation**: Parent skills gate on hard failures, but batch workflows tolerate partial success when enough worker results are valid.
-- **Common types**: `UsageError`, `ConfigError`, `ValidationError`, `RuntimeError`, `PrerequisiteError`, `ParseError`, `NotFoundError`.
-- **Evidence**: `cli/shared/errors.ts`, `cli/src/build/validator.ts`, `cli/src/agent-tools/workflow-bootstrap/index.ts`
+- **Strategy**: Returns `Either` or `TaskEither<CLIError, A>`; formats errors once at CLI boundary via `formatError`; `tryCatchTE` wraps async
+- **Propagation**: Parent skills gate on hard failures; batch workflows tolerate partial success
+- **Validation staging**: L1 (syntax) then L2 (schema) in build pipeline
+- **Error discrimination**: `isValidProject` distinguishes ENOENT from transient I/O errors instead of swallowing all
+- **Common types**: UsageError, NotFoundError, ConfigError, RuntimeError, PrerequisiteError, ParseError, ValidationError, GenerationError, TransformError, PortInUseError
 
-## Validation & Boundaries
+## Validation
 
-- **Where validation happens**: At workflow intake and command boundaries, not deep in execution. Build pipeline enforces L1 (syntax) then L2 (schema) validation on all YAML frontmatter.
-- **How validation happens**: Explicit enum/default tables, existence checks, compatibility aliases, and stop/continue gates. Tracked workflows validate `run_policy`/`identity_args` coherence at build and bootstrap time.
-- **Normalization**: `list_marker` is canonical while `list_style` is preserved as a compatibility alias; fence markers carry semver versions for staleness detection.
-- **Evidence**: `cli/src/build/validator.ts`, `cli/src/lib/fence-check.ts`, `cli/src/agent-tools/workflow-bootstrap/index.ts`
+- **Location**: Workflow intake and command boundaries
+- **Method**: Explicit enum/default tables, existence checks, compatibility aliases
+- **Additive-field propagation**: New fields (e.g., `arcadeTracked`) flow parser -> models -> validator -> template -> registry without breaking existing paths
+- **Argument validation**: Each definition validated field-by-field with early return on first error
+
+## fp-ts Pipeline Pattern
+
+- Arcade command uses `pipe(loadConfig, TE.fromEither, TE.chain(...))` for all operation modes
+- `tryCatchTE` wraps async operations with error factories
+- `map`, `flatMap`, `isLeft` preferred over overengineered abstractions
+
+## Concurrency Patterns
+
+- **Async mutex**: `withRegistryLock` in server/registry.ts serializes read-modify-write cycles via promise-chain mutex
+- **Toast dedup guard**: `NotificationContainer` uses functional state updater (`setToasts(prev => ...)`) to prevent duplicate toasts from concurrent WebSocket messages
+- **Request identity tracking**: Web-UI hooks use `useCallback`/`useRef` to handle stale async responses
+- **Lazy loading**: Heavy subsystems (daemon, emit relay) loaded via dynamic `import()` at runtime
+
+## I/O Patterns
+
+- **Database**: SQLite via `bun:sqlite` for runs, events, artifacts, annotations, notifications. Upsert semantics; dedup via `hasNotificationForSource`
+- **File I/O**: Atomic writes via temp-file + rename (registry `saveRegistry`); PID file with mode 0o600; diagnostic log uses `appendFileSync`
+- **HTTP clients**: Web-UI SPA fetches `/api/v2/` with paginated notification loading; daemon health checks use polling with configurable interval
+
+## UI Patterns
+
+- **Contextual commands**: Views register `CommandDefinition[]` via `useContextualShortcuts` hook, surfaced in command palette alongside navigation/action commands
+- **SessionStorage persistence**: `showFrontmatter`/`showMetadata` use `useState` + `sessionStorage` for per-tab, per-view toggle persistence
+- **Notification lifecycle**: Toasts auto-dismiss 6s with dedup guard; sidebar groups by attention level; "Read all" bulk dismiss
+- **Attention-level styling**: `itemClassForLevel` maps attention levels to differentiated background colors for visual triage
 
 ## Observability
 
-- **Logging**: CLI entrypoints attach a logger in `preAction`, map `--verbose` and `--trace` to levels.
-- **Events**: Six canonical event types (`status_change`, `artifact_registered`, `annotation_updated`, `waiting_for_user`, `btw_update`, `subflow_registered`) are persisted to SQLite via the emit pipeline and broadcast over WebSocket to the daemon.
-- **Notifications**: Auto-generated from emit pipeline for completed/failed runs and `waiting_for_user` events, with deduplication by source.
-- **Evidence**: `cli/shared/events.ts`, `cli/src/agent-tools/emit/index.ts`, `cli/src/agent-tools/emit/notification-generator.ts`
+- **CLI logging**: consola-based logger with `--verbose`/`--trace` mapping to numeric levels
+- **Daemon diagnostics**: Append-only NDJSON to `daemon.log` via `logDaemonEvent` with structured event/data fields; failures silently swallowed
+- **Correlation**: `runId`, `projectId`, and source IDs in notification and event records
 
-## Testing Idioms
+## Extension Points
 
-- **Organization**: Tests live under `cli/src/__tests__/` mirroring feature areas with shared helpers in `helpers/`. Evals share assertions and tool-name canonicalization under `evals/suites/shared/`.
-- **Fixtures**: Common patterns include temp directories, explicit env save/restore, and helper unwraps for `Either` and `TaskEither`.
-- **Levels**: Unit-heavy, with integration-style setup around CLI, filesystem, config, and build pipeline behavior. Golden-file tests validate rendered template output.
-- **Evidence**: `cli/src/__tests__/build/validator.test.ts`, `cli/src/__tests__/agent-tools/workflow-bootstrap/workflow-bootstrap.test.ts`, `evals/suites/shared/assertions/tool-calls.ts`
+- Commands registered centrally via `program.addCommand` in `main.ts`
+- Agent tools register via `registerTool()`
+- Build pipeline uses LiquidJS templates with registered lint rules and filters
+- State machines declared in `stateDiagram-v2` blocks with auto-skip and auto-complete
+- Views register contextual commands via `useContextualShortcuts` hook for command palette integration
 
-## I/O & Integration
+## Testing
 
-- **Workflow I/O**: Doc workflows are explicit `scan -> approve -> process` pipelines that read and write JSON artifacts and use `git` plus `Glob/Grep/Edit` instead of opaque repo sweeps.
-- **CLI entrypoints**: `cli/src/main.ts` lazy-loads heavy or special entrypoints such as `agent-tools` and the daemon server; concrete commands adapt flags into executor args and delegate.
-- **Database**: SQLite (via `bun:sqlite`) stores runs, events, artifacts, annotations, and notifications. The emit module uses upsert semantics and the web-ui V2 API reads from the same DB.
-- **Evidence**: `cli/src/main.ts`, `cli/src/agent-tools/emit/database.ts`, `cli/web-ui/src/server/routes/v2-api.ts`
-
-## Concurrency & Async
-
-- **Async usage**: TS entrypoints use async functions and dynamic imports; workflow prompts describe concurrency declaratively via background agent dispatch and later aggregation.
-- **Parallelism**: Batch by five, run background `rp1-base:scribe` workers, then aggregate counts and errors into one persisted result.
-- **Safety**: Parent workflows keep durable intermediates so retries and gates do not depend on transient prompt context. Daemon notification is best-effort with silent failure.
-- **Evidence**: `cli/src/main.ts`, `cli/src/agent-tools/emit/index.ts`
-
-## Dependency & Configuration
-
-- **Injection**: rp1 skills declare capabilities and parameters declaratively in frontmatter; agents receive pre-resolved parameters from parents and do not re-parse arguments.
-- **Config resolution**: `resolve-args` and `rp1-root-dir` centralize argument and directory resolution. `workflow-bootstrap` unifies run creation/resumption for tracked workflows, resolving schema paths across worktrees and installed manifests.
-- **Settings**: Project and user settings remain TOML-backed and layered under the shared configuration model.
-- **Evidence**: `cli/src/agent-tools/resolve-args/index.ts`, `cli/src/agent-tools/workflow-bootstrap/index.ts`, `cli/shared/directory-resolution.ts`
-
-## Extension Mechanisms
-
-- **CLI extension**: Commands are added centrally with `program.addCommand(...)`, while heavy subsystems stay behind thin adapters. Agent tools register via `registerTool()` with name/description/execute.
-- **Prompt extension**: Workflows compose through `sub_agents` metadata, Liquid tags such as `dispatch_agent`, `ask_user`, `plan_tool`, and companion references loaded on demand.
-- **Build extension**: One prompt source is rendered into Claude Code, OpenCode, and Codex artifacts through a shared LiquidJS-based build pipeline with registered lint rules (`registerLintRule`). Build-time catalog generation derives CATALOG.md from a shared registry.
-- **State machines**: Workflows declare `stateDiagram-v2` blocks; the emit pipeline validates steps against loaded state machines, auto-skips unreached steps, and auto-completes predecessor steps.
-- **Evidence**: `cli/src/build/lint/index.ts`, `cli/src/catalog/registry.ts`, `cli/src/agent-tools/emit/step-validation.ts`
-
-## Content Fencing
-
-- **Mechanism**: Injected content in instruction files (CLAUDE.md, AGENTS.md, .gitignore) is wrapped in versioned fence markers (`<!-- rp1:start:vX.Y.Z -->` / `<!-- rp1:end:vX.Y.Z -->`).
-- **Staleness**: `LATEST_FENCE_VERSION` in `fence-version.ts` is bumped when stanza content changes. `fence-check.ts` scans markers to detect outdated files; `stanza-upgrade.ts` performs in-place upgrades.
-- **Evidence**: `cli/src/init/comment-fence.ts`, `cli/src/lib/fence-check.ts`, `cli/src/migrate/stanza-upgrade.ts`
+- Tests under `cli/src/__tests__/` mirror feature areas with shared helpers
+- Common patterns: temp directories, explicit env save/restore, Either/TaskEither unwrap helpers
+- Unit-heavy with integration-style setup for CLI, filesystem, config, and build pipeline
+- Golden-file tests validate rendered template output
+- Evals share assertions under `evals/suites/shared/`

--- a/.rp1/context/state.json
+++ b/.rp1/context/state.json
@@ -11,8 +11,8 @@
     "docs/"
   ],
   "generated_at": "2026-04-12T00:00:00Z",
-  "git_commit": "9f8313662db6b11d91a4dc138c7371e004d1a3d8",
-  "files_analyzed": 286,
+  "git_commit": "c0e31eb1b9bcebe4720181365667bf38fa435ea6",
+  "files_analyzed": 919,
   "languages": [
     "TypeScript",
     "TSX",
@@ -26,7 +26,7 @@
   ],
   "metrics": {
     "modules": 22,
-    "components": 11,
-    "concepts": 33
+    "components": 12,
+    "concepts": 36
   }
 }

--- a/cli/web-ui/src/__tests__/app/V2Layout.test.tsx
+++ b/cli/web-ui/src/__tests__/app/V2Layout.test.tsx
@@ -147,6 +147,29 @@ async function renderLayout() {
 	return render(<RouterProvider router={router} />);
 }
 
+async function renderLayoutAt(initialEntry: string) {
+	installLayoutMocks();
+	const { AppLayout } = await import(
+		`../../app/V2Layout.tsx?v2-layout-test=${++v2LayoutImportVersion}`
+	);
+	const router = createMemoryRouter(
+		[
+			{
+				path: "/",
+				element: <AppLayout />,
+				children: [
+					{ index: true, element: <div>Activity page</div> },
+					{ path: "projects", element: <div>Projects page</div> },
+					{ path: "runs/:runId", element: <div>Run detail page</div> },
+				],
+			},
+		],
+		{ initialEntries: [initialEntry] },
+	);
+
+	return render(<RouterProvider router={router} />);
+}
+
 function getNotificationTriggers(): HTMLButtonElement[] {
 	return screen.getAllByRole("button", {
 		name: /^Open notifications\./i,
@@ -285,5 +308,18 @@ describe("AppLayout notifications shell wiring", () => {
 			}
 			expect(document.activeElement).toBe(desktopTrigger);
 		});
+	});
+
+	test("renders the workspace strip alongside durable shell navigation for open workspaces", async () => {
+		await renderLayoutAt("/runs/run-1");
+
+		expect(
+			screen.getByRole("navigation", { name: "Open workspaces" }),
+		).toBeTruthy();
+		expect(screen.getByRole("button", { name: "Run run-1" })).toBeTruthy();
+		expect(
+			screen.getByRole("navigation", { name: "Mobile navigation" }),
+		).toBeTruthy();
+		expect(screen.getByTestId("icon-rail")).toBeTruthy();
 	});
 });

--- a/cli/web-ui/src/__tests__/components/v2/ArtifactViewerPanel.test.tsx
+++ b/cli/web-ui/src/__tests__/components/v2/ArtifactViewerPanel.test.tsx
@@ -1,0 +1,142 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import type { Artifact, Step } from "@/types/runs";
+
+let importVersion = 0;
+
+const step: Step = {
+	id: "build",
+	name: "Build",
+	status: "running",
+	startedAt: "2026-04-12T00:00:00.000Z",
+	completedAt: null,
+	taskCount: 1,
+	completedTaskCount: 0,
+};
+
+const artifact: Artifact = {
+	docId: "doc-1",
+	path: ".rp1/work/features/feature-1/tasks.md",
+	absolutePath: "/repo/.rp1/work/features/feature-1/tasks.md",
+	type: "markdown",
+	updatedDuringRun: true,
+	isNew: false,
+	step: "build",
+};
+
+mock.module("@/providers/AnnotationProvider", () => ({
+	AnnotationProvider: ({ children }: { children?: ReactNode }) => (
+		<>{children}</>
+	),
+}));
+
+mock.module("@/providers/WebSocketProvider", () => ({
+	useWebSocket: () => ({
+		onFileChange: () => () => {},
+	}),
+}));
+
+mock.module("@/components/MarkdownViewer/MermaidDiagram", () => ({
+	MermaidDiagram: () => <div data-testid="mermaid-diagram" />,
+}));
+
+mock.module("@/components/ui/scroll-area", () => ({
+	ScrollArea: ({
+		children,
+		className,
+	}: {
+		children?: ReactNode;
+		className?: string;
+	}) => <div className={className}>{children}</div>,
+}));
+
+mock.module("@/components/v2/AnnotationSidebar", () => ({
+	AnnotationSidebar: () => <div data-testid="annotation-sidebar" />,
+}));
+
+mock.module("@/components/v2/AnnotationToggleBtn", () => ({
+	AnnotationToggleBtn: () => <button type="button">Annotations</button>,
+}));
+
+mock.module("@/components/v2/TableOfContents", () => ({
+	TableOfContents: () => <div data-testid="toc">ToC</div>,
+}));
+
+mock.module("@/components/v2/UnifiedContentRenderer", () => ({
+	UnifiedContentRenderer: () => <div data-testid="unified-content-renderer" />,
+	SaveStatusIndicator: () => null,
+}));
+
+mock.module("@/components/v2/ContentPanel", () => ({
+	ContentPanel: ({
+		content,
+		error,
+		isLoading,
+	}: {
+		content?: string | null;
+		error?: string | null;
+		isLoading?: boolean;
+	}) => (
+		<div
+			data-testid="artifact-content-panel"
+			data-loading={String(isLoading ?? false)}
+			data-content={content ?? ""}
+			data-error={error ?? ""}
+		>
+			{error ?? content ?? ""}
+		</div>
+	),
+}));
+
+async function renderPanel() {
+	const { ArtifactViewerPanel } = await import(
+		`../../../components/v2/ArtifactViewerPanel.tsx?artifact-viewer-panel-test=${++importVersion}`
+	);
+
+	return render(
+		<ArtifactViewerPanel
+			step={step}
+			artifacts={[artifact]}
+			selectedArtifact={artifact}
+			runId="run-1"
+		/>,
+	);
+}
+
+describe("ArtifactViewerPanel", () => {
+	beforeEach(() => {
+		mock.restore();
+		document.body.innerHTML = "";
+		global.fetch = mock(async () => ({
+			ok: true,
+			json: async () => ({ content: "# Hello" }),
+		})) as unknown as typeof fetch;
+	});
+
+	afterEach(() => {
+		cleanup();
+		mock.restore();
+	});
+
+	test("surfaces initial fetch failures as an error when no cached content exists", async () => {
+		global.fetch = mock(async () => ({
+			ok: false,
+			statusText: "Internal Server Error",
+			json: async () => ({
+				error: "Failed to fetch artifact: Internal Server Error",
+			}),
+		})) as unknown as typeof fetch;
+
+		await renderPanel();
+
+		await waitFor(() => {
+			expect(screen.getByTestId("artifact-content-panel").dataset.loading).toBe(
+				"false",
+			);
+			expect(screen.getByTestId("artifact-content-panel").dataset.error).toBe(
+				"Failed to fetch artifact: Internal Server Error",
+			);
+		});
+	});
+});

--- a/cli/web-ui/src/__tests__/components/v2/NotificationsSidebar.test.tsx
+++ b/cli/web-ui/src/__tests__/components/v2/NotificationsSidebar.test.tsx
@@ -8,6 +8,11 @@ import {
 	waitFor,
 } from "@testing-library/react";
 import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
+import {
+	WORKSPACE_TABS_STORAGE_KEY,
+	type WorkspaceTab,
+	WorkspaceTabsProvider,
+} from "@/hooks/useWorkspaceTabs";
 
 let notificationsSidebarImportVersion = 0;
 
@@ -29,15 +34,36 @@ async function loadNotificationsSidebar() {
 	return NotificationsSidebar;
 }
 
+function setStoredState(state: {
+	readonly tabs: readonly WorkspaceTab[];
+	readonly activeKey: string | null;
+	readonly lastDurableRoute: string;
+}) {
+	sessionStorage.setItem(WORKSPACE_TABS_STORAGE_KEY, JSON.stringify(state));
+}
+
+function renderWithWorkspaceTabs(
+	children: JSX.Element,
+	initialEntries: readonly string[] = ["/"],
+) {
+	return render(
+		<MemoryRouter initialEntries={[...initialEntries]}>
+			<WorkspaceTabsProvider>{children}</WorkspaceTabsProvider>
+		</MemoryRouter>,
+	);
+}
+
 describe("NotificationsSidebar", () => {
 	beforeEach(() => {
 		mock.restore();
 		document.body.innerHTML = "";
+		sessionStorage.clear();
 	});
 
 	afterEach(() => {
 		cleanup();
 		mock.restore();
+		sessionStorage.clear();
 	});
 
 	function LocationProbe() {
@@ -51,57 +77,73 @@ describe("NotificationsSidebar", () => {
 		const closeMock = mock(() => {});
 		const NotificationsSidebar = await loadNotificationsSidebar();
 
-		render(
-			<MemoryRouter initialEntries={["/"]}>
-				<Routes>
-					<Route
-						path="*"
-						element={
-							<>
-								<LocationProbe />
-								<NotificationsSidebar
-									open={true}
-									onClose={closeMock}
-									onDismissNotification={dismissMock}
-									onDismissAllNotifications={dismissAllMock}
-									isLoading={false}
-									error={null}
-									notifications={[
-										{
-											id: 1,
-											message: "Approval needed",
-											sourceType: "agent",
-											sourceId: "run-1",
-											route: "/runs/run-1",
-											projectId: "proj-1",
-											createdAt: "2026-04-11T00:00:00.000Z",
-											harness: "codex",
-											runCommand: "/build",
-											runName: "Sidebar Build",
-											projectName: "Alpha Project",
-											attentionLevel: "action_required",
-										},
-										{
-											id: 2,
-											message: "Verify completed",
-											sourceType: "run",
-											sourceId: "run-2",
-											route: "/runs/run-2",
-											projectId: "proj-1",
-											createdAt: "2026-04-11T00:02:00.000Z",
-											harness: "claude-code",
-											runCommand: "/verify",
-											runName: "Sidebar Verify",
-											projectName: "Alpha Project",
-											attentionLevel: "info",
-										},
-									]}
-								/>
-							</>
-						}
-					/>
-				</Routes>
-			</MemoryRouter>,
+		setStoredState({
+			tabs: [
+				{
+					key: "run:run-1",
+					kind: "run",
+					currentPath: "/runs/run-1/step/build",
+					rootPath: "/runs/run-1",
+					title: "Run one",
+					subtitle: null,
+					projectId: null,
+					lastVisitedAt: 1,
+				},
+			],
+			activeKey: null,
+			lastDurableRoute: "/",
+		});
+
+		renderWithWorkspaceTabs(
+			<Routes>
+				<Route
+					path="*"
+					element={
+						<>
+							<LocationProbe />
+							<NotificationsSidebar
+								open={true}
+								onClose={closeMock}
+								onDismissNotification={dismissMock}
+								onDismissAllNotifications={dismissAllMock}
+								isLoading={false}
+								error={null}
+								notifications={[
+									{
+										id: 1,
+										message: "Approval needed",
+										sourceType: "agent",
+										sourceId: "run-1",
+										route: "/runs/run-1",
+										projectId: "proj-1",
+										createdAt: "2026-04-11T00:00:00.000Z",
+										harness: "codex",
+										runCommand: "/build",
+										runName: "Sidebar Build",
+										projectName: "Alpha Project",
+										attentionLevel: "action_required",
+									},
+									{
+										id: 2,
+										message: "Verify completed",
+										sourceType: "run",
+										sourceId: "run-2",
+										route: "/runs/run-2",
+										projectId: "proj-1",
+										createdAt: "2026-04-11T00:02:00.000Z",
+										harness: "claude-code",
+										runCommand: "/verify",
+										runName: "Sidebar Verify",
+										projectName: "Alpha Project",
+										attentionLevel: "info",
+									},
+								]}
+							/>
+						</>
+					}
+				/>
+			</Routes>,
+			["/"],
 		);
 
 		expect(screen.getByRole("dialog", { name: "Notifications" })).toBeTruthy();
@@ -116,7 +158,7 @@ describe("NotificationsSidebar", () => {
 
 		await waitFor(() => {
 			expect(screen.getByTestId("location-probe").textContent).toBe(
-				"/runs/run-1",
+				"/runs/run-1/step/build",
 			);
 		});
 		expect(closeMock).toHaveBeenCalledTimes(1);
@@ -135,18 +177,16 @@ describe("NotificationsSidebar", () => {
 	test("shows loading and empty states inside the drawer", async () => {
 		const NotificationsSidebar = await loadNotificationsSidebar();
 
-		const { rerender } = render(
-			<MemoryRouter>
-				<NotificationsSidebar
-					open={true}
-					onClose={() => {}}
-					onDismissNotification={() => Promise.resolve()}
-					onDismissAllNotifications={() => Promise.resolve()}
-					isLoading={true}
-					error={null}
-					notifications={[]}
-				/>
-			</MemoryRouter>,
+		const { rerender } = renderWithWorkspaceTabs(
+			<NotificationsSidebar
+				open={true}
+				onClose={() => {}}
+				onDismissNotification={() => Promise.resolve()}
+				onDismissAllNotifications={() => Promise.resolve()}
+				isLoading={true}
+				error={null}
+				notifications={[]}
+			/>,
 		);
 
 		expect(screen.getByRole("dialog", { name: "Notifications" })).toBeTruthy();
@@ -154,15 +194,17 @@ describe("NotificationsSidebar", () => {
 
 		rerender(
 			<MemoryRouter>
-				<NotificationsSidebar
-					open={true}
-					onClose={() => {}}
-					onDismissNotification={() => Promise.resolve()}
-					onDismissAllNotifications={() => Promise.resolve()}
-					isLoading={false}
-					error={null}
-					notifications={[]}
-				/>
+				<WorkspaceTabsProvider>
+					<NotificationsSidebar
+						open={true}
+						onClose={() => {}}
+						onDismissNotification={() => Promise.resolve()}
+						onDismissAllNotifications={() => Promise.resolve()}
+						isLoading={false}
+						error={null}
+						notifications={[]}
+					/>
+				</WorkspaceTabsProvider>
 			</MemoryRouter>,
 		);
 
@@ -180,33 +222,31 @@ describe("NotificationsSidebar", () => {
 			);
 			const NotificationsSidebar = await loadNotificationsSidebar();
 
-			render(
-				<MemoryRouter>
-					<NotificationsSidebar
-						open={true}
-						onClose={() => {}}
-						onDismissNotification={dismissMock}
-						onDismissAllNotifications={() => Promise.resolve()}
-						isLoading={false}
-						error={null}
-						notifications={[
-							{
-								id: 1,
-								message: "Approval needed",
-								sourceType: "agent",
-								sourceId: "run-1",
-								route: "/runs/run-1",
-								projectId: "proj-1",
-								createdAt: "2026-04-11T00:00:00.000Z",
-								harness: "codex",
-								runCommand: "/build",
-								runName: "Sidebar Build",
-								projectName: "Alpha Project",
-								attentionLevel: "action_required",
-							},
-						]}
-					/>
-				</MemoryRouter>,
+			renderWithWorkspaceTabs(
+				<NotificationsSidebar
+					open={true}
+					onClose={() => {}}
+					onDismissNotification={dismissMock}
+					onDismissAllNotifications={() => Promise.resolve()}
+					isLoading={false}
+					error={null}
+					notifications={[
+						{
+							id: 1,
+							message: "Approval needed",
+							sourceType: "agent",
+							sourceId: "run-1",
+							route: "/runs/run-1",
+							projectId: "proj-1",
+							createdAt: "2026-04-11T00:00:00.000Z",
+							harness: "codex",
+							runCommand: "/build",
+							runName: "Sidebar Build",
+							projectName: "Alpha Project",
+							attentionLevel: "action_required",
+						},
+					]}
+				/>,
 			);
 
 			fireEvent.click(
@@ -228,33 +268,31 @@ describe("NotificationsSidebar", () => {
 		const dismissAllMock = mock(() => Promise.resolve());
 		const NotificationsSidebar = await loadNotificationsSidebar();
 
-		render(
-			<MemoryRouter>
-				<NotificationsSidebar
-					open={true}
-					onClose={() => {}}
-					onDismissNotification={() => Promise.resolve()}
-					onDismissAllNotifications={dismissAllMock}
-					isLoading={false}
-					error={null}
-					notifications={[
-						{
-							id: 1,
-							message: "Approval needed",
-							sourceType: "agent",
-							sourceId: "run-1",
-							route: "/runs/run-1",
-							projectId: "proj-1",
-							createdAt: "2026-04-11T00:00:00.000Z",
-							harness: "codex",
-							runCommand: "/build",
-							runName: "Sidebar Build",
-							projectName: "Alpha Project",
-							attentionLevel: "action_required",
-						},
-					]}
-				/>
-			</MemoryRouter>,
+		renderWithWorkspaceTabs(
+			<NotificationsSidebar
+				open={true}
+				onClose={() => {}}
+				onDismissNotification={() => Promise.resolve()}
+				onDismissAllNotifications={dismissAllMock}
+				isLoading={false}
+				error={null}
+				notifications={[
+					{
+						id: 1,
+						message: "Approval needed",
+						sourceType: "agent",
+						sourceId: "run-1",
+						route: "/runs/run-1",
+						projectId: "proj-1",
+						createdAt: "2026-04-11T00:00:00.000Z",
+						harness: "codex",
+						runCommand: "/build",
+						runName: "Sidebar Build",
+						projectName: "Alpha Project",
+						attentionLevel: "action_required",
+					},
+				]}
+			/>,
 		);
 
 		await act(async () => {

--- a/cli/web-ui/src/__tests__/components/v2/WorkspaceShellIntegration.test.tsx
+++ b/cli/web-ui/src/__tests__/components/v2/WorkspaceShellIntegration.test.tsx
@@ -1,0 +1,192 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+	cleanup,
+	fireEvent,
+	render,
+	screen,
+	waitFor,
+} from "@testing-library/react";
+import { useEffect } from "react";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
+import {
+	BreadcrumbProvider,
+	useBreadcrumbContext,
+} from "@/hooks/useBreadcrumbContext";
+import { useWorkspaceDescriptor } from "@/hooks/useWorkspaceDescriptor";
+import {
+	WORKSPACE_TABS_STORAGE_KEY,
+	type WorkspaceTab,
+	WorkspaceTabsProvider,
+} from "@/hooks/useWorkspaceTabs";
+
+mock.module("@/components/v2/HarnessIcon", () => ({
+	HarnessIcon: () => <span data-testid="harness-icon" />,
+}));
+
+let importVersion = 0;
+
+function setStoredState(state: {
+	readonly tabs: readonly WorkspaceTab[];
+	readonly activeKey: string | null;
+	readonly lastDurableRoute: string;
+}) {
+	sessionStorage.setItem(WORKSPACE_TABS_STORAGE_KEY, JSON.stringify(state));
+}
+
+function LocationProbe() {
+	const location = useLocation();
+	return <span data-testid="location-probe">{location.pathname}</span>;
+}
+
+function RunWorkspace() {
+	const { setProject, setRunInfo } = useBreadcrumbContext();
+
+	useWorkspaceDescriptor({
+		title: "Build One",
+		subtitle: "Project One",
+		projectId: "proj-1",
+	});
+
+	useEffect(() => {
+		setProject("proj-1", "Project One");
+		setRunInfo({
+			startedAt: "2026-04-12T00:00:00.000Z",
+			harness: "codex",
+			command: "/build-fast",
+			displayName: "Build One",
+			projectName: "Project One",
+			projectId: "proj-1",
+		});
+
+		return () => {
+			setRunInfo(null);
+			setProject(null, null);
+		};
+	}, [setProject, setRunInfo]);
+
+	return <LocationProbe />;
+}
+
+function ProjectWorkspace() {
+	const { setProject, setRunInfo } = useBreadcrumbContext();
+
+	useWorkspaceDescriptor({
+		title: "Project One",
+		subtitle: "/repo/project-one",
+		projectId: "proj-1",
+	});
+
+	useEffect(() => {
+		setRunInfo(null);
+		setProject("proj-1", "Project One");
+
+		return () => {
+			setProject(null, null);
+		};
+	}, [setProject, setRunInfo]);
+
+	return <LocationProbe />;
+}
+
+async function renderShell(initialEntries: readonly string[]) {
+	const { TerminalBreadcrumb } = await import(
+		`../../../components/v2/TerminalBreadcrumb.tsx?workspace-shell-test=${++importVersion}`
+	);
+	const { WorkspaceTabStrip } = await import(
+		`../../../components/v2/WorkspaceTabStrip.tsx?workspace-shell-test=${importVersion}`
+	);
+
+	return render(
+		<MemoryRouter initialEntries={[...initialEntries]}>
+			<BreadcrumbProvider>
+				<WorkspaceTabsProvider>
+					<TerminalBreadcrumb />
+					<WorkspaceTabStrip />
+					<Routes>
+						<Route path="/runs/:runId/*" element={<RunWorkspace />} />
+						<Route path="/projects/:projectId" element={<ProjectWorkspace />} />
+						<Route path="/projects" element={<LocationProbe />} />
+					</Routes>
+				</WorkspaceTabsProvider>
+			</BreadcrumbProvider>
+		</MemoryRouter>,
+	);
+}
+
+describe("workspace shell integration", () => {
+	beforeEach(() => {
+		sessionStorage.clear();
+	});
+
+	afterEach(() => {
+		cleanup();
+		sessionStorage.clear();
+	});
+
+	test("keeps breadcrumb chrome synchronized with the active workspace tab", async () => {
+		setStoredState({
+			tabs: [
+				{
+					key: "run:run-1",
+					kind: "run",
+					currentPath: "/runs/run-1",
+					rootPath: "/runs/run-1",
+					title: "Build One",
+					subtitle: "Project One",
+					projectId: "proj-1",
+					lastVisitedAt: 1,
+				},
+				{
+					key: "project:proj-1",
+					kind: "project",
+					currentPath: "/projects/proj-1",
+					rootPath: "/projects/proj-1",
+					title: "Project One",
+					subtitle: "/repo/project-one",
+					projectId: "proj-1",
+					lastVisitedAt: 2,
+				},
+			],
+			activeKey: "run:run-1",
+			lastDurableRoute: "/projects",
+		});
+
+		await renderShell(["/runs/run-1"]);
+
+		await waitFor(() => {
+			expect(screen.getByRole("navigation", { name: "Run info" })).toBeTruthy();
+		});
+		expect(screen.getByTestId("location-probe").textContent).toBe(
+			"/runs/run-1",
+		);
+		expect(screen.getByText("/build-fast")).toBeTruthy();
+		expect(
+			screen.getByRole("button", { name: "Build One, Project One" }),
+		).toBeTruthy();
+
+		fireEvent.click(
+			screen.getByRole("button", { name: "Project One, /repo/project-one" }),
+		);
+
+		await waitFor(() => {
+			expect(screen.getByTestId("location-probe").textContent).toBe(
+				"/projects/proj-1",
+			);
+		});
+		expect(screen.getByRole("navigation", { name: "Breadcrumb" })).toBeTruthy();
+		expect(screen.getByRole("link", { name: /Project One/i })).toBeTruthy();
+		expect(screen.queryByRole("navigation", { name: "Run info" })).toBeNull();
+
+		fireEvent.click(
+			screen.getByRole("button", { name: "Build One, Project One" }),
+		);
+
+		await waitFor(() => {
+			expect(screen.getByTestId("location-probe").textContent).toBe(
+				"/runs/run-1",
+			);
+		});
+		expect(screen.getByRole("navigation", { name: "Run info" })).toBeTruthy();
+		expect(screen.getByText("/build-fast")).toBeTruthy();
+	});
+});

--- a/cli/web-ui/src/__tests__/components/v2/WorkspaceTabStrip.test.tsx
+++ b/cli/web-ui/src/__tests__/components/v2/WorkspaceTabStrip.test.tsx
@@ -45,6 +45,7 @@ describe("WorkspaceTabStrip", () => {
 				openWorkspace: (_targetRoute: string) => {},
 				activateWorkspace: activateWorkspaceMock,
 				closeWorkspace: closeWorkspaceMock,
+				updateWorkspaceMetadata: () => {},
 			}),
 		}));
 

--- a/cli/web-ui/src/__tests__/components/v2/WorkspaceTabStrip.test.tsx
+++ b/cli/web-ui/src/__tests__/components/v2/WorkspaceTabStrip.test.tsx
@@ -6,6 +6,7 @@ import {
 	screen,
 	waitFor,
 } from "@testing-library/react";
+import type { ReactNode } from "react";
 import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
 import {
 	WORKSPACE_TABS_STORAGE_KEY,
@@ -58,7 +59,12 @@ function LocationProbe() {
 	return <span data-testid="location-probe">{location.pathname}</span>;
 }
 
-async function renderStrip(initialEntries: readonly string[]) {
+async function renderStrip(
+	initialEntries: readonly string[],
+	options: {
+		action?: ReactNode;
+	} = {},
+) {
 	mock.module("@/hooks/usePrefersReducedMotion", () => ({
 		usePrefersReducedMotion: () => prefersReducedMotion,
 	}));
@@ -70,7 +76,7 @@ async function renderStrip(initialEntries: readonly string[]) {
 	return render(
 		<MemoryRouter initialEntries={[...initialEntries]}>
 			<WorkspaceTabsProvider>
-				<WorkspaceTabStrip />
+				<WorkspaceTabStrip action={options.action} />
 				<Routes>
 					<Route path="/" element={<LocationProbe />} />
 					<Route path="/runs/:runId/*" element={<LocationProbe />} />
@@ -208,5 +214,16 @@ describe("WorkspaceTabStrip", () => {
 				expect.objectContaining({ behavior: "smooth" }),
 			);
 		});
+	});
+
+	test("keeps the top bar visible for actions even when there are no open tabs", async () => {
+		await renderStrip(["/"], {
+			action: <button type="button">Notifications</button>,
+		});
+
+		expect(screen.getByRole("button", { name: "Notifications" })).toBeTruthy();
+		expect(
+			screen.queryByRole("navigation", { name: "Open workspaces" }),
+		).toBeNull();
 	});
 });

--- a/cli/web-ui/src/__tests__/components/v2/WorkspaceTabStrip.test.tsx
+++ b/cli/web-ui/src/__tests__/components/v2/WorkspaceTabStrip.test.tsx
@@ -1,11 +1,19 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
-import type { WorkspaceTab } from "@/hooks/useWorkspaceTabs";
+import {
+	cleanup,
+	fireEvent,
+	render,
+	screen,
+	waitFor,
+} from "@testing-library/react";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
+import {
+	WORKSPACE_TABS_STORAGE_KEY,
+	type WorkspaceTab,
+	WorkspaceTabsProvider,
+} from "@/hooks/useWorkspaceTabs";
 
-const activateWorkspaceMock = mock((_key: string) => {});
-const closeWorkspaceMock = mock((_key: string) => {});
-
-const tabs: readonly WorkspaceTab[] = [
+const baseTabs: readonly WorkspaceTab[] = [
 	{
 		key: "run:run-1",
 		kind: "run",
@@ -28,55 +36,177 @@ const tabs: readonly WorkspaceTab[] = [
 	},
 ];
 
+const originalRequestAnimationFrame = window.requestAnimationFrame;
+const originalScrollIntoView = HTMLElement.prototype.scrollIntoView;
+const scrollIntoViewMock = mock(
+	(_options?: boolean | ScrollIntoViewOptions) => {},
+);
+
+let importVersion = 0;
+let prefersReducedMotion = true;
+
+function setStoredState(state: {
+	readonly tabs: readonly WorkspaceTab[];
+	readonly activeKey: string | null;
+	readonly lastDurableRoute: string;
+}) {
+	sessionStorage.setItem(WORKSPACE_TABS_STORAGE_KEY, JSON.stringify(state));
+}
+
+function LocationProbe() {
+	const location = useLocation();
+	return <span data-testid="location-probe">{location.pathname}</span>;
+}
+
+async function renderStrip(initialEntries: readonly string[]) {
+	mock.module("@/hooks/usePrefersReducedMotion", () => ({
+		usePrefersReducedMotion: () => prefersReducedMotion,
+	}));
+
+	const { WorkspaceTabStrip } = await import(
+		`../../../components/v2/WorkspaceTabStrip.tsx?workspace-tab-strip-test=${++importVersion}`
+	);
+
+	return render(
+		<MemoryRouter initialEntries={[...initialEntries]}>
+			<WorkspaceTabsProvider>
+				<WorkspaceTabStrip />
+				<Routes>
+					<Route path="/" element={<LocationProbe />} />
+					<Route path="/runs/:runId/*" element={<LocationProbe />} />
+					<Route path="/projects/:projectId" element={<LocationProbe />} />
+				</Routes>
+			</WorkspaceTabsProvider>
+		</MemoryRouter>,
+	);
+}
+
 describe("WorkspaceTabStrip", () => {
 	beforeEach(() => {
 		mock.restore();
-		activateWorkspaceMock.mockClear();
-		closeWorkspaceMock.mockClear();
-		HTMLElement.prototype.scrollIntoView = mock(
-			() => {},
-		) as typeof HTMLElement.prototype.scrollIntoView;
-
-		mock.module("@/hooks/useWorkspaceTabs", () => ({
-			useWorkspaceTabs: () => ({
-				tabs,
-				activeKey: "run:run-1",
-				lastDurableRoute: "/",
-				openWorkspace: (_targetRoute: string) => {},
-				activateWorkspace: activateWorkspaceMock,
-				closeWorkspace: closeWorkspaceMock,
-				updateWorkspaceMetadata: () => {},
-			}),
-		}));
-
-		mock.module("@/hooks/usePrefersReducedMotion", () => ({
-			usePrefersReducedMotion: () => true,
-		}));
+		scrollIntoViewMock.mockClear();
+		prefersReducedMotion = true;
+		sessionStorage.clear();
+		HTMLElement.prototype.scrollIntoView =
+			scrollIntoViewMock as typeof HTMLElement.prototype.scrollIntoView;
+		window.requestAnimationFrame = ((callback: FrameRequestCallback) => {
+			callback(0);
+			return 1;
+		}) as typeof window.requestAnimationFrame;
 	});
 
 	afterEach(() => {
 		cleanup();
 		mock.restore();
+		sessionStorage.clear();
+		window.requestAnimationFrame = originalRequestAnimationFrame;
+		HTMLElement.prototype.scrollIntoView = originalScrollIntoView;
 	});
 
-	test("renders tabs and supports keyboard activation and close", async () => {
-		const { WorkspaceTabStrip } = await import(
-			"../../../components/v2/WorkspaceTabStrip"
-		);
+	test("renders close affordances and supports keyboard activation and close", async () => {
+		setStoredState({
+			tabs: baseTabs,
+			activeKey: "run:run-1",
+			lastDurableRoute: "/",
+		});
 
-		render(<WorkspaceTabStrip />);
+		await renderStrip(["/runs/run-1"]);
 
-		const firstTab = screen.getByRole("button", { name: "Run run-1" });
+		const firstTab = await screen.findByRole("button", { name: "Run run-1" });
 		const secondTab = screen.getByRole("button", { name: "proj-1, workspace" });
+
+		expect(
+			screen.getByRole("button", { name: "Close Run run-1" }),
+		).toBeTruthy();
+		expect(screen.getByRole("button", { name: "Close proj-1" })).toBeTruthy();
 
 		firstTab.focus();
 		fireEvent.keyDown(firstTab, { key: "ArrowRight" });
 		expect(document.activeElement).toBe(secondTab);
 
 		fireEvent.keyDown(secondTab, { key: "Enter" });
-		expect(activateWorkspaceMock).toHaveBeenCalledWith("project:proj-1");
+		await waitFor(() => {
+			expect(screen.getByTestId("location-probe").textContent).toBe(
+				"/projects/proj-1",
+			);
+		});
 
 		fireEvent.keyDown(secondTab, { key: "Delete" });
-		expect(closeWorkspaceMock).toHaveBeenCalledWith("project:proj-1");
+		await waitFor(() => {
+			expect(screen.getByTestId("location-probe").textContent).toBe(
+				"/runs/run-1",
+			);
+		});
+	});
+
+	test("supports home/end focus movement plus space and backspace keyboard controls", async () => {
+		setStoredState({
+			tabs: baseTabs,
+			activeKey: "run:run-1",
+			lastDurableRoute: "/",
+		});
+
+		await renderStrip(["/runs/run-1"]);
+
+		const firstTab = await screen.findByRole("button", { name: "Run run-1" });
+		const secondTab = screen.getByRole("button", { name: "proj-1, workspace" });
+		const secondCloseButton = screen.getByRole("button", {
+			name: "Close proj-1",
+		});
+
+		firstTab.focus();
+		fireEvent.keyDown(firstTab, { key: "End" });
+		expect(document.activeElement).toBe(secondTab);
+
+		fireEvent.keyDown(secondTab, { key: " " });
+		await waitFor(() => {
+			expect(screen.getByTestId("location-probe").textContent).toBe(
+				"/projects/proj-1",
+			);
+		});
+
+		fireEvent.keyDown(secondTab, { key: "Home" });
+		expect(document.activeElement).toBe(firstTab);
+
+		secondCloseButton.focus();
+		fireEvent.keyDown(secondCloseButton, { key: "Backspace" });
+		await waitFor(() => {
+			expect(screen.getByTestId("location-probe").textContent).toBe(
+				"/runs/run-1",
+			);
+		});
+	});
+
+	test("scrolls the active tab with auto behavior when reduced motion is enabled", async () => {
+		setStoredState({
+			tabs: baseTabs,
+			activeKey: "run:run-1",
+			lastDurableRoute: "/",
+		});
+
+		await renderStrip(["/runs/run-1"]);
+
+		await waitFor(() => {
+			expect(scrollIntoViewMock).toHaveBeenCalledWith(
+				expect.objectContaining({ behavior: "auto" }),
+			);
+		});
+	});
+
+	test("scrolls the active tab with smooth behavior when reduced motion is disabled", async () => {
+		prefersReducedMotion = false;
+		setStoredState({
+			tabs: baseTabs,
+			activeKey: "run:run-1",
+			lastDurableRoute: "/",
+		});
+
+		await renderStrip(["/runs/run-1"]);
+
+		await waitFor(() => {
+			expect(scrollIntoViewMock).toHaveBeenCalledWith(
+				expect.objectContaining({ behavior: "smooth" }),
+			);
+		});
 	});
 });

--- a/cli/web-ui/src/__tests__/components/v2/WorkspaceTabStrip.test.tsx
+++ b/cli/web-ui/src/__tests__/components/v2/WorkspaceTabStrip.test.tsx
@@ -1,0 +1,81 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type { WorkspaceTab } from "@/hooks/useWorkspaceTabs";
+
+const activateWorkspaceMock = mock((_key: string) => {});
+const closeWorkspaceMock = mock((_key: string) => {});
+
+const tabs: readonly WorkspaceTab[] = [
+	{
+		key: "run:run-1",
+		kind: "run",
+		currentPath: "/runs/run-1",
+		rootPath: "/runs/run-1",
+		title: "Run run-1",
+		subtitle: null,
+		projectId: null,
+		lastVisitedAt: 1,
+	},
+	{
+		key: "project:proj-1",
+		kind: "project",
+		currentPath: "/projects/proj-1",
+		rootPath: "/projects/proj-1",
+		title: "proj-1",
+		subtitle: "workspace",
+		projectId: "proj-1",
+		lastVisitedAt: 2,
+	},
+];
+
+describe("WorkspaceTabStrip", () => {
+	beforeEach(() => {
+		mock.restore();
+		activateWorkspaceMock.mockClear();
+		closeWorkspaceMock.mockClear();
+		HTMLElement.prototype.scrollIntoView = mock(
+			() => {},
+		) as typeof HTMLElement.prototype.scrollIntoView;
+
+		mock.module("@/hooks/useWorkspaceTabs", () => ({
+			useWorkspaceTabs: () => ({
+				tabs,
+				activeKey: "run:run-1",
+				lastDurableRoute: "/",
+				openWorkspace: (_targetRoute: string) => {},
+				activateWorkspace: activateWorkspaceMock,
+				closeWorkspace: closeWorkspaceMock,
+			}),
+		}));
+
+		mock.module("@/hooks/usePrefersReducedMotion", () => ({
+			usePrefersReducedMotion: () => true,
+		}));
+	});
+
+	afterEach(() => {
+		cleanup();
+		mock.restore();
+	});
+
+	test("renders tabs and supports keyboard activation and close", async () => {
+		const { WorkspaceTabStrip } = await import(
+			"../../../components/v2/WorkspaceTabStrip"
+		);
+
+		render(<WorkspaceTabStrip />);
+
+		const firstTab = screen.getByRole("button", { name: "Run run-1" });
+		const secondTab = screen.getByRole("button", { name: "proj-1, workspace" });
+
+		firstTab.focus();
+		fireEvent.keyDown(firstTab, { key: "ArrowRight" });
+		expect(document.activeElement).toBe(secondTab);
+
+		fireEvent.keyDown(secondTab, { key: "Enter" });
+		expect(activateWorkspaceMock).toHaveBeenCalledWith("project:proj-1");
+
+		fireEvent.keyDown(secondTab, { key: "Delete" });
+		expect(closeWorkspaceMock).toHaveBeenCalledWith("project:proj-1");
+	});
+});

--- a/cli/web-ui/src/__tests__/hooks/useProjectFileTree.test.ts
+++ b/cli/web-ui/src/__tests__/hooks/useProjectFileTree.test.ts
@@ -1,85 +1,57 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
-import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, renderHook, waitFor } from "@testing-library/react";
 
-type ReconnectCallback = () => void;
+let useProjectFileTreeImportVersion = 0;
 
-let reconnectListeners: ReconnectCallback[] = [];
-let fetchMock: ReturnType<typeof mock>;
-let fetchCount = 0;
+async function loadUseProjectFileTree() {
+	mock.module("../../hooks/useReconnectRecovery", () => ({
+		useReconnectRecovery: () => {},
+	}));
 
-mock.module("@/providers/WebSocketProvider", () => ({
-	useWebSocket: () => ({
-		subscribeToReconnect: (cb: ReconnectCallback) => {
-			reconnectListeners.push(cb);
-			return () => {
-				reconnectListeners = reconnectListeners.filter(
-					(listener) => listener !== cb,
-				);
-			};
-		},
-	}),
-}));
-
-function emitReconnect() {
-	for (const listener of reconnectListeners) {
-		listener();
-	}
+	return import(
+		`../../hooks/useProjectFileTree.ts?use-project-file-tree-test=${++useProjectFileTreeImportVersion}`
+	);
 }
 
-beforeEach(() => {
-	reconnectListeners = [];
-	fetchCount = 0;
-
-	fetchMock = mock(() => {
-		fetchCount += 1;
-		if (fetchCount === 1) {
-			return Promise.resolve({
-				ok: false,
-				statusText: "Service Unavailable",
-				status: 503,
-			});
-		}
-
-		return Promise.resolve({
+describe("useProjectFileTree", () => {
+	beforeEach(() => {
+		mock.restore();
+		global.fetch = mock(async () => ({
 			ok: true,
-			json: () =>
-				Promise.resolve([
-					{
-						name: "context",
-						path: ".rp1/context",
-						type: "directory",
-						children: [],
-					},
-				]),
-		});
+			json: async () => [
+				{
+					name: "docs",
+					path: "docs",
+					type: "directory",
+					children: [],
+				},
+			],
+		})) as unknown as typeof fetch;
 	});
 
-	globalThis.fetch = fetchMock as unknown as typeof fetch;
-});
+	afterEach(() => {
+		cleanup();
+		mock.restore();
+	});
 
-describe("useProjectFileTree", () => {
-	test("recovers automatically after websocket reconnect", async () => {
-		const { useProjectFileTree } = await import(
-			"../../hooks/useProjectFileTree"
-		);
-		const { result } = renderHook(() => useProjectFileTree("proj-1"));
-
-		await waitFor(() => {
-			expect(result.current.loading).toBe(false);
-		});
-		expect(result.current.error).toBe(
-			"Failed to fetch file tree: Service Unavailable",
-		);
-		expect(result.current.tree).toEqual([]);
-
-		act(() => {
-			emitReconnect();
-		});
+	test("reuses cached tree data across remounts without returning to loading", async () => {
+		const { useProjectFileTree } = await loadUseProjectFileTree();
+		const firstRender = renderHook(() => useProjectFileTree("proj-1"));
 
 		await waitFor(() => {
-			expect(result.current.error).toBeNull();
-			expect(result.current.tree).toHaveLength(1);
+			expect(firstRender.result.current.loading).toBe(false);
 		});
-		expect(fetchMock).toHaveBeenCalledTimes(2);
+		expect(firstRender.result.current.tree).toHaveLength(1);
+
+		firstRender.unmount();
+
+		global.fetch = mock(
+			() => new Promise<Response>(() => {}),
+		) as unknown as typeof fetch;
+
+		const secondRender = renderHook(() => useProjectFileTree("proj-1"));
+
+		expect(secondRender.result.current.loading).toBe(false);
+		expect(secondRender.result.current.tree).toHaveLength(1);
 	});
 });

--- a/cli/web-ui/src/__tests__/hooks/useRunDetail.test.ts
+++ b/cli/web-ui/src/__tests__/hooks/useRunDetail.test.ts
@@ -241,6 +241,27 @@ describe("useRunDetail", () => {
 		expect(result.current.run?.events).toHaveLength(0);
 	});
 
+	test("reuses cached run data across remounts without returning to loading", async () => {
+		const { useRunDetail } = await loadUseRunDetail();
+		const firstRender = renderHook(() => useRunDetail("run-1"));
+
+		await waitFor(() => {
+			expect(firstRender.result.current.isLoading).toBe(false);
+		});
+		expect(firstRender.result.current.run?.id).toBe("run-1");
+
+		firstRender.unmount();
+
+		globalThis.fetch = mock(
+			() => new Promise<Response>(() => {}),
+		) as unknown as typeof fetch;
+
+		const secondRender = renderHook(() => useRunDetail("run-1"));
+
+		expect(secondRender.result.current.run?.id).toBe("run-1");
+		expect(secondRender.result.current.isLoading).toBe(false);
+	});
+
 	test("reconciled artifact updates local state without refetching the run", async () => {
 		runResponse = {
 			...baseRun,

--- a/cli/web-ui/src/__tests__/hooks/useWorkspaceDescriptor.test.tsx
+++ b/cli/web-ui/src/__tests__/hooks/useWorkspaceDescriptor.test.tsx
@@ -1,0 +1,193 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+	act,
+	cleanup,
+	fireEvent,
+	render,
+	screen,
+	waitFor,
+} from "@testing-library/react";
+import { MemoryRouter, useLocation } from "react-router-dom";
+import { useWorkspaceDescriptor } from "../../hooks/useWorkspaceDescriptor";
+import {
+	useWorkspaceTabs,
+	WORKSPACE_TABS_STORAGE_KEY,
+	type WorkspaceTab,
+	WorkspaceTabsProvider,
+} from "../../hooks/useWorkspaceTabs";
+
+function setStoredState(state: {
+	readonly tabs: readonly WorkspaceTab[];
+	readonly activeKey: string | null;
+	readonly lastDurableRoute: string;
+}) {
+	sessionStorage.setItem(WORKSPACE_TABS_STORAGE_KEY, JSON.stringify(state));
+}
+
+function DescriptorHarness({
+	title,
+	subtitle,
+	projectId,
+	unavailable = false,
+}: {
+	readonly title?: string | null;
+	readonly subtitle?: string | null;
+	readonly projectId?: string | null;
+	readonly unavailable?: boolean;
+}) {
+	const { workspaceCommands } = useWorkspaceDescriptor({
+		title,
+		subtitle,
+		projectId,
+		unavailable,
+	});
+	const { tabs, activeKey } = useWorkspaceTabs();
+	const location = useLocation();
+
+	return (
+		<div>
+			<div data-testid="location">{location.pathname}</div>
+			<div data-testid="active-key">{activeKey ?? "null"}</div>
+			<pre data-testid="tabs">{JSON.stringify(tabs)}</pre>
+			{workspaceCommands.map((command) => (
+				<button key={command.id} type="button" onClick={command.action}>
+					{command.id}
+				</button>
+			))}
+		</div>
+	);
+}
+
+function parseTabs(): WorkspaceTab[] {
+	return JSON.parse(
+		screen.getByTestId("tabs").textContent ?? "[]",
+	) as WorkspaceTab[];
+}
+
+function renderHarness(
+	initialEntries: readonly string[],
+	props: {
+		readonly title?: string | null;
+		readonly subtitle?: string | null;
+		readonly projectId?: string | null;
+		readonly unavailable?: boolean;
+	},
+) {
+	return render(
+		<MemoryRouter initialEntries={[...initialEntries]}>
+			<WorkspaceTabsProvider>
+				<DescriptorHarness {...props} />
+			</WorkspaceTabsProvider>
+		</MemoryRouter>,
+	);
+}
+
+describe("useWorkspaceDescriptor", () => {
+	beforeEach(() => {
+		sessionStorage.clear();
+	});
+
+	afterEach(() => {
+		cleanup();
+		sessionStorage.clear();
+	});
+
+	test("publishes metadata and exposes adjacent workspace commands", async () => {
+		setStoredState({
+			tabs: [
+				{
+					key: "run:run-0",
+					kind: "run",
+					currentPath: "/runs/run-0",
+					rootPath: "/runs/run-0",
+					title: "Run 0",
+					subtitle: null,
+					projectId: null,
+					lastVisitedAt: 1,
+				},
+				{
+					key: "run:run-1",
+					kind: "run",
+					currentPath: "/runs/run-1",
+					rootPath: "/runs/run-1",
+					title: "Run 1",
+					subtitle: null,
+					projectId: null,
+					lastVisitedAt: 2,
+				},
+				{
+					key: "run:run-2",
+					kind: "run",
+					currentPath: "/runs/run-2",
+					rootPath: "/runs/run-2",
+					title: "Run 2",
+					subtitle: null,
+					projectId: null,
+					lastVisitedAt: 3,
+				},
+			],
+			activeKey: "run:run-1",
+			lastDurableRoute: "/projects",
+		});
+
+		renderHarness(["/runs/run-1"], {
+			title: "Primary Run",
+			subtitle: "Project One",
+			projectId: "proj-1",
+		});
+
+		await waitFor(() => {
+			expect(parseTabs()[1]).toMatchObject({
+				title: "Primary Run",
+				subtitle: "Project One",
+				projectId: "proj-1",
+			});
+		});
+		expect(
+			screen.getByRole("button", { name: "previous-workspace" }),
+		).toBeTruthy();
+		expect(screen.getByRole("button", { name: "next-workspace" })).toBeTruthy();
+		expect(
+			screen.getByRole("button", { name: "close-workspace" }),
+		).toBeTruthy();
+
+		act(() => {
+			fireEvent.click(
+				screen.getByRole("button", { name: "previous-workspace" }),
+			);
+		});
+
+		await waitFor(() => {
+			expect(screen.getByTestId("location").textContent).toBe("/runs/run-0");
+		});
+	});
+
+	test("reconciles unavailable workspaces to the last durable route", async () => {
+		setStoredState({
+			tabs: [
+				{
+					key: "run:run-1",
+					kind: "run",
+					currentPath: "/runs/run-1",
+					rootPath: "/runs/run-1",
+					title: "Run 1",
+					subtitle: null,
+					projectId: null,
+					lastVisitedAt: 1,
+				},
+			],
+			activeKey: "run:run-1",
+			lastDurableRoute: "/projects",
+		});
+
+		renderHarness(["/runs/run-1"], {
+			unavailable: true,
+		});
+
+		await waitFor(() => {
+			expect(screen.getByTestId("location").textContent).toBe("/projects");
+		});
+		expect(parseTabs()).toEqual([]);
+		expect(screen.getByTestId("active-key").textContent).toBe("null");
+	});
+});

--- a/cli/web-ui/src/__tests__/hooks/useWorkspaceTabs.test.tsx
+++ b/cli/web-ui/src/__tests__/hooks/useWorkspaceTabs.test.tsx
@@ -1,0 +1,237 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+	act,
+	cleanup,
+	fireEvent,
+	render,
+	screen,
+	waitFor,
+} from "@testing-library/react";
+import { MemoryRouter, useLocation } from "react-router-dom";
+import {
+	useWorkspaceTabs,
+	WORKSPACE_TABS_STORAGE_KEY,
+	type WorkspaceTab,
+	WorkspaceTabsProvider,
+} from "../../hooks/useWorkspaceTabs";
+
+function WorkspaceTabsHarness() {
+	const { tabs, activeKey, lastDurableRoute, openWorkspace, closeWorkspace } =
+		useWorkspaceTabs();
+	const location = useLocation();
+
+	return (
+		<div>
+			<div data-testid="location">
+				{location.pathname}
+				{location.search}
+				{location.hash}
+			</div>
+			<div data-testid="active-key">{activeKey ?? "null"}</div>
+			<div data-testid="last-durable-route">{lastDurableRoute}</div>
+			<pre data-testid="tabs">{JSON.stringify(tabs)}</pre>
+			<button type="button" onClick={() => openWorkspace("/runs/run-1")}>
+				open-run-1
+			</button>
+			<button type="button" onClick={() => closeWorkspace("run:run-1")}>
+				close-run-1
+			</button>
+			<button type="button" onClick={() => closeWorkspace("run:run-2")}>
+				close-run-2
+			</button>
+		</div>
+	);
+}
+
+function setStoredState(state: {
+	readonly tabs: readonly WorkspaceTab[];
+	readonly activeKey: string | null;
+	readonly lastDurableRoute: string;
+}) {
+	sessionStorage.setItem(WORKSPACE_TABS_STORAGE_KEY, JSON.stringify(state));
+}
+
+function parseTabs(): WorkspaceTab[] {
+	return JSON.parse(
+		screen.getByTestId("tabs").textContent ?? "[]",
+	) as WorkspaceTab[];
+}
+
+function renderHarness(initialEntries: readonly string[]) {
+	return render(
+		<MemoryRouter initialEntries={[...initialEntries]}>
+			<WorkspaceTabsProvider>
+				<WorkspaceTabsHarness />
+			</WorkspaceTabsProvider>
+		</MemoryRouter>,
+	);
+}
+
+describe("useWorkspaceTabs", () => {
+	beforeEach(() => {
+		sessionStorage.clear();
+	});
+
+	afterEach(() => {
+		cleanup();
+		sessionStorage.clear();
+	});
+
+	test("hydrates and deduplicates stored workspaces", async () => {
+		setStoredState({
+			tabs: [
+				{
+					key: "run:run-1",
+					kind: "run",
+					currentPath: "/runs/run-1",
+					rootPath: "/runs/run-1",
+					title: "Run one",
+					subtitle: null,
+					projectId: null,
+					lastVisitedAt: 1,
+				},
+				{
+					key: "run:run-1",
+					kind: "run",
+					currentPath: "/runs/run-1/step/build",
+					rootPath: "/runs/run-1",
+					title: "Run one",
+					subtitle: null,
+					projectId: null,
+					lastVisitedAt: 2,
+				},
+			],
+			activeKey: "run:run-1",
+			lastDurableRoute: "/projects",
+		});
+
+		renderHarness(["/projects"]);
+
+		await waitFor(() => {
+			expect(parseTabs()).toHaveLength(1);
+		});
+		expect(parseTabs()[0]?.currentPath).toBe("/runs/run-1/step/build");
+		expect(screen.getByTestId("active-key").textContent).toBe("null");
+		expect(screen.getByTestId("last-durable-route").textContent).toBe(
+			"/projects",
+		);
+	});
+
+	test("tracks the active workspace from the current route", async () => {
+		renderHarness(["/runs/run-2/step/test/artifact/doc-9"]);
+
+		await waitFor(() => {
+			expect(screen.getByTestId("active-key").textContent).toBe("run:run-2");
+		});
+
+		const [tab] = parseTabs();
+		expect(tab).toMatchObject({
+			key: "run:run-2",
+			kind: "run",
+			currentPath: "/runs/run-2/step/test/artifact/doc-9",
+			rootPath: "/runs/run-2",
+		});
+	});
+
+	test("reopens an existing workspace at its stored path", async () => {
+		setStoredState({
+			tabs: [
+				{
+					key: "run:run-1",
+					kind: "run",
+					currentPath: "/runs/run-1/step/build",
+					rootPath: "/runs/run-1",
+					title: "Run one",
+					subtitle: null,
+					projectId: null,
+					lastVisitedAt: 5,
+				},
+			],
+			activeKey: null,
+			lastDurableRoute: "/projects",
+		});
+
+		renderHarness(["/projects"]);
+
+		act(() => {
+			fireEvent.click(screen.getByRole("button", { name: "open-run-1" }));
+		});
+
+		await waitFor(() => {
+			expect(screen.getByTestId("location").textContent).toBe(
+				"/runs/run-1/step/build",
+			);
+		});
+	});
+
+	test("closes the active workspace to the nearest remaining tab", async () => {
+		setStoredState({
+			tabs: [
+				{
+					key: "run:run-1",
+					kind: "run",
+					currentPath: "/runs/run-1",
+					rootPath: "/runs/run-1",
+					title: "Run one",
+					subtitle: null,
+					projectId: null,
+					lastVisitedAt: 1,
+				},
+				{
+					key: "run:run-2",
+					kind: "run",
+					currentPath: "/runs/run-2",
+					rootPath: "/runs/run-2",
+					title: "Run two",
+					subtitle: null,
+					projectId: null,
+					lastVisitedAt: 2,
+				},
+			],
+			activeKey: "run:run-2",
+			lastDurableRoute: "/projects",
+		});
+
+		renderHarness(["/runs/run-2"]);
+
+		act(() => {
+			fireEvent.click(screen.getByRole("button", { name: "close-run-2" }));
+		});
+
+		await waitFor(() => {
+			expect(screen.getByTestId("location").textContent).toBe("/runs/run-1");
+		});
+		expect(parseTabs().map((tab) => tab.key)).toEqual(["run:run-1"]);
+	});
+
+	test("falls back to the last durable route when closing the final tab", async () => {
+		setStoredState({
+			tabs: [
+				{
+					key: "run:run-1",
+					kind: "run",
+					currentPath: "/runs/run-1",
+					rootPath: "/runs/run-1",
+					title: "Run one",
+					subtitle: null,
+					projectId: null,
+					lastVisitedAt: 1,
+				},
+			],
+			activeKey: "run:run-1",
+			lastDurableRoute: "/projects",
+		});
+
+		renderHarness(["/runs/run-1"]);
+
+		act(() => {
+			fireEvent.click(screen.getByRole("button", { name: "close-run-1" }));
+		});
+
+		await waitFor(() => {
+			expect(screen.getByTestId("location").textContent).toBe("/projects");
+		});
+		expect(parseTabs()).toEqual([]);
+		expect(screen.getByTestId("active-key").textContent).toBe("null");
+	});
+});

--- a/cli/web-ui/src/__tests__/hooks/useWorkspaceTabs.test.tsx
+++ b/cli/web-ui/src/__tests__/hooks/useWorkspaceTabs.test.tsx
@@ -133,6 +133,19 @@ describe("useWorkspaceTabs", () => {
 		});
 	});
 
+	test("keeps the full route path, including search and hash, as the workspace current path", async () => {
+		renderHarness(["/runs/run-2/step/test/artifact/doc-9?view=raw#section-1"]);
+
+		await waitFor(() => {
+			expect(screen.getByTestId("active-key").textContent).toBe("run:run-2");
+		});
+
+		expect(parseTabs()[0]).toMatchObject({
+			currentPath: "/runs/run-2/step/test/artifact/doc-9?view=raw#section-1",
+			rootPath: "/runs/run-2",
+		});
+	});
+
 	test("reopens an existing workspace at its stored path", async () => {
 		setStoredState({
 			tabs: [
@@ -162,6 +175,24 @@ describe("useWorkspaceTabs", () => {
 				"/runs/run-1/step/build",
 			);
 		});
+	});
+
+	test("falls back to the default durable route when stored durable state is invalid", async () => {
+		sessionStorage.setItem(
+			WORKSPACE_TABS_STORAGE_KEY,
+			JSON.stringify({
+				tabs: [],
+				activeKey: null,
+				lastDurableRoute: "/settings",
+			}),
+		);
+
+		renderHarness(["/settings"]);
+
+		await waitFor(() => {
+			expect(screen.getByTestId("last-durable-route").textContent).toBe("/");
+		});
+		expect(screen.getByTestId("active-key").textContent).toBe("null");
 	});
 
 	test("closes the active workspace to the nearest remaining tab", async () => {
@@ -201,6 +232,49 @@ describe("useWorkspaceTabs", () => {
 		await waitFor(() => {
 			expect(screen.getByTestId("location").textContent).toBe("/runs/run-1");
 		});
+		expect(parseTabs().map((tab) => tab.key)).toEqual(["run:run-1"]);
+	});
+
+	test("removes an inactive workspace without changing the active route", async () => {
+		setStoredState({
+			tabs: [
+				{
+					key: "run:run-1",
+					kind: "run",
+					currentPath: "/runs/run-1/step/build?view=raw#artifact",
+					rootPath: "/runs/run-1",
+					title: "Run one",
+					subtitle: null,
+					projectId: null,
+					lastVisitedAt: 1,
+				},
+				{
+					key: "run:run-2",
+					kind: "run",
+					currentPath: "/runs/run-2",
+					rootPath: "/runs/run-2",
+					title: "Run two",
+					subtitle: null,
+					projectId: null,
+					lastVisitedAt: 2,
+				},
+			],
+			activeKey: "run:run-1",
+			lastDurableRoute: "/projects",
+		});
+
+		renderHarness(["/runs/run-1/step/build?view=raw#artifact"]);
+
+		act(() => {
+			fireEvent.click(screen.getByRole("button", { name: "close-run-2" }));
+		});
+
+		await waitFor(() => {
+			expect(screen.getByTestId("location").textContent).toBe(
+				"/runs/run-1/step/build?view=raw#artifact",
+			);
+		});
+		expect(screen.getByTestId("active-key").textContent).toBe("run:run-1");
 		expect(parseTabs().map((tab) => tab.key)).toEqual(["run:run-1"]);
 	});
 

--- a/cli/web-ui/src/__tests__/lib/workspace-routes.test.ts
+++ b/cli/web-ui/src/__tests__/lib/workspace-routes.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "bun:test";
+import {
+	isDurableWorkspaceRoute,
+	normalizeWorkspaceRoute,
+} from "../../lib/workspace-routes";
+
+describe("workspace route normalization", () => {
+	test("classifies durable routes", () => {
+		expect(normalizeWorkspaceRoute("/")).toEqual({
+			type: "durable",
+			durableRoute: "activity",
+			rootPath: "/",
+		});
+		expect(normalizeWorkspaceRoute("/projects")).toEqual({
+			type: "durable",
+			durableRoute: "projects",
+			rootPath: "/projects",
+		});
+		expect(isDurableWorkspaceRoute("/projects")).toBe(true);
+	});
+
+	test("classifies run workspaces across nested routes", () => {
+		expect(
+			normalizeWorkspaceRoute("/runs/run-42/step/build/artifact/doc-1"),
+		).toEqual({
+			type: "workspace",
+			key: "run:run-42",
+			kind: "run",
+			rootPath: "/runs/run-42",
+			title: "Run run-42",
+			subtitle: null,
+			projectId: null,
+		});
+		expect(
+			normalizeWorkspaceRoute("/runs/run-42/artifacts/work/output.md"),
+		).toEqual({
+			type: "workspace",
+			key: "run:run-42",
+			kind: "run",
+			rootPath: "/runs/run-42",
+			title: "Run run-42",
+			subtitle: null,
+			projectId: null,
+		});
+	});
+
+	test("distinguishes project overview and file browser workspaces", () => {
+		expect(normalizeWorkspaceRoute("/projects/proj-1")).toEqual({
+			type: "workspace",
+			key: "project:proj-1",
+			kind: "project",
+			rootPath: "/projects/proj-1",
+			title: "proj-1",
+			subtitle: null,
+			projectId: "proj-1",
+		});
+		expect(
+			normalizeWorkspaceRoute("/projects/proj-1/files/work/docs/readme.md"),
+		).toEqual({
+			type: "workspace",
+			key: "files:proj-1",
+			kind: "files",
+			rootPath: "/projects/proj-1/files",
+			title: "proj-1 files",
+			subtitle: null,
+			projectId: "proj-1",
+		});
+	});
+
+	test("returns unknown for non-workspace routes", () => {
+		expect(normalizeWorkspaceRoute("/settings")).toEqual({ type: "unknown" });
+	});
+});

--- a/cli/web-ui/src/__tests__/lib/workspace-routes.test.ts
+++ b/cli/web-ui/src/__tests__/lib/workspace-routes.test.ts
@@ -19,6 +19,27 @@ describe("workspace route normalization", () => {
 		expect(isDurableWorkspaceRoute("/projects")).toBe(true);
 	});
 
+	test("treats runs index as durable and ignores query, hash, and trailing slashes", () => {
+		expect(normalizeWorkspaceRoute("/runs")).toEqual({
+			type: "durable",
+			durableRoute: "activity",
+			rootPath: "/",
+		});
+		expect(
+			normalizeWorkspaceRoute(
+				"/projects/proj-1/files/src/index.ts/?line=12#L12",
+			),
+		).toEqual({
+			type: "workspace",
+			key: "files:proj-1",
+			kind: "files",
+			rootPath: "/projects/proj-1/files",
+			title: "proj-1 files",
+			subtitle: null,
+			projectId: "proj-1",
+		});
+	});
+
 	test("classifies run workspaces across nested routes", () => {
 		expect(
 			normalizeWorkspaceRoute("/runs/run-42/step/build/artifact/doc-1"),

--- a/cli/web-ui/src/__tests__/pages/v2/ArtifactViewerPage.test.tsx
+++ b/cli/web-ui/src/__tests__/pages/v2/ArtifactViewerPage.test.tsx
@@ -1,0 +1,301 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, render, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import {
+	WORKSPACE_TABS_STORAGE_KEY,
+	WorkspaceTabsProvider,
+} from "@/hooks/useWorkspaceTabs";
+import type { ShortcutRegistryData } from "@/providers/ShortcutRegistryProvider";
+import {
+	ShortcutRegistryProvider,
+	useShortcutRegistry,
+} from "@/providers/ShortcutRegistryProvider";
+import type { Run } from "@/types/runs";
+
+let importVersion = 0;
+let latestRegistry: ShortcutRegistryData | null = null;
+
+const breadcrumbApi = {
+	setActiveArtifact: mock(() => {}),
+	setProject: mock(() => {}),
+	setRunInfo: mock(() => {}),
+};
+
+const webSocketApi = {
+	onFileChange: () => () => {},
+	setProjectId: mock(() => {}),
+};
+
+const run: Run = {
+	id: "run-1",
+	projectId: "proj-1",
+	projectName: "Project One",
+	featureId: "feature-1",
+	featureName: "Feature One",
+	name: "Build One",
+	command: "/build-fast",
+	status: "running",
+	harness: "codex",
+	currentStep: "build",
+	startedAt: "2026-04-12T00:00:00.000Z",
+	completedAt: null,
+	error: null,
+	lastEventAt: null,
+	steps: [
+		{
+			id: "build",
+			name: "Build",
+			status: "running",
+			startedAt: "2026-04-12T00:00:00.000Z",
+			completedAt: null,
+			taskCount: 1,
+			completedTaskCount: 0,
+		},
+	],
+	artifacts: [
+		{
+			docId: "doc-1",
+			path: "docs/tasks.md",
+			absolutePath: "/repo/docs/tasks.md",
+			type: "markdown",
+			updatedDuringRun: true,
+			isNew: false,
+			step: "build",
+		},
+	],
+	events: [],
+	agentSteps: null,
+};
+
+mock.module("@/hooks/useRunDetail", () => ({
+	useRunDetail: () => ({
+		run,
+		isLoading: false,
+		error: null,
+		refetch: mock(() => {}),
+	}),
+}));
+
+mock.module("@/hooks/useBreadcrumbContext", () => ({
+	useBreadcrumbContext: () => breadcrumbApi,
+}));
+
+mock.module("@/providers/WebSocketProvider", () => ({
+	useWebSocket: () => webSocketApi,
+}));
+
+mock.module("@/hooks/useMediaQuery", () => ({
+	useIsMobile: () => false,
+}));
+
+mock.module("@/hooks/useReconnectRecovery", () => ({
+	useReconnectRecovery: () => {},
+}));
+
+mock.module("@/hooks/useAnnotations", () => ({
+	useAnnotations: () => ({ count: 0 }),
+}));
+
+mock.module("@/hooks/useFollowMode", () => ({
+	useFollowMode: () => ({
+		followMode: false,
+		hasNewUpdates: false,
+		setFollowMode: () => {},
+		scrollToNew: () => {},
+		handleScroll: () => {},
+	}),
+}));
+
+mock.module("@/providers/AnnotationProvider", () => ({
+	AnnotationProvider: ({ children }: { children?: ReactNode }) => (
+		<>{children}</>
+	),
+}));
+
+mock.module("@/components/ui/button", () => ({
+	Button: ({
+		children,
+		onClick,
+	}: {
+		children?: ReactNode;
+		onClick?: () => void;
+	}) => (
+		<button type="button" onClick={onClick}>
+			{children}
+		</button>
+	),
+}));
+
+mock.module("@/components/ui/drawer", () => ({
+	Drawer: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+}));
+
+mock.module("@/components/ui/resizable", () => ({
+	ResizablePanelGroup: ({ children }: { children?: ReactNode }) => (
+		<div>{children}</div>
+	),
+	ResizablePanel: ({ children }: { children?: ReactNode }) => (
+		<div>{children}</div>
+	),
+	ResizableHandle: () => <div data-testid="resizable-handle" />,
+}));
+
+mock.module("@/components/ui/scroll-area", () => ({
+	ScrollArea: ({
+		children,
+		className,
+	}: {
+		children?: ReactNode;
+		className?: string;
+	}) => <div className={className}>{children}</div>,
+}));
+
+mock.module("@/components/ui/tooltip", () => ({
+	TooltipProvider: ({ children }: { children?: ReactNode }) => <>{children}</>,
+	Tooltip: ({ children }: { children?: ReactNode }) => <>{children}</>,
+	TooltipTrigger: ({ children }: { children?: ReactNode }) => <>{children}</>,
+	TooltipContent: ({ children }: { children?: ReactNode }) => <>{children}</>,
+}));
+
+mock.module("@/components/v2/ArtifactSidebar", () => ({
+	ArtifactSidebar: () => <div data-testid="artifact-sidebar" />,
+}));
+
+mock.module("@/components/v2/AnnotationSidebar", () => ({
+	AnnotationSidebar: () => <div data-testid="annotation-sidebar" />,
+}));
+
+mock.module("@/components/v2/FollowModeToggle", () => ({
+	FollowModeToggle: () => <div data-testid="follow-mode-toggle" />,
+}));
+
+mock.module("@/components/v2/KeyHints", () => ({
+	KeyHints: () => <div data-testid="key-hints" />,
+	VIEWER_HINTS: [],
+}));
+
+mock.module("@/components/v2/NewUpdatesChip", () => ({
+	NewUpdatesChip: () => <div data-testid="new-updates-chip" />,
+}));
+
+mock.module("@/components/v2/TableOfContents", () => ({
+	TableOfContents: () => <div data-testid="toc">ToC</div>,
+}));
+
+const unifiedContentRendererMock = {
+	UnifiedContentRenderer: ({
+		content,
+		path,
+	}: {
+		content: string;
+		path: string;
+	}) => (
+		<div data-testid="artifact-renderer">
+			{path}:{content}
+		</div>
+	),
+	SaveStatusIndicator: () => null,
+};
+
+mock.module(
+	"@/components/v2/UnifiedContentRenderer",
+	() => unifiedContentRendererMock,
+);
+
+mock.module(
+	"@/components/v2/UnifiedContentRenderer.tsx",
+	() => unifiedContentRendererMock,
+);
+
+function RegistryProbe() {
+	latestRegistry = useShortcutRegistry();
+	return null;
+}
+
+function readStoredTabs() {
+	const raw = sessionStorage.getItem(WORKSPACE_TABS_STORAGE_KEY);
+	return raw
+		? (JSON.parse(raw) as {
+				tabs: Array<{ title: string; subtitle: string | null }>;
+			})
+		: null;
+}
+
+async function renderArtifactViewerPage() {
+	const { ArtifactViewerPage } = await import(
+		`../../../pages/v2/ArtifactViewerPage.tsx?artifact-viewer-page-test=${++importVersion}`
+	);
+
+	return render(
+		<MemoryRouter initialEntries={["/runs/run-1/artifacts/docs/tasks.md"]}>
+			<WorkspaceTabsProvider>
+				<ShortcutRegistryProvider>
+					<Routes>
+						<Route
+							path="/runs/:runId/artifacts/*"
+							element={
+								<>
+									<RegistryProbe />
+									<ArtifactViewerPage />
+								</>
+							}
+						/>
+					</Routes>
+				</ShortcutRegistryProvider>
+			</WorkspaceTabsProvider>
+		</MemoryRouter>,
+	);
+}
+
+describe("ArtifactViewerPage", () => {
+	beforeEach(() => {
+		mock.restore();
+		document.body.innerHTML = "";
+		sessionStorage.clear();
+		latestRegistry = null;
+		breadcrumbApi.setActiveArtifact.mockClear();
+		breadcrumbApi.setProject.mockClear();
+		breadcrumbApi.setRunInfo.mockClear();
+		webSocketApi.setProjectId.mockClear();
+		global.fetch = mock(async () => ({
+			ok: true,
+			json: async () => ({ content: "# Tasks" }),
+		})) as unknown as typeof fetch;
+	});
+
+	afterEach(() => {
+		cleanup();
+		mock.restore();
+	});
+
+	test("publishes workspace metadata and commands for the standalone artifact viewer route", async () => {
+		await renderArtifactViewerPage();
+
+		await waitFor(() => {
+			expect(
+				latestRegistry?.contextualShortcuts?.commands.some(
+					(command) => command.id === "close-workspace",
+				),
+			).toBe(true);
+		});
+
+		await waitFor(() => {
+			expect(readStoredTabs()?.tabs[0]).toMatchObject({
+				title: "Build One",
+				subtitle: "tasks.md",
+			});
+		});
+
+		expect(breadcrumbApi.setProject).toHaveBeenCalledWith(
+			"proj-1",
+			"Project One",
+		);
+		expect(webSocketApi.setProjectId).toHaveBeenCalledWith("proj-1");
+		expect(breadcrumbApi.setRunInfo).toHaveBeenCalled();
+		expect(breadcrumbApi.setActiveArtifact).toHaveBeenCalledWith(
+			"run-1",
+			"docs/tasks.md",
+		);
+	});
+});

--- a/cli/web-ui/src/__tests__/pages/v2/FileBrowserPage.test.tsx
+++ b/cli/web-ui/src/__tests__/pages/v2/FileBrowserPage.test.tsx
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { WorkspaceTabsProvider } from "@/hooks/useWorkspaceTabs";
 import type { ShortcutRegistryData } from "@/providers/ShortcutRegistryProvider";
 import {
 	ShortcutRegistryProvider,
@@ -131,19 +132,21 @@ async function renderFileBrowser() {
 
 	return render(
 		<MemoryRouter initialEntries={["/projects/proj-1/files/docs/test.md"]}>
-			<ShortcutRegistryProvider>
-				<Routes>
-					<Route
-						path="/projects/:projectId/files/*"
-						element={
-							<>
-								<RegistryProbe />
-								<FileBrowserPage />
-							</>
-						}
-					/>
-				</Routes>
-			</ShortcutRegistryProvider>
+			<WorkspaceTabsProvider>
+				<ShortcutRegistryProvider>
+					<Routes>
+						<Route
+							path="/projects/:projectId/files/*"
+							element={
+								<>
+									<RegistryProbe />
+									<FileBrowserPage />
+								</>
+							}
+						/>
+					</Routes>
+				</ShortcutRegistryProvider>
+			</WorkspaceTabsProvider>
 		</MemoryRouter>,
 	);
 }
@@ -176,14 +179,20 @@ describe("FileBrowserPage", () => {
 		const firstRender = await renderFileBrowser();
 
 		await waitFor(() => {
-			expect(latestRegistry?.contextualShortcuts?.commands.length).toBe(1);
+			expect(
+				latestRegistry?.contextualShortcuts?.commands.some(
+					(candidate) => candidate.id === "toggle-file-frontmatter",
+				),
+			).toBe(true);
 		});
 
 		expect(screen.getByTestId("file-panel-frontmatter").textContent).toBe(
 			"false",
 		);
 
-		const command = latestRegistry?.contextualShortcuts?.commands[0];
+		const command = latestRegistry?.contextualShortcuts?.commands.find(
+			(candidate) => candidate.id === "toggle-file-frontmatter",
+		);
 		expect(command?.id).toBe("toggle-file-frontmatter");
 
 		act(() => {

--- a/cli/web-ui/src/__tests__/pages/v2/FileBrowserPage.test.tsx
+++ b/cli/web-ui/src/__tests__/pages/v2/FileBrowserPage.test.tsx
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
-import type { ReactNode } from "react";
+import type { ComponentType, ReactNode } from "react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { WorkspaceTabsProvider } from "@/hooks/useWorkspaceTabs";
 import type { ShortcutRegistryData } from "@/providers/ShortcutRegistryProvider";
@@ -113,9 +113,24 @@ mock.module("@/components/v2/TableOfContents", () => ({
 }));
 
 mock.module("@/components/v2/ContentPanel", () => ({
-	ContentPanel: ({ showFrontmatter }: { showFrontmatter?: boolean }) => (
-		<div data-testid="file-panel-frontmatter">
-			{String(showFrontmatter ?? false)}
+	ContentPanel: ({
+		content,
+		isLoading,
+		showFrontmatter,
+	}: {
+		content?: string | null;
+		isLoading?: boolean;
+		showFrontmatter?: boolean;
+	}) => (
+		<div
+			data-testid="file-panel"
+			data-loading={String(isLoading ?? false)}
+			data-content={content ?? ""}
+		>
+			<div data-testid="file-panel-frontmatter">
+				{String(showFrontmatter ?? false)}
+			</div>
+			<div data-testid="file-panel-content">{content ?? ""}</div>
 		</div>
 	),
 }));
@@ -130,6 +145,10 @@ async function renderFileBrowser() {
 		`../../../pages/v2/FileBrowserPage.tsx?file-browser-test=${++importVersion}`
 	);
 
+	return renderFileBrowserWithComponent(FileBrowserPage);
+}
+
+function renderFileBrowserWithComponent(FileBrowserPage: ComponentType) {
 	return render(
 		<MemoryRouter initialEntries={["/projects/proj-1/files/docs/test.md"]}>
 			<WorkspaceTabsProvider>
@@ -211,5 +230,31 @@ describe("FileBrowserPage", () => {
 		expect(screen.getByTestId("file-panel-frontmatter").textContent).toBe(
 			"true",
 		);
+	});
+
+	test("reuses cached content when the file workspace remounts", async () => {
+		const { FileBrowserPage } = await import(
+			`../../../pages/v2/FileBrowserPage.tsx?file-browser-cache-test=${++importVersion}`
+		);
+
+		const firstRender = renderFileBrowserWithComponent(FileBrowserPage);
+		await waitFor(() => {
+			expect(screen.getByTestId("file-panel-content").textContent).toContain(
+				"# Hello",
+			);
+		});
+
+		firstRender.unmount();
+
+		global.fetch = mock(
+			() => new Promise<Response>(() => {}),
+		) as unknown as typeof fetch;
+
+		renderFileBrowserWithComponent(FileBrowserPage);
+
+		expect(screen.getByTestId("file-panel-content").textContent).toContain(
+			"# Hello",
+		);
+		expect(screen.getByTestId("file-panel").dataset.loading).toBe("false");
 	});
 });

--- a/cli/web-ui/src/__tests__/pages/v2/FileBrowserPage.test.tsx
+++ b/cli/web-ui/src/__tests__/pages/v2/FileBrowserPage.test.tsx
@@ -115,10 +115,12 @@ mock.module("@/components/v2/TableOfContents", () => ({
 mock.module("@/components/v2/ContentPanel", () => ({
 	ContentPanel: ({
 		content,
+		error,
 		isLoading,
 		showFrontmatter,
 	}: {
 		content?: string | null;
+		error?: string | null;
 		isLoading?: boolean;
 		showFrontmatter?: boolean;
 	}) => (
@@ -126,10 +128,12 @@ mock.module("@/components/v2/ContentPanel", () => ({
 			data-testid="file-panel"
 			data-loading={String(isLoading ?? false)}
 			data-content={content ?? ""}
+			data-error={error ?? ""}
 		>
 			<div data-testid="file-panel-frontmatter">
 				{String(showFrontmatter ?? false)}
 			</div>
+			<div data-testid="file-panel-error">{error ?? ""}</div>
 			<div data-testid="file-panel-content">{content ?? ""}</div>
 		</div>
 	),
@@ -256,5 +260,22 @@ describe("FileBrowserPage", () => {
 			"# Hello",
 		);
 		expect(screen.getByTestId("file-panel").dataset.loading).toBe("false");
+	});
+
+	test("surfaces initial fetch failures as an error when no cached content exists", async () => {
+		global.fetch = mock(async () => ({
+			ok: false,
+			status: 500,
+			statusText: "Internal Server Error",
+		})) as unknown as typeof fetch;
+
+		await renderFileBrowser();
+
+		await waitFor(() => {
+			expect(screen.getByTestId("file-panel").dataset.loading).toBe("false");
+			expect(screen.getByTestId("file-panel-error").textContent).toBe(
+				"Failed to fetch content: Internal Server Error",
+			);
+		});
 	});
 });

--- a/cli/web-ui/src/__tests__/pages/v2/HomePage.test.tsx
+++ b/cli/web-ui/src/__tests__/pages/v2/HomePage.test.tsx
@@ -1,0 +1,190 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+	cleanup,
+	fireEvent,
+	render,
+	screen,
+	waitFor,
+} from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
+import {
+	WORKSPACE_TABS_STORAGE_KEY,
+	type WorkspaceTab,
+	WorkspaceTabsProvider,
+} from "@/hooks/useWorkspaceTabs";
+
+let importVersion = 0;
+
+function installHomePageMocks() {
+	mock.module("@/hooks/useFeed", () => ({
+		useFeed: () => ({
+			items: [
+				{
+					id: "run-1",
+					run: {
+						id: "run-1",
+						name: "Build One",
+						command: "/build-fast",
+						status: "running",
+						harness: "codex",
+						startedAt: "2026-04-12T00:00:00.000Z",
+						lastEventAt: "2026-04-12T00:05:00.000Z",
+						projectId: "proj-1",
+						projectName: "Project One",
+					},
+				},
+			],
+			total: 1,
+			isLoading: false,
+		}),
+	}));
+
+	mock.module("@/hooks/usePrefersReducedMotion", () => ({
+		usePrefersReducedMotion: () => true,
+	}));
+
+	mock.module("@/components/v2/FilterBar", () => ({
+		FilterBar: () => <div data-testid="filter-bar" />,
+	}));
+
+	mock.module("@/components/v2/HarnessIcon", () => ({
+		HarnessIcon: () => <span data-testid="harness-icon" />,
+	}));
+
+	mock.module("framer-motion", () => ({
+		motion: new Proxy(
+			{},
+			{
+				get(_target: object, prop: string) {
+					return ({
+						children,
+						...props
+					}: Record<string, unknown> & { children?: ReactNode }) =>
+						createElement(prop, props, children);
+				},
+			},
+		),
+		AnimatePresence: ({ children }: { children?: ReactNode }) => children,
+	}));
+}
+
+function setStoredState(state: {
+	readonly tabs: readonly WorkspaceTab[];
+	readonly activeKey: string | null;
+	readonly lastDurableRoute: string;
+}) {
+	sessionStorage.setItem(WORKSPACE_TABS_STORAGE_KEY, JSON.stringify(state));
+}
+
+function LocationProbe() {
+	const location = useLocation();
+	return (
+		<span data-testid="location-probe">
+			{location.pathname}
+			{location.search}
+		</span>
+	);
+}
+
+async function renderHomePage() {
+	installHomePageMocks();
+
+	const { HomePage } = await import(
+		`../../../pages/v2/HomePage.tsx?home-page-test=${++importVersion}`
+	);
+
+	return render(
+		<MemoryRouter initialEntries={["/"]}>
+			<WorkspaceTabsProvider>
+				<Routes>
+					<Route
+						path="/"
+						element={
+							<>
+								<LocationProbe />
+								<HomePage />
+							</>
+						}
+					/>
+					<Route path="/runs/:runId/*" element={<LocationProbe />} />
+					<Route path="/projects/:projectId" element={<LocationProbe />} />
+				</Routes>
+			</WorkspaceTabsProvider>
+		</MemoryRouter>,
+	);
+}
+
+describe("HomePage", () => {
+	beforeEach(() => {
+		mock.restore();
+		document.body.innerHTML = "";
+		sessionStorage.clear();
+	});
+
+	afterEach(() => {
+		cleanup();
+		mock.restore();
+		sessionStorage.clear();
+	});
+
+	test("reopens an existing run workspace from the activity feed entry", async () => {
+		setStoredState({
+			tabs: [
+				{
+					key: "run:run-1",
+					kind: "run",
+					currentPath: "/runs/run-1/step/build/artifact/doc-1",
+					rootPath: "/runs/run-1",
+					title: "Build One",
+					subtitle: "Project One",
+					projectId: "proj-1",
+					lastVisitedAt: 1,
+				},
+			],
+			activeKey: null,
+			lastDurableRoute: "/",
+		});
+
+		await renderHomePage();
+
+		fireEvent.click(screen.getByText("Build One").closest('[role="button"]')!);
+
+		await waitFor(() => {
+			expect(screen.getByTestId("location-probe").textContent).toBe(
+				"/runs/run-1/step/build/artifact/doc-1",
+			);
+		});
+	});
+
+	test("reopens an existing project workspace from the feed project action", async () => {
+		setStoredState({
+			tabs: [
+				{
+					key: "project:proj-1",
+					kind: "project",
+					currentPath: "/projects/proj-1?view=summary",
+					rootPath: "/projects/proj-1",
+					title: "Project One",
+					subtitle: null,
+					projectId: "proj-1",
+					lastVisitedAt: 1,
+				},
+			],
+			activeKey: null,
+			lastDurableRoute: "/",
+		});
+
+		await renderHomePage();
+
+		fireEvent.click(
+			screen.getByRole("button", { name: "Open project Project One" }),
+		);
+
+		await waitFor(() => {
+			expect(screen.getByTestId("location-probe").textContent).toBe(
+				"/projects/proj-1?view=summary",
+			);
+		});
+	});
+});

--- a/cli/web-ui/src/__tests__/pages/v2/ProjectOverviewPage.test.tsx
+++ b/cli/web-ui/src/__tests__/pages/v2/ProjectOverviewPage.test.tsx
@@ -6,7 +6,7 @@ import {
 	screen,
 	waitFor,
 } from "@testing-library/react";
-import type { ReactNode } from "react";
+import type { ComponentType, ReactNode } from "react";
 import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
 import {
 	WORKSPACE_TABS_STORAGE_KEY,
@@ -73,6 +73,16 @@ async function renderProjectOverview(
 		`../../../pages/v2/ProjectOverviewPage.tsx?project-overview-test=${++importVersion}`
 	);
 
+	return renderProjectOverviewWithComponent(
+		ProjectOverviewPage,
+		initialEntries,
+	);
+}
+
+function renderProjectOverviewWithComponent(
+	ProjectOverviewPage: ComponentType,
+	initialEntries: readonly string[] = ["/projects/proj-1"],
+) {
 	return render(
 		<MemoryRouter initialEntries={[...initialEntries]}>
 			<WorkspaceTabsProvider>
@@ -251,5 +261,27 @@ describe("ProjectOverviewPage", () => {
 				"/projects/proj-1/files/src/index.ts",
 			);
 		});
+	});
+
+	test("reuses cached project data when the workspace remounts", async () => {
+		const { ProjectOverviewPage } = await import(
+			`../../../pages/v2/ProjectOverviewPage.tsx?project-overview-cache-test=${++importVersion}`
+		);
+
+		const firstRender = renderProjectOverviewWithComponent(ProjectOverviewPage);
+		expect(
+			await screen.findByRole("heading", { name: "Project One" }),
+		).toBeTruthy();
+
+		firstRender.unmount();
+
+		global.fetch = mock(
+			() => new Promise<Response>(() => {}),
+		) as unknown as typeof fetch;
+
+		renderProjectOverviewWithComponent(ProjectOverviewPage);
+
+		expect(screen.getByRole("heading", { name: "Project One" })).toBeTruthy();
+		expect(screen.queryByText("...")).toBeNull();
 	});
 });

--- a/cli/web-ui/src/__tests__/pages/v2/ProjectOverviewPage.test.tsx
+++ b/cli/web-ui/src/__tests__/pages/v2/ProjectOverviewPage.test.tsx
@@ -1,8 +1,18 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import { cleanup, render, screen } from "@testing-library/react";
+import {
+	cleanup,
+	fireEvent,
+	render,
+	screen,
+	waitFor,
+} from "@testing-library/react";
 import type { ReactNode } from "react";
-import { MemoryRouter, Route, Routes } from "react-router-dom";
-import { WorkspaceTabsProvider } from "@/hooks/useWorkspaceTabs";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
+import {
+	WORKSPACE_TABS_STORAGE_KEY,
+	type WorkspaceTab,
+	WorkspaceTabsProvider,
+} from "@/hooks/useWorkspaceTabs";
 import type { ShortcutRegistryData } from "@/providers/ShortcutRegistryProvider";
 import {
 	ShortcutRegistryProvider,
@@ -43,13 +53,28 @@ function RegistryProbe() {
 	return null;
 }
 
-async function renderProjectOverview() {
+function LocationProbe() {
+	const location = useLocation();
+	return <span data-testid="location-probe">{location.pathname}</span>;
+}
+
+function setStoredState(state: {
+	readonly tabs: readonly WorkspaceTab[];
+	readonly activeKey: string | null;
+	readonly lastDurableRoute: string;
+}) {
+	sessionStorage.setItem(WORKSPACE_TABS_STORAGE_KEY, JSON.stringify(state));
+}
+
+async function renderProjectOverview(
+	initialEntries: readonly string[] = ["/projects/proj-1"],
+) {
 	const { ProjectOverviewPage } = await import(
 		`../../../pages/v2/ProjectOverviewPage.tsx?project-overview-test=${++importVersion}`
 	);
 
 	return render(
-		<MemoryRouter initialEntries={["/projects/proj-1"]}>
+		<MemoryRouter initialEntries={[...initialEntries]}>
 			<WorkspaceTabsProvider>
 				<ShortcutRegistryProvider>
 					<Routes>
@@ -58,10 +83,16 @@ async function renderProjectOverview() {
 							element={
 								<>
 									<RegistryProbe />
+									<LocationProbe />
 									<ProjectOverviewPage />
 								</>
 							}
 						/>
+						<Route
+							path="/projects/:projectId/files/*"
+							element={<LocationProbe />}
+						/>
+						<Route path="/runs/:runId/*" element={<LocationProbe />} />
 					</Routes>
 				</ShortcutRegistryProvider>
 			</WorkspaceTabsProvider>
@@ -123,5 +154,102 @@ describe("ProjectOverviewPage", () => {
 		expect(latestRegistry?.contextualShortcuts?.viewId).toBe(
 			"project-overview",
 		);
+	});
+
+	test("reopens an existing run workspace from recent runs", async () => {
+		setStoredState({
+			tabs: [
+				{
+					key: "run:run-1",
+					kind: "run",
+					currentPath: "/runs/run-1/step/build",
+					rootPath: "/runs/run-1",
+					title: "Run one",
+					subtitle: null,
+					projectId: null,
+					lastVisitedAt: 1,
+				},
+			],
+			activeKey: null,
+			lastDurableRoute: "/projects",
+		});
+		global.fetch = mock(async (input: RequestInfo | URL) => {
+			const url = String(input);
+			if (url.includes("/api/v2/projects/proj-1") && !url.includes("runs?")) {
+				return {
+					ok: true,
+					status: 200,
+					json: async () => ({
+						id: "proj-1",
+						name: "Project One",
+						path: "/repo/project-one",
+						available: true,
+						runCount: 3,
+						lastActivityAt: "2026-04-12T00:00:00.000Z",
+					}),
+				} satisfies Partial<Response>;
+			}
+
+			return {
+				ok: true,
+				status: 200,
+				json: async () => ({
+					runs: [
+						{
+							id: "run-1",
+							command: "/build",
+							status: "running",
+							projectId: "proj-1",
+							projectName: "Project One",
+							harness: "codex",
+							startedAt: "2026-04-12T00:00:00.000Z",
+							lastEventAt: "2026-04-12T00:00:00.000Z",
+						},
+					],
+					total: 1,
+				}),
+			} satisfies Partial<Response>;
+		}) as unknown as typeof fetch;
+
+		await renderProjectOverview();
+
+		fireEvent.click(await screen.findByRole("button", { name: "Run" }));
+
+		await waitFor(() => {
+			expect(screen.getByTestId("location-probe").textContent).toBe(
+				"/runs/run-1/step/build",
+			);
+		});
+	});
+
+	test("reopens an existing files workspace from the browse files action", async () => {
+		setStoredState({
+			tabs: [
+				{
+					key: "files:proj-1",
+					kind: "files",
+					currentPath: "/projects/proj-1/files/src/index.ts",
+					rootPath: "/projects/proj-1/files",
+					title: "Project One files",
+					subtitle: "index.ts",
+					projectId: "proj-1",
+					lastVisitedAt: 1,
+				},
+			],
+			activeKey: null,
+			lastDurableRoute: "/projects",
+		});
+
+		await renderProjectOverview();
+
+		fireEvent.click(
+			await screen.findByRole("button", { name: "Browse files" }),
+		);
+
+		await waitFor(() => {
+			expect(screen.getByTestId("location-probe").textContent).toBe(
+				"/projects/proj-1/files/src/index.ts",
+			);
+		});
 	});
 });

--- a/cli/web-ui/src/__tests__/pages/v2/ProjectOverviewPage.test.tsx
+++ b/cli/web-ui/src/__tests__/pages/v2/ProjectOverviewPage.test.tsx
@@ -1,0 +1,127 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { WorkspaceTabsProvider } from "@/hooks/useWorkspaceTabs";
+import type { ShortcutRegistryData } from "@/providers/ShortcutRegistryProvider";
+import {
+	ShortcutRegistryProvider,
+	useShortcutRegistry,
+} from "@/providers/ShortcutRegistryProvider";
+
+let importVersion = 0;
+let latestRegistry: ShortcutRegistryData | null = null;
+
+const breadcrumbApi = {
+	setProject: mock(() => {}),
+};
+
+mock.module("@/hooks/useBreadcrumbContext", () => ({
+	useBreadcrumbContext: () => breadcrumbApi,
+}));
+
+mock.module("@/hooks/useReconnectRecovery", () => ({
+	useReconnectRecovery: () => {},
+}));
+
+mock.module("@/components/v2/RunCard", () => ({
+	RunCard: ({
+		children,
+		onClick,
+	}: {
+		children?: ReactNode;
+		onClick?: () => void;
+	}) => (
+		<button type="button" onClick={onClick}>
+			{children ?? "Run"}
+		</button>
+	),
+}));
+
+function RegistryProbe() {
+	latestRegistry = useShortcutRegistry();
+	return null;
+}
+
+async function renderProjectOverview() {
+	const { ProjectOverviewPage } = await import(
+		`../../../pages/v2/ProjectOverviewPage.tsx?project-overview-test=${++importVersion}`
+	);
+
+	return render(
+		<MemoryRouter initialEntries={["/projects/proj-1"]}>
+			<WorkspaceTabsProvider>
+				<ShortcutRegistryProvider>
+					<Routes>
+						<Route
+							path="/projects/:projectId"
+							element={
+								<>
+									<RegistryProbe />
+									<ProjectOverviewPage />
+								</>
+							}
+						/>
+					</Routes>
+				</ShortcutRegistryProvider>
+			</WorkspaceTabsProvider>
+		</MemoryRouter>,
+	);
+}
+
+describe("ProjectOverviewPage", () => {
+	beforeEach(() => {
+		mock.restore();
+		document.body.innerHTML = "";
+		sessionStorage.clear();
+		latestRegistry = null;
+		breadcrumbApi.setProject.mockClear();
+		global.fetch = mock(async (input: RequestInfo | URL) => {
+			const url = String(input);
+			if (url.includes("/api/v2/projects/proj-1") && !url.includes("runs?")) {
+				return {
+					ok: true,
+					status: 200,
+					json: async () => ({
+						id: "proj-1",
+						name: "Project One",
+						path: "/repo/project-one",
+						available: true,
+						runCount: 3,
+						lastActivityAt: "2026-04-12T00:00:00.000Z",
+					}),
+				} satisfies Partial<Response>;
+			}
+
+			return {
+				ok: true,
+				status: 200,
+				json: async () => ({
+					runs: [],
+					total: 0,
+				}),
+			} satisfies Partial<Response>;
+		}) as unknown as typeof fetch;
+	});
+
+	afterEach(() => {
+		cleanup();
+		mock.restore();
+	});
+
+	test("publishes workspace metadata and registers workspace commands", async () => {
+		await renderProjectOverview();
+
+		expect(
+			await screen.findByRole("heading", { name: "Project One" }),
+		).toBeTruthy();
+		expect(screen.getByText("/repo/project-one")).toBeTruthy();
+		expect(breadcrumbApi.setProject).toHaveBeenCalledWith(
+			"proj-1",
+			"Project One",
+		);
+		expect(latestRegistry?.contextualShortcuts?.viewId).toBe(
+			"project-overview",
+		);
+	});
+});

--- a/cli/web-ui/src/__tests__/pages/v2/ProjectsPage.test.tsx
+++ b/cli/web-ui/src/__tests__/pages/v2/ProjectsPage.test.tsx
@@ -1,0 +1,145 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+	cleanup,
+	fireEvent,
+	render,
+	screen,
+	waitFor,
+} from "@testing-library/react";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
+import type { V2Project } from "@/hooks/useProjects";
+import {
+	WORKSPACE_TABS_STORAGE_KEY,
+	type WorkspaceTab,
+	WorkspaceTabsProvider,
+} from "@/hooks/useWorkspaceTabs";
+
+let importVersion = 0;
+
+const projects: readonly V2Project[] = [
+	{
+		id: "proj-1",
+		name: "Project One",
+		path: "/repo/project-one",
+		available: true,
+		runCount: 3,
+		lastActivityAt: "2026-04-12T00:00:00.000Z",
+	},
+];
+
+mock.module("@/hooks/useProjects", () => ({
+	useProjects: () => ({
+		projects,
+		isLoading: false,
+		error: null,
+		refetch: () => {},
+	}),
+}));
+
+mock.module("@/hooks/useRuns", () => ({
+	useRuns: () => ({
+		runs: [],
+	}),
+}));
+
+function LocationProbe() {
+	const location = useLocation();
+	return <span data-testid="location-probe">{location.pathname}</span>;
+}
+
+function setStoredState(state: {
+	readonly tabs: readonly WorkspaceTab[];
+	readonly activeKey: string | null;
+	readonly lastDurableRoute: string;
+}) {
+	sessionStorage.setItem(WORKSPACE_TABS_STORAGE_KEY, JSON.stringify(state));
+}
+
+async function renderProjectsPage(
+	initialEntries: readonly string[] = ["/projects"],
+) {
+	const { ProjectsPage } = await import(
+		`../../../pages/v2/ProjectsPage.tsx?projects-page-test=${++importVersion}`
+	);
+
+	return render(
+		<MemoryRouter initialEntries={[...initialEntries]}>
+			<WorkspaceTabsProvider>
+				<Routes>
+					<Route
+						path="/projects"
+						element={
+							<>
+								<LocationProbe />
+								<ProjectsPage />
+							</>
+						}
+					/>
+					<Route path="/projects/:projectId" element={<LocationProbe />} />
+					<Route
+						path="/projects/:projectId/files/*"
+						element={<LocationProbe />}
+					/>
+					<Route path="/" element={<LocationProbe />} />
+				</Routes>
+			</WorkspaceTabsProvider>
+		</MemoryRouter>,
+	);
+}
+
+describe("ProjectsPage", () => {
+	beforeEach(() => {
+		mock.restore();
+		document.body.innerHTML = "";
+		sessionStorage.clear();
+	});
+
+	afterEach(() => {
+		cleanup();
+		mock.restore();
+		sessionStorage.clear();
+	});
+
+	test("opens the selected project overview from the project row", async () => {
+		await renderProjectsPage();
+
+		fireEvent.click(screen.getByText("Project One").closest("button")!);
+
+		await waitFor(() => {
+			expect(screen.getByTestId("location-probe").textContent).toBe(
+				"/projects/proj-1",
+			);
+		});
+	});
+
+	test("reopens an existing files workspace from the files action", async () => {
+		setStoredState({
+			tabs: [
+				{
+					key: "files:proj-1",
+					kind: "files",
+					currentPath: "/projects/proj-1/files/src/index.ts",
+					rootPath: "/projects/proj-1/files",
+					title: "Project One files",
+					subtitle: "index.ts",
+					projectId: "proj-1",
+					lastVisitedAt: 1,
+				},
+			],
+			activeKey: null,
+			lastDurableRoute: "/projects",
+		});
+
+		await renderProjectsPage();
+
+		fireEvent.click(
+			screen.getByRole("button", { name: "Files for Project One" }),
+		);
+
+		await waitFor(() => {
+			expect(screen.getByTestId("location-probe").textContent).toBe(
+				"/projects/proj-1/files/src/index.ts",
+			);
+		});
+	});
+});

--- a/cli/web-ui/src/__tests__/pages/v2/RunDetailPage.test.tsx
+++ b/cli/web-ui/src/__tests__/pages/v2/RunDetailPage.test.tsx
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { WorkspaceTabsProvider } from "@/hooks/useWorkspaceTabs";
 import type { ShortcutRegistryData } from "@/providers/ShortcutRegistryProvider";
 import {
 	ShortcutRegistryProvider,
@@ -131,19 +132,21 @@ async function renderRunDetail() {
 
 	return render(
 		<MemoryRouter initialEntries={["/runs/run-1/step/build/artifact/doc-1"]}>
-			<ShortcutRegistryProvider>
-				<Routes>
-					<Route
-						path="/runs/:runId/step/:stepId/artifact/:docId"
-						element={
-							<>
-								<RegistryProbe />
-								<RunDetailPage />
-							</>
-						}
-					/>
-				</Routes>
-			</ShortcutRegistryProvider>
+			<WorkspaceTabsProvider>
+				<ShortcutRegistryProvider>
+					<Routes>
+						<Route
+							path="/runs/:runId/step/:stepId/artifact/:docId"
+							element={
+								<>
+									<RegistryProbe />
+									<RunDetailPage />
+								</>
+							}
+						/>
+					</Routes>
+				</ShortcutRegistryProvider>
+			</WorkspaceTabsProvider>
 		</MemoryRouter>,
 	);
 }
@@ -174,7 +177,21 @@ describe("RunDetailPage", () => {
 		}
 
 		await waitFor(() => {
-			expect(latestRegistry?.contextualShortcuts?.commands.length).toBe(2);
+			expect(
+				latestRegistry?.contextualShortcuts?.commands.some(
+					(command) => command.id === "toggle-run-metadata",
+				),
+			).toBe(true);
+			expect(
+				latestRegistry?.contextualShortcuts?.commands.some(
+					(command) => command.id === "toggle-run-frontmatter",
+				),
+			).toBe(true);
+			expect(
+				latestRegistry?.contextualShortcuts?.commands.some(
+					(command) => command.id === "close-workspace",
+				),
+			).toBe(true);
 		});
 
 		const metadataCommand = latestRegistry?.contextualShortcuts?.commands.find(
@@ -187,6 +204,11 @@ describe("RunDetailPage", () => {
 
 		expect(metadataCommand).toBeTruthy();
 		expect(frontmatterCommand).toBeTruthy();
+		expect(
+			latestRegistry?.contextualShortcuts?.commands.some(
+				(command) => command.id === "close-workspace",
+			),
+		).toBe(true);
 
 		act(() => {
 			metadataCommand?.action();

--- a/cli/web-ui/src/app/V2Layout.tsx
+++ b/cli/web-ui/src/app/V2Layout.tsx
@@ -134,7 +134,7 @@ export function AppLayout() {
 						<IconRail className="hidden md:flex" />
 
 						<div className="flex min-h-0 flex-1 flex-col overflow-hidden">
-							<TerminalBreadcrumb
+							<WorkspaceTabStrip
 								action={
 									<NotificationTrigger
 										summary={summary}
@@ -143,7 +143,7 @@ export function AppLayout() {
 									/>
 								}
 							/>
-							<WorkspaceTabStrip />
+							<TerminalBreadcrumb />
 							{isFullHeight ? (
 								<main className="min-h-0 flex-1 overflow-hidden">
 									<AnimatePresence mode="wait">

--- a/cli/web-ui/src/app/V2Layout.tsx
+++ b/cli/web-ui/src/app/V2Layout.tsx
@@ -10,6 +10,7 @@ import { NotificationContainer } from "@/components/v2/NotificationToast";
 import { NotificationTrigger } from "@/components/v2/NotificationTrigger";
 import { ShortcutHelpOverlay } from "@/components/v2/ShortcutHelpOverlay";
 import { TerminalBreadcrumb } from "@/components/v2/TerminalBreadcrumb";
+import { WorkspaceTabStrip } from "@/components/v2/WorkspaceTabStrip";
 import { BreadcrumbProvider } from "@/hooks/useBreadcrumbContext";
 import { useGlobalShortcuts } from "@/hooks/useGlobalShortcuts";
 import { useNotifications } from "@/hooks/useNotifications";
@@ -102,7 +103,7 @@ export function AppLayout() {
 					<div className="flex h-screen bg-background">
 						<IconRail className="hidden md:flex" />
 
-						<div className="flex flex-1 flex-col overflow-hidden">
+						<div className="flex min-h-0 flex-1 flex-col overflow-hidden">
 							<TerminalBreadcrumb
 								action={
 									<NotificationTrigger
@@ -112,8 +113,9 @@ export function AppLayout() {
 									/>
 								}
 							/>
+							<WorkspaceTabStrip />
 							{isFullHeight ? (
-								<main className="flex-1 overflow-hidden">
+								<main className="min-h-0 flex-1 overflow-hidden">
 									<AnimatePresence mode="wait">
 										<motion.div
 											key={animationKey}
@@ -129,7 +131,7 @@ export function AppLayout() {
 									</AnimatePresence>
 								</main>
 							) : (
-								<main className="flex-1 overflow-hidden">
+								<main className="min-h-0 flex-1 overflow-hidden">
 									<ScrollArea className="h-full">
 										<AnimatePresence mode="wait">
 											<motion.div

--- a/cli/web-ui/src/app/V2Layout.tsx
+++ b/cli/web-ui/src/app/V2Layout.tsx
@@ -14,6 +14,7 @@ import { BreadcrumbProvider } from "@/hooks/useBreadcrumbContext";
 import { useGlobalShortcuts } from "@/hooks/useGlobalShortcuts";
 import { useNotifications } from "@/hooks/useNotifications";
 import { usePrefersReducedMotion } from "@/hooks/usePrefersReducedMotion";
+import { WorkspaceTabsProvider } from "@/hooks/useWorkspaceTabs";
 import {
 	pageTransition,
 	pageTransitionReduced,
@@ -96,39 +97,23 @@ export function AppLayout() {
 
 	return (
 		<BreadcrumbProvider>
-			<ShortcutRegistryProvider>
-				<div className="flex h-screen bg-background">
-					<IconRail className="hidden md:flex" />
+			<WorkspaceTabsProvider>
+				<ShortcutRegistryProvider>
+					<div className="flex h-screen bg-background">
+						<IconRail className="hidden md:flex" />
 
-					<div className="flex flex-1 flex-col overflow-hidden">
-						<TerminalBreadcrumb
-							action={
-								<NotificationTrigger
-									summary={summary}
-									open={activeOverlay === "notifications"}
-									onClick={handleToggleNotifications}
-								/>
-							}
-						/>
-						{isFullHeight ? (
-							<main className="flex-1 overflow-hidden">
-								<AnimatePresence mode="wait">
-									<motion.div
-										key={animationKey}
-										variants={variants}
-										initial="initial"
-										animate="animate"
-										exit="exit"
-										transition={transition}
-										className="h-full"
-									>
-										<Outlet />
-									</motion.div>
-								</AnimatePresence>
-							</main>
-						) : (
-							<main className="flex-1 overflow-hidden">
-								<ScrollArea className="h-full">
+						<div className="flex flex-1 flex-col overflow-hidden">
+							<TerminalBreadcrumb
+								action={
+									<NotificationTrigger
+										summary={summary}
+										open={activeOverlay === "notifications"}
+										onClick={handleToggleNotifications}
+									/>
+								}
+							/>
+							{isFullHeight ? (
+								<main className="flex-1 overflow-hidden">
 									<AnimatePresence mode="wait">
 										<motion.div
 											key={animationKey}
@@ -137,54 +122,72 @@ export function AppLayout() {
 											animate="animate"
 											exit="exit"
 											transition={transition}
-											className="p-6"
+											className="h-full"
 										>
 											<Outlet />
 										</motion.div>
 									</AnimatePresence>
-								</ScrollArea>
-							</main>
-						)}
+								</main>
+							) : (
+								<main className="flex-1 overflow-hidden">
+									<ScrollArea className="h-full">
+										<AnimatePresence mode="wait">
+											<motion.div
+												key={animationKey}
+												variants={variants}
+												initial="initial"
+												animate="animate"
+												exit="exit"
+												transition={transition}
+												className="p-6"
+											>
+												<Outlet />
+											</motion.div>
+										</AnimatePresence>
+									</ScrollArea>
+								</main>
+							)}
+						</div>
+
+						<MobileTabBar
+							className="fixed inset-x-0 bottom-0 md:hidden"
+							onOpenCommandPalette={handleOpenCommandPalette}
+							notificationAction={
+								<NotificationTrigger
+									summary={summary}
+									open={activeOverlay === "notifications"}
+									onClick={handleToggleNotifications}
+									className="h-11 w-11"
+								/>
+							}
+						/>
+
+						<CommandPalette
+							open={activeOverlay === "command-palette"}
+							onOpenChange={(open) => {
+								setActiveOverlay((current) => {
+									if (open) {
+										return "command-palette";
+									}
+
+									return current === "command-palette" ? "none" : current;
+								});
+							}}
+						/>
+						<NotificationsSidebar
+							open={activeOverlay === "notifications"}
+							onClose={handleCloseActiveOverlay}
+							notifications={notifications}
+							isLoading={isLoading}
+							error={error}
+							onDismissNotification={dismissNotification}
+							onDismissAllNotifications={dismissAllNotifications}
+						/>
 					</div>
-
-					<MobileTabBar
-						className="fixed inset-x-0 bottom-0 md:hidden"
-						onOpenCommandPalette={handleOpenCommandPalette}
-						notificationAction={
-							<NotificationTrigger
-								summary={summary}
-								open={activeOverlay === "notifications"}
-								onClick={handleToggleNotifications}
-								className="h-11 w-11"
-							/>
-						}
-					/>
-
-					<CommandPalette
-						open={activeOverlay === "command-palette"}
-						onOpenChange={(open) => {
-							setActiveOverlay((current) => {
-								if (open) {
-									return "command-palette";
-								}
-
-								return current === "command-palette" ? "none" : current;
-							});
-						}}
-					/>
-					<NotificationsSidebar
-						open={activeOverlay === "notifications"}
-						onClose={handleCloseActiveOverlay}
-						notifications={notifications}
-						isLoading={isLoading}
-						error={error}
-						onDismissNotification={dismissNotification}
-						onDismissAllNotifications={dismissAllNotifications}
-					/>
-				</div>
-				<ShortcutHelpOverlay />
-				<NotificationContainer />
-			</ShortcutRegistryProvider>
+					<ShortcutHelpOverlay />
+					<NotificationContainer />
+				</ShortcutRegistryProvider>
+			</WorkspaceTabsProvider>
 		</BreadcrumbProvider>
 	);
 }

--- a/cli/web-ui/src/app/V2Layout.tsx
+++ b/cli/web-ui/src/app/V2Layout.tsx
@@ -1,5 +1,5 @@
 import { AnimatePresence, motion } from "framer-motion";
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Outlet, useLocation, useNavigate } from "react-router-dom";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { CommandPalette } from "@/components/v2/CommandPalette";
@@ -22,6 +22,7 @@ import {
 	pageVariants,
 	pageVariantsReduced,
 } from "@/lib/motion-config";
+import { normalizeWorkspaceRoute } from "@/lib/workspace-routes";
 import { ShortcutRegistryProvider } from "@/providers/ShortcutRegistryProvider";
 
 const FULL_HEIGHT_ROUTES = ["/runs/"];
@@ -39,6 +40,14 @@ function isFullHeightRoute(pathname: string): boolean {
 }
 
 type ActiveOverlay = "none" | "command-palette" | "notifications";
+
+function createCurrentPath(
+	pathname: string,
+	search: string,
+	hash: string,
+): string {
+	return `${pathname}${search}${hash}`;
+}
 
 export function AppLayout() {
 	const [activeOverlay, setActiveOverlay] = useState<ActiveOverlay>("none");
@@ -59,11 +68,32 @@ export function AppLayout() {
 		location.pathname.match(/^\/runs\/[^/]+/)?.[0] ??
 		location.pathname.match(/^\/projects\/[^/]+\/files/)?.[0] ??
 		location.pathname;
+	const currentRoute = useMemo(
+		() =>
+			normalizeWorkspaceRoute(
+				createCurrentPath(location.pathname, location.search, location.hash),
+			),
+		[location.hash, location.pathname, location.search],
+	);
+	const previousRouteRef = useRef(currentRoute);
 
 	const reducedMotion = usePrefersReducedMotion();
-	const variants = reducedMotion ? pageVariantsReduced : pageVariants;
-	const transition = reducedMotion ? pageTransitionReduced : pageTransition;
+	const skipWorkspaceTransition =
+		previousRouteRef.current.type === "workspace" &&
+		currentRoute.type === "workspace";
+	const variants =
+		reducedMotion || skipWorkspaceTransition
+			? pageVariantsReduced
+			: pageVariants;
+	const transition =
+		reducedMotion || skipWorkspaceTransition
+			? pageTransitionReduced
+			: pageTransition;
 	const isOverlayOpen = activeOverlay !== "none" || shortcutHelpOpen;
+
+	useEffect(() => {
+		previousRouteRef.current = currentRoute;
+	}, [currentRoute]);
 
 	const handleOpenCommandPalette = useCallback(() => {
 		setActiveOverlay("command-palette");

--- a/cli/web-ui/src/components/v2/ArtifactViewerPanel.tsx
+++ b/cli/web-ui/src/components/v2/ArtifactViewerPanel.tsx
@@ -123,8 +123,8 @@ function ArtifactViewerInner({
 				const isTerminalError =
 					message.startsWith("Artifact not found:") ||
 					message.startsWith("Run not found");
-				if (isTerminalError) {
-					if (artifactCacheKey) {
+				if (isTerminalError || cachedContent === null) {
+					if (isTerminalError && artifactCacheKey) {
 						artifactContentCache.delete(artifactCacheKey);
 					}
 					setContentError(message);

--- a/cli/web-ui/src/components/v2/ArtifactViewerPanel.tsx
+++ b/cli/web-ui/src/components/v2/ArtifactViewerPanel.tsx
@@ -17,6 +17,8 @@ import { useWebSocket } from "@/providers/WebSocketProvider";
 
 import type { Artifact, Step } from "@/types/runs";
 
+const artifactContentCache = new Map<string, string>();
+
 export interface ArtifactViewerPanelProps {
 	readonly step: Step | null;
 	readonly artifacts: readonly Artifact[];
@@ -40,8 +42,18 @@ function ArtifactViewerInner({
 	subflowDiagram,
 	showFrontmatter = false,
 }: ArtifactViewerPanelProps) {
-	const [content, setContent] = useState<string | null>(null);
-	const [contentLoading, setContentLoading] = useState(false);
+	const artifactPath = selectedArtifact?.path ?? null;
+	const artifactCacheKey =
+		runId && artifactPath ? `${runId}:${artifactPath}` : null;
+	const [content, setContent] = useState<string | null>(() =>
+		artifactCacheKey
+			? (artifactContentCache.get(artifactCacheKey) ?? null)
+			: null,
+	);
+	const [contentLoading, setContentLoading] = useState(
+		() =>
+			artifactCacheKey !== null && !artifactContentCache.has(artifactCacheKey),
+	);
 	const [contentError, setContentError] = useState<string | null>(null);
 	const [headings, setHeadings] = useState<readonly HeadingEntry[]>([]);
 	const [annotationSidebarOpen, setAnnotationSidebarOpen] = useState(false);
@@ -64,8 +76,6 @@ function ArtifactViewerInner({
 		setShowSubflow(shouldShowSubflow);
 	}, [shouldShowSubflow]);
 
-	const artifactPath = selectedArtifact?.path ?? null;
-
 	const fetchContent = useCallback(
 		async (preserveScroll: boolean) => {
 			if (!artifactPath || !runId) {
@@ -73,7 +83,11 @@ function ArtifactViewerInner({
 				return;
 			}
 
-			if (!preserveScroll) {
+			const cachedContent = artifactCacheKey
+				? (artifactContentCache.get(artifactCacheKey) ?? null)
+				: null;
+
+			if (!preserveScroll && cachedContent === null) {
 				setContentLoading(true);
 				setHeadings([]);
 			}
@@ -98,24 +112,47 @@ function ArtifactViewerInner({
 					throw new Error(errorMessage);
 				}
 				const data = (await response.json()) as { content: string };
+				if (artifactCacheKey) {
+					artifactContentCache.set(artifactCacheKey, data.content);
+				}
 				setContent((current) =>
 					current === data.content ? current : data.content,
 				);
 			} catch (err) {
-				setContentError(err instanceof Error ? err.message : String(err));
-				setContent(null);
+				const message = err instanceof Error ? err.message : String(err);
+				const isTerminalError =
+					message.startsWith("Artifact not found:") ||
+					message.startsWith("Run not found");
+				if (isTerminalError) {
+					if (artifactCacheKey) {
+						artifactContentCache.delete(artifactCacheKey);
+					}
+					setContentError(message);
+					setContent(null);
+				}
 			} finally {
 				if (!preserveScroll) {
 					setContentLoading(false);
 				}
 			}
 		},
-		[artifactPath, runId],
+		[artifactPath, artifactCacheKey, runId],
 	);
 
 	useEffect(() => {
-		fetchContent(false);
-	}, [fetchContent]);
+		if (!artifactCacheKey) {
+			setContent(null);
+			setContentLoading(false);
+			setContentError(null);
+			return;
+		}
+
+		const cachedContent = artifactContentCache.get(artifactCacheKey) ?? null;
+		setContent(cachedContent);
+		setContentLoading(cachedContent === null);
+		setContentError(null);
+		void fetchContent(false);
+	}, [artifactCacheKey, fetchContent]);
 
 	useEffect(() => {
 		if (!artifactPath || !runId) return;

--- a/cli/web-ui/src/components/v2/NotificationsSidebar.tsx
+++ b/cli/web-ui/src/components/v2/NotificationsSidebar.tsx
@@ -1,12 +1,12 @@
 import { Bell, Loader2, NotebookTabs, X } from "lucide-react";
 import { useCallback, useMemo, useState } from "react";
-import { useNavigate } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { Drawer } from "@/components/ui/drawer";
 import type {
 	NotificationAttentionLevel,
 	NotificationListItem,
 } from "@/hooks/useNotifications";
+import { useWorkspaceTabs } from "@/hooks/useWorkspaceTabs";
 import { formatRelativeTime } from "@/lib/time";
 import { cn } from "@/lib/utils";
 import { HarnessIcon } from "./HarnessIcon";
@@ -92,7 +92,7 @@ export function NotificationsSidebar({
 	onDismissAllNotifications,
 	className,
 }: NotificationsSidebarProps) {
-	const navigate = useNavigate();
+	const { openWorkspace } = useWorkspaceTabs();
 	const [dismissingIds, setDismissingIds] = useState<readonly number[]>([]);
 	const [isDismissingAll, setIsDismissingAll] = useState(false);
 	const groups = useMemo(
@@ -106,18 +106,18 @@ export function NotificationsSidebar({
 				return;
 			}
 
-			navigate(notification.route);
+			openWorkspace(notification.route);
 			onClose();
 		},
-		[navigate, onClose],
+		[openWorkspace, onClose],
 	);
 
 	const handleOpenProject = useCallback(
 		(projectId: string) => {
-			navigate(`/projects/${projectId}`);
+			openWorkspace(`/projects/${projectId}`);
 			onClose();
 		},
-		[navigate, onClose],
+		[openWorkspace, onClose],
 	);
 
 	const handleDismiss = useCallback(

--- a/cli/web-ui/src/components/v2/RunCard.tsx
+++ b/cli/web-ui/src/components/v2/RunCard.tsx
@@ -1,5 +1,6 @@
 import { NotebookTabs } from "lucide-react";
 import type React from "react";
+import { useWorkspaceTabs } from "@/hooks/useWorkspaceTabs";
 import { resolveRunDisplayName } from "@/lib/run-display";
 import { formatRelativeTime } from "@/lib/time";
 import { cn } from "@/lib/utils";
@@ -37,6 +38,8 @@ export function RunCard({
 	showProject = true,
 	className,
 }: RunCardProps) {
+	const { openWorkspace } = useWorkspaceTabs();
+
 	const handleKeyDown = (event: React.KeyboardEvent) => {
 		if (onClick && (event.key === "Enter" || event.key === " ")) {
 			event.preventDefault();
@@ -84,12 +87,12 @@ export function RunCard({
 					tabIndex={0}
 					onClick={(e) => {
 						e.stopPropagation();
-						window.location.href = `/projects/${run.projectId}`;
+						openWorkspace(`/projects/${run.projectId}`);
 					}}
 					onKeyDown={(e) => {
 						if (e.key === "Enter") {
 							e.stopPropagation();
-							window.location.href = `/projects/${run.projectId}`;
+							openWorkspace(`/projects/${run.projectId}`);
 						}
 					}}
 					className="ml-auto shrink-0 flex items-center gap-1 pl-4 type-secondary italic text-fg-ghost hover:text-fg-muted transition-colors duration-150 cursor-pointer"

--- a/cli/web-ui/src/components/v2/TerminalBreadcrumb.tsx
+++ b/cli/web-ui/src/components/v2/TerminalBreadcrumb.tsx
@@ -1,8 +1,9 @@
 import { NotebookTabs } from "lucide-react";
 import type { ReactNode } from "react";
-import { Link, useLocation, useNavigate } from "react-router-dom";
+import { Link, useLocation } from "react-router-dom";
 import { HarnessIcon } from "@/components/v2/HarnessIcon";
 import { useBreadcrumbContext } from "@/hooks/useBreadcrumbContext";
+import { useWorkspaceTabs } from "@/hooks/useWorkspaceTabs";
 import { formatRelativeTime } from "@/lib/time";
 import { cn } from "@/lib/utils";
 
@@ -29,8 +30,8 @@ export function TerminalBreadcrumb({
 	action,
 }: TerminalBreadcrumbProps) {
 	const { pathname } = useLocation();
-	const navigate = useNavigate();
 	const { projectName, projectId, runInfo } = useBreadcrumbContext();
+	const { openWorkspace } = useWorkspaceTabs();
 
 	if (runInfo) {
 		return (
@@ -58,9 +59,11 @@ export function TerminalBreadcrumb({
 					<span
 						role="link"
 						tabIndex={0}
-						onClick={() => navigate(`/projects/${runInfo.projectId}`)}
+						onClick={() => openWorkspace(`/projects/${runInfo.projectId}`)}
 						onKeyDown={(e) => {
-							if (e.key === "Enter") navigate(`/projects/${runInfo.projectId}`);
+							if (e.key === "Enter") {
+								openWorkspace(`/projects/${runInfo.projectId}`);
+							}
 						}}
 						className="flex items-center gap-1 type-secondary italic text-fg-ghost hover:text-fg-muted transition-colors duration-150 cursor-pointer"
 						aria-label={`Open project ${runInfo.projectName}`}

--- a/cli/web-ui/src/components/v2/WorkspaceTabStrip.tsx
+++ b/cli/web-ui/src/components/v2/WorkspaceTabStrip.tsx
@@ -1,0 +1,215 @@
+import { X } from "lucide-react";
+import { useEffect, useRef } from "react";
+import { usePrefersReducedMotion } from "@/hooks/usePrefersReducedMotion";
+import { useWorkspaceTabs, type WorkspaceTab } from "@/hooks/useWorkspaceTabs";
+import { cn } from "@/lib/utils";
+
+function getNextFocusableKey(
+	tabs: readonly WorkspaceTab[],
+	currentKey: string,
+	direction: "previous" | "next",
+): string | null {
+	const currentIndex = tabs.findIndex((tab) => tab.key === currentKey);
+	if (currentIndex < 0) return null;
+
+	const nextIndex =
+		direction === "previous" ? currentIndex - 1 : currentIndex + 1;
+
+	if (nextIndex < 0 || nextIndex >= tabs.length) {
+		return null;
+	}
+
+	return tabs[nextIndex]?.key ?? null;
+}
+
+export function WorkspaceTabStrip() {
+	const { tabs, activeKey, activateWorkspace, closeWorkspace } =
+		useWorkspaceTabs();
+	const reducedMotion = usePrefersReducedMotion();
+	const itemRefs = useRef<Map<string, HTMLButtonElement>>(new Map());
+
+	useEffect(() => {
+		if (!activeKey) return;
+
+		const activeItem = itemRefs.current.get(activeKey);
+		activeItem?.scrollIntoView({
+			behavior: reducedMotion ? "auto" : "smooth",
+			block: "nearest",
+			inline: "nearest",
+		});
+	}, [activeKey, reducedMotion]);
+
+	if (tabs.length === 0) {
+		return null;
+	}
+
+	const focusItem = (key: string | null) => {
+		if (!key) return;
+		const item = itemRefs.current.get(key);
+		item?.focus();
+		item?.scrollIntoView({
+			behavior: reducedMotion ? "auto" : "smooth",
+			block: "nearest",
+			inline: "nearest",
+		});
+	};
+
+	const closeAndRefocus = (tab: WorkspaceTab) => {
+		const currentIndex = tabs.findIndex((item) => item.key === tab.key);
+		const remainingTabs = tabs.filter((item) => item.key !== tab.key);
+		const fallbackIndex = Math.max(0, currentIndex - 1);
+		const nextFocusableKey =
+			remainingTabs[fallbackIndex]?.key ?? remainingTabs[0]?.key ?? null;
+
+		closeWorkspace(tab.key);
+
+		if (!nextFocusableKey || typeof window === "undefined") {
+			return;
+		}
+
+		window.requestAnimationFrame(() => {
+			focusItem(nextFocusableKey);
+		});
+	};
+
+	const handleNavigationKey = (
+		event: React.KeyboardEvent<HTMLButtonElement>,
+		tab: WorkspaceTab,
+	) => {
+		switch (event.key) {
+			case "ArrowLeft":
+				event.preventDefault();
+				focusItem(getNextFocusableKey(tabs, tab.key, "previous"));
+				return;
+			case "ArrowRight":
+				event.preventDefault();
+				focusItem(getNextFocusableKey(tabs, tab.key, "next"));
+				return;
+			case "Home":
+				event.preventDefault();
+				focusItem(tabs[0]?.key ?? null);
+				return;
+			case "End":
+				event.preventDefault();
+				focusItem(tabs.at(-1)?.key ?? null);
+				return;
+			case "Delete":
+			case "Backspace":
+				event.preventDefault();
+				closeAndRefocus(tab);
+				return;
+			case "Enter":
+			case " ":
+				event.preventDefault();
+				activateWorkspace(tab.key);
+				return;
+		}
+	};
+
+	const handleCloseKey = (
+		event: React.KeyboardEvent<HTMLButtonElement>,
+		tab: WorkspaceTab,
+	) => {
+		switch (event.key) {
+			case "ArrowLeft":
+				event.preventDefault();
+				focusItem(getNextFocusableKey(tabs, tab.key, "previous"));
+				return;
+			case "ArrowRight":
+				event.preventDefault();
+				focusItem(getNextFocusableKey(tabs, tab.key, "next"));
+				return;
+			case "Home":
+				event.preventDefault();
+				focusItem(tabs[0]?.key ?? null);
+				return;
+			case "End":
+				event.preventDefault();
+				focusItem(tabs.at(-1)?.key ?? null);
+				return;
+			case "Delete":
+			case "Backspace":
+			case "Enter":
+			case " ":
+				event.preventDefault();
+				closeAndRefocus(tab);
+				return;
+		}
+	};
+
+	return (
+		<nav
+			aria-label="Open workspaces"
+			className="border-b border-border/50 bg-surface-void"
+		>
+			<div className="overflow-x-auto px-3 py-2 md:px-4">
+				<div className="flex min-w-max items-center gap-2">
+					{tabs.map((tab) => {
+						const isActive = tab.key === activeKey;
+
+						return (
+							<div
+								key={tab.key}
+								className={cn(
+									"group flex max-w-[13rem] shrink-0 items-center gap-1 rounded-md border px-2 py-1 md:max-w-[18rem]",
+									isActive
+										? "border-border bg-surface text-fg"
+										: "border-transparent bg-transparent text-fg-muted hover:border-border/60 hover:bg-muted/30 hover:text-fg",
+								)}
+							>
+								<button
+									type="button"
+									ref={(node) => {
+										if (node) {
+											itemRefs.current.set(tab.key, node);
+											return;
+										}
+
+										itemRefs.current.delete(tab.key);
+									}}
+									onClick={() => activateWorkspace(tab.key)}
+									onKeyDown={(event) => handleNavigationKey(event, tab)}
+									className={cn(
+										"flex min-w-0 flex-1 items-center gap-1.5 rounded-sm bg-transparent text-left",
+										"focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-border",
+									)}
+									aria-current={isActive ? "page" : undefined}
+									aria-label={
+										tab.subtitle ? `${tab.title}, ${tab.subtitle}` : tab.title
+									}
+								>
+									<span className="truncate type-secondary font-medium">
+										{tab.title}
+									</span>
+									{tab.subtitle ? (
+										<span className="hidden truncate type-secondary text-fg-ghost md:inline">
+											{tab.subtitle}
+										</span>
+									) : null}
+								</button>
+								<button
+									type="button"
+									onClick={() => closeAndRefocus(tab)}
+									onKeyDown={(event) => handleCloseKey(event, tab)}
+									className={cn(
+										"shrink-0 rounded-sm p-1 text-fg-ghost hover:text-fg",
+										"focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-border",
+										reducedMotion
+											? ""
+											: "transition-[opacity,color] duration-150",
+										isActive
+											? "opacity-100"
+											: "opacity-100 md:opacity-0 md:group-hover:opacity-100 md:group-focus-within:opacity-100",
+									)}
+									aria-label={`Close ${tab.title}`}
+								>
+									<X className="h-3 w-3" strokeWidth={1.5} aria-hidden="true" />
+								</button>
+							</div>
+						);
+					})}
+				</div>
+			</div>
+		</nav>
+	);
+}

--- a/cli/web-ui/src/components/v2/WorkspaceTabStrip.tsx
+++ b/cli/web-ui/src/components/v2/WorkspaceTabStrip.tsx
@@ -1,4 +1,4 @@
-import { X } from "lucide-react";
+import { Activity, FolderOpen, NotebookTabs, X } from "lucide-react";
 import { useEffect, useRef } from "react";
 import { usePrefersReducedMotion } from "@/hooks/usePrefersReducedMotion";
 import { useWorkspaceTabs, type WorkspaceTab } from "@/hooks/useWorkspaceTabs";
@@ -20,6 +20,35 @@ function getNextFocusableKey(
 	}
 
 	return tabs[nextIndex]?.key ?? null;
+}
+
+function WorkspaceKindIcon({ kind }: Pick<WorkspaceTab, "kind">) {
+	switch (kind) {
+		case "run":
+			return (
+				<Activity
+					className="h-3.5 w-3.5 shrink-0"
+					strokeWidth={1.5}
+					aria-hidden="true"
+				/>
+			);
+		case "project":
+			return (
+				<NotebookTabs
+					className="h-3.5 w-3.5 shrink-0"
+					strokeWidth={1.5}
+					aria-hidden="true"
+				/>
+			);
+		case "files":
+			return (
+				<FolderOpen
+					className="h-3.5 w-3.5 shrink-0"
+					strokeWidth={1.5}
+					aria-hidden="true"
+				/>
+			);
+	}
 }
 
 export function WorkspaceTabStrip() {
@@ -178,6 +207,7 @@ export function WorkspaceTabStrip() {
 										tab.subtitle ? `${tab.title}, ${tab.subtitle}` : tab.title
 									}
 								>
+									<WorkspaceKindIcon kind={tab.kind} />
 									<span className="truncate type-secondary font-medium">
 										{tab.title}
 									</span>

--- a/cli/web-ui/src/components/v2/WorkspaceTabStrip.tsx
+++ b/cli/web-ui/src/components/v2/WorkspaceTabStrip.tsx
@@ -1,4 +1,5 @@
 import { Activity, FolderOpen, NotebookTabs, X } from "lucide-react";
+import type { ReactNode } from "react";
 import { useEffect, useRef } from "react";
 import { usePrefersReducedMotion } from "@/hooks/usePrefersReducedMotion";
 import { useWorkspaceTabs, type WorkspaceTab } from "@/hooks/useWorkspaceTabs";
@@ -51,7 +52,15 @@ function WorkspaceKindIcon({ kind }: Pick<WorkspaceTab, "kind">) {
 	}
 }
 
-export function WorkspaceTabStrip() {
+export interface WorkspaceTabStripProps {
+	action?: ReactNode;
+	className?: string;
+}
+
+export function WorkspaceTabStrip({
+	action,
+	className,
+}: WorkspaceTabStripProps = {}) {
 	const { tabs, activeKey, activateWorkspace, closeWorkspace } =
 		useWorkspaceTabs();
 	const reducedMotion = usePrefersReducedMotion();
@@ -68,7 +77,9 @@ export function WorkspaceTabStrip() {
 		});
 	}, [activeKey, reducedMotion]);
 
-	if (tabs.length === 0) {
+	const hasTabs = tabs.length > 0;
+
+	if (!hasTabs && !action) {
 		return null;
 	}
 
@@ -167,79 +178,95 @@ export function WorkspaceTabStrip() {
 	};
 
 	return (
-		<nav
-			aria-label="Open workspaces"
-			className="border-b border-border/50 bg-surface-void"
+		<div
+			className={cn(
+				"flex min-h-11 items-center gap-3 border-b border-border/50 bg-surface-void px-3 py-2 md:px-4",
+				className,
+			)}
 		>
-			<div className="overflow-x-auto px-3 py-2 md:px-4">
-				<div className="flex min-w-max items-center gap-2">
-					{tabs.map((tab) => {
-						const isActive = tab.key === activeKey;
+			{hasTabs ? (
+				<nav
+					aria-label="Open workspaces"
+					className="min-w-0 flex-1 overflow-x-auto"
+				>
+					<div className="flex min-w-max items-center gap-2">
+						{tabs.map((tab) => {
+							const isActive = tab.key === activeKey;
 
-						return (
-							<div
-								key={tab.key}
-								className={cn(
-									"group flex max-w-[13rem] shrink-0 items-center gap-1 rounded-md border px-2 py-1 md:max-w-[18rem]",
-									isActive
-										? "border-border bg-surface text-fg"
-										: "border-transparent bg-transparent text-fg-muted hover:border-border/60 hover:bg-muted/30 hover:text-fg",
-								)}
-							>
-								<button
-									type="button"
-									ref={(node) => {
-										if (node) {
-											itemRefs.current.set(tab.key, node);
-											return;
-										}
-
-										itemRefs.current.delete(tab.key);
-									}}
-									onClick={() => activateWorkspace(tab.key)}
-									onKeyDown={(event) => handleNavigationKey(event, tab)}
+							return (
+								<div
+									key={tab.key}
 									className={cn(
-										"flex min-w-0 flex-1 items-center gap-1.5 rounded-sm bg-transparent text-left",
-										"focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-border",
-									)}
-									aria-current={isActive ? "page" : undefined}
-									aria-label={
-										tab.subtitle ? `${tab.title}, ${tab.subtitle}` : tab.title
-									}
-								>
-									<WorkspaceKindIcon kind={tab.kind} />
-									<span className="truncate type-secondary font-medium">
-										{tab.title}
-									</span>
-									{tab.subtitle ? (
-										<span className="hidden truncate type-secondary text-fg-ghost md:inline">
-											{tab.subtitle}
-										</span>
-									) : null}
-								</button>
-								<button
-									type="button"
-									onClick={() => closeAndRefocus(tab)}
-									onKeyDown={(event) => handleCloseKey(event, tab)}
-									className={cn(
-										"shrink-0 rounded-sm p-1 text-fg-ghost hover:text-fg",
-										"focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-border",
-										reducedMotion
-											? ""
-											: "transition-[opacity,color] duration-150",
+										"group flex max-w-[13rem] shrink-0 items-center gap-1 rounded-md border px-2 py-1 md:max-w-[18rem]",
 										isActive
-											? "opacity-100"
-											: "opacity-100 md:opacity-0 md:group-hover:opacity-100 md:group-focus-within:opacity-100",
+											? "border-border bg-surface text-fg"
+											: "border-transparent bg-transparent text-fg-muted hover:border-border/60 hover:bg-muted/30 hover:text-fg",
 									)}
-									aria-label={`Close ${tab.title}`}
 								>
-									<X className="h-3 w-3" strokeWidth={1.5} aria-hidden="true" />
-								</button>
-							</div>
-						);
-					})}
-				</div>
-			</div>
-		</nav>
+									<button
+										type="button"
+										ref={(node) => {
+											if (node) {
+												itemRefs.current.set(tab.key, node);
+												return;
+											}
+
+											itemRefs.current.delete(tab.key);
+										}}
+										onClick={() => activateWorkspace(tab.key)}
+										onKeyDown={(event) => handleNavigationKey(event, tab)}
+										className={cn(
+											"flex min-w-0 flex-1 items-center gap-1.5 rounded-sm bg-transparent text-left",
+											"focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-border",
+										)}
+										aria-current={isActive ? "page" : undefined}
+										aria-label={
+											tab.subtitle ? `${tab.title}, ${tab.subtitle}` : tab.title
+										}
+									>
+										<WorkspaceKindIcon kind={tab.kind} />
+										<span className="truncate type-secondary font-medium">
+											{tab.title}
+										</span>
+										{tab.subtitle ? (
+											<span className="hidden truncate type-secondary text-fg-ghost md:inline">
+												{tab.subtitle}
+											</span>
+										) : null}
+									</button>
+									<button
+										type="button"
+										onClick={() => closeAndRefocus(tab)}
+										onKeyDown={(event) => handleCloseKey(event, tab)}
+										className={cn(
+											"shrink-0 rounded-sm p-1 text-fg-ghost hover:text-fg",
+											"focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-border",
+											reducedMotion
+												? ""
+												: "transition-[opacity,color] duration-150",
+											isActive
+												? "opacity-100"
+												: "opacity-100 md:opacity-0 md:group-hover:opacity-100 md:group-focus-within:opacity-100",
+										)}
+										aria-label={`Close ${tab.title}`}
+									>
+										<X
+											className="h-3 w-3"
+											strokeWidth={1.5}
+											aria-hidden="true"
+										/>
+									</button>
+								</div>
+							);
+						})}
+					</div>
+				</nav>
+			) : (
+				<div className="flex-1" aria-hidden="true" />
+			)}
+			{action ? (
+				<div className="flex shrink-0 items-center">{action}</div>
+			) : null}
+		</div>
 	);
 }

--- a/cli/web-ui/src/hooks/useProjectFileTree.ts
+++ b/cli/web-ui/src/hooks/useProjectFileTree.ts
@@ -4,6 +4,8 @@ import { useReconnectRecovery } from "./useReconnectRecovery";
 
 export type { FileNode };
 
+const projectFileTreeCache = new Map<string, FileNode[]>();
+
 interface UseProjectFileTreeResult {
 	tree: FileNode[];
 	loading: boolean;
@@ -14,8 +16,12 @@ interface UseProjectFileTreeResult {
 export function useProjectFileTree(
 	projectId: string | undefined,
 ): UseProjectFileTreeResult {
-	const [tree, setTree] = useState<FileNode[]>([]);
-	const [loading, setLoading] = useState(true);
+	const [tree, setTree] = useState<FileNode[]>(() =>
+		projectId ? (projectFileTreeCache.get(projectId) ?? []) : [],
+	);
+	const [loading, setLoading] = useState(() =>
+		projectId ? !projectFileTreeCache.has(projectId) : false,
+	);
 	const [error, setError] = useState<string | null>(null);
 
 	const fetchTree = useCallback(async () => {
@@ -25,7 +31,6 @@ export function useProjectFileTree(
 			return;
 		}
 
-		setLoading(true);
 		setError(null);
 
 		try {
@@ -34,22 +39,43 @@ export function useProjectFileTree(
 			);
 			if (!response.ok) {
 				if (response.status === 410) {
+					projectFileTreeCache.delete(projectId);
 					throw new Error(`Project unavailable: ${projectId}`);
 				}
 				throw new Error(`Failed to fetch file tree: ${response.statusText}`);
 			}
-			const data = await response.json();
+			const data = (await response.json()) as FileNode[];
+			projectFileTreeCache.set(projectId, data);
 			setTree(data);
+			setError(null);
 		} catch (err) {
-			setError(err instanceof Error ? err.message : String(err));
+			const message = err instanceof Error ? err.message : String(err);
+			const shouldKeepStaleTree =
+				projectFileTreeCache.has(projectId) &&
+				!message.startsWith("Project unavailable:");
+			if (!shouldKeepStaleTree) {
+				setError(message);
+				setTree([]);
+			}
 		} finally {
 			setLoading(false);
 		}
 	}, [projectId]);
 
 	useEffect(() => {
-		fetchTree();
-	}, [fetchTree]);
+		if (!projectId) {
+			setTree([]);
+			setError(null);
+			setLoading(false);
+			return;
+		}
+
+		const cachedTree = projectFileTreeCache.get(projectId) ?? [];
+		setTree(cachedTree);
+		setError(null);
+		setLoading(!projectFileTreeCache.has(projectId));
+		void fetchTree();
+	}, [projectId, fetchTree]);
 
 	useReconnectRecovery(fetchTree);
 

--- a/cli/web-ui/src/hooks/useRunDetail.ts
+++ b/cli/web-ui/src/hooks/useRunDetail.ts
@@ -12,6 +12,8 @@ import type {
 	EventNotificationMessage,
 } from "@/types/websocket";
 
+const runDetailCache = new Map<string, Run>();
+
 interface UseRunDetailResult {
 	run: Run | null;
 	isLoading: boolean;
@@ -20,8 +22,12 @@ interface UseRunDetailResult {
 }
 
 export function useRunDetail(runId: string | undefined): UseRunDetailResult {
-	const [run, setRun] = useState<Run | null>(null);
-	const [isLoading, setIsLoading] = useState(true);
+	const [run, setRun] = useState<Run | null>(() =>
+		runId ? (runDetailCache.get(runId) ?? null) : null,
+	);
+	const [isLoading, setIsLoading] = useState(() =>
+		runId ? !runDetailCache.has(runId) : false,
+	);
 	const [error, setError] = useState<Error | null>(null);
 	const { onEventNotification, status: wsStatus } = useWebSocket();
 	const prevWsStatusRef = useRef<ConnectionStatus>(wsStatus);
@@ -38,6 +44,7 @@ export function useRunDetail(runId: string | undefined): UseRunDetailResult {
 			const response = await fetch(`/api/v2/runs/${runId}`);
 			if (!response.ok) {
 				if (response.status === 404) {
+					runDetailCache.delete(runId);
 					throw new Error("Run not found");
 				}
 				throw new Error(`Failed to fetch run: ${response.statusText}`);
@@ -45,20 +52,43 @@ export function useRunDetail(runId: string | undefined): UseRunDetailResult {
 			const runData = (await response.json()) as Run;
 			setRun(runData);
 			runRef.current = runData;
+			runDetailCache.set(runId, runData);
 			setError(null);
 		} catch (err) {
-			setError(err instanceof Error ? err : new Error(String(err)));
-			setRun(null);
-			runRef.current = null;
+			const nextError = err instanceof Error ? err : new Error(String(err));
+			const shouldKeepStaleRun =
+				runRef.current !== null && nextError.message !== "Run not found";
+			if (!shouldKeepStaleRun) {
+				setError(nextError);
+				setRun(null);
+				runRef.current = null;
+			}
 		} finally {
 			setIsLoading(false);
 		}
 	}, [runId]);
 
 	useEffect(() => {
-		setIsLoading(true);
-		fetchRun();
-	}, [fetchRun]);
+		if (!runId) {
+			setRun(null);
+			runRef.current = null;
+			setError(null);
+			setIsLoading(false);
+			return;
+		}
+
+		const cachedRun = runDetailCache.get(runId) ?? null;
+		setRun(cachedRun);
+		runRef.current = cachedRun;
+		setError(null);
+		setIsLoading(cachedRun === null);
+		void fetchRun();
+	}, [runId, fetchRun]);
+
+	useEffect(() => {
+		if (!runId || !run) return;
+		runDetailCache.set(runId, run);
+	}, [runId, run]);
 
 	const debouncedFetchRef = useRef<ReturnType<typeof setTimeout>>();
 

--- a/cli/web-ui/src/hooks/useWorkspaceDescriptor.ts
+++ b/cli/web-ui/src/hooks/useWorkspaceDescriptor.ts
@@ -1,0 +1,131 @@
+import { useEffect, useMemo } from "react";
+import { useLocation } from "react-router-dom";
+import { normalizeWorkspaceRoute } from "@/lib/workspace-routes";
+import type { CommandDefinition } from "./useContextualShortcuts";
+import { useWorkspaceTabs } from "./useWorkspaceTabs";
+
+export interface UseWorkspaceDescriptorOptions {
+	readonly title?: string | null;
+	readonly subtitle?: string | null;
+	readonly projectId?: string | null;
+	readonly unavailable?: boolean;
+}
+
+interface UseWorkspaceDescriptorResult {
+	readonly workspaceCommands: readonly CommandDefinition[];
+}
+
+function createCurrentPath(
+	pathname: string,
+	search: string,
+	hash: string,
+): string {
+	return `${pathname}${search}${hash}`;
+}
+
+export function useWorkspaceDescriptor({
+	title,
+	subtitle,
+	projectId,
+	unavailable = false,
+}: UseWorkspaceDescriptorOptions): UseWorkspaceDescriptorResult {
+	const location = useLocation();
+	const {
+		tabs,
+		activeKey,
+		activateWorkspace,
+		closeWorkspace,
+		updateWorkspaceMetadata,
+	} = useWorkspaceTabs();
+
+	const currentPath = createCurrentPath(
+		location.pathname,
+		location.search,
+		location.hash,
+	);
+	const normalized = useMemo(
+		() => normalizeWorkspaceRoute(currentPath),
+		[currentPath],
+	);
+	const currentKey = normalized.type === "workspace" ? normalized.key : null;
+	const currentIndex =
+		currentKey === null ? -1 : tabs.findIndex((tab) => tab.key === currentKey);
+	const previousTab =
+		currentIndex > 0 ? (tabs[currentIndex - 1] ?? null) : null;
+	const nextTab =
+		currentIndex >= 0 && currentIndex < tabs.length - 1
+			? (tabs[currentIndex + 1] ?? null)
+			: null;
+
+	useEffect(() => {
+		if (normalized.type !== "workspace") {
+			return;
+		}
+
+		const trimmedTitle = title?.trim();
+		if (!trimmedTitle) {
+			return;
+		}
+
+		updateWorkspaceMetadata(normalized.key, {
+			title: trimmedTitle,
+			subtitle: subtitle?.trim() ? subtitle.trim() : null,
+			projectId: projectId ?? normalized.projectId,
+		});
+	}, [normalized, title, subtitle, projectId, updateWorkspaceMetadata]);
+
+	useEffect(() => {
+		if (normalized.type !== "workspace" || !unavailable) {
+			return;
+		}
+
+		closeWorkspace(normalized.key);
+	}, [normalized, unavailable, closeWorkspace]);
+
+	const workspaceCommands = useMemo<readonly CommandDefinition[]>(() => {
+		if (currentKey === null || activeKey !== currentKey) {
+			return [];
+		}
+
+		const commands: CommandDefinition[] = [];
+
+		if (previousTab) {
+			commands.push({
+				id: "previous-workspace",
+				label: "Previous Workspace",
+				description: `Open ${previousTab.title}`,
+				keywords: ["workspace", "tab", "previous", "back"],
+				action: () => activateWorkspace(previousTab.key),
+			});
+		}
+
+		if (nextTab) {
+			commands.push({
+				id: "next-workspace",
+				label: "Next Workspace",
+				description: `Open ${nextTab.title}`,
+				keywords: ["workspace", "tab", "next", "forward"],
+				action: () => activateWorkspace(nextTab.key),
+			});
+		}
+
+		commands.push({
+			id: "close-workspace",
+			label: "Close Workspace",
+			description: "Close the current workspace tab",
+			keywords: ["workspace", "tab", "close"],
+			action: () => closeWorkspace(currentKey),
+		});
+
+		return commands;
+	}, [
+		activeKey,
+		activateWorkspace,
+		closeWorkspace,
+		currentKey,
+		nextTab,
+		previousTab,
+	]);
+
+	return { workspaceCommands };
+}

--- a/cli/web-ui/src/hooks/useWorkspaceTabs.tsx
+++ b/cli/web-ui/src/hooks/useWorkspaceTabs.tsx
@@ -4,6 +4,7 @@ import {
 	useCallback,
 	useContext,
 	useEffect,
+	useLayoutEffect,
 	useMemo,
 	useRef,
 	useState,
@@ -32,10 +33,20 @@ export interface WorkspaceTabsState {
 	readonly lastDurableRoute: string;
 }
 
+export interface WorkspaceTabMetadata {
+	readonly title: string;
+	readonly subtitle: string | null;
+	readonly projectId: string | null;
+}
+
 interface WorkspaceTabsContextValue extends WorkspaceTabsState {
 	readonly openWorkspace: (targetRoute: string) => void;
 	readonly activateWorkspace: (key: string) => void;
 	readonly closeWorkspace: (key: string) => void;
+	readonly updateWorkspaceMetadata: (
+		key: string,
+		metadata: WorkspaceTabMetadata,
+	) => void;
 }
 
 interface StoredWorkspaceTabsState {
@@ -202,6 +213,37 @@ function getCloseNavigationTarget(
 	return remainingTabs[fallbackIndex]?.currentPath ?? lastDurableRoute;
 }
 
+function updateWorkspaceTabMetadata(
+	tabs: readonly WorkspaceTab[],
+	key: string,
+	metadata: WorkspaceTabMetadata,
+): readonly WorkspaceTab[] {
+	const existingIndex = tabs.findIndex((tab) => tab.key === key);
+	if (existingIndex < 0) {
+		return tabs;
+	}
+
+	const existingTab = tabs[existingIndex]!;
+	const nextTab: WorkspaceTab = {
+		...existingTab,
+		title: metadata.title,
+		subtitle: metadata.subtitle,
+		projectId: metadata.projectId,
+	};
+
+	if (
+		existingTab.title === nextTab.title &&
+		existingTab.subtitle === nextTab.subtitle &&
+		existingTab.projectId === nextTab.projectId
+	) {
+		return tabs;
+	}
+
+	const nextTabs = [...tabs];
+	nextTabs[existingIndex] = nextTab;
+	return nextTabs;
+}
+
 export function WorkspaceTabsProvider({
 	children,
 }: {
@@ -223,7 +265,7 @@ export function WorkspaceTabsProvider({
 		sessionStorage.setItem(WORKSPACE_TABS_STORAGE_KEY, JSON.stringify(state));
 	}, [state]);
 
-	useEffect(() => {
+	useLayoutEffect(() => {
 		const currentPath = createCurrentPath(
 			location.pathname,
 			location.search,
@@ -327,6 +369,27 @@ export function WorkspaceTabsProvider({
 		[navigate],
 	);
 
+	const updateWorkspaceMetadata = useCallback(
+		(key: string, metadata: WorkspaceTabMetadata) => {
+			setState((current) => {
+				const nextTabs = updateWorkspaceTabMetadata(
+					current.tabs,
+					key,
+					metadata,
+				);
+				if (nextTabs === current.tabs) {
+					return current;
+				}
+
+				return {
+					...current,
+					tabs: nextTabs,
+				};
+			});
+		},
+		[],
+	);
+
 	const value = useMemo<WorkspaceTabsContextValue>(
 		() => ({
 			tabs: state.tabs,
@@ -335,8 +398,15 @@ export function WorkspaceTabsProvider({
 			openWorkspace,
 			activateWorkspace,
 			closeWorkspace,
+			updateWorkspaceMetadata,
 		}),
-		[state, openWorkspace, activateWorkspace, closeWorkspace],
+		[
+			state,
+			openWorkspace,
+			activateWorkspace,
+			closeWorkspace,
+			updateWorkspaceMetadata,
+		],
 	);
 
 	return (

--- a/cli/web-ui/src/hooks/useWorkspaceTabs.tsx
+++ b/cli/web-ui/src/hooks/useWorkspaceTabs.tsx
@@ -1,0 +1,357 @@
+import {
+	createContext,
+	type ReactNode,
+	useCallback,
+	useContext,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+} from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+import {
+	normalizeWorkspaceRoute,
+	type WorkspaceKind,
+	type WorkspaceRouteDescriptor,
+} from "@/lib/workspace-routes";
+
+export interface WorkspaceTab {
+	readonly key: string;
+	readonly kind: WorkspaceKind;
+	readonly currentPath: string;
+	readonly rootPath: string;
+	readonly title: string;
+	readonly subtitle: string | null;
+	readonly projectId: string | null;
+	readonly lastVisitedAt: number;
+}
+
+export interface WorkspaceTabsState {
+	readonly tabs: readonly WorkspaceTab[];
+	readonly activeKey: string | null;
+	readonly lastDurableRoute: string;
+}
+
+interface WorkspaceTabsContextValue extends WorkspaceTabsState {
+	readonly openWorkspace: (targetRoute: string) => void;
+	readonly activateWorkspace: (key: string) => void;
+	readonly closeWorkspace: (key: string) => void;
+}
+
+interface StoredWorkspaceTabsState {
+	readonly tabs?: unknown;
+	readonly activeKey?: unknown;
+	readonly lastDurableRoute?: unknown;
+}
+
+export const WORKSPACE_TABS_STORAGE_KEY = "rp1-workspace-tabs:v1";
+
+const DEFAULT_STATE: WorkspaceTabsState = {
+	tabs: [],
+	activeKey: null,
+	lastDurableRoute: "/",
+};
+
+const WorkspaceTabsContext = createContext<WorkspaceTabsContextValue | null>(
+	null,
+);
+
+function createCurrentPath(
+	pathname: string,
+	search: string,
+	hash: string,
+): string {
+	return `${pathname}${search}${hash}`;
+}
+
+function isWorkspaceTabRecord(value: unknown): value is Partial<WorkspaceTab> {
+	return typeof value === "object" && value !== null;
+}
+
+function isWorkspaceTab(value: WorkspaceTab | null): value is WorkspaceTab {
+	return value !== null;
+}
+
+function sanitizeStoredTab(record: unknown): WorkspaceTab | null {
+	if (!isWorkspaceTabRecord(record) || typeof record.currentPath !== "string") {
+		return null;
+	}
+
+	const normalized = normalizeWorkspaceRoute(record.currentPath);
+	if (normalized.type !== "workspace") return null;
+
+	return {
+		key: normalized.key,
+		kind: normalized.kind,
+		currentPath: record.currentPath,
+		rootPath:
+			typeof record.rootPath === "string" && record.rootPath.length > 0
+				? record.rootPath
+				: normalized.rootPath,
+		title:
+			typeof record.title === "string" && record.title.length > 0
+				? record.title
+				: normalized.title,
+		subtitle: typeof record.subtitle === "string" ? record.subtitle : null,
+		projectId:
+			typeof record.projectId === "string"
+				? record.projectId
+				: normalized.projectId,
+		lastVisitedAt:
+			typeof record.lastVisitedAt === "number" &&
+			Number.isFinite(record.lastVisitedAt)
+				? record.lastVisitedAt
+				: 0,
+	};
+}
+
+function dedupeTabs(tabs: readonly WorkspaceTab[]): readonly WorkspaceTab[] {
+	const order: string[] = [];
+	const byKey = new Map<string, WorkspaceTab>();
+
+	for (const tab of tabs) {
+		const existing = byKey.get(tab.key);
+		if (!existing) {
+			order.push(tab.key);
+			byKey.set(tab.key, tab);
+			continue;
+		}
+
+		if (tab.lastVisitedAt >= existing.lastVisitedAt) {
+			byKey.set(tab.key, tab);
+		}
+	}
+
+	return order.map((key) => byKey.get(key)!);
+}
+
+function loadWorkspaceTabsState(): WorkspaceTabsState {
+	if (typeof window === "undefined") return DEFAULT_STATE;
+
+	try {
+		const raw = sessionStorage.getItem(WORKSPACE_TABS_STORAGE_KEY);
+		if (!raw) return DEFAULT_STATE;
+
+		const parsed = JSON.parse(raw) as StoredWorkspaceTabsState;
+		const parsedTabs = Array.isArray(parsed.tabs)
+			? dedupeTabs(parsed.tabs.map(sanitizeStoredTab).filter(isWorkspaceTab))
+			: [];
+		const normalizedDurableRoute =
+			typeof parsed.lastDurableRoute === "string" &&
+			normalizeWorkspaceRoute(parsed.lastDurableRoute).type === "durable"
+				? parsed.lastDurableRoute
+				: "/";
+		const activeKey =
+			typeof parsed.activeKey === "string" &&
+			parsedTabs.some((tab) => tab.key === parsed.activeKey)
+				? parsed.activeKey
+				: null;
+
+		return {
+			tabs: parsedTabs,
+			activeKey,
+			lastDurableRoute: normalizedDurableRoute,
+		};
+	} catch {
+		return DEFAULT_STATE;
+	}
+}
+
+function upsertWorkspaceTab(
+	tabs: readonly WorkspaceTab[],
+	descriptor: WorkspaceRouteDescriptor,
+	currentPath: string,
+	timestamp: number,
+): readonly WorkspaceTab[] {
+	const existingIndex = tabs.findIndex((tab) => tab.key === descriptor.key);
+	const existingTab = existingIndex >= 0 ? tabs[existingIndex] : null;
+	const nextTab: WorkspaceTab = {
+		key: descriptor.key,
+		kind: descriptor.kind,
+		currentPath,
+		rootPath: descriptor.rootPath,
+		title: existingTab?.title || descriptor.title,
+		subtitle: existingTab?.subtitle ?? descriptor.subtitle,
+		projectId: descriptor.projectId ?? existingTab?.projectId ?? null,
+		lastVisitedAt: timestamp,
+	};
+
+	if (existingIndex < 0) {
+		return [...tabs, nextTab];
+	}
+
+	const nextTabs = [...tabs];
+	nextTabs[existingIndex] = nextTab;
+	return nextTabs;
+}
+
+function getCloseNavigationTarget(
+	tabs: readonly WorkspaceTab[],
+	closingKey: string,
+	lastDurableRoute: string,
+): string | null {
+	const closingIndex = tabs.findIndex((tab) => tab.key === closingKey);
+	if (closingIndex < 0) return null;
+
+	const remainingTabs = tabs.filter((tab) => tab.key !== closingKey);
+	if (remainingTabs.length === 0) {
+		return lastDurableRoute;
+	}
+
+	const fallbackIndex = Math.max(0, closingIndex - 1);
+	return remainingTabs[fallbackIndex]?.currentPath ?? lastDurableRoute;
+}
+
+export function WorkspaceTabsProvider({
+	children,
+}: {
+	readonly children: ReactNode;
+}) {
+	const [state, setState] = useState<WorkspaceTabsState>(() =>
+		loadWorkspaceTabsState(),
+	);
+	const stateRef = useRef(state);
+	const location = useLocation();
+	const navigate = useNavigate();
+
+	useEffect(() => {
+		stateRef.current = state;
+	}, [state]);
+
+	useEffect(() => {
+		if (typeof window === "undefined") return;
+		sessionStorage.setItem(WORKSPACE_TABS_STORAGE_KEY, JSON.stringify(state));
+	}, [state]);
+
+	useEffect(() => {
+		const currentPath = createCurrentPath(
+			location.pathname,
+			location.search,
+			location.hash,
+		);
+		const normalized = normalizeWorkspaceRoute(currentPath);
+
+		setState((current) => {
+			if (normalized.type === "durable") {
+				if (
+					current.activeKey === null &&
+					current.lastDurableRoute === normalized.rootPath
+				) {
+					return current;
+				}
+
+				return {
+					...current,
+					activeKey: null,
+					lastDurableRoute: normalized.rootPath,
+				};
+			}
+
+			if (normalized.type !== "workspace") {
+				return current.activeKey === null
+					? current
+					: {
+							...current,
+							activeKey: null,
+						};
+			}
+
+			const nextTabs = upsertWorkspaceTab(
+				current.tabs,
+				normalized,
+				currentPath,
+				Date.now(),
+			);
+
+			if (current.activeKey === normalized.key && nextTabs === current.tabs) {
+				return current;
+			}
+
+			return {
+				...current,
+				tabs: nextTabs,
+				activeKey: normalized.key,
+			};
+		});
+	}, [location.hash, location.pathname, location.search]);
+
+	const openWorkspace = useCallback(
+		(targetRoute: string) => {
+			const normalized = normalizeWorkspaceRoute(targetRoute);
+			if (normalized.type !== "workspace") {
+				navigate(targetRoute);
+				return;
+			}
+
+			const existingTab = stateRef.current.tabs.find(
+				(tab) => tab.key === normalized.key,
+			);
+			navigate(existingTab?.currentPath ?? targetRoute);
+		},
+		[navigate],
+	);
+
+	const activateWorkspace = useCallback(
+		(key: string) => {
+			const targetTab = stateRef.current.tabs.find((tab) => tab.key === key);
+			if (!targetTab) return;
+			navigate(targetTab.currentPath);
+		},
+		[navigate],
+	);
+
+	const closeWorkspace = useCallback(
+		(key: string) => {
+			const current = stateRef.current;
+			const isActive = current.activeKey === key;
+			const nextTabs = current.tabs.filter((tab) => tab.key !== key);
+			const nextActiveKey = isActive
+				? null
+				: nextTabs.some((tab) => tab.key === current.activeKey)
+					? current.activeKey
+					: null;
+			const navigationTarget = isActive
+				? getCloseNavigationTarget(current.tabs, key, current.lastDurableRoute)
+				: null;
+
+			setState({
+				tabs: nextTabs,
+				activeKey: nextActiveKey,
+				lastDurableRoute: current.lastDurableRoute,
+			});
+
+			if (navigationTarget) {
+				navigate(navigationTarget);
+			}
+		},
+		[navigate],
+	);
+
+	const value = useMemo<WorkspaceTabsContextValue>(
+		() => ({
+			tabs: state.tabs,
+			activeKey: state.activeKey,
+			lastDurableRoute: state.lastDurableRoute,
+			openWorkspace,
+			activateWorkspace,
+			closeWorkspace,
+		}),
+		[state, openWorkspace, activateWorkspace, closeWorkspace],
+	);
+
+	return (
+		<WorkspaceTabsContext.Provider value={value}>
+			{children}
+		</WorkspaceTabsContext.Provider>
+	);
+}
+
+export function useWorkspaceTabs(): WorkspaceTabsContextValue {
+	const context = useContext(WorkspaceTabsContext);
+	if (!context) {
+		throw new Error(
+			"useWorkspaceTabs must be used within a WorkspaceTabsProvider",
+		);
+	}
+	return context;
+}

--- a/cli/web-ui/src/lib/workspace-routes.ts
+++ b/cli/web-ui/src/lib/workspace-routes.ts
@@ -1,0 +1,117 @@
+export type DurableWorkspaceRouteId = "activity" | "projects";
+export type WorkspaceKind = "run" | "project" | "files";
+
+export interface DurableWorkspaceRoute {
+	readonly type: "durable";
+	readonly durableRoute: DurableWorkspaceRouteId;
+	readonly rootPath: "/" | "/projects";
+}
+
+export interface WorkspaceRouteDescriptor {
+	readonly type: "workspace";
+	readonly key: string;
+	readonly kind: WorkspaceKind;
+	readonly rootPath: string;
+	readonly title: string;
+	readonly subtitle: string | null;
+	readonly projectId: string | null;
+}
+
+export interface UnknownWorkspaceRoute {
+	readonly type: "unknown";
+}
+
+export type NormalizedWorkspaceRoute =
+	| DurableWorkspaceRoute
+	| WorkspaceRouteDescriptor
+	| UnknownWorkspaceRoute;
+
+function stripQueryAndHash(route: string): string {
+	const [pathname] = route.split(/[?#]/, 1);
+	return pathname || "/";
+}
+
+function normalizePathname(route: string): string {
+	const pathname = stripQueryAndHash(route);
+	if (pathname === "") return "/";
+	if (pathname === "/") return pathname;
+	return pathname.endsWith("/") ? pathname.slice(0, -1) : pathname;
+}
+
+function safeDecodeSegment(segment: string): string {
+	try {
+		return decodeURIComponent(segment);
+	} catch {
+		return segment;
+	}
+}
+
+export function normalizeWorkspaceRoute(
+	route: string,
+): NormalizedWorkspaceRoute {
+	const pathname = normalizePathname(route);
+
+	if (pathname === "/" || pathname === "/runs") {
+		return {
+			type: "durable",
+			durableRoute: "activity",
+			rootPath: "/",
+		};
+	}
+
+	if (pathname === "/projects") {
+		return {
+			type: "durable",
+			durableRoute: "projects",
+			rootPath: "/projects",
+		};
+	}
+
+	const filesMatch = pathname.match(/^\/projects\/([^/]+)\/files(?:\/.*)?$/);
+	if (filesMatch) {
+		const projectId = safeDecodeSegment(filesMatch[1]!);
+		return {
+			type: "workspace",
+			key: `files:${projectId}`,
+			kind: "files",
+			rootPath: `/projects/${projectId}/files`,
+			title: `${projectId} files`,
+			subtitle: null,
+			projectId,
+		};
+	}
+
+	const projectMatch = pathname.match(/^\/projects\/([^/]+)$/);
+	if (projectMatch) {
+		const projectId = safeDecodeSegment(projectMatch[1]!);
+		return {
+			type: "workspace",
+			key: `project:${projectId}`,
+			kind: "project",
+			rootPath: `/projects/${projectId}`,
+			title: projectId,
+			subtitle: null,
+			projectId,
+		};
+	}
+
+	const runMatch = pathname.match(/^\/runs\/([^/]+)(?:\/.*)?$/);
+	if (runMatch) {
+		const runId = safeDecodeSegment(runMatch[1]!);
+		return {
+			type: "workspace",
+			key: `run:${runId}`,
+			kind: "run",
+			rootPath: `/runs/${runId}`,
+			title: `Run ${runId}`,
+			subtitle: null,
+			projectId: null,
+		};
+	}
+
+	return { type: "unknown" };
+}
+
+export function isDurableWorkspaceRoute(route: string): boolean {
+	return normalizeWorkspaceRoute(route).type === "durable";
+}

--- a/cli/web-ui/src/pages/v2/ArtifactViewerPage.tsx
+++ b/cli/web-ui/src/pages/v2/ArtifactViewerPage.tsx
@@ -38,12 +38,14 @@ import { NewUpdatesChip } from "@/components/v2/NewUpdatesChip";
 import { TableOfContents } from "@/components/v2/TableOfContents";
 import { UnifiedContentRenderer } from "@/components/v2/UnifiedContentRenderer";
 import { useAnnotations } from "@/hooks/useAnnotations";
+import { useBreadcrumbContext } from "@/hooks/useBreadcrumbContext";
 import { useContextualShortcuts } from "@/hooks/useContextualShortcuts";
 import { useFollowMode } from "@/hooks/useFollowMode";
 import type { HeadingEntry } from "@/hooks/useHeadingExtraction";
 import { useIsMobile } from "@/hooks/useMediaQuery";
 import { useReconnectRecovery } from "@/hooks/useReconnectRecovery";
 import { useRunDetail } from "@/hooks/useRunDetail";
+import { useWorkspaceDescriptor } from "@/hooks/useWorkspaceDescriptor";
 import { resolveRunDisplayName } from "@/lib/run-display";
 
 import { AnnotationProvider } from "@/providers/AnnotationProvider";
@@ -155,7 +157,8 @@ export function ArtifactViewerPage() {
 	const { runId, "*": artifactPathParam } = useParams();
 	const navigate = useNavigate();
 	const { run, isLoading, error, refetch } = useRunDetail(runId);
-	const { onFileChange } = useWebSocket();
+	const { setActiveArtifact, setProject, setRunInfo } = useBreadcrumbContext();
+	const { onFileChange, setProjectId } = useWebSocket();
 	const isMobile = useIsMobile();
 
 	const [artifactContent, setArtifactContent] =
@@ -219,6 +222,54 @@ export function ArtifactViewerPage() {
 			null
 		);
 	}, [run, selectedArtifactPath]);
+	const workspaceSubtitle = useMemo(() => {
+		if (!run) return null;
+		const artifactName = selectedArtifact?.path.split("/").at(-1) ?? null;
+		return artifactName ?? run.projectName;
+	}, [run, selectedArtifact]);
+
+	useEffect(() => {
+		if (run?.projectName && run?.projectId) {
+			setProject(run.projectId, run.projectName);
+			setProjectId(run.projectId);
+		}
+
+		return () => {
+			setProject(null, null);
+			setProjectId(null);
+		};
+	}, [run?.projectId, run?.projectName, setProject, setProjectId]);
+
+	useEffect(() => {
+		if (run) {
+			setRunInfo({
+				startedAt: run.startedAt,
+				harness: run.harness,
+				command: run.command,
+				displayName: resolveRunDisplayName(run) || run.command,
+				projectName: run.projectName,
+				projectId: run.projectId,
+			});
+		}
+
+		return () => {
+			setRunInfo(null);
+		};
+	}, [run, setRunInfo]);
+
+	useEffect(() => {
+		if (selectedArtifact && runId) {
+			setActiveArtifact(runId, selectedArtifact.path);
+		} else {
+			setActiveArtifact(runId ?? "", null);
+		}
+	}, [selectedArtifact, runId, setActiveArtifact]);
+
+	useEffect(() => {
+		return () => {
+			setActiveArtifact(runId ?? "", null);
+		};
+	}, [runId, setActiveArtifact]);
 
 	const handleToggleTocCollapse = useCallback(() => {
 		setTocCollapsed((prev) => {
@@ -499,6 +550,15 @@ export function ArtifactViewerPage() {
 		};
 	}, [handleKeyDown]);
 
+	const { workspaceCommands } = useWorkspaceDescriptor({
+		title: run ? resolveRunDisplayName(run) || run.command : null,
+		subtitle: workspaceSubtitle,
+		projectId: run?.projectId ?? null,
+		unavailable:
+			!isLoading &&
+			(error?.message === "Run not found" || (!error && run === null)),
+	});
+
 	useContextualShortcuts({
 		viewId: "artifact-viewer",
 		viewLabel: "Artifact Viewer",
@@ -550,19 +610,22 @@ export function ArtifactViewerPage() {
 				},
 			},
 		],
-		commands: selectedArtifactPath
-			? [
-					{
-						id: "toggle-artifact-frontmatter",
-						label: showFrontmatter ? "Hide Frontmatter" : "Show Frontmatter",
-						description: showFrontmatter
-							? "Hide frontmatter in the current artifact viewer"
-							: "Show frontmatter in the current artifact viewer",
-						keywords: ["frontmatter", "metadata", "yaml", "artifact"],
-						action: handleToggleFrontmatter,
-					},
-				]
-			: [],
+		commands: [
+			...workspaceCommands,
+			...(selectedArtifactPath
+				? [
+						{
+							id: "toggle-artifact-frontmatter",
+							label: showFrontmatter ? "Hide Frontmatter" : "Show Frontmatter",
+							description: showFrontmatter
+								? "Hide frontmatter in the current artifact viewer"
+								: "Show frontmatter in the current artifact viewer",
+							keywords: ["frontmatter", "metadata", "yaml", "artifact"],
+							action: handleToggleFrontmatter,
+						},
+					]
+				: []),
+		],
 		enabled: !!run,
 	});
 

--- a/cli/web-ui/src/pages/v2/FileBrowserPage.tsx
+++ b/cli/web-ui/src/pages/v2/FileBrowserPage.tsx
@@ -204,9 +204,9 @@ export function FileBrowserPage() {
 					message.startsWith("File not found:") ||
 					message.startsWith("Project unavailable:");
 
-				if (isTerminalError) {
+				if (isTerminalError || cachedContent === null) {
 					savedScrollState.current = null;
-					if (contentCacheKey) {
+					if (isTerminalError && contentCacheKey) {
 						fileBrowserContentCache.delete(contentCacheKey);
 					}
 					setContentError(message);

--- a/cli/web-ui/src/pages/v2/FileBrowserPage.tsx
+++ b/cli/web-ui/src/pages/v2/FileBrowserPage.tsx
@@ -31,6 +31,7 @@ import { useIsMobile } from "@/hooks/useMediaQuery";
 import { useProjectFileTree } from "@/hooks/useProjectFileTree";
 import { useProjects } from "@/hooks/useProjects";
 import { useReconnectRecovery } from "@/hooks/useReconnectRecovery";
+import { useWorkspaceDescriptor } from "@/hooks/useWorkspaceDescriptor";
 import { useWebSocket } from "@/providers/WebSocketProvider";
 
 import type { FileContent } from "../../server/routes/content-utils";
@@ -107,6 +108,7 @@ export function FileBrowserPage() {
 		: null;
 	const projectName = project?.name ?? projectId ?? null;
 	const projectPath = project?.path ?? null;
+	const selectedFileName = selectedPath?.split("/").at(-1) ?? null;
 
 	useEffect(() => {
 		if (projectId) {
@@ -373,6 +375,18 @@ export function FileBrowserPage() {
 		return () => document.removeEventListener("keydown", handleKeyDown);
 	}, [handleKeyDown]);
 
+	const { workspaceCommands } = useWorkspaceDescriptor({
+		title:
+			projectName && projectId ? `${projectName} files` : (projectName ?? null),
+		subtitle: selectedFileName,
+		projectId: projectId ?? null,
+		unavailable:
+			!treeLoading &&
+			typeof treeError === "string" &&
+			(treeError.includes("Project unavailable") ||
+				treeError.includes("Not Found")),
+	});
+
 	useContextualShortcuts({
 		viewId: "file-browser",
 		viewLabel: "File Browser",
@@ -396,20 +410,23 @@ export function FileBrowserPage() {
 				},
 			},
 		],
-		commands: selectedPath
-			? [
-					{
-						id: "toggle-file-frontmatter",
-						label: showFrontmatter ? "Hide Frontmatter" : "Show Frontmatter",
-						description: showFrontmatter
-							? "Hide frontmatter in the current file viewer"
-							: "Show frontmatter in the current file viewer",
-						keywords: ["frontmatter", "metadata", "yaml", "file"],
-						action: handleToggleFrontmatter,
-					},
-				]
-			: [],
-		enabled: !!selectedPath,
+		commands: [
+			...workspaceCommands,
+			...(selectedPath
+				? [
+						{
+							id: "toggle-file-frontmatter",
+							label: showFrontmatter ? "Hide Frontmatter" : "Show Frontmatter",
+							description: showFrontmatter
+								? "Hide frontmatter in the current file viewer"
+								: "Show frontmatter in the current file viewer",
+							keywords: ["frontmatter", "metadata", "yaml", "file"],
+							action: handleToggleFrontmatter,
+						},
+					]
+				: []),
+		],
+		enabled: !!projectId,
 	});
 
 	const liveRegion = (

--- a/cli/web-ui/src/pages/v2/FileBrowserPage.tsx
+++ b/cli/web-ui/src/pages/v2/FileBrowserPage.tsx
@@ -38,6 +38,7 @@ import type { FileContent } from "../../server/routes/content-utils";
 
 const STORAGE_KEY_TOC_COLLAPSED = "rp1-file-browser-toc-collapsed";
 const STORAGE_KEY_FRONTMATTER_VISIBLE = "rp1-file-browser-frontmatter-visible";
+const fileBrowserContentCache = new Map<string, FileContent>();
 
 function isSameFileContent(
 	left: FileContent | null,
@@ -60,6 +61,8 @@ export function FileBrowserPage() {
 	const navigate = useNavigate();
 	const isMobile = useIsMobile();
 	const selectedPath = filePath || null;
+	const contentCacheKey =
+		projectId && selectedPath ? `${projectId}:${selectedPath}` : null;
 
 	const {
 		tree,
@@ -69,8 +72,15 @@ export function FileBrowserPage() {
 	} = useProjectFileTree(projectId);
 	const { setProjectId, onTreeChange, onFileChange } = useWebSocket();
 
-	const [content, setContent] = useState<FileContent | null>(null);
-	const [contentLoading, setContentLoading] = useState(false);
+	const [content, setContent] = useState<FileContent | null>(() =>
+		contentCacheKey
+			? (fileBrowserContentCache.get(contentCacheKey) ?? null)
+			: null,
+	);
+	const [contentLoading, setContentLoading] = useState(
+		() =>
+			contentCacheKey !== null && !fileBrowserContentCache.has(contentCacheKey),
+	);
 	const [contentError, setContentError] = useState<string | null>(null);
 	const [isRefreshing, setIsRefreshing] = useState(false);
 	const [headings, setHeadings] = useState<readonly HeadingEntry[]>([]);
@@ -149,7 +159,11 @@ export function FileBrowserPage() {
 				};
 			}
 
-			if (!preserveScroll) {
+			const cachedContent = contentCacheKey
+				? (fileBrowserContentCache.get(contentCacheKey) ?? null)
+				: null;
+
+			if (!preserveScroll && cachedContent === null) {
 				savedScrollState.current = null;
 				setContentLoading(true);
 				setHeadings([]);
@@ -171,6 +185,9 @@ export function FileBrowserPage() {
 					throw new Error(`Failed to fetch content: ${response.statusText}`);
 				}
 				const data = (await response.json()) as FileContent;
+				if (contentCacheKey) {
+					fileBrowserContentCache.set(contentCacheKey, data);
+				}
 				setContent((current) => {
 					if (isSameFileContent(current, data)) {
 						if (preserveScroll) {
@@ -182,20 +199,41 @@ export function FileBrowserPage() {
 					return data;
 				});
 			} catch (err) {
-				savedScrollState.current = null;
-				setContentError(err instanceof Error ? err.message : String(err));
-				setContent(null);
+				const message = err instanceof Error ? err.message : String(err);
+				const isTerminalError =
+					message.startsWith("File not found:") ||
+					message.startsWith("Project unavailable:");
+
+				if (isTerminalError) {
+					savedScrollState.current = null;
+					if (contentCacheKey) {
+						fileBrowserContentCache.delete(contentCacheKey);
+					}
+					setContentError(message);
+					setContent(null);
+				}
 			} finally {
 				setContentLoading(false);
 				setIsRefreshing(false);
 			}
 		},
-		[selectedPath, projectId],
+		[selectedPath, projectId, contentCacheKey],
 	);
 
 	useEffect(() => {
-		fetchContent(false);
-	}, [fetchContent]);
+		if (!contentCacheKey) {
+			setContent(null);
+			setContentLoading(false);
+			setContentError(null);
+			return;
+		}
+
+		const cachedContent = fileBrowserContentCache.get(contentCacheKey) ?? null;
+		setContent(cachedContent);
+		setContentLoading(cachedContent === null);
+		setContentError(null);
+		void fetchContent(false);
+	}, [contentCacheKey, fetchContent]);
 
 	useReconnectRecovery(() => fetchContent(true));
 

--- a/cli/web-ui/src/pages/v2/HomePage.tsx
+++ b/cli/web-ui/src/pages/v2/HomePage.tsx
@@ -1,12 +1,13 @@
 import { AnimatePresence, motion } from "framer-motion";
 import { Activity, NotebookTabs, SlidersHorizontal } from "lucide-react";
 import { useCallback, useState } from "react";
-import { useNavigate, useSearchParams } from "react-router-dom";
+import { useSearchParams } from "react-router-dom";
 import { FilterBar } from "@/components/v2/FilterBar";
 import { HarnessIcon } from "@/components/v2/HarnessIcon";
 import type { FeedItem } from "@/hooks/useFeed";
 import { useFeed } from "@/hooks/useFeed";
 import { usePrefersReducedMotion } from "@/hooks/usePrefersReducedMotion";
+import { useWorkspaceTabs } from "@/hooks/useWorkspaceTabs";
 import { resolveRunDisplayName } from "@/lib/run-display";
 import { formatRelativeTime } from "@/lib/time";
 import { cn } from "@/lib/utils";
@@ -148,7 +149,7 @@ function FeedEntry({
 }
 
 export function HomePage() {
-	const navigate = useNavigate();
+	const { openWorkspace } = useWorkspaceTabs();
 	const [searchParams, setSearchParams] = useSearchParams();
 	const reducedMotion = usePrefersReducedMotion();
 
@@ -193,16 +194,16 @@ export function HomePage() {
 
 	const handleRunClick = useCallback(
 		(runId: string) => {
-			navigate(`/runs/${runId}`);
+			openWorkspace(`/runs/${runId}`);
 		},
-		[navigate],
+		[openWorkspace],
 	);
 
 	const handleProjectClick = useCallback(
 		(projectId: string) => {
-			navigate(`/projects/${projectId}`);
+			openWorkspace(`/projects/${projectId}`);
 		},
-		[navigate],
+		[openWorkspace],
 	);
 
 	const renderFeedItem = useCallback(

--- a/cli/web-ui/src/pages/v2/ProjectOverviewPage.tsx
+++ b/cli/web-ui/src/pages/v2/ProjectOverviewPage.tsx
@@ -6,6 +6,7 @@ import { useBreadcrumbContext } from "@/hooks/useBreadcrumbContext";
 import { useContextualShortcuts } from "@/hooks/useContextualShortcuts";
 import { useReconnectRecovery } from "@/hooks/useReconnectRecovery";
 import { useWorkspaceDescriptor } from "@/hooks/useWorkspaceDescriptor";
+import { useWorkspaceTabs } from "@/hooks/useWorkspaceTabs";
 import { formatRelativeTime } from "@/lib/time";
 import { cn } from "@/lib/utils";
 import type { V2Project } from "@/types/projects";
@@ -98,6 +99,7 @@ function Breadcrumb({ projectName }: { projectName: string | null }) {
 export function ProjectOverviewPage() {
 	const { projectId } = useParams<{ projectId: string }>();
 	const navigate = useNavigate();
+	const { openWorkspace } = useWorkspaceTabs();
 
 	const [project, setProject] = useState<V2Project | null>(null);
 	const [runs, setRuns] = useState<Run[]>([]);
@@ -165,10 +167,15 @@ export function ProjectOverviewPage() {
 
 	const handleRunClick = useCallback(
 		(run: Run) => {
-			navigate(`/runs/${run.id}`);
+			openWorkspace(`/runs/${run.id}`);
 		},
-		[navigate],
+		[openWorkspace],
 	);
+
+	const handleFilesClick = useCallback(() => {
+		if (!projectId) return;
+		openWorkspace(`/projects/${projectId}/files`);
+	}, [openWorkspace, projectId]);
 
 	const handleDrillOut = useCallback(() => {
 		navigate("/projects");
@@ -275,13 +282,14 @@ export function ProjectOverviewPage() {
 					</p>
 				</div>
 
-				<Link
-					to={`/projects/${projectId}/files`}
-					className="text-fg-ghost transition-colors duration-150 hover:text-fg"
+				<button
+					type="button"
+					onClick={handleFilesClick}
+					className="cursor-pointer border-none bg-transparent p-0 text-fg-ghost transition-colors duration-150 hover:text-fg"
 					aria-label="Browse files"
 				>
 					<FolderOpen className="h-4 w-4" strokeWidth={1.5} />
-				</Link>
+				</button>
 			</header>
 
 			<div className="flex items-center gap-3 type-secondary text-fg-muted">

--- a/cli/web-ui/src/pages/v2/ProjectOverviewPage.tsx
+++ b/cli/web-ui/src/pages/v2/ProjectOverviewPage.tsx
@@ -19,6 +19,13 @@ interface RunsResponse {
 	total: number;
 }
 
+interface ProjectOverviewCacheEntry {
+	readonly project: V2Project;
+	readonly runs: readonly Run[];
+}
+
+const projectOverviewCache = new Map<string, ProjectOverviewCacheEntry>();
+
 function LoadingSkeleton() {
 	return (
 		<div className="space-y-6">
@@ -100,10 +107,15 @@ export function ProjectOverviewPage() {
 	const { projectId } = useParams<{ projectId: string }>();
 	const navigate = useNavigate();
 	const { openWorkspace } = useWorkspaceTabs();
+	const cachedEntry = projectId
+		? (projectOverviewCache.get(projectId) ?? null)
+		: null;
 
-	const [project, setProject] = useState<V2Project | null>(null);
-	const [runs, setRuns] = useState<Run[]>([]);
-	const [isLoading, setIsLoading] = useState(true);
+	const [project, setProject] = useState<V2Project | null>(
+		cachedEntry?.project ?? null,
+	);
+	const [runs, setRuns] = useState<Run[]>(() => [...(cachedEntry?.runs ?? [])]);
+	const [isLoading, setIsLoading] = useState(cachedEntry === null);
 	const [error, setError] = useState<Error | null>(null);
 	const [notFound, setNotFound] = useState(false);
 	const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
@@ -127,7 +139,6 @@ export function ProjectOverviewPage() {
 		if (!projectId) return;
 
 		try {
-			setIsLoading(true);
 			setError(null);
 			setNotFound(false);
 
@@ -137,7 +148,10 @@ export function ProjectOverviewPage() {
 			]);
 
 			if (projectRes.status === 404) {
+				projectOverviewCache.delete(projectId);
 				setNotFound(true);
+				setProject(null);
+				setRuns([]);
 				return;
 			}
 
@@ -151,17 +165,44 @@ export function ProjectOverviewPage() {
 			if (runsRes.ok) {
 				const runsData = (await runsRes.json()) as RunsResponse;
 				setRuns(runsData.runs);
+				projectOverviewCache.set(projectId, {
+					project: projectData,
+					runs: runsData.runs,
+				});
+				return;
 			}
+
+			projectOverviewCache.set(projectId, {
+				project: projectData,
+				runs: projectOverviewCache.get(projectId)?.runs ?? [],
+			});
 		} catch (err) {
-			setError(err instanceof Error ? err : new Error(String(err)));
+			if (!projectOverviewCache.has(projectId)) {
+				setError(err instanceof Error ? err : new Error(String(err)));
+			}
 		} finally {
 			setIsLoading(false);
 		}
 	}, [projectId]);
 
 	useEffect(() => {
-		fetchData();
-	}, [fetchData]);
+		if (!projectId) {
+			setProject(null);
+			setRuns([]);
+			setError(null);
+			setNotFound(false);
+			setIsLoading(false);
+			return;
+		}
+
+		const nextCachedEntry = projectOverviewCache.get(projectId) ?? null;
+		setProject(nextCachedEntry?.project ?? null);
+		setRuns([...(nextCachedEntry?.runs ?? [])]);
+		setError(null);
+		setNotFound(false);
+		setIsLoading(nextCachedEntry === null);
+		void fetchData();
+	}, [projectId, fetchData]);
 
 	useReconnectRecovery(fetchData);
 

--- a/cli/web-ui/src/pages/v2/ProjectOverviewPage.tsx
+++ b/cli/web-ui/src/pages/v2/ProjectOverviewPage.tsx
@@ -3,7 +3,9 @@ import { useCallback, useEffect, useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import { RunCard } from "@/components/v2/RunCard";
 import { useBreadcrumbContext } from "@/hooks/useBreadcrumbContext";
+import { useContextualShortcuts } from "@/hooks/useContextualShortcuts";
 import { useReconnectRecovery } from "@/hooks/useReconnectRecovery";
+import { useWorkspaceDescriptor } from "@/hooks/useWorkspaceDescriptor";
 import { formatRelativeTime } from "@/lib/time";
 import { cn } from "@/lib/utils";
 import type { V2Project } from "@/types/projects";
@@ -112,6 +114,13 @@ export function ProjectOverviewPage() {
 		return () => setBreadcrumbProject(null, null);
 	}, [projectId, project?.name, setBreadcrumbProject, project]);
 
+	const { workspaceCommands } = useWorkspaceDescriptor({
+		title: project?.name ?? null,
+		subtitle: project?.path ?? null,
+		projectId: projectId ?? null,
+		unavailable: !isLoading && (notFound || project?.available === false),
+	});
+
 	const fetchData = useCallback(async () => {
 		if (!projectId) return;
 
@@ -214,6 +223,14 @@ export function ProjectOverviewPage() {
 		document.addEventListener("keydown", handleKeyDown);
 		return () => document.removeEventListener("keydown", handleKeyDown);
 	}, [runs, selectedIndex, handleRunClick, handleDrillOut]);
+
+	useContextualShortcuts({
+		viewId: "project-overview",
+		viewLabel: "Project Overview",
+		shortcuts: [],
+		commands: [...workspaceCommands],
+		enabled: !!projectId,
+	});
 
 	if (isLoading) {
 		return (

--- a/cli/web-ui/src/pages/v2/ProjectsPage.tsx
+++ b/cli/web-ui/src/pages/v2/ProjectsPage.tsx
@@ -4,6 +4,7 @@ import { useNavigate } from "react-router-dom";
 import { useKeyboardNav } from "@/hooks/useKeyboardNav";
 import { useProjects, type V2Project } from "@/hooks/useProjects";
 import { useRuns } from "@/hooks/useRuns";
+import { useWorkspaceTabs } from "@/hooks/useWorkspaceTabs";
 import { cn } from "@/lib/utils";
 
 function LoadingSkeleton() {
@@ -121,13 +122,14 @@ function ProjectRow({
 
 export function ProjectsPage() {
 	const navigate = useNavigate();
+	const { openWorkspace } = useWorkspaceTabs();
 	const { projects, isLoading, error, refetch } = useProjects();
 
 	const handleProjectClick = useCallback(
 		(project: V2Project) => {
-			navigate(`/projects/${project.id}`);
+			openWorkspace(`/projects/${project.id}`);
 		},
-		[navigate],
+		[openWorkspace],
 	);
 
 	const handleDrillOut = useCallback(() => {
@@ -234,7 +236,7 @@ export function ProjectsPage() {
 								}}
 								onFilesClick={(e) => {
 									e.stopPropagation();
-									navigate(`/projects/${project.id}/files`);
+									openWorkspace(`/projects/${project.id}/files`);
 								}}
 							/>
 						</li>

--- a/cli/web-ui/src/pages/v2/RunDetailPage.tsx
+++ b/cli/web-ui/src/pages/v2/RunDetailPage.tsx
@@ -16,6 +16,7 @@ import {
 	commandToWorkflowName,
 	useWorkflowSteps,
 } from "@/hooks/useWorkflowSteps";
+import { useWorkspaceDescriptor } from "@/hooks/useWorkspaceDescriptor";
 import { resolveRunDisplayName } from "@/lib/run-display";
 import { cn } from "@/lib/utils";
 import { useWebSocket } from "@/providers/WebSocketProvider";
@@ -89,6 +90,11 @@ export function RunDetailPage() {
 		if (!urlDocId || !run) return null;
 		return run.artifacts.find((a) => a.docId === urlDocId) ?? null;
 	}, [urlDocId, run]);
+	const workspaceSubtitle = useMemo(() => {
+		if (!run) return null;
+		const artifactName = selectedArtifact?.path.split("/").at(-1) ?? null;
+		return artifactName ?? run.projectName;
+	}, [run, selectedArtifact]);
 
 	const displaySteps = useMemo<readonly Step[]>(() => {
 		return run ? run.steps : [];
@@ -251,11 +257,21 @@ export function RunDetailPage() {
 		};
 	}, [runId, setActiveArtifact]);
 
+	const { workspaceCommands } = useWorkspaceDescriptor({
+		title: run ? resolveRunDisplayName(run) || run.command : null,
+		subtitle: workspaceSubtitle,
+		projectId: run?.projectId ?? null,
+		unavailable:
+			!isLoading &&
+			(error?.message === "Run not found" || (!error && run === null)),
+	});
+
 	useContextualShortcuts({
 		viewId: "run-detail",
 		viewLabel: "Run Detail",
 		shortcuts: [],
 		commands: [
+			...workspaceCommands,
 			...(run?.invocation
 				? [
 						{
@@ -283,7 +299,7 @@ export function RunDetailPage() {
 					]
 				: []),
 		],
-		enabled: !!run,
+		enabled: !!runId,
 	});
 
 	if (isLoading || isWorkflowLoading) {

--- a/docs/arcade/dashboard.md
+++ b/docs/arcade/dashboard.md
@@ -202,18 +202,27 @@ stay on the current page while checking what needs attention.
 
 | Surface | Behavior |
 |---------|----------|
-| Left icon rail | Navigate between Activity (`/`) and Projects (`/projects`) |
-| Breadcrumb bar | Shows the current page, project, or run context |
+| Left icon rail | Durable navigation for Activity (`/`) and Projects (`/projects`); these destinations are never closeable workspace tabs |
+| Breadcrumb bar | Shows the current page, project, or run context for the active durable destination or workspace |
+| Workspace strip | Shows closable run, project overview, and file-browser workspaces under the breadcrumb bar; reopening an existing workspace focuses the existing tab and restores its last route |
 | Top-right bell trigger | Opens or closes the notifications drawer without navigating away |
 
 ### Narrow layouts
 
 | Surface | Behavior |
 |---------|----------|
-| Bottom activity button | Opens the activity dashboard |
-| Bottom projects button | Opens the projects view |
+| Bottom activity button | Opens the activity dashboard as durable navigation, not a closable workspace |
+| Bottom projects button | Opens the projects view as durable navigation, not a closable workspace |
+| Workspace strip above page content | Shows open run, project overview, and file-browser workspaces in a horizontal strip while keeping the bottom bar reserved for durable navigation |
 | Bottom bell trigger | Opens or closes the notifications drawer |
 | Bottom command button | Opens the command palette |
+
+### Workspace behavior
+
+- Eligible workspaces are run detail, project overview, and project file browser routes.
+- Individual files stay inside a project file-browser workspace and do not become top-level tabs.
+- Reopening an already open workspace returns you to that existing tab instead of creating a duplicate.
+- Closing the active workspace moves to the nearest remaining workspace, or back to the last durable route if no workspaces remain.
 
 ### Notifications drawer behavior
 
@@ -230,6 +239,11 @@ stay on the current page while checking what needs attention.
 ## Keyboard Shortcuts
 
 The dashboard supports a comprehensive keyboard-first interaction model. See [Keyboard Shortcuts](keyboard-shortcuts.md) for the full reference.
+
+Workspace tabs do not add new global single-key shortcuts in v1. The existing
+shell shortcuts continue to own durable navigation, while workspace navigation
+uses natural focus movement inside the strip plus contextual command-palette
+actions on active workspace pages.
 
 ### Global
 
@@ -250,6 +264,22 @@ The dashboard supports a comprehensive keyboard-first interaction model. See [Ke
 | `g` then `r` | Activity dashboard (alternate alias) |
 | `g` then `p` | Projects |
 
+These chords continue to target durable shell destinations only. They do not
+open, close, or cycle workspace tabs.
+
+### Workspace Strip
+
+| Key | Action |
+|-----|--------|
+| `Tab` | Move focus into the open-workspaces strip when tabs are present |
+| `Arrow Left` / `Arrow Right` | Move focus across adjacent workspace tabs |
+| `Home` / `End` | Jump focus to the first or last workspace tab |
+| `Enter` / `Space` | Activate the focused workspace tab |
+| `Delete` / `Backspace` | Close the focused workspace tab |
+
+Active workspace pages also register `Previous Workspace`, `Next Workspace`,
+and `Close Workspace` actions in the command palette.
+
 ### List Navigation
 
 | Key | Action |
@@ -262,6 +292,31 @@ The dashboard supports a comprehensive keyboard-first interaction model. See [Ke
 | `Escape` | Clear selection |
 
 Keyboard navigation uses the roving tabindex pattern for accessibility.
+
+---
+
+## Tabs Verification Gate
+
+Tabs UI changes are not considered release-ready without live browser
+verification against the real Arcade app.
+
+1. Start the actual UI with `just serve-web-ui`.
+2. Use `playwright-cli` against the running app, not a mocked component harness.
+3. Validate both a desktop-sized viewport and a mobile-sized viewport.
+4. Capture screenshots or snapshots under `/tmp` as review evidence.
+5. Treat any failed browser scenario as release-blocking until it is fixed and
+   revalidated.
+
+Minimum browser coverage for tabs work:
+
+- Open run, project overview, and file-browser workspaces from their existing entry points.
+- Reopen an already open workspace and confirm the existing tab is focused instead of duplicated.
+- Switch among open tabs and confirm the breadcrumb and shared chrome update immediately.
+- Close inactive and active tabs while keeping durable navigation available.
+- Reload on an eligible workspace and confirm the route and active tab are preserved.
+- Use browser back and forward across workspace transitions and confirm the visible state stays aligned with the URL.
+- Verify keyboard-only tab focus, activation, and close behavior.
+- Verify the mobile layout keeps the bottom durable navigation separate from the workspace strip.
 
 ---
 

--- a/docs/arcade/keyboard-shortcuts.md
+++ b/docs/arcade/keyboard-shortcuts.md
@@ -21,7 +21,10 @@ Press **Cmd+K** (macOS) or **Ctrl+K** (other platforms) to open the command pale
 | Enter | Select highlighted item |
 | Escape | Close the palette |
 
-The palette includes navigation items (Home, Runs, Projects) and actions (Toggle Theme, Refresh Data).
+The palette includes navigation items (Home, Runs, Projects), shell actions
+(Toggle Theme, Refresh Data), and workspace actions such as **Previous
+Workspace**, **Next Workspace**, and **Close Workspace** when a run, project
+overview, or file-browser workspace is active.
 
 ---
 
@@ -69,11 +72,40 @@ Press **g** followed by a second key within 500ms to jump to a section.
 Each chord jumps directly to its mapped section. Waiting longer than 500ms
 cancels the chord.
 
+These chords continue to target durable shell destinations only. Workspace tabs
+do not add new global single-key shortcuts in v1.
+
+---
+
+## Workspace Strip
+
+When run, project overview, or file-browser workspaces are open, Arcade shows a
+horizontal **Open workspaces** strip above the page content. It uses normal
+focus order and route navigation rather than hidden tab panels.
+
+| Key | Action |
+|-----|--------|
+| Tab | Move focus into the workspace strip |
+| Arrow Left | Move focus to the previous workspace tab |
+| Arrow Right | Move focus to the next workspace tab |
+| Home | Jump focus to the first workspace tab |
+| End | Jump focus to the last workspace tab |
+| Enter / Space | Activate the focused workspace tab |
+| Delete / Backspace | Close the focused workspace tab |
+
+The close button on each workspace follows the same Arrow, Home, End, Enter,
+Space, Delete, and Backspace behavior so keyboard users can close tabs without
+leaving the strip.
+
 ---
 
 ## List Navigation
 
 Navigate runs, artifacts, and attention items using these keys.
+
+These bindings continue to apply to list and drill-navigation surfaces. The
+workspace strip uses the horizontal behavior above instead of introducing new
+global `h`/`l` tab shortcuts.
 
 ### Movement
 


### PR DESCRIPTION
## Summary
- add persistent workspace tabs for runs, projects, and files with workspace routing and metadata syncing
- wire the shell so workspace tabs can reopen surfaces cleanly, show tab icons, reduce switch flashing, and keep tabs in the top chrome with notifications pinned to the right
- expand automated coverage and update docs/KB artifacts for the workspace tabs feature

## Testing
- `cd cli/web-ui && bun test src/__tests__/components/v2/WorkspaceTabStrip.test.tsx src/__tests__/components/v2/WorkspaceShellIntegration.test.tsx src/__tests__/app/V2Layout.test.tsx`
- `cd cli/web-ui && bunx tsc --noEmit`
- `cd cli/web-ui && bunx biome check src/app/V2Layout.tsx src/components/v2/WorkspaceTabStrip.tsx src/__tests__/components/v2/WorkspaceTabStrip.test.tsx src/__tests__/components/v2/WorkspaceShellIntegration.test.tsx src/__tests__/app/V2Layout.test.tsx`
- pre-push hook passed: `eval-verify`, `catalog`, `typecheck-cli`, `typecheck-webui`