### PR TITLE
fix(cli): harden update lifecycle and routing

### DIFF
--- a/cli/src/__tests__/lib/command-routing.test.ts
+++ b/cli/src/__tests__/lib/command-routing.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "bun:test";
+import {
+	getTopLevelCommandToken,
+	isTopLevelCommandInvocation,
+} from "../../lib/command-routing.js";
+
+describe("command-routing", () => {
+	test("detects direct agent-tools invocation", () => {
+		expect(getTopLevelCommandToken(["agent-tools", "workflow-bootstrap"])).toBe(
+			"agent-tools",
+		);
+		expect(
+			isTopLevelCommandInvocation(
+				["agent-tools", "workflow-bootstrap"],
+				"agent-tools",
+			),
+		).toBe(true);
+	});
+
+	test("detects agent-tools after root global flags", () => {
+		expect(
+			getTopLevelCommandToken([
+				"--trace",
+				"-v",
+				"agent-tools",
+				"workflow-bootstrap",
+				"--name",
+				"build",
+			]),
+		).toBe("agent-tools");
+	});
+
+	test("detects daemon server after root global flags", () => {
+		expect(
+			isTopLevelCommandInvocation(
+				["--verbose", "_daemon-server", "--port", "7710"],
+				"_daemon-server",
+			),
+		).toBe(true);
+	});
+
+	test("does not route when help/version terminates parsing first", () => {
+		expect(getTopLevelCommandToken(["--help", "agent-tools"])).toBeUndefined();
+		expect(
+			getTopLevelCommandToken(["--version", "agent-tools"]),
+		).toBeUndefined();
+	});
+
+	test("does not route through unknown leading options", () => {
+		expect(
+			getTopLevelCommandToken([
+				"--unknown-option",
+				"agent-tools",
+				"workflow-bootstrap",
+			]),
+		).toBeUndefined();
+	});
+});

--- a/cli/src/agent-tools/command.ts
+++ b/cli/src/agent-tools/command.ts
@@ -384,7 +384,7 @@ Examples:
 				const inputResult = await readInput(options.file)();
 
 				if (E.isLeft(inputResult)) {
-					console.error(
+					console.log(
 						createErrorResponse(toolName, formatError(inputResult.left, false)),
 					);
 					process.exit(1);
@@ -396,7 +396,7 @@ Examples:
 
 			const tool = getTool(toolName);
 			if (!tool) {
-				console.error(
+				console.log(
 					createErrorResponse(toolName, "Tool not found in registry"),
 				);
 				process.exit(1);
@@ -410,7 +410,7 @@ Examples:
 			const result = await tool.execute(content, toolOptions)();
 
 			if (E.isLeft(result)) {
-				console.error(
+				console.log(
 					createErrorResponse(toolName, formatError(result.left, false)),
 				);
 				process.exit(1);
@@ -512,7 +512,7 @@ Examples:
 				const inputResult = await readInput(options.file)();
 
 				if (E.isLeft(inputResult)) {
-					console.error(
+					console.log(
 						createErrorResponse(toolName, formatError(inputResult.left, false)),
 					);
 					process.exit(1);
@@ -524,7 +524,7 @@ Examples:
 
 			const tool = getTool(toolName);
 			if (!tool) {
-				console.error(
+				console.log(
 					createErrorResponse(toolName, "Tool not found in registry"),
 				);
 				process.exit(1);
@@ -538,7 +538,7 @@ Examples:
 			const result = await tool.execute(content, toolOptions)();
 
 			if (E.isLeft(result)) {
-				console.error(
+				console.log(
 					createErrorResponse(toolName, formatError(result.left, false)),
 				);
 				process.exit(1);

--- a/cli/src/commands/update/__tests__/post-self-update.test.ts
+++ b/cli/src/commands/update/__tests__/post-self-update.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, test } from "bun:test";
+import {
+	isPostSelfUpdateProcess,
+	POST_SELF_UPDATE_DAEMON_PORT_ENV,
+	POST_SELF_UPDATE_DAEMON_WAS_RUNNING_ENV,
+	POST_SELF_UPDATE_ENV,
+	readPostSelfUpdateState,
+	relaunchPostSelfUpdate,
+} from "../post-self-update.js";
+
+type SpawnSyncImpl = NonNullable<
+	Parameters<typeof relaunchPostSelfUpdate>[0]
+>["spawnSyncImpl"];
+
+describe("post-self-update handoff", () => {
+	test("detects post-self-update relaunch from environment", () => {
+		expect(isPostSelfUpdateProcess({ [POST_SELF_UPDATE_ENV]: "1" })).toBe(true);
+		expect(isPostSelfUpdateProcess({})).toBe(false);
+	});
+
+	test("reads daemon lifecycle state from environment", () => {
+		expect(
+			readPostSelfUpdateState({
+				[POST_SELF_UPDATE_DAEMON_WAS_RUNNING_ENV]: "1",
+				[POST_SELF_UPDATE_DAEMON_PORT_ENV]: "7710",
+			}),
+		).toEqual({
+			daemonWasRunning: true,
+			daemonPort: 7710,
+		});
+
+		expect(
+			readPostSelfUpdateState({
+				[POST_SELF_UPDATE_DAEMON_WAS_RUNNING_ENV]: "0",
+				[POST_SELF_UPDATE_DAEMON_PORT_ENV]: "not-a-number",
+			}),
+		).toEqual({
+			daemonWasRunning: false,
+			daemonPort: undefined,
+		});
+	});
+
+	test("relaunches update with yes flag and environment marker", () => {
+		let recorded: {
+			command?: string;
+			args?: readonly string[];
+			env?: NodeJS.ProcessEnv;
+		} = {};
+		const spawnSyncImpl: SpawnSyncImpl = (command, args, options) => {
+			recorded = {
+				command: String(command),
+				args,
+				env: options.env,
+			};
+			return { status: 0 };
+		};
+
+		const result = relaunchPostSelfUpdate({
+			yes: true,
+			execPath: "/opt/homebrew/bin/rp1",
+			env: { HOME: "/tmp/home" },
+			state: {
+				daemonWasRunning: true,
+				daemonPort: 7710,
+			},
+			spawnSyncImpl,
+		});
+
+		expect(result).toEqual({ success: true, exitCode: 0 });
+		expect(recorded.command).toBe("/opt/homebrew/bin/rp1");
+		expect(recorded.args).toEqual(["update", "--yes"]);
+		expect(recorded.env?.HOME).toBe("/tmp/home");
+		expect(recorded.env?.[POST_SELF_UPDATE_ENV]).toBe("1");
+		expect(recorded.env?.[POST_SELF_UPDATE_DAEMON_WAS_RUNNING_ENV]).toBe("1");
+		expect(recorded.env?.[POST_SELF_UPDATE_DAEMON_PORT_ENV]).toBe("7710");
+	});
+
+	test("surfaces spawn failures", () => {
+		const spawnSyncImpl: SpawnSyncImpl = () => ({
+			status: null,
+			error: new Error("spawn failed"),
+		});
+
+		const result = relaunchPostSelfUpdate({
+			spawnSyncImpl,
+		});
+
+		expect(result.success).toBe(false);
+		expect(result.exitCode).toBe(1);
+		expect(result.error).toContain("spawn failed");
+	});
+});

--- a/cli/src/commands/update/__tests__/post-self-update.test.ts
+++ b/cli/src/commands/update/__tests__/post-self-update.test.ts
@@ -6,6 +6,7 @@ import {
 	POST_SELF_UPDATE_ENV,
 	readPostSelfUpdateState,
 	relaunchPostSelfUpdate,
+	resolvePostSelfUpdateCommand,
 } from "../post-self-update.js";
 
 type SpawnSyncImpl = NonNullable<
@@ -38,6 +39,29 @@ describe("post-self-update handoff", () => {
 			daemonWasRunning: false,
 			daemonPort: undefined,
 		});
+	});
+
+	test("uses explicit relaunch path when provided", () => {
+		expect(
+			resolvePostSelfUpdateCommand({ execPath: "/opt/homebrew/bin/rp1" }),
+		).toBe("/opt/homebrew/bin/rp1");
+	});
+
+	test("falls back to rp1 in source-run environments", () => {
+		const originalExecPath = process.execPath;
+		Object.defineProperty(process, "execPath", {
+			value: "/opt/homebrew/bin/bun",
+			configurable: true,
+		});
+
+		try {
+			expect(resolvePostSelfUpdateCommand()).toBe("rp1");
+		} finally {
+			Object.defineProperty(process, "execPath", {
+				value: originalExecPath,
+				configurable: true,
+			});
+		}
 	});
 
 	test("relaunches update with yes flag and environment marker", () => {

--- a/cli/src/commands/update/index.ts
+++ b/cli/src/commands/update/index.ts
@@ -12,15 +12,11 @@
 
 import { Command } from "commander";
 import * as E from "fp-ts/lib/Either.js";
-import { formatError } from "../../../shared/errors.js";
+import { resolveDirectorySet } from "../../../shared/directory-resolution.js";
+import { formatError, getExitCode } from "../../../shared/errors.js";
 import type { Logger } from "../../../shared/logger.js";
 import { loadToolsRegistry } from "../../config/supported-tools.js";
-import { updatePlugin } from "../../install/claudecode/installer.js";
-import {
-	isStale,
-	type PlatformVersions,
-	readAllVersionMarkers,
-} from "../../install/version-marker.js";
+import { detectTools } from "../../init/tool-detector.js";
 import { DEFAULT_TTL_HOURS, writeCache } from "../../lib/cache.js";
 import { getColorFns } from "../../lib/colors.js";
 import {
@@ -38,11 +34,17 @@ import {
 	getDisplayVersion,
 	getInstalledVersion,
 } from "../../lib/version.js";
+import { executeMigrate, formatMigrateSummary } from "../../migrate/index.js";
 import {
 	type InstallContext,
-	installForSpecificTool,
+	installAllDetectedTools,
 } from "../../shared/install-core.js";
-import { pluginsSubcommand } from "./plugins.js";
+import { formatUpdateAllResult, pluginsSubcommand } from "./plugins.js";
+import {
+	isPostSelfUpdateProcess,
+	readPostSelfUpdateState,
+	relaunchPostSelfUpdate,
+} from "./post-self-update.js";
 
 /**
  * GitHub releases URL for manual installation instructions.
@@ -196,7 +198,11 @@ export const executeSelfUpdate = async (
 	options: { dryRun: boolean; force: boolean },
 	logger: Logger | undefined,
 	isTTY: boolean,
-): Promise<{ success: boolean; exitCode: number }> => {
+): Promise<{
+	success: boolean;
+	exitCode: number;
+	updatedBinary: boolean;
+}> => {
 	const { green, yellow, cyan, dim } = getColorFns(isTTY);
 
 	logger?.debug(
@@ -224,7 +230,7 @@ export const executeSelfUpdate = async (
 		console.log(`  1. Visit: ${cyan(GITHUB_RELEASES_URL)}`);
 		console.log("  2. Download the latest release for your platform");
 		console.log("  3. Replace your current rp1 binary");
-		return { success: false, exitCode: 2 };
+		return { success: false, exitCode: 2, updatedBinary: false };
 	}
 
 	console.log(green(`${methodName} installation detected`));
@@ -249,7 +255,7 @@ export const executeSelfUpdate = async (
 			console.log(
 				dim("Use --force to reinstall the current version if needed."),
 			);
-			return { success: true, exitCode: 0 };
+			return { success: true, exitCode: 0, updatedBinary: false };
 		}
 
 		if (versionCheck.updateAvailable && versionCheck.latestVersion) {
@@ -268,7 +274,7 @@ export const executeSelfUpdate = async (
 		console.log(`  Installation method: ${methodName}`);
 		console.log(`  Current version: v${currentVersion}`);
 		console.log(`  Update command: ${updateCmd}`);
-		return { success: true, exitCode: 0 };
+		return { success: true, exitCode: 0, updatedBinary: false };
 	}
 
 	// Step 4: Run the update
@@ -286,7 +292,7 @@ export const executeSelfUpdate = async (
 		console.log("");
 		console.log("You can try updating manually:");
 		console.log(`  ${updateCmd}`);
-		return { success: false, exitCode: 1 };
+		return { success: false, exitCode: 1, updatedBinary: false };
 	}
 
 	// Step 5: Update cache with new version to suppress update banner
@@ -323,90 +329,127 @@ export const executeSelfUpdate = async (
 		console.log(green("Update completed successfully"));
 	}
 
-	return { success: true, exitCode: 0 };
+	return { success: true, exitCode: 0, updatedBinary: true };
+};
+
+const noopLogger: Logger = {
+	trace: () => {},
+	debug: () => {},
+	info: () => {},
+	warn: () => {},
+	error: () => {},
+	start: () => {},
+	success: () => {},
+	fail: () => {},
+	box: () => {},
+};
+
+interface UpdateArcadeState {
+	readonly daemonWasRunning: boolean;
+	readonly daemonPort?: number;
+}
+
+interface PostUpdatePhaseResult {
+	readonly success: boolean;
+	readonly exitCode: number;
+}
+
+/**
+ * Stop the Arcade daemon before any mutating update work begins.
+ */
+const stopArcadeBeforeUpdate = async (
+	logger: Logger,
+	isTTY: boolean,
+): Promise<UpdateArcadeState> => {
+	const { green, bold, dim } = getColorFns(isTTY);
+	const { getStatus, stopDaemon } = await import(
+		"../../../web-ui/src/daemon/index.js"
+	);
+
+	console.log("");
+	console.log(bold("Preparing Arcade daemon..."));
+
+	const status = await getStatus();
+	if (!status.running) {
+		console.log(dim("Arcade daemon is not running."));
+		return { daemonWasRunning: false };
+	}
+
+	logger.debug(
+		`Stopping Arcade daemon before update (port=${status.port ?? "unknown"})`,
+	);
+	const stopped = await stopDaemon();
+	if (!stopped) {
+		throw new Error("Failed to stop the running Arcade daemon.");
+	}
+
+	console.log(green("Arcade daemon stopped."));
+	return {
+		daemonWasRunning: true,
+		daemonPort: status.port,
+	};
 };
 
 /**
- * Known platforms for staleness detection.
- * Order determines display order in status output.
+ * Restart the Arcade daemon if it was running before the update began.
  */
-const KNOWN_PLATFORMS = ["claude-code", "opencode", "codex"] as const;
+const restartArcadeAfterUpdate = async (
+	state: UpdateArcadeState,
+	logger: Logger,
+	isTTY: boolean,
+): Promise<PostUpdatePhaseResult> => {
+	const { green, bold, dim } = getColorFns(isTTY);
+
+	if (!state.daemonWasRunning) {
+		console.log("");
+		console.log(
+			dim("Arcade daemon was not running before update. Skipping restart."),
+		);
+		return { success: true, exitCode: 0 };
+	}
+
+	console.log("");
+	console.log(bold("Restarting Arcade daemon..."));
+
+	try {
+		const { ensureDaemon } = await import(
+			"../../../web-ui/src/daemon/index.js"
+		);
+		const result = await ensureDaemon(state.daemonPort, getInstalledVersion());
+		logger.debug(
+			`Arcade daemon ready after update (port=${result.connection.port}, reused=${result.wasRunning})`,
+		);
+		console.log(
+			green(`Arcade daemon ready on port ${result.connection.port}.`),
+		);
+		return { success: true, exitCode: 0 };
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		console.error(`Failed to restart Arcade daemon: ${message}`);
+		return { success: false, exitCode: 1 };
+	}
+};
 
 /**
- * Check plugin staleness via version markers and reinstall stale platforms.
- * Reads the centralized version markers file and compares each platform's
- * installed version against the current binary version. Stale platforms
- * are automatically re-extracted and reinstalled from the binary.
- *
- * For Claude Code, additionally runs `claude plugin update` after reinstall
- * to ensure Claude picks up the new plugin files.
- *
- * @param options - Update options (dryRun)
- * @param logger - Logger instance
- * @param isTTY - Whether running in TTY mode
+ * Update plugins for all detected tools using the standard install/update path.
  */
-const checkAndReinstallStalePlugins = async (
+const updateDetectedPlugins = async (
 	options: { dryRun: boolean; yes: boolean },
 	logger: Logger,
 	isTTY: boolean,
-): Promise<void> => {
-	const { green, yellow, bold, dim } = getColorFns(isTTY);
-	const currentVersion = getInstalledVersion();
+): Promise<PostUpdatePhaseResult> => {
+	const { bold, dim } = getColorFns(isTTY);
+	const registry = await loadToolsRegistry();
+	const detection = await detectTools(registry)();
 
 	console.log("");
-	console.log(bold("Checking plugin staleness..."));
+	console.log(bold("Updating plugins for detected tools..."));
 
-	const markersResult = await readAllVersionMarkers()();
-
-	if (E.isLeft(markersResult)) {
+	if (E.isRight(detection) && detection.right.detected.length === 0) {
 		console.log(
-			yellow("Warning: Could not read version markers. Skipping plugin check."),
+			dim("No installed agentic tools detected. Skipping plugin refresh."),
 		);
-		logger.debug(
-			`Version marker read failed: ${formatError(markersResult.left, false)}`,
-		);
-		return;
-	}
-
-	const markers: PlatformVersions = markersResult.right;
-	const stalePlatforms: string[] = [];
-	const upToDatePlatforms: string[] = [];
-
-	for (const platform of KNOWN_PLATFORMS) {
-		const marker = markers[platform] ?? null;
-		if (isStale(marker, currentVersion)) {
-			stalePlatforms.push(platform);
-		} else {
-			upToDatePlatforms.push(platform);
-		}
-	}
-
-	if (stalePlatforms.length === 0) {
-		console.log(green("All platform plugins are up to date."));
-		console.log("");
-		for (const platform of upToDatePlatforms) {
-			console.log(
-				dim(
-					`  ${platform}: v${markers[platform]?.version ?? "unknown"} (current)`,
-				),
-			);
-		}
-		return;
-	}
-
-	console.log("");
-	console.log(
-		`Stale plugins detected for: ${stalePlatforms.map((p) => bold(p)).join(", ")}`,
-	);
-
-	if (options.dryRun) {
-		console.log("");
-		console.log("Dry run mode - would reinstall plugins for:");
-		for (const platform of stalePlatforms) {
-			const markerVersion = markers[platform]?.version ?? "none";
-			console.log(`  ${platform}: ${markerVersion} -> ${currentVersion}`);
-		}
-		return;
+		return { success: true, exitCode: 0 };
 	}
 
 	const ctx: InstallContext = {
@@ -416,57 +459,69 @@ const checkAndReinstallStalePlugins = async (
 		skipPrompt: options.yes || !isTTY,
 	};
 
-	const registry = await loadToolsRegistry();
-
-	console.log("");
-	console.log(bold("Reinstalling stale plugins..."));
-	console.log("");
-
-	for (const platform of stalePlatforms) {
-		const markerVersion = markers[platform]?.version ?? "none";
-		console.log(
-			`Updating ${platform} plugins (${markerVersion} -> ${currentVersion})...`,
-		);
-
-		const result = await installForSpecificTool(platform, registry, ctx)();
-
-		if (E.isLeft(result)) {
-			console.log(yellow(`  ${platform}: Failed to reinstall`));
-			logger.debug(`  Error: ${formatError(result.left, false)}`);
-			continue;
-		}
-
-		if (result.right.success) {
-			console.log(green(`  ${platform}: Plugins reinstalled`));
-
-			if (platform === "claude-code") {
-				console.log(dim("  Running claude plugin update..."));
-				for (const pluginName of ["rp1-base", "rp1-dev"]) {
-					const updateResult = await updatePlugin(
-						pluginName,
-						"user",
-						logger,
-						options.dryRun,
-						isTTY,
-					)();
-					if (E.isLeft(updateResult)) {
-						logger.debug(
-							`  claude plugin update for ${pluginName} failed: ${formatError(updateResult.left, false)}`,
-						);
-					}
-				}
-			}
-		} else {
-			console.log(yellow(`  ${platform}: Reinstall failed`));
-			if (result.right.error) {
-				logger.debug(`  Error: ${formatError(result.right.error, false)}`);
-			}
-		}
+	const result = await installAllDetectedTools(registry, ctx)();
+	if (E.isLeft(result)) {
+		console.error(formatError(result.left, isTTY));
+		return {
+			success: false,
+			exitCode: getExitCode(result.left),
+		};
 	}
 
+	formatUpdateAllResult(result.right, isTTY);
+
+	if (result.right.installed < result.right.results.length) {
+		return { success: false, exitCode: 1 };
+	}
+
+	return { success: true, exitCode: 0 };
+};
+
+/**
+ * Run project migrations after plugin refresh. This is best-effort when the
+ * current working directory is not an rp1 project.
+ */
+const runProjectMigrations = async (
+	cwd: string,
+	options: { dryRun: boolean },
+	isTTY: boolean,
+): Promise<PostUpdatePhaseResult> => {
+	const { bold, dim } = getColorFns(isTTY);
+	const directories = resolveDirectorySet(cwd);
+
 	console.log("");
-	for (const platform of upToDatePlatforms) {
-		console.log(dim(`  ${platform}: Already up to date`));
+	console.log(
+		bold(
+			options.dryRun
+				? "Checking project migrations..."
+				: "Running project migrations...",
+		),
+	);
+
+	if (E.isLeft(directories)) {
+		console.log(
+			dim(
+				"No rp1 project detected from current directory. Skipping migrations.",
+			),
+		);
+		return { success: true, exitCode: 0 };
+	}
+
+	if (options.dryRun) {
+		console.log(
+			dim(`Would run project migrations for ${directories.right.projectRoot}.`),
+		);
+		return { success: true, exitCode: 0 };
+	}
+
+	try {
+		const result = await executeMigrate(cwd);
+		console.log(formatMigrateSummary(result));
+		return { success: true, exitCode: 0 };
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		console.error(`Migration failed: ${message}`);
+		return { success: false, exitCode: 1 };
 	}
 };
 
@@ -491,6 +546,11 @@ export const executeUpdateAction = async (
 	isTTY: boolean,
 ): Promise<void> => {
 	const { dim } = getColorFns(isTTY);
+	const resumingPostSelfUpdate = isPostSelfUpdateProcess();
+	const lifecycleLogger = logger ?? noopLogger;
+	let arcadeState: UpdateArcadeState = resumingPostSelfUpdate
+		? readPostSelfUpdateState()
+		: { daemonWasRunning: false };
 
 	logger?.debug(
 		`Update action starting (check=${options.check}, dry-run=${options.dryRun}, force=${options.force}, yes=${options.yes}, json=${options.json}, format=${options.format})`,
@@ -577,50 +637,90 @@ export const executeUpdateAction = async (
 		}
 	}
 
-	// Standard update flow: self-update then check plugin staleness
-	const updateResult = await executeSelfUpdate(
-		{ dryRun: options.dryRun, force: options.force },
-		logger,
-		isTTY,
-	);
-
-	// If self-update had a hard failure (not manual-install), exit immediately
-	if (!updateResult.success && updateResult.exitCode !== 2) {
-		process.exit(updateResult.exitCode);
+	if (!options.dryRun && !resumingPostSelfUpdate) {
+		try {
+			arcadeState = await stopArcadeBeforeUpdate(lifecycleLogger, isTTY);
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			console.error(`Failed to prepare Arcade daemon: ${message}`);
+			process.exit(1);
+		}
 	}
 
-	// Check plugin staleness and reinstall if needed.
-	// This runs for both successful updates AND manual installs (exitCode 2),
-	// so curl/direct-download users still get plugin staleness checks.
-	if (logger) {
-		await checkAndReinstallStalePlugins(
-			{ dryRun: options.dryRun, yes: options.yes },
+	let updateResult: {
+		success: boolean;
+		exitCode: number;
+		updatedBinary: boolean;
+	} = {
+		success: true,
+		exitCode: 0,
+		updatedBinary: false,
+	};
+
+	if (!resumingPostSelfUpdate) {
+		// Standard update flow: self-update, then continue with the same
+		// lifecycle in the freshly installed binary if the executable changed.
+		updateResult = await executeSelfUpdate(
+			{ dryRun: options.dryRun, force: options.force },
 			logger,
 			isTTY,
 		);
-	}
 
-	// Check fence staleness and report if stale
-	try {
-		const fenceResult = checkFenceStaleness(process.cwd());
-		if (fenceResult.hasProject && fenceResult.staleFiles.length > 0) {
-			const { yellow, cyan } = getColorFns(isTTY);
-			const currentDisplay = fenceResult.oldestVersion ?? "0.0.0";
-			console.log("");
-			console.log(
-				`${yellow("Stanza configuration is outdated")} (v${currentDisplay} -> v${fenceResult.latestFenceVersion}).`,
-			);
-			console.log(`  Outdated: ${fenceResult.staleFiles.join(", ")}`);
-			console.log(`  Run '${cyan("rp1 migrate")}' to update.`);
+		if (!updateResult.success && updateResult.exitCode !== 2) {
+			if (!options.dryRun) {
+				await restartArcadeAfterUpdate(arcadeState, lifecycleLogger, isTTY);
+			}
+			process.exit(updateResult.exitCode);
 		}
-	} catch {
-		// Fence check is best-effort; do not block update output
+
+		if (updateResult.updatedBinary) {
+			console.log("");
+			console.log("Relaunching updated rp1 for post-update lifecycle...");
+
+			const handoff = relaunchPostSelfUpdate({
+				yes: options.yes,
+				state: arcadeState,
+			});
+			if (!handoff.success && handoff.error) {
+				console.error(
+					`Failed to relaunch updated rp1 for post-update lifecycle: ${handoff.error}`,
+				);
+				if (!options.dryRun) {
+					await restartArcadeAfterUpdate(arcadeState, lifecycleLogger, isTTY);
+				}
+			}
+			process.exit(handoff.exitCode);
+		}
 	}
 
-	// If self-update required manual intervention (manual install), exit
-	// after plugin checks have completed
+	const pluginResult = await updateDetectedPlugins(
+		{ dryRun: options.dryRun, yes: options.yes },
+		lifecycleLogger,
+		isTTY,
+	);
+	const migrationResult = await runProjectMigrations(
+		process.cwd(),
+		{ dryRun: options.dryRun },
+		isTTY,
+	);
+	const restartResult = options.dryRun
+		? { success: true, exitCode: 0 }
+		: await restartArcadeAfterUpdate(arcadeState, lifecycleLogger, isTTY);
+
+	const postUpdateFailed =
+		!pluginResult.success || !migrationResult.success || !restartResult.success;
+	const postUpdateExitCode = !pluginResult.success
+		? pluginResult.exitCode
+		: !migrationResult.success
+			? migrationResult.exitCode
+			: restartResult.exitCode;
+
 	if (!updateResult.success || updateResult.exitCode !== 0) {
 		process.exit(updateResult.exitCode);
+	}
+
+	if (postUpdateFailed) {
+		process.exit(postUpdateExitCode || 1);
 	}
 
 	console.log("");
@@ -668,7 +768,7 @@ Options:
   -y, --yes  Skip all confirmation prompts
 
 Examples:
-  rp1 update                   Update CLI, then prompt for plugin update
+  rp1 update                   Update CLI, plugins, migrations, and Arcade lifecycle
   rp1 update --check           Check if updates are available
   rp1 update --check --json    Check for updates with JSON output
   rp1 update --check --format hook-text  Emit shell-friendly hook text

--- a/cli/src/commands/update/index.ts
+++ b/cli/src/commands/update/index.ts
@@ -698,11 +698,21 @@ export const executeUpdateAction = async (
 		lifecycleLogger,
 		isTTY,
 	);
-	const migrationResult = await runProjectMigrations(
-		process.cwd(),
-		{ dryRun: options.dryRun },
-		isTTY,
-	);
+	let migrationResult: PostUpdatePhaseResult;
+	if (pluginResult.success) {
+		migrationResult = await runProjectMigrations(
+			process.cwd(),
+			{ dryRun: options.dryRun },
+			isTTY,
+		);
+	} else {
+		console.log("");
+		console.log("Skipping project migrations because plugin refresh failed.");
+		migrationResult = {
+			success: false,
+			exitCode: pluginResult.exitCode,
+		};
+	}
 	const restartResult = options.dryRun
 		? { success: true, exitCode: 0 }
 		: await restartArcadeAfterUpdate(arcadeState, lifecycleLogger, isTTY);
@@ -715,12 +725,12 @@ export const executeUpdateAction = async (
 			? migrationResult.exitCode
 			: restartResult.exitCode;
 
-	if (!updateResult.success || updateResult.exitCode !== 0) {
-		process.exit(updateResult.exitCode);
-	}
-
 	if (postUpdateFailed) {
 		process.exit(postUpdateExitCode || 1);
+	}
+
+	if (!updateResult.success || updateResult.exitCode !== 0) {
+		process.exit(updateResult.exitCode);
 	}
 
 	console.log("");

--- a/cli/src/commands/update/plugins.ts
+++ b/cli/src/commands/update/plugins.ts
@@ -26,7 +26,7 @@ type ValidTool = (typeof VALID_TOOLS)[number];
 /**
  * Format output for plugin update result.
  */
-const formatPluginUpdateResult = (
+export const formatPluginUpdateResult = (
 	result: ToolInstallResult,
 	isTTY: boolean,
 ): void => {
@@ -54,7 +54,7 @@ const formatPluginUpdateResult = (
 /**
  * Format output for update all result.
  */
-const formatUpdateAllResult = (
+export const formatUpdateAllResult = (
 	result: InstallAllResult,
 	isTTY: boolean,
 ): void => {

--- a/cli/src/commands/update/post-self-update.ts
+++ b/cli/src/commands/update/post-self-update.ts
@@ -1,0 +1,103 @@
+import { spawnSync } from "node:child_process";
+
+export const POST_SELF_UPDATE_ENV = "RP1_POST_SELF_UPDATE";
+export const POST_SELF_UPDATE_DAEMON_WAS_RUNNING_ENV =
+	"RP1_POST_SELF_UPDATE_DAEMON_WAS_RUNNING";
+export const POST_SELF_UPDATE_DAEMON_PORT_ENV =
+	"RP1_POST_SELF_UPDATE_DAEMON_PORT";
+
+export interface PostSelfUpdateState {
+	readonly daemonWasRunning: boolean;
+	readonly daemonPort?: number;
+}
+
+export interface PostSelfUpdateRelaunchResult {
+	readonly success: boolean;
+	readonly exitCode: number;
+	readonly error?: string;
+}
+
+type SpawnResult = Pick<ReturnType<typeof spawnSync>, "status" | "error">;
+type RelaunchSpawnFn = (
+	command: string,
+	args: readonly string[],
+	options: {
+		readonly env: NodeJS.ProcessEnv;
+		readonly stdio: "inherit";
+	},
+) => SpawnResult;
+
+export const isPostSelfUpdateProcess = (
+	env: NodeJS.ProcessEnv = process.env,
+): boolean => env[POST_SELF_UPDATE_ENV] === "1";
+
+export const readPostSelfUpdateState = (
+	env: NodeJS.ProcessEnv = process.env,
+): PostSelfUpdateState => {
+	const daemonPortRaw = env[POST_SELF_UPDATE_DAEMON_PORT_ENV];
+	const parsedPort =
+		daemonPortRaw === undefined
+			? undefined
+			: Number.parseInt(daemonPortRaw, 10);
+
+	return {
+		daemonWasRunning: env[POST_SELF_UPDATE_DAEMON_WAS_RUNNING_ENV] === "1",
+		daemonPort:
+			parsedPort === undefined || Number.isNaN(parsedPort)
+				? undefined
+				: parsedPort,
+	};
+};
+
+/**
+ * Relaunch `rp1 update` from the freshly installed binary so post-update work
+ * runs with the new code instead of the process image that was already in
+ * memory before Homebrew/Scoop replaced the executable on disk.
+ */
+export const relaunchPostSelfUpdate = (options?: {
+	readonly yes?: boolean;
+	readonly execPath?: string;
+	readonly env?: NodeJS.ProcessEnv;
+	readonly state?: PostSelfUpdateState;
+	readonly spawnSyncImpl?: RelaunchSpawnFn;
+}): PostSelfUpdateRelaunchResult => {
+	const args = ["update"];
+	if (options?.yes) {
+		args.push("--yes");
+	}
+
+	const execPath = options?.execPath ?? process.execPath;
+	const env = {
+		...(options?.env ?? process.env),
+		[POST_SELF_UPDATE_ENV]: "1",
+		[POST_SELF_UPDATE_DAEMON_WAS_RUNNING_ENV]: options?.state?.daemonWasRunning
+			? "1"
+			: "0",
+		...(options?.state?.daemonPort === undefined
+			? {}
+			: {
+					[POST_SELF_UPDATE_DAEMON_PORT_ENV]: String(options.state.daemonPort),
+				}),
+	};
+	const spawnImpl: RelaunchSpawnFn =
+		options?.spawnSyncImpl ??
+		((command, commandArgs, spawnOptions) =>
+			spawnSync(command, [...commandArgs], spawnOptions));
+	const result = spawnImpl(execPath, args, {
+		env,
+		stdio: "inherit",
+	});
+
+	if (result.error) {
+		return {
+			success: false,
+			exitCode: 1,
+			error: result.error.message,
+		};
+	}
+
+	return {
+		success: result.status === 0,
+		exitCode: result.status ?? 1,
+	};
+};

--- a/cli/src/commands/update/post-self-update.ts
+++ b/cli/src/commands/update/post-self-update.ts
@@ -1,4 +1,5 @@
 import { spawnSync } from "node:child_process";
+import path from "node:path";
 
 export const POST_SELF_UPDATE_ENV = "RP1_POST_SELF_UPDATE";
 export const POST_SELF_UPDATE_DAEMON_WAS_RUNNING_ENV =
@@ -49,6 +50,21 @@ export const readPostSelfUpdateState = (
 	};
 };
 
+const isRp1ExecutablePath = (value: string): boolean => {
+	const executable = path.basename(value).toLowerCase();
+	return executable === "rp1" || executable === "rp1.exe";
+};
+
+export const resolvePostSelfUpdateCommand = (options?: {
+	readonly execPath?: string;
+}): string => {
+	if (options?.execPath) {
+		return options.execPath;
+	}
+
+	return isRp1ExecutablePath(process.execPath) ? process.execPath : "rp1";
+};
+
 /**
  * Relaunch `rp1 update` from the freshly installed binary so post-update work
  * runs with the new code instead of the process image that was already in
@@ -66,7 +82,7 @@ export const relaunchPostSelfUpdate = (options?: {
 		args.push("--yes");
 	}
 
-	const execPath = options?.execPath ?? process.execPath;
+	const execPath = resolvePostSelfUpdateCommand(options);
 	const env = {
 		...(options?.env ?? process.env),
 		[POST_SELF_UPDATE_ENV]: "1",

--- a/cli/src/lib/command-routing.ts
+++ b/cli/src/lib/command-routing.ts
@@ -1,0 +1,34 @@
+const ROOT_BOOLEAN_OPTIONS = new Set(["-v", "--verbose", "--trace"]);
+const ROOT_TERMINATING_OPTIONS = new Set(["-V", "--version", "-h", "--help"]);
+
+/**
+ * Return the first top-level command token after known root boolean flags.
+ * This keeps lazy command routing working when users place global flags before
+ * the command, such as `rp1 --trace agent-tools ...`.
+ */
+export const getTopLevelCommandToken = (
+	args: readonly string[],
+): string | undefined => {
+	for (const arg of args) {
+		if (ROOT_BOOLEAN_OPTIONS.has(arg)) {
+			continue;
+		}
+
+		if (ROOT_TERMINATING_OPTIONS.has(arg) || arg === "--") {
+			return undefined;
+		}
+
+		if (arg.startsWith("-")) {
+			return undefined;
+		}
+
+		return arg;
+	}
+
+	return undefined;
+};
+
+export const isTopLevelCommandInvocation = (
+	args: readonly string[],
+	commandName: string,
+): boolean => getTopLevelCommandToken(args) === commandName;

--- a/cli/src/main.ts
+++ b/cli/src/main.ts
@@ -24,14 +24,14 @@ import { settingsCommand } from "./commands/settings.js";
 import { uninstallCommand } from "./commands/uninstall.js";
 import { updateCommand } from "./commands/update/index.js";
 import { verifyCommand } from "./commands/verify/index.js";
+import { isTopLevelCommandInvocation } from "./lib/command-routing.js";
 
 /**
  * Check if agent-tools command is being invoked.
  * Used for lazy loading to avoid loading puppeteer at CLI startup.
  */
 const isAgentToolsCommand = (): boolean => {
-	const args = process.argv.slice(2);
-	return args.length > 0 && args[0] === "agent-tools";
+	return isTopLevelCommandInvocation(process.argv.slice(2), "agent-tools");
 };
 
 /**
@@ -39,8 +39,7 @@ const isAgentToolsCommand = (): boolean => {
  * Used for spawning the web UI daemon server.
  */
 const isDaemonServerCommand = (): boolean => {
-	const args = process.argv.slice(2);
-	return args.length > 0 && args[0] === "_daemon-server";
+	return isTopLevelCommandInvocation(process.argv.slice(2), "_daemon-server");
 };
 
 /**

--- a/cli/web-ui/src/__tests__/components/FileTree/FileTreeNode.test.ts
+++ b/cli/web-ui/src/__tests__/components/FileTree/FileTreeNode.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test";
+import { getCopyableFilePath } from "../../../components/FileTree/FileTreeNode";
+
+describe("getCopyableFilePath", () => {
+	test("joins project root with canonical rp1 file paths without duplicating .rp1", () => {
+		expect(
+			getCopyableFilePath(
+				"/Users/prem/Development/1up",
+				".rp1/work/research/2026-04-13-impact-horizon-for-1up.md",
+			),
+		).toBe(
+			"/Users/prem/Development/1up/.rp1/work/research/2026-04-13-impact-horizon-for-1up.md",
+		);
+	});
+
+	test("normalizes windows separators when copying file paths", () => {
+		expect(
+			getCopyableFilePath(
+				"C:\\Users\\prem\\Development\\1up",
+				".rp1/work/research/impact.md",
+			),
+		).toBe(
+			"C:\\Users\\prem\\Development\\1up\\.rp1\\work\\research\\impact.md",
+		);
+	});
+
+	test("returns the file path unchanged when project root is unavailable", () => {
+		expect(getCopyableFilePath(undefined, ".rp1/work/research/impact.md")).toBe(
+			".rp1/work/research/impact.md",
+		);
+	});
+});

--- a/cli/web-ui/src/components/FileTree/FileTreeNode.tsx
+++ b/cli/web-ui/src/components/FileTree/FileTreeNode.tsx
@@ -22,6 +22,23 @@ interface FileTreeNodeProps {
 	projectPath?: string | null;
 }
 
+export const getCopyableFilePath = (
+	projectPath: string | null | undefined,
+	filePath: string,
+): string => {
+	if (!projectPath) {
+		return filePath;
+	}
+
+	const separator = projectPath.includes("\\") ? "\\" : "/";
+	const normalizedProjectPath = projectPath.replace(/[\\/]+$/, "");
+	const normalizedFilePath = filePath
+		.replace(/^[\\/]+/, "")
+		.replace(/[\\/]/g, separator);
+
+	return `${normalizedProjectPath}${separator}${normalizedFilePath}`;
+};
+
 export function FileTreeNode({
 	node,
 	depth,
@@ -117,12 +134,10 @@ export function FileTreeNode({
 				{!isDirectory ? (
 					<button
 						type="button"
-						title={projectPath ? `${projectPath}/.rp1/${node.path}` : node.path}
+						title={getCopyableFilePath(projectPath, node.path)}
 						onClick={(e) => {
 							e.stopPropagation();
-							const fullPath = projectPath
-								? `${projectPath}/.rp1/${node.path}`
-								: node.path;
+							const fullPath = getCopyableFilePath(projectPath, node.path);
 							navigator.clipboard.writeText(fullPath).then(() => {
 								setCopied(true);
 								setTimeout(() => setCopied(false), 2000);

--- a/docs/reference/base/self-update.md
+++ b/docs/reference/base/self-update.md
@@ -25,8 +25,13 @@ The `self-update` command detects your rp1 installation method and runs the appr
 command. It supports automatic updates for Homebrew and Scoop installations, and provides manual
 instructions for other installation methods.
 
-After a successful CLI update, the command prompts you to update plugins for all detected agentic
-tools (Claude Code, OpenCode). You can also update plugins separately with `rp1 update plugins`.
+`rp1 update` now runs a coordinated lifecycle:
+- stop the Arcade daemon first when it is already running
+- update the rp1 binary
+- relaunch post-update work in the freshly installed binary
+- refresh plugins for all detected tools
+- run project migrations when the current directory is an rp1 project
+- restore the Arcade daemon after the update finishes
 
 ## Options
 
@@ -136,13 +141,8 @@ For manual installations or when automatic update fails, download the latest ver
 
 ## Plugin Updates
 
-After updating the CLI, the command prompts you to update plugins for all detected agentic tools:
-
-```
-Would you like to update rp1 plugins as well? (y/N)
-```
-
-If you confirm (or use `-y`), the command detects installed tools and updates their plugins:
+After the binary step, `rp1 update` automatically detects installed tools and refreshes their
+plugins:
 
 ```
 Updating plugins for all detected tools...
@@ -154,7 +154,7 @@ Claude Code: Plugins updated
 OpenCode: Plugins updated
 ```
 
-You can also update plugins independently:
+You can also refresh plugins independently:
 
 ```bash
 rp1 update plugins                  # Update all detected tools

--- a/plugins/base/skills/guide/CATALOG.md
+++ b/plugins/base/skills/guide/CATALOG.md
@@ -71,7 +71,7 @@
 | `/knowledge-base-templates` | base | Provides reusable templates for generating comprehensive codebase knowledge bases including architecture diagrams, concept maps, and module documentation. Supports both single-project and monorepo structures. Use when creating project documentation, knowledge bases, or when user mentions KB templates, codebase documentation, or project documentation structure. |  |  |  |  |
 | `/knowledge-build` | base | Orchestrates parallel KB generation using spatial analysis and a map-reduce architecture with incremental and feature-learning modes. | `FEATURE_ID` | Yes | fresh |  |
 | `/knowledge-load` | base | Ingests and prepares codebase documentation, builds internal knowledge graphs, and creates optimized context representations for downstream analysis tasks. | `LOAD_MODE` |  |  |  |
-| `/self-update` | base | Update rp1 CLI and all plugins to the latest version. |  |  |  |  |
+| `/self-update` | base | Update rp1 and run the full post-update lifecycle. |  |  |  |  |
 
 ## Strategy
 

--- a/plugins/base/skills/self-update/SKILL.md
+++ b/plugins/base/skills/self-update/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: self-update
-description: "Update rp1 CLI and all plugins to the latest version."
+description: "Update rp1 and run the full post-update lifecycle."
 metadata:
   category: knowledge
   is_workflow: false
@@ -16,18 +16,18 @@ metadata:
 
 # Self-Update Command
 
-Update rp1 CLI to the latest version and update all installed plugins.
+Update rp1 using the unified lifecycle command. `rp1 update` now coordinates:
+- CLI self-update
+- plugin refresh for all detected tools using the latest installer logic
+- project migrations when the current directory is an rp1 project
+- Arcade daemon stop/restart when Arcade was already running
 
 ## Execution
 
-Run the following commands sequentially via Bash:
+Run the following command via Bash:
 
 ```bash
-# 1. Update the CLI itself
 rp1 update
-
-# 2. Update all plugins
-rp1 update plugins all
 ```
 
 ## Interpreting Results
@@ -61,7 +61,7 @@ Please download the latest version from:
 https://github.com/rp1-run/rp1/releases/latest
 ```
 
-**Report to user**: Explain that they need to update the CLI manually and provide the GitHub releases link. Continue with plugin update.
+**Report to user**: Explain that they need to update the CLI manually and provide the GitHub releases link. `rp1 update` may still refresh plugins and run migrations with the currently installed binary, but the CLI binary itself still requires manual replacement.
 
 #### Error (Exit Code 1)
 
@@ -72,12 +72,13 @@ Error: brew upgrade failed: Permission denied
 
 **Report to user**: Show the error message and suggest checking permissions or trying manual update.
 
-### Plugin Update (`rp1 update plugins all`)
+### Unified Lifecycle (`rp1 update`)
 
-After CLI update, the plugin update command will:
+After the binary step, the same command continues by:
 
-1. Detect all installed agentic tools (Claude Code, OpenCode)
-2. Update plugins for each detected tool
+1. Refreshing plugins for all detected agentic tools
+2. Running project migrations when applicable
+3. Restoring the Arcade daemon if it was running before update
 
 Example output:
 ```
@@ -91,7 +92,7 @@ Updating plugins for OpenCode...
 Successfully updated plugins for OpenCode
 ```
 
-**Report to user**: Confirm which tools had their plugins updated.
+**Report to user**: Confirm which tools were refreshed and whether migrations ran.
 
 ## Restart Reminder
 
@@ -103,7 +104,6 @@ This is important because the updated CLI and plugins will not take effect until
 
 ## Notes
 
-- `rp1 update` handles CLI self-update using the appropriate package manager (Homebrew, Scoop, or manual)
-- `rp1 update plugins all` updates plugins for all detected agentic tools
-- The plugin command ensures both CLI and plugins are updated together
-- Both commands are safe to run even if already on the latest version
+- `rp1 update` handles the full lifecycle using the appropriate package manager (Homebrew, Scoop, or manual)
+- `rp1 update plugins` remains available for plugin-only repair or targeted tool refresh
+- The command is safe to run even if you are already on the latest version


### PR DESCRIPTION
## Summary
- stop the Arcade daemon before `rp1 update`, relaunch post-update work in the freshly installed binary, refresh all detected plugins, run migrations, and restore the daemon if it was previously running
- fix lazy top-level command routing so root flags like `--trace` still dispatch `agent-tools` and `_daemon-server` correctly
- return structured `agent-tools` command errors on stdout so shell wrappers can parse failure payloads reliably

## Testing
- `just check-cli`
- `bun test cli/src/commands/update/__tests__/post-self-update.test.ts cli/src/__tests__/lib/command-routing.test.ts cli/src/commands/update/__tests__/index.test.ts`
- `bun run cli/src/main.ts update --help`
- `bun run cli/src/main.ts --trace agent-tools workflow-bootstrap --help`

## Notes
- `bun run cli/src/main.ts update --dry-run -y` still reports the existing local OpenCode artifact issue in this dev checkout; that is unrelated to this PR