### PR TITLE
fix(registry): migrate project registry from file to DB-backed storage

### DIFF
--- a/cli/src/__tests__/agent-tools/emit/database.test.ts
+++ b/cli/src/__tests__/agent-tools/emit/database.test.ts
@@ -88,7 +88,7 @@ describe("emit database", () => {
 			expect(tableNames).toContain("schema_version");
 		});
 
-		test("schema_version is set to 11", async () => {
+		test("schema_version is set to 12", async () => {
 			const dbPath = join(tempDir, "version-test.db");
 			const db = await expectTaskRight(getEmitDatabase(dbPath));
 
@@ -96,7 +96,7 @@ describe("emit database", () => {
 				version: number;
 			};
 
-			expect(row.version).toBe(11);
+			expect(row.version).toBe(12);
 		});
 
 		test("artifacts table includes subflow column", async () => {
@@ -237,7 +237,7 @@ describe("emit database", () => {
 			const versionRow = db
 				.prepare("SELECT version FROM schema_version")
 				.get() as { version: number };
-			expect(versionRow.version).toBe(11);
+			expect(versionRow.version).toBe(12);
 		});
 
 		test("migrates v2 schema to add subflow column to artifacts", async () => {
@@ -328,7 +328,7 @@ describe("emit database", () => {
 			const versionRow = db
 				.prepare("SELECT version FROM schema_version")
 				.get() as { version: number };
-			expect(versionRow.version).toBe(11);
+			expect(versionRow.version).toBe(12);
 		});
 
 		test("v3 to v4 migration adds baseline column and cleans orphaned edit-diff annotations", async () => {
@@ -415,7 +415,7 @@ describe("emit database", () => {
 			const versionRow = db
 				.prepare("SELECT version FROM schema_version")
 				.get() as { version: number };
-			expect(versionRow.version).toBe(11);
+			expect(versionRow.version).toBe(12);
 
 			const annotations = db.prepare("SELECT * FROM annotations").all() as {
 				content: string;
@@ -571,7 +571,7 @@ describe("emit database", () => {
 			const versionRow = db
 				.prepare("SELECT version FROM schema_version")
 				.get() as { version: number };
-			expect(versionRow.version).toBe(11);
+			expect(versionRow.version).toBe(12);
 		});
 
 		test("foreign key constraints are enforced", async () => {

--- a/cli/src/__tests__/agent-tools/emit/database.test.ts
+++ b/cli/src/__tests__/agent-tools/emit/database.test.ts
@@ -1807,7 +1807,6 @@ describe("emit database", () => {
 			});
 			deriveRunStatus(db, "run-older");
 
-			// Small delay to ensure different created_at timestamps
 			await new Promise((resolve) => setTimeout(resolve, 10));
 
 			insertRun(db, {
@@ -3612,9 +3611,6 @@ describe("emit database", () => {
 				closeDatabase();
 				resetInstance();
 
-				// We need to re-import or use the default path behavior
-				// The DEFAULT_DB_PATH is set at module load time, so we test
-				// by passing the path directly
 				const db = await expectTaskRight(getEmitDatabase(customPath));
 				expect(db).toBeDefined();
 				expect(existsSync(customPath)).toBe(true);

--- a/cli/src/agent-tools/emit/database.ts
+++ b/cli/src/agent-tools/emit/database.ts
@@ -37,7 +37,7 @@ CREATE TABLE IF NOT EXISTS schema_version (
     version INTEGER NOT NULL
 );
 
-INSERT INTO schema_version (version) VALUES (11);
+INSERT INTO schema_version (version) VALUES (12);
 
 CREATE TABLE IF NOT EXISTS runs (
     id TEXT PRIMARY KEY NOT NULL,
@@ -161,6 +161,25 @@ CREATE INDEX IF NOT EXISTS idx_notifications_dismissed ON notifications(dismisse
 CREATE INDEX IF NOT EXISTS idx_notifications_project ON notifications(project_id);
 CREATE INDEX IF NOT EXISTS idx_notifications_created ON notifications(created_at);
 CREATE INDEX IF NOT EXISTS idx_notifications_project_dismissed ON notifications(project_id, dismissed, created_at);
+
+CREATE TABLE IF NOT EXISTS projects (
+    id TEXT NOT NULL,
+    project_id TEXT,
+    path TEXT NOT NULL,
+    name TEXT NOT NULL,
+    added_at TEXT NOT NULL,
+    last_accessed_at TEXT NOT NULL,
+    available INTEGER NOT NULL DEFAULT 1
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_projects_path ON projects(path);
+CREATE INDEX IF NOT EXISTS idx_projects_project_id ON projects(project_id);
+CREATE INDEX IF NOT EXISTS idx_projects_last_accessed ON projects(last_accessed_at);
+
+CREATE TABLE IF NOT EXISTS project_registry_meta (
+    key TEXT PRIMARY KEY NOT NULL,
+    value TEXT
+);
 `;
 
 /** Terminal statuses that indicate a run is no longer active */
@@ -828,6 +847,35 @@ const applyMigrations = (db: Database): void => {
 		);
 
 		db.prepare("UPDATE schema_version SET version = 11").run();
+	}
+
+	const postV11Version = db
+		.prepare("SELECT version FROM schema_version LIMIT 1")
+		.get() as { version: number } | null;
+
+	if ((postV11Version?.version ?? 11) < 12) {
+		db.exec(`
+			CREATE TABLE IF NOT EXISTS projects (
+				id TEXT NOT NULL,
+				project_id TEXT,
+				path TEXT NOT NULL,
+				name TEXT NOT NULL,
+				added_at TEXT NOT NULL,
+				last_accessed_at TEXT NOT NULL,
+				available INTEGER NOT NULL DEFAULT 1
+			);
+
+			CREATE UNIQUE INDEX IF NOT EXISTS idx_projects_path ON projects(path);
+			CREATE INDEX IF NOT EXISTS idx_projects_project_id ON projects(project_id);
+			CREATE INDEX IF NOT EXISTS idx_projects_last_accessed ON projects(last_accessed_at);
+
+			CREATE TABLE IF NOT EXISTS project_registry_meta (
+				key TEXT PRIMARY KEY NOT NULL,
+				value TEXT
+			);
+		`);
+
+		db.prepare("UPDATE schema_version SET version = 12").run();
 	}
 };
 

--- a/cli/src/agent-tools/emit/database.ts
+++ b/cli/src/agent-tools/emit/database.ts
@@ -163,7 +163,7 @@ CREATE INDEX IF NOT EXISTS idx_notifications_created ON notifications(created_at
 CREATE INDEX IF NOT EXISTS idx_notifications_project_dismissed ON notifications(project_id, dismissed, created_at);
 
 CREATE TABLE IF NOT EXISTS projects (
-    id TEXT NOT NULL,
+    id TEXT NOT NULL UNIQUE,
     project_id TEXT,
     path TEXT NOT NULL,
     name TEXT NOT NULL,
@@ -856,7 +856,7 @@ const applyMigrations = (db: Database): void => {
 	if ((postV11Version?.version ?? 11) < 12) {
 		db.exec(`
 			CREATE TABLE IF NOT EXISTS projects (
-				id TEXT NOT NULL,
+				id TEXT NOT NULL UNIQUE,
 				project_id TEXT,
 				path TEXT NOT NULL,
 				name TEXT NOT NULL,

--- a/cli/web-ui/src/__tests__/server/project-lookup.test.ts
+++ b/cli/web-ui/src/__tests__/server/project-lookup.test.ts
@@ -58,4 +58,46 @@ describe("project-lookup", () => {
 
 		expect(project?.id).toBe("legacy-project");
 	});
+
+	test("clones sharing projectId resolve independently by path", () => {
+		const clones: readonly ProjectEntry[] = [
+			{
+				id: "shared-uuid",
+				projectId: "shared-uuid",
+				path: "/repo/clone-a",
+				name: "clone-a",
+				addedAt: "2026-04-01T00:00:00.000Z",
+				lastAccessedAt: "2026-04-01T00:00:00.000Z",
+				available: true,
+			},
+			{
+				id: "clone-b-slug",
+				projectId: "shared-uuid",
+				path: "/repo/clone-b",
+				name: "clone-b",
+				addedAt: "2026-04-01T00:00:00.000Z",
+				lastAccessedAt: "2026-04-01T00:00:00.000Z",
+				available: true,
+			},
+		];
+
+		const lookup = buildProjectLookup(clones);
+
+		const a = findProjectByIdentity(lookup, {
+			projectId: "shared-uuid",
+			rp1ProjectRoot: "/repo/clone-a",
+		});
+		expect(a?.id).toBe("shared-uuid");
+
+		const b = findProjectByIdentity(lookup, {
+			projectId: "shared-uuid",
+			rp1ProjectRoot: "/repo/clone-b",
+		});
+		expect(b?.id).toBe("clone-b-slug");
+
+		const byProjectIdOnly = findProjectByIdentity(lookup, {
+			projectId: "shared-uuid",
+		});
+		expect(byProjectIdOnly).toBeUndefined();
+	});
 });

--- a/cli/web-ui/src/__tests__/server/registry.test.ts
+++ b/cli/web-ui/src/__tests__/server/registry.test.ts
@@ -70,7 +70,7 @@ import {
 
 const REGISTRY_SCHEMA_SQL = `
 CREATE TABLE IF NOT EXISTS projects (
-    id TEXT NOT NULL,
+    id TEXT NOT NULL UNIQUE,
     project_id TEXT,
     path TEXT NOT NULL,
     name TEXT NOT NULL,
@@ -252,6 +252,28 @@ describe("registry (DB-backed)", () => {
 
 			const entry = await registerProject(db, projDir);
 			expect(entry.available).toBe(false);
+		});
+
+		test("assigns unique ids when two paths share the same project_id", async () => {
+			const uuid = "shared-uuid-1234-5678-abcd-ef1234567890";
+
+			const projA = join(tempRoot, "dup-id-a");
+			mkdirSync(join(projA, ".rp1"), { recursive: true });
+			writeFileSync(join(projA, ".rp1", "project_id"), uuid);
+
+			const projB = join(tempRoot, "dup-id-b");
+			mkdirSync(join(projB, ".rp1"), { recursive: true });
+			writeFileSync(join(projB, ".rp1", "project_id"), uuid);
+
+			const entryA = await registerProject(db, projA);
+			const entryB = await registerProject(db, projB);
+
+			expect(entryA.id).not.toBe(entryB.id);
+			expect(entryA.path).toBe(projA);
+			expect(entryB.path).toBe(projB);
+
+			const allProjects = await getAllProjects(db);
+			expect(allProjects).toHaveLength(2);
 		});
 	});
 
@@ -439,15 +461,15 @@ describe("registry (DB-backed)", () => {
 	});
 
 	describe("getProjectCount", () => {
-		test("returns 0 for empty table", () => {
-			expect(getProjectCount(db)).toBe(0);
+		test("returns 0 for empty table", async () => {
+			expect(await getProjectCount(db)).toBe(0);
 		});
 
-		test("returns correct count", () => {
+		test("returns correct count", async () => {
 			insertProject(db, { id: "p1", path: "/a", name: "a" });
 			insertProject(db, { id: "p2", path: "/b", name: "b" });
 
-			expect(getProjectCount(db)).toBe(2);
+			expect(await getProjectCount(db)).toBe(2);
 		});
 	});
 
@@ -684,6 +706,36 @@ describe("registry (DB-backed)", () => {
 
 			expect(existsSync(jsonPath)).toBe(false);
 		});
+
+		test("concurrent callers await the same hydration run", async () => {
+			const jsonPath = join(mockConfigDir, "projects.json");
+			await writeFile(
+				jsonPath,
+				JSON.stringify({
+					projects: {
+						"concurrent-proj": {
+							id: "concurrent-proj",
+							path: "/test/concurrent",
+							name: "concurrent",
+							addedAt: "2026-01-01T00:00:00.000Z",
+							lastAccessedAt: "2026-01-01T00:00:00.000Z",
+						},
+					},
+				}),
+			);
+
+			await Promise.all([
+				ensureHydrated(db),
+				ensureHydrated(db),
+				ensureHydrated(db),
+			]);
+
+			const projects = db.prepare("SELECT * FROM projects").all() as {
+				id: string;
+			}[];
+			expect(projects).toHaveLength(1);
+			expect(projects[0].id).toBe("concurrent-proj");
+		});
 	});
 
 	describe("worktree path resolution", () => {
@@ -824,7 +876,7 @@ describe("registry (DB-backed)", () => {
 			const lastInvoked = await getLastInvokedProjectId(db);
 			expect(lastInvoked).toBeNull();
 
-			expect(getProjectCount(db)).toBe(0);
+			expect(await getProjectCount(db)).toBe(0);
 
 			const removed = await removeProject(db, "nonexistent");
 			expect(removed).toBe(false);

--- a/cli/web-ui/src/__tests__/server/registry.test.ts
+++ b/cli/web-ui/src/__tests__/server/registry.test.ts
@@ -1,0 +1,683 @@
+/**
+ * Unit tests for the DB-backed project registry.
+ * Tests CRUD operations, hydration from projects.json, re-keying,
+ * availability refresh, stale project pruning, and lastInvoked round-trips.
+ */
+
+import { Database } from "bun:sqlite";
+import {
+	afterAll,
+	afterEach,
+	beforeAll,
+	beforeEach,
+	describe,
+	expect,
+	mock,
+	test,
+} from "bun:test";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+let mockConfigDir: string;
+
+mock.module("../../daemon/config-dir", () => ({
+	getConfigDir: () => mockConfigDir,
+	ensureConfigDir: async () => {
+		await mkdir(mockConfigDir, { recursive: true });
+		return mockConfigDir;
+	},
+}));
+
+import {
+	_resetHydrated,
+	ensureHydrated,
+	getAllProjects,
+	getLastInvokedProjectId,
+	getProject,
+	getProjectCount,
+	pruneStaleProjects,
+	refreshProjectAvailability,
+	registerProject,
+	removeProject,
+	setLastInvoked,
+} from "../../server/registry.js";
+
+const REGISTRY_SCHEMA_SQL = `
+CREATE TABLE IF NOT EXISTS projects (
+    id TEXT NOT NULL,
+    project_id TEXT,
+    path TEXT NOT NULL,
+    name TEXT NOT NULL,
+    added_at TEXT NOT NULL,
+    last_accessed_at TEXT NOT NULL,
+    available INTEGER NOT NULL DEFAULT 1
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_projects_path ON projects(path);
+CREATE INDEX IF NOT EXISTS idx_projects_project_id ON projects(project_id);
+CREATE INDEX IF NOT EXISTS idx_projects_last_accessed ON projects(last_accessed_at);
+
+CREATE TABLE IF NOT EXISTS project_registry_meta (
+    key TEXT PRIMARY KEY NOT NULL,
+    value TEXT
+);
+`;
+
+function createDb(): Database {
+	const db = new Database(":memory:");
+	db.exec(REGISTRY_SCHEMA_SQL);
+	return db;
+}
+
+function insertProject(
+	db: Database,
+	fields: {
+		id: string;
+		projectId?: string;
+		path: string;
+		name: string;
+		addedAt?: string;
+		lastAccessedAt?: string;
+		available?: number;
+	},
+): void {
+	db.prepare(
+		"INSERT INTO projects (id, project_id, path, name, added_at, last_accessed_at, available) VALUES (?, ?, ?, ?, ?, ?, ?)",
+	).run(
+		fields.id,
+		fields.projectId ?? null,
+		fields.path,
+		fields.name,
+		fields.addedAt ?? "2026-01-01T00:00:00.000Z",
+		fields.lastAccessedAt ?? "2026-01-01T00:00:00.000Z",
+		fields.available ?? 1,
+	);
+}
+
+describe("registry (DB-backed)", () => {
+	let tempRoot: string;
+	let db: Database;
+
+	beforeAll(async () => {
+		tempRoot = join(tmpdir(), `registry-test-${Date.now()}`);
+		await mkdir(tempRoot, { recursive: true });
+		mockConfigDir = join(tempRoot, "config");
+		await mkdir(mockConfigDir, { recursive: true });
+	});
+
+	beforeEach(() => {
+		db = createDb();
+		_resetHydrated();
+	});
+
+	afterEach(() => {
+		db.close();
+	});
+
+	afterAll(async () => {
+		await rm(tempRoot, { recursive: true, force: true });
+	});
+
+	describe("schema", () => {
+		test("projects table has correct columns", () => {
+			const columns = db.prepare("PRAGMA table_info(projects)").all() as {
+				name: string;
+				type: string;
+			}[];
+
+			const colNames = columns.map((c) => c.name);
+			expect(colNames).toContain("id");
+			expect(colNames).toContain("project_id");
+			expect(colNames).toContain("path");
+			expect(colNames).toContain("name");
+			expect(colNames).toContain("added_at");
+			expect(colNames).toContain("last_accessed_at");
+			expect(colNames).toContain("available");
+			expect(columns).toHaveLength(7);
+		});
+
+		test("projects table has unique index on path", () => {
+			const indexes = db
+				.prepare(
+					"SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='projects'",
+				)
+				.all() as { name: string }[];
+
+			const indexNames = indexes.map((i) => i.name);
+			expect(indexNames).toContain("idx_projects_path");
+			expect(indexNames).toContain("idx_projects_project_id");
+			expect(indexNames).toContain("idx_projects_last_accessed");
+		});
+
+		test("project_registry_meta table has correct columns", () => {
+			const columns = db
+				.prepare("PRAGMA table_info(project_registry_meta)")
+				.all() as { name: string; type: string }[];
+
+			const colNames = columns.map((c) => c.name);
+			expect(colNames).toContain("key");
+			expect(colNames).toContain("value");
+			expect(columns).toHaveLength(2);
+		});
+	});
+
+	describe("registerProject", () => {
+		test("inserts new entry with correct fields and sets lastInvoked", async () => {
+			const projDir = join(tempRoot, "register-new");
+			mkdirSync(join(projDir, ".rp1"), { recursive: true });
+
+			const entry = await registerProject(db, projDir);
+
+			expect(entry.path).toBe(projDir);
+			expect(entry.name).toBe("register-new");
+			expect(entry.available).toBe(true);
+			expect(entry.addedAt).toBeTruthy();
+			expect(entry.lastAccessedAt).toBeTruthy();
+			expect(entry.id).toBeTruthy();
+
+			const lastInvoked = await getLastInvokedProjectId(db);
+			expect(lastInvoked).toBe(entry.id);
+		});
+
+		test("updates existing entry preserving addedAt", async () => {
+			const projDir = join(tempRoot, "register-update");
+			mkdirSync(join(projDir, ".rp1"), { recursive: true });
+
+			const first = await registerProject(db, projDir);
+			const firstAddedAt = first.addedAt;
+
+			// Small delay to ensure different timestamp
+			await new Promise((resolve) => setTimeout(resolve, 10));
+
+			const second = await registerProject(db, projDir);
+
+			expect(second.addedAt).toBe(firstAddedAt);
+			expect(second.path).toBe(first.path);
+			expect(second.id).toBe(first.id);
+		});
+
+		test("re-keys id when project acquires UUID", async () => {
+			const projDir = join(tempRoot, "register-rekey");
+			mkdirSync(join(projDir, ".rp1"), { recursive: true });
+
+			const first = await registerProject(db, projDir);
+			const slugId = first.id;
+			expect(slugId).not.toMatch(
+				/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+			);
+
+			const uuid = "a1b2c3d4-e5f6-7890-abcd-ef1234567890";
+			writeFileSync(join(projDir, ".rp1", "project_id"), uuid);
+
+			const second = await registerProject(db, projDir);
+			expect(second.id).toBe(uuid);
+			expect(second.projectId).toBe(uuid);
+
+			const lastInvoked = await getLastInvokedProjectId(db);
+			expect(lastInvoked).toBe(uuid);
+
+			const allProjects = await getAllProjects(db);
+			expect(allProjects).toHaveLength(1);
+		});
+
+		test("marks project unavailable when .rp1/ is missing", async () => {
+			const projDir = join(tempRoot, "register-unavailable");
+			mkdirSync(projDir, { recursive: true });
+
+			const entry = await registerProject(db, projDir);
+			expect(entry.available).toBe(false);
+		});
+	});
+
+	describe("removeProject", () => {
+		test("deletes project row from DB", async () => {
+			insertProject(db, {
+				id: "proj-remove",
+				path: "/test/remove",
+				name: "remove",
+			});
+
+			const removed = await removeProject(db, "proj-remove");
+			expect(removed).toBe(true);
+
+			const entry = await getProject(db, "proj-remove");
+			expect(entry).toBeNull();
+		});
+
+		test("returns false for non-existent project", async () => {
+			const removed = await removeProject(db, "non-existent");
+			expect(removed).toBe(false);
+		});
+
+		test("clears lastInvoked when removed project was last invoked", async () => {
+			insertProject(db, {
+				id: "proj-last",
+				path: "/test/last",
+				name: "last",
+			});
+			db.prepare(
+				"INSERT OR REPLACE INTO project_registry_meta (key, value) VALUES ('last_invoked_project_id', 'proj-last')",
+			).run();
+
+			await removeProject(db, "proj-last");
+
+			const lastInvoked = await getLastInvokedProjectId(db);
+			expect(lastInvoked).toBeNull();
+		});
+
+		test("preserves lastInvoked when removed project was not last invoked", async () => {
+			insertProject(db, {
+				id: "proj-a",
+				path: "/test/a",
+				name: "a",
+			});
+			insertProject(db, {
+				id: "proj-b",
+				path: "/test/b",
+				name: "b",
+			});
+			db.prepare(
+				"INSERT OR REPLACE INTO project_registry_meta (key, value) VALUES ('last_invoked_project_id', 'proj-a')",
+			).run();
+
+			await removeProject(db, "proj-b");
+
+			const lastInvoked = await getLastInvokedProjectId(db);
+			expect(lastInvoked).toBe("proj-a");
+		});
+	});
+
+	describe("getProject", () => {
+		test("returns correct entry for existing project", async () => {
+			insertProject(db, {
+				id: "proj-get",
+				projectId: "uuid-get",
+				path: "/test/get",
+				name: "get-project",
+				addedAt: "2026-03-01T00:00:00.000Z",
+				lastAccessedAt: "2026-03-15T00:00:00.000Z",
+				available: 1,
+			});
+
+			const entry = await getProject(db, "proj-get");
+
+			expect(entry).not.toBeNull();
+			expect(entry!.id).toBe("proj-get");
+			expect(entry!.projectId).toBe("uuid-get");
+			expect(entry!.path).toBe("/test/get");
+			expect(entry!.name).toBe("get-project");
+			expect(entry!.addedAt).toBe("2026-03-01T00:00:00.000Z");
+			expect(entry!.lastAccessedAt).toBe("2026-03-15T00:00:00.000Z");
+			expect(entry!.available).toBe(true);
+		});
+
+		test("returns null for non-existent id", async () => {
+			const entry = await getProject(db, "does-not-exist");
+			expect(entry).toBeNull();
+		});
+
+		test("maps available=0 to false", async () => {
+			insertProject(db, {
+				id: "proj-unavail",
+				path: "/test/unavail",
+				name: "unavail",
+				available: 0,
+			});
+
+			const entry = await getProject(db, "proj-unavail");
+			expect(entry!.available).toBe(false);
+		});
+
+		test("maps null project_id to undefined", async () => {
+			insertProject(db, {
+				id: "proj-no-uuid",
+				path: "/test/no-uuid",
+				name: "no-uuid",
+			});
+
+			const entry = await getProject(db, "proj-no-uuid");
+			expect(entry!.projectId).toBeUndefined();
+		});
+	});
+
+	describe("getAllProjects", () => {
+		test("returns empty array when no projects exist", async () => {
+			const projects = await getAllProjects(db);
+			expect(projects).toEqual([]);
+		});
+
+		test("returns all rows as ProjectEntry array", async () => {
+			insertProject(db, {
+				id: "proj-1",
+				path: "/test/one",
+				name: "one",
+			});
+			insertProject(db, {
+				id: "proj-2",
+				path: "/test/two",
+				name: "two",
+			});
+			insertProject(db, {
+				id: "proj-3",
+				path: "/test/three",
+				name: "three",
+			});
+
+			const projects = await getAllProjects(db);
+			expect(projects).toHaveLength(3);
+
+			const ids = projects.map((p) => p.id).sort();
+			expect(ids).toEqual(["proj-1", "proj-2", "proj-3"]);
+		});
+	});
+
+	describe("setLastInvoked + getLastInvokedProjectId", () => {
+		test("round-trips correctly", async () => {
+			insertProject(db, {
+				id: "proj-invoke",
+				path: "/test/invoke",
+				name: "invoke",
+			});
+
+			await setLastInvoked(db, "proj-invoke");
+			const lastInvoked = await getLastInvokedProjectId(db);
+
+			expect(lastInvoked).toBe("proj-invoke");
+		});
+
+		test("returns null when no lastInvoked set", async () => {
+			const lastInvoked = await getLastInvokedProjectId(db);
+			expect(lastInvoked).toBeNull();
+		});
+
+		test("setLastInvoked updates last_accessed_at on the project row", async () => {
+			const oldTimestamp = "2020-01-01T00:00:00.000Z";
+			insertProject(db, {
+				id: "proj-ts",
+				path: "/test/ts",
+				name: "ts",
+				lastAccessedAt: oldTimestamp,
+			});
+
+			await setLastInvoked(db, "proj-ts");
+
+			const entry = await getProject(db, "proj-ts");
+			expect(entry!.lastAccessedAt).not.toBe(oldTimestamp);
+		});
+
+		test("setLastInvoked throws for non-existent project", async () => {
+			expect(setLastInvoked(db, "non-existent")).rejects.toThrow(
+				"Project non-existent not found in registry",
+			);
+		});
+	});
+
+	describe("getProjectCount", () => {
+		test("returns 0 for empty table", () => {
+			expect(getProjectCount(db)).toBe(0);
+		});
+
+		test("returns correct count", () => {
+			insertProject(db, { id: "p1", path: "/a", name: "a" });
+			insertProject(db, { id: "p2", path: "/b", name: "b" });
+
+			expect(getProjectCount(db)).toBe(2);
+		});
+	});
+
+	describe("refreshProjectAvailability", () => {
+		test("updates available flag for changed projects", async () => {
+			const validDir = join(tempRoot, "refresh-valid");
+			const invalidDir = join(tempRoot, "refresh-invalid");
+			mkdirSync(join(validDir, ".rp1"), { recursive: true });
+			mkdirSync(invalidDir, { recursive: true });
+
+			insertProject(db, {
+				id: "valid-proj",
+				path: validDir,
+				name: "valid",
+				available: 0,
+			});
+			insertProject(db, {
+				id: "invalid-proj",
+				path: invalidDir,
+				name: "invalid",
+				available: 1,
+			});
+
+			await refreshProjectAvailability(db);
+
+			const valid = await getProject(db, "valid-proj");
+			const invalid = await getProject(db, "invalid-proj");
+
+			expect(valid!.available).toBe(true);
+			expect(invalid!.available).toBe(false);
+		});
+	});
+
+	describe("pruneStaleProjects", () => {
+		test("removes projects with invalid paths", async () => {
+			const validDir = join(tempRoot, "prune-valid");
+			mkdirSync(join(validDir, ".rp1"), { recursive: true });
+
+			insertProject(db, {
+				id: "keep-proj",
+				path: validDir,
+				name: "keep",
+			});
+			insertProject(db, {
+				id: "stale-proj",
+				path: "/nonexistent/path/does/not/exist",
+				name: "stale",
+			});
+
+			const pruned = await pruneStaleProjects(db);
+
+			expect(pruned).toBe(1);
+
+			const remaining = await getAllProjects(db);
+			expect(remaining).toHaveLength(1);
+			expect(remaining[0].id).toBe("keep-proj");
+		});
+
+		test("clears lastInvoked when pruned project was last invoked", async () => {
+			const validDir = join(tempRoot, "prune-lastinvoked");
+			mkdirSync(join(validDir, ".rp1"), { recursive: true });
+
+			insertProject(db, {
+				id: "valid-proj-2",
+				path: validDir,
+				name: "valid",
+			});
+			insertProject(db, {
+				id: "stale-proj-2",
+				path: "/nonexistent/stale/project",
+				name: "stale",
+			});
+			db.prepare(
+				"INSERT OR REPLACE INTO project_registry_meta (key, value) VALUES ('last_invoked_project_id', 'stale-proj-2')",
+			).run();
+
+			await pruneStaleProjects(db);
+
+			const lastInvoked = await getLastInvokedProjectId(db);
+			expect(lastInvoked).toBeNull();
+		});
+
+		test("returns 0 when no projects are stale", async () => {
+			const validDir = join(tempRoot, "prune-none-stale");
+			mkdirSync(join(validDir, ".rp1"), { recursive: true });
+
+			insertProject(db, {
+				id: "all-good",
+				path: validDir,
+				name: "good",
+			});
+
+			const pruned = await pruneStaleProjects(db);
+			expect(pruned).toBe(0);
+		});
+	});
+
+	describe("ensureHydrated", () => {
+		test("reads and inserts from valid projects.json", async () => {
+			const registryData = {
+				version: 1,
+				lastInvoked: "hydrated-proj",
+				projects: {
+					"hydrated-proj": {
+						id: "hydrated-proj",
+						projectId: "uuid-hydrated",
+						path: "/test/hydrated",
+						name: "hydrated",
+						addedAt: "2026-02-01T00:00:00.000Z",
+						lastAccessedAt: "2026-02-15T00:00:00.000Z",
+						available: true,
+					},
+					"hydrated-proj-2": {
+						id: "hydrated-proj-2",
+						path: "/test/hydrated-2",
+						name: "hydrated-2",
+						addedAt: "2026-02-01T00:00:00.000Z",
+						lastAccessedAt: "2026-02-10T00:00:00.000Z",
+						available: false,
+					},
+				},
+			};
+
+			const jsonPath = join(mockConfigDir, "projects.json");
+			await writeFile(jsonPath, JSON.stringify(registryData));
+
+			await ensureHydrated(db);
+
+			const projects = db.prepare("SELECT * FROM projects").all() as {
+				id: string;
+				path: string;
+				available: number;
+			}[];
+			expect(projects).toHaveLength(2);
+
+			const proj1 = projects.find((p) => p.id === "hydrated-proj");
+			expect(proj1).toBeTruthy();
+			expect(proj1!.path).toBe("/test/hydrated");
+
+			const proj2 = projects.find((p) => p.id === "hydrated-proj-2");
+			expect(proj2).toBeTruthy();
+			expect(proj2!.available).toBe(0);
+
+			const meta = db
+				.prepare(
+					"SELECT value FROM project_registry_meta WHERE key = 'last_invoked_project_id'",
+				)
+				.get() as { value: string } | null;
+			expect(meta?.value).toBe("hydrated-proj");
+		});
+
+		test("skips hydration when table already has rows", async () => {
+			insertProject(db, {
+				id: "existing",
+				path: "/test/existing",
+				name: "existing",
+			});
+
+			const jsonPath = join(mockConfigDir, "projects.json");
+			await writeFile(
+				jsonPath,
+				JSON.stringify({
+					projects: {
+						"should-not-appear": {
+							id: "should-not-appear",
+							path: "/test/ghost",
+							name: "ghost",
+							addedAt: "2026-01-01T00:00:00.000Z",
+							lastAccessedAt: "2026-01-01T00:00:00.000Z",
+						},
+					},
+				}),
+			);
+
+			await ensureHydrated(db);
+
+			const projects = db.prepare("SELECT * FROM projects").all() as {
+				id: string;
+			}[];
+			expect(projects).toHaveLength(1);
+			expect(projects[0].id).toBe("existing");
+
+			// Clean up
+			try {
+				const { unlink } = await import("node:fs/promises");
+				await unlink(jsonPath);
+			} catch {}
+		});
+
+		test("handles missing projects.json gracefully", async () => {
+			const jsonPath = join(mockConfigDir, "projects.json");
+			if (existsSync(jsonPath)) {
+				const { unlink } = await import("node:fs/promises");
+				await unlink(jsonPath);
+			}
+
+			await ensureHydrated(db);
+
+			const projects = db.prepare("SELECT * FROM projects").all() as {
+				id: string;
+			}[];
+			expect(projects).toHaveLength(0);
+		});
+
+		test("handles corrupt projects.json gracefully", async () => {
+			const jsonPath = join(mockConfigDir, "projects.json");
+			await writeFile(jsonPath, "not valid json {{{");
+
+			await ensureHydrated(db);
+
+			const projects = db.prepare("SELECT * FROM projects").all() as {
+				id: string;
+			}[];
+			expect(projects).toHaveLength(0);
+		});
+
+		test("deletes projects.json after successful insertion", async () => {
+			const jsonPath = join(mockConfigDir, "projects.json");
+			await writeFile(
+				jsonPath,
+				JSON.stringify({
+					projects: {
+						"del-proj": {
+							id: "del-proj",
+							path: "/test/delete-after",
+							name: "delete-after",
+							addedAt: "2026-01-01T00:00:00.000Z",
+							lastAccessedAt: "2026-01-01T00:00:00.000Z",
+						},
+					},
+				}),
+			);
+
+			await ensureHydrated(db);
+
+			expect(existsSync(jsonPath)).toBe(false);
+		});
+	});
+
+	describe("fresh startup with empty state", () => {
+		test("all operations work with empty registry", async () => {
+			const projects = await getAllProjects(db);
+			expect(projects).toEqual([]);
+
+			const lastInvoked = await getLastInvokedProjectId(db);
+			expect(lastInvoked).toBeNull();
+
+			expect(getProjectCount(db)).toBe(0);
+
+			const removed = await removeProject(db, "nonexistent");
+			expect(removed).toBe(false);
+
+			const found = await getProject(db, "nonexistent");
+			expect(found).toBeNull();
+		});
+	});
+});

--- a/cli/web-ui/src/__tests__/server/registry.test.ts
+++ b/cli/web-ui/src/__tests__/server/registry.test.ts
@@ -30,6 +30,30 @@ mock.module("../../daemon/config-dir", () => ({
 	},
 }));
 
+let resolveOverride:
+	| ((startPath: string) => { _tag: string; right?: unknown; left?: unknown })
+	| null = null;
+
+mock.module("../../../../shared/directory-resolution.js", () => ({
+	resolveDirectorySet: (
+		startPath: string = process.cwd(),
+		_options?: unknown,
+	) => {
+		if (resolveOverride) return resolveOverride(startPath);
+		return {
+			_tag: "Right",
+			right: {
+				projectRoot: startPath,
+				projectId: undefined,
+				kbRoot: `${startPath}/.rp1/context`,
+				workRoot: `${startPath}/.rp1/work`,
+				isWorktree: false,
+			},
+		};
+	},
+	normalizeProjectKey: (key: string) => key,
+}));
+
 import {
 	_resetHydrated,
 	ensureHydrated,
@@ -113,6 +137,7 @@ describe("registry (DB-backed)", () => {
 	});
 
 	afterEach(() => {
+		resolveOverride = null;
 		db.close();
 	});
 
@@ -660,6 +685,136 @@ describe("registry (DB-backed)", () => {
 			await ensureHydrated(db);
 
 			expect(existsSync(jsonPath)).toBe(false);
+		});
+	});
+
+	describe("worktree path resolution", () => {
+		test("stores main work tree root when called with linked worktree path", async () => {
+			const mainRepoDir = join(tempRoot, "wt-main-1");
+			const worktreeDir = join(tempRoot, "wt-linked-1");
+			mkdirSync(join(mainRepoDir, ".rp1"), { recursive: true });
+			mkdirSync(worktreeDir, { recursive: true });
+
+			resolveOverride = (startPath: string) => {
+				if (startPath === worktreeDir) {
+					return {
+						_tag: "Right",
+						right: {
+							projectRoot: mainRepoDir,
+							projectId: undefined,
+							kbRoot: `${mainRepoDir}/.rp1/context`,
+							workRoot: `${mainRepoDir}/.rp1/work`,
+							isWorktree: true,
+							worktreeName: "feature-branch",
+						},
+					};
+				}
+				return {
+					_tag: "Right",
+					right: {
+						projectRoot: startPath,
+						projectId: undefined,
+						kbRoot: `${startPath}/.rp1/context`,
+						workRoot: `${startPath}/.rp1/work`,
+						isWorktree: false,
+					},
+				};
+			};
+
+			const entry = await registerProject(db, worktreeDir);
+
+			expect(entry.path).toBe(mainRepoDir);
+			expect(entry.name).toBe("wt-main-1");
+
+			const row = db
+				.prepare("SELECT path FROM projects WHERE id = ?")
+				.get(entry.id) as { path: string };
+			expect(row.path).toBe(mainRepoDir);
+		});
+
+		test("resolves subdirectory within worktree to main work tree root", async () => {
+			const mainRepoDir = join(tempRoot, "wt-main-2");
+			const subDir = join(tempRoot, "wt-linked-2", "src", "components");
+			mkdirSync(join(mainRepoDir, ".rp1"), { recursive: true });
+			mkdirSync(subDir, { recursive: true });
+
+			resolveOverride = (startPath: string) => {
+				if (startPath === subDir) {
+					return {
+						_tag: "Right",
+						right: {
+							projectRoot: mainRepoDir,
+							projectId: undefined,
+							kbRoot: `${mainRepoDir}/.rp1/context`,
+							workRoot: `${mainRepoDir}/.rp1/work`,
+							isWorktree: true,
+							worktreeName: "feature-branch",
+						},
+					};
+				}
+				return {
+					_tag: "Right",
+					right: {
+						projectRoot: startPath,
+						projectId: undefined,
+						kbRoot: `${startPath}/.rp1/context`,
+						workRoot: `${startPath}/.rp1/work`,
+						isWorktree: false,
+					},
+				};
+			};
+
+			const entry = await registerProject(db, subDir);
+
+			expect(entry.path).toBe(mainRepoDir);
+			expect(entry.name).toBe("wt-main-2");
+
+			const allProjects = await getAllProjects(db);
+			expect(allProjects).toHaveLength(1);
+			expect(allProjects[0].path).toBe(mainRepoDir);
+		});
+
+		test("deduplicates registration from worktree and main repo", async () => {
+			const mainRepoDir = join(tempRoot, "wt-main-3");
+			const worktreeDir = join(tempRoot, "wt-linked-3");
+			mkdirSync(join(mainRepoDir, ".rp1"), { recursive: true });
+			mkdirSync(worktreeDir, { recursive: true });
+
+			resolveOverride = (startPath: string) => {
+				if (startPath === worktreeDir) {
+					return {
+						_tag: "Right",
+						right: {
+							projectRoot: mainRepoDir,
+							projectId: undefined,
+							kbRoot: `${mainRepoDir}/.rp1/context`,
+							workRoot: `${mainRepoDir}/.rp1/work`,
+							isWorktree: true,
+							worktreeName: "feature-branch",
+						},
+					};
+				}
+				return {
+					_tag: "Right",
+					right: {
+						projectRoot: startPath,
+						projectId: undefined,
+						kbRoot: `${startPath}/.rp1/context`,
+						workRoot: `${startPath}/.rp1/work`,
+						isWorktree: false,
+					},
+				};
+			};
+
+			const firstEntry = await registerProject(db, mainRepoDir);
+			const secondEntry = await registerProject(db, worktreeDir);
+
+			expect(firstEntry.path).toBe(mainRepoDir);
+			expect(secondEntry.path).toBe(mainRepoDir);
+			expect(secondEntry.id).toBe(firstEntry.id);
+
+			const allProjects = await getAllProjects(db);
+			expect(allProjects).toHaveLength(1);
 		});
 	});
 

--- a/cli/web-ui/src/__tests__/server/registry.test.ts
+++ b/cli/web-ui/src/__tests__/server/registry.test.ts
@@ -213,7 +213,6 @@ describe("registry (DB-backed)", () => {
 			const first = await registerProject(db, projDir);
 			const firstAddedAt = first.addedAt;
 
-			// Small delay to ensure different timestamp
 			await new Promise((resolve) => setTimeout(resolve, 10));
 
 			const second = await registerProject(db, projDir);
@@ -631,7 +630,6 @@ describe("registry (DB-backed)", () => {
 			expect(projects).toHaveLength(1);
 			expect(projects[0].id).toBe("existing");
 
-			// Clean up
 			try {
 				const { unlink } = await import("node:fs/promises");
 				await unlink(jsonPath);

--- a/cli/web-ui/src/__tests__/server/v2-api-feed.test.ts
+++ b/cli/web-ui/src/__tests__/server/v2-api-feed.test.ts
@@ -19,7 +19,6 @@ import {
 	resetInstance,
 } from "../../../../src/agent-tools/emit/database.js";
 import { insertNotification } from "../../../../src/agent-tools/emit/notification-database.js";
-import { saveRegistry } from "../../server/registry.js";
 import { handleV2FeedRequest } from "../../server/routes/v2-api.js";
 
 async function setupProject(tempDir: string, suffix: string) {
@@ -30,23 +29,23 @@ async function setupProject(tempDir: string, suffix: string) {
 
 	process.env.HOME = homeDir;
 	await mkdir(projectRoot, { recursive: true });
-	await saveRegistry({
-		version: 1,
-		lastInvoked: `project-${suffix}`,
-		projects: {
-			[`project-${suffix}`]: {
-				id: `project-${suffix}`,
-				projectId: `project-uuid-${suffix}`,
-				path: projectRoot,
-				name: `Project ${suffix}`,
-				addedAt: now,
-				lastAccessedAt: now,
-				available: true,
-			},
-		},
-	});
 
 	const db = await expectTaskRight(getEmitDatabase(dbPath));
+
+	db.prepare(
+		"INSERT INTO projects (id, project_id, path, name, added_at, last_accessed_at, available) VALUES (?, ?, ?, ?, ?, ?, ?)",
+	).run(
+		`project-${suffix}`,
+		`project-uuid-${suffix}`,
+		projectRoot,
+		`Project ${suffix}`,
+		now,
+		now,
+		1,
+	);
+	db.prepare(
+		"INSERT OR REPLACE INTO project_registry_meta (key, value) VALUES ('last_invoked_project_id', ?)",
+	).run(`project-${suffix}`);
 
 	return {
 		db,

--- a/cli/web-ui/src/__tests__/server/v2-api-notifications.test.ts
+++ b/cli/web-ui/src/__tests__/server/v2-api-notifications.test.ts
@@ -17,7 +17,6 @@ import {
 	resetInstance,
 } from "../../../../src/agent-tools/emit/database.js";
 import { insertNotification } from "../../../../src/agent-tools/emit/notification-database.js";
-import { saveRegistry } from "../../server/registry.js";
 import { handleV2NotificationsListRequest } from "../../server/routes/v2-api.js";
 
 describe("handleV2NotificationsListRequest", () => {
@@ -57,23 +56,23 @@ describe("handleV2NotificationsListRequest", () => {
 
 		process.env.HOME = homeDir;
 		await mkdir(projectRoot, { recursive: true });
-		await saveRegistry({
-			version: 1,
-			lastInvoked: "project-alpha",
-			projects: {
-				"project-alpha": {
-					id: "project-alpha",
-					projectId: "project-uuid-1",
-					path: projectRoot,
-					name: "Alpha Project",
-					addedAt: now,
-					lastAccessedAt: now,
-					available: true,
-				},
-			},
-		});
 
 		const db = await expectTaskRight(getEmitDatabase(dbPath));
+
+		db.prepare(
+			"INSERT INTO projects (id, project_id, path, name, added_at, last_accessed_at, available) VALUES (?, ?, ?, ?, ?, ?, ?)",
+		).run(
+			"project-alpha",
+			"project-uuid-1",
+			projectRoot,
+			"Alpha Project",
+			now,
+			now,
+			1,
+		);
+		db.prepare(
+			"INSERT OR REPLACE INTO project_registry_meta (key, value) VALUES ('last_invoked_project_id', ?)",
+		).run("project-alpha");
 
 		insertRun(db, {
 			id: "run-failed",

--- a/cli/web-ui/src/__tests__/server/v2-api-run-detail.test.ts
+++ b/cli/web-ui/src/__tests__/server/v2-api-run-detail.test.ts
@@ -22,7 +22,7 @@ import {
 mock.module("../../server/registry.js", () => ({
 	getAllProjects: async () => [],
 	getProject: async () => null,
-	getProjectCount: () => 0,
+	getProjectCount: async () => 0,
 	isValidProject: async () => false,
 	registerProject: async () => {
 		throw new Error("registerProject should not be called in run detail tests");

--- a/cli/web-ui/src/__tests__/server/v2-api-run-detail.test.ts
+++ b/cli/web-ui/src/__tests__/server/v2-api-run-detail.test.ts
@@ -22,8 +22,8 @@ import {
 mock.module("../../server/registry.js", () => ({
 	getAllProjects: async () => [],
 	getProject: async () => null,
+	getProjectCount: () => 0,
 	isValidProject: async () => false,
-	loadRegistry: async () => ({ version: 1, lastInvoked: null, projects: {} }),
 	registerProject: async () => {
 		throw new Error("registerProject should not be called in run detail tests");
 	},

--- a/cli/web-ui/src/daemon/config-dir.ts
+++ b/cli/web-ui/src/daemon/config-dir.ts
@@ -56,13 +56,6 @@ export function getPidFilePath(): string {
 }
 
 /**
- * Get the path to the project registry file.
- */
-export function getRegistryPath(): string {
-	return join(getConfigDir(), "projects.json");
-}
-
-/**
  * Daemon state file shape for tracking recovery state across restarts.
  */
 export interface DaemonState {

--- a/cli/web-ui/src/daemon/index.ts
+++ b/cli/web-ui/src/daemon/index.ts
@@ -9,7 +9,6 @@ export {
 	getConfigDir,
 	getDaemonStatePath,
 	getPidFilePath,
-	getRegistryPath,
 	readDaemonState,
 	writeDaemonState,
 } from "./config-dir";

--- a/cli/web-ui/src/server.ts
+++ b/cli/web-ui/src/server.ts
@@ -54,7 +54,7 @@ async function runStartupRecovery(websocketHub: WebSocketHub): Promise<void> {
 		return;
 	}
 
-	const projects = await getAllProjects();
+	const projects = await getAllProjects(db);
 	const projectLookup = buildProjectLookup(projects);
 	const runCache = new Map<
 		string,
@@ -188,7 +188,20 @@ export function createServer(options: ServerOptions) {
 		console.warn("[recovery] Startup recovery failed:", err);
 	});
 
-	pruneStaleProjects().catch((err) => {
+	(async () => {
+		const { isLeft } = await import("fp-ts/lib/Either.js");
+		const { getEmitDatabase } = await import(
+			"../../src/agent-tools/emit/database"
+		);
+		const dbResult = await getEmitDatabase()();
+		if (isLeft(dbResult)) {
+			console.warn(
+				"[startup] Could not open database for stale project pruning",
+			);
+			return;
+		}
+		await pruneStaleProjects(dbResult.right);
+	})().catch((err) => {
 		console.warn("[startup] Stale project pruning failed:", err);
 	});
 

--- a/cli/web-ui/src/server/project-lookup.ts
+++ b/cli/web-ui/src/server/project-lookup.ts
@@ -16,11 +16,17 @@ export function buildProjectLookup(
 ): ProjectLookup {
 	const byId = new Map<string, ProjectEntry>();
 	const byPath = new Map<string, ProjectEntry>();
+	const seenProjectIds = new Set<string>();
 
 	for (const project of projects) {
 		byId.set(project.id, project);
 		if (project.projectId) {
-			byId.set(project.projectId, project);
+			if (seenProjectIds.has(project.projectId)) {
+				byId.delete(project.projectId);
+			} else {
+				seenProjectIds.add(project.projectId);
+				byId.set(project.projectId, project);
+			}
 		}
 		byPath.set(project.path, project);
 	}
@@ -32,13 +38,6 @@ export function findProjectByIdentity(
 	lookup: ProjectLookup,
 	identity: ProjectIdentity,
 ): ProjectEntry | undefined {
-	if (identity.projectId) {
-		const byId = lookup.byId.get(identity.projectId);
-		if (byId) {
-			return byId;
-		}
-	}
-
 	if (identity.rp1ProjectRoot) {
 		const byRoot = lookup.byPath.get(identity.rp1ProjectRoot);
 		if (byRoot) {
@@ -47,7 +46,17 @@ export function findProjectByIdentity(
 	}
 
 	if (identity.projectPath) {
-		return lookup.byPath.get(identity.projectPath);
+		const byPath = lookup.byPath.get(identity.projectPath);
+		if (byPath) {
+			return byPath;
+		}
+	}
+
+	if (identity.projectId) {
+		const byId = lookup.byId.get(identity.projectId);
+		if (byId) {
+			return byId;
+		}
 	}
 
 	return undefined;

--- a/cli/web-ui/src/server/registry.ts
+++ b/cli/web-ui/src/server/registry.ts
@@ -125,17 +125,21 @@ export function getProjectName(projectPath: string): string {
 	return basename(projectPath);
 }
 
-let _hydrated = false;
+let _hydrationPromise: Promise<void> | null = null;
 
 /**
  * One-time bootstrap hydration from projects.json into the DB.
  * Runs once per process lifetime. Only hydrates when the projects table is empty
  * and a projects.json file exists. Handles missing or corrupt files silently.
+ * Uses a promise guard so concurrent callers await the same hydration run.
  */
 export async function ensureHydrated(db: Database): Promise<void> {
-	if (_hydrated) return;
-	_hydrated = true;
+	if (_hydrationPromise) return _hydrationPromise;
+	_hydrationPromise = doHydrate(db);
+	return _hydrationPromise;
+}
 
+async function doHydrate(db: Database): Promise<void> {
 	const row = db.prepare("SELECT COUNT(*) as count FROM projects").get() as {
 		count: number;
 	};
@@ -202,7 +206,7 @@ export async function ensureHydrated(db: Database): Promise<void> {
  * Reset hydration state. Exported for test use only.
  */
 export function _resetHydrated(): void {
-	_hydrated = false;
+	_hydrationPromise = null;
 }
 
 /**
@@ -272,7 +276,10 @@ export async function registerProject(
 				(r) => r.id,
 			),
 		);
-		const id = uuid ?? generateProjectId(normalizedPath, existingIds);
+		const id =
+			uuid && !existingIds.has(uuid)
+				? uuid
+				: generateProjectId(normalizedPath, existingIds);
 		const name = getProjectName(normalizedPath);
 
 		db.prepare(
@@ -461,9 +468,11 @@ export async function setLastInvoked(
 
 /**
  * Get the total number of registered projects.
- * Synchronous helper for the health endpoint.
+ * Ensures hydration has completed before reading the count.
  */
-export function getProjectCount(db: Database): number {
+export async function getProjectCount(db: Database): Promise<number> {
+	await ensureHydrated(db);
+
 	const row = db.prepare("SELECT COUNT(*) as count FROM projects").get() as {
 		count: number;
 	};

--- a/cli/web-ui/src/server/registry.ts
+++ b/cli/web-ui/src/server/registry.ts
@@ -1,19 +1,15 @@
 /**
  * Project registry for multi-project support.
- * Handles persistent storage of registered rp1 projects with atomic file operations.
+ * DB-backed storage layer using the rp1.db projects and project_registry_meta tables.
  */
 
-import { readFile, rename, stat, unlink, writeFile } from "node:fs/promises";
-import { basename, dirname } from "node:path";
+import type { Database } from "bun:sqlite";
+import { readFile, stat, unlink } from "node:fs/promises";
+import { basename, dirname, join } from "node:path";
 import * as E from "fp-ts/lib/Either.js";
 import { resolveDirectorySet } from "../../../shared/directory-resolution.js";
 import { readProjectId } from "../../../shared/project-id.js";
-import { ensureConfigDir, getRegistryPath } from "../daemon/config-dir";
-
-/**
- * Registry file version for future migrations.
- */
-const REGISTRY_VERSION = 1;
+import { getConfigDir } from "../daemon/config-dir";
 
 /**
  * Single project entry in the registry.
@@ -37,26 +33,25 @@ export interface ProjectEntry {
 	readonly activeFeatureCount?: number;
 }
 
-/**
- * Root registry structure stored in projects.json.
- */
-export interface ProjectRegistry {
-	/** Schema version for migrations */
-	readonly version: number;
-	/** Project ID of last invoked project (for default selection) */
-	readonly lastInvoked: string | null;
-	/** Map of project ID to project entry */
-	readonly projects: Record<string, ProjectEntry>;
+interface ProjectRow {
+	id: string;
+	project_id: string | null;
+	path: string;
+	name: string;
+	added_at: string;
+	last_accessed_at: string;
+	available: number;
 }
 
-/**
- * Create an empty registry.
- */
-function createEmptyRegistry(): ProjectRegistry {
+function rowToEntry(row: ProjectRow): ProjectEntry {
 	return {
-		version: REGISTRY_VERSION,
-		lastInvoked: null,
-		projects: {},
+		id: row.id,
+		projectId: row.project_id ?? undefined,
+		path: row.path,
+		name: row.name,
+		addedAt: row.added_at,
+		lastAccessedAt: row.last_accessed_at,
+		available: row.available === 1,
 	};
 }
 
@@ -123,28 +118,6 @@ export async function isValidProject(projectPath: string): Promise<boolean> {
 }
 
 /**
- * In-process async mutex to serialize registry mutations.
- * Prevents read-modify-write races between concurrent async operations
- * (e.g., pruneStaleProjects running during a registerProject call).
- */
-let _lockQueue: Promise<void> = Promise.resolve();
-
-async function withRegistryLock<T>(fn: () => Promise<T>): Promise<T> {
-	let release!: () => void;
-	const gate = new Promise<void>((resolve) => {
-		release = resolve;
-	});
-	const previous = _lockQueue;
-	_lockQueue = gate;
-	await previous;
-	try {
-		return await fn();
-	} finally {
-		release();
-	}
-}
-
-/**
  * Get project display name from directory name.
  * Always uses directory name for consistency and clarity.
  */
@@ -152,308 +125,348 @@ export function getProjectName(projectPath: string): string {
 	return basename(projectPath);
 }
 
+let _hydrated = false;
+
 /**
- * Load registry from disk, creating empty if missing or corrupted.
+ * One-time bootstrap hydration from projects.json into the DB.
+ * Runs once per process lifetime. Only hydrates when the projects table is empty
+ * and a projects.json file exists. Handles missing or corrupt files silently.
  */
-export async function loadRegistry(): Promise<ProjectRegistry> {
-	const registryPath = getRegistryPath();
+export async function ensureHydrated(db: Database): Promise<void> {
+	if (_hydrated) return;
+	_hydrated = true;
+
+	const row = db.prepare("SELECT COUNT(*) as count FROM projects").get() as {
+		count: number;
+	};
+	if (row.count > 0) return;
+
+	const registryPath = join(getConfigDir(), "projects.json");
 
 	try {
 		const content = await readFile(registryPath, "utf-8");
-		const parsed = JSON.parse(content) as ProjectRegistry;
+		const parsed = JSON.parse(content) as {
+			lastInvoked?: string | null;
+			projects?: Record<
+				string,
+				{
+					id: string;
+					projectId?: string;
+					path: string;
+					name: string;
+					addedAt: string;
+					lastAccessedAt: string;
+					available?: boolean;
+				}
+			>;
+		};
 
-		// Basic validation
-		if (
-			typeof parsed.version !== "number" ||
-			typeof parsed.projects !== "object"
-		) {
-			console.warn("Registry file corrupted, creating new registry");
-			return createEmptyRegistry();
+		if (parsed.projects && typeof parsed.projects === "object") {
+			const insertStmt = db.prepare(
+				"INSERT OR IGNORE INTO projects (id, project_id, path, name, added_at, last_accessed_at, available) VALUES (?, ?, ?, ?, ?, ?, ?)",
+			);
+
+			for (const entry of Object.values(parsed.projects)) {
+				insertStmt.run(
+					entry.id,
+					entry.projectId ?? null,
+					entry.path,
+					entry.name,
+					entry.addedAt,
+					entry.lastAccessedAt,
+					entry.available !== false ? 1 : 0,
+				);
+			}
+
+			if (parsed.lastInvoked) {
+				db.prepare(
+					"INSERT OR REPLACE INTO project_registry_meta (key, value) VALUES ('last_invoked_project_id', ?)",
+				).run(parsed.lastInvoked);
+			}
 		}
 
-		return parsed;
-	} catch (error) {
-		if ((error as NodeJS.ErrnoException).code === "ENOENT") {
-			// File doesn't exist yet
-			return createEmptyRegistry();
-		}
-
-		console.warn("Failed to read registry, creating new:", error);
-		return createEmptyRegistry();
-	}
-}
-
-/**
- * Save registry to disk atomically using temp file + rename.
- */
-export async function saveRegistry(registry: ProjectRegistry): Promise<void> {
-	await ensureConfigDir();
-
-	const registryPath = getRegistryPath();
-	const tempPath = `${registryPath}.tmp.${Date.now()}`;
-
-	try {
-		// Write to temp file
-		await writeFile(tempPath, JSON.stringify(registry, null, 2), {
-			mode: 0o600,
-		});
-
-		// Atomic rename
-		await rename(tempPath, registryPath);
-	} catch (error) {
 		try {
-			await unlink(tempPath);
-		} catch {}
-		throw error;
+			await unlink(registryPath);
+		} catch (unlinkError) {
+			console.warn(
+				"[registry] Could not delete projects.json after migration:",
+				unlinkError,
+			);
+		}
+	} catch {
+		// File missing, corrupt, or unreadable -- silently continue with empty registry
 	}
 }
 
 /**
- * Check if the current process is running in eval mode.
- * Eval workspaces should not pollute the project registry.
+ * Reset hydration state. Exported for test use only.
  */
-function isEvalContext(projectPath: string): boolean {
-	if (process.env.RP1_EVAL_MODE === "true") return true;
-	// Also guard against eval workspace paths directly
-	return (
-		projectPath.startsWith("/tmp/rp1-evals/") ||
-		projectPath.startsWith("/private/tmp/rp1-evals/")
-	);
+export function _resetHydrated(): void {
+	_hydrated = false;
 }
 
 /**
  * Register a project in the registry.
  * Returns the project entry with its assigned ID.
- * Skips registration for eval workspaces to prevent registry pollution.
+ * Normalizes paths through resolveDirectorySet so worktrees resolve
+ * to the main repo path instead of being registered as separate projects.
  */
 export async function registerProject(
+	db: Database,
 	projectPath: string,
 ): Promise<ProjectEntry> {
-	if (isEvalContext(projectPath)) {
-		const now = new Date().toISOString();
-		return {
-			id: "eval-workspace",
-			projectId: undefined,
-			path: projectPath,
-			name: "eval-workspace",
-			addedAt: now,
-			lastAccessedAt: now,
-			available: false,
-		};
-	}
+	await ensureHydrated(db);
 
-	// Normalize path through directory resolution so worktrees resolve
-	// to the main repo path instead of being registered as separate projects.
 	const resolved = resolveDirectorySet(projectPath);
 	const normalizedPath = E.isRight(resolved)
 		? resolved.right.projectRoot
 		: projectPath;
 
-	return withRegistryLock(async () => {
-		const registry = await loadRegistry();
-		const existingIds = new Set(Object.keys(registry.projects));
-		const uuid = readProjectId(normalizedPath);
+	const available = await isValidProject(normalizedPath);
+	const uuid = readProjectId(normalizedPath);
+	const now = new Date().toISOString();
 
-		const existing = Object.values(registry.projects).find(
-			(p) => p.path === normalizedPath,
-		);
-
-		const now = new Date().toISOString();
-		const available = await isValidProject(normalizedPath);
+	const doRegister = db.transaction(() => {
+		const existing = db
+			.prepare("SELECT * FROM projects WHERE path = ?")
+			.get(normalizedPath) as ProjectRow | null;
 
 		if (existing) {
-			const needsRekey = uuid && existing.id !== uuid;
+			const needsRekey = !!(uuid && existing.id !== uuid);
 			const updatedId = uuid ?? existing.id;
-			const updated: ProjectEntry = {
-				...existing,
-				id: updatedId,
-				projectId: uuid ?? existing.projectId,
-				lastAccessedAt: now,
-				available,
-			};
+			const updatedProjectId = uuid ?? existing.project_id;
 
-			const projects = { ...registry.projects };
 			if (needsRekey) {
-				delete projects[existing.id];
+				db.prepare(
+					"UPDATE projects SET id = ?, project_id = ?, last_accessed_at = ?, available = ? WHERE path = ?",
+				).run(
+					updatedId,
+					updatedProjectId,
+					now,
+					available ? 1 : 0,
+					normalizedPath,
+				);
+			} else {
+				db.prepare(
+					"UPDATE projects SET project_id = ?, last_accessed_at = ?, available = ? WHERE path = ?",
+				).run(updatedProjectId, now, available ? 1 : 0, normalizedPath);
 			}
-			projects[updatedId] = updated;
 
-			const updatedRegistry: ProjectRegistry = {
-				...registry,
-				lastInvoked: updatedId,
-				projects,
-			};
+			db.prepare(
+				"INSERT OR REPLACE INTO project_registry_meta (key, value) VALUES ('last_invoked_project_id', ?)",
+			).run(updatedId);
 
-			await saveRegistry(updatedRegistry);
-			return updated;
+			return rowToEntry({
+				id: updatedId,
+				project_id: updatedProjectId,
+				path: normalizedPath,
+				name: existing.name,
+				added_at: existing.added_at,
+				last_accessed_at: now,
+				available: available ? 1 : 0,
+			});
 		}
 
+		const existingIds = new Set(
+			(db.prepare("SELECT id FROM projects").all() as { id: string }[]).map(
+				(r) => r.id,
+			),
+		);
 		const id = uuid ?? generateProjectId(normalizedPath, existingIds);
 		const name = getProjectName(normalizedPath);
 
-		const entry: ProjectEntry = {
+		db.prepare(
+			"INSERT INTO projects (id, project_id, path, name, added_at, last_accessed_at, available) VALUES (?, ?, ?, ?, ?, ?, ?)",
+		).run(id, uuid ?? null, normalizedPath, name, now, now, available ? 1 : 0);
+
+		db.prepare(
+			"INSERT OR REPLACE INTO project_registry_meta (key, value) VALUES ('last_invoked_project_id', ?)",
+		).run(id);
+
+		return rowToEntry({
 			id,
-			projectId: uuid,
+			project_id: uuid ?? null,
 			path: normalizedPath,
 			name,
-			addedAt: now,
-			lastAccessedAt: now,
-			available,
-		};
-
-		const updatedRegistry: ProjectRegistry = {
-			...registry,
-			lastInvoked: id,
-			projects: {
-				...registry.projects,
-				[id]: entry,
-			},
-		};
-
-		await saveRegistry(updatedRegistry);
-		return entry;
+			added_at: now,
+			last_accessed_at: now,
+			available: available ? 1 : 0,
+		});
 	});
+
+	return doRegister();
 }
 
 /**
  * Remove a project from the registry by ID.
  * Returns true if the project was found and removed.
  */
-export async function removeProject(projectId: string): Promise<boolean> {
-	return withRegistryLock(async () => {
-		const registry = await loadRegistry();
+export async function removeProject(
+	db: Database,
+	projectId: string,
+): Promise<boolean> {
+	await ensureHydrated(db);
 
-		if (!registry.projects[projectId]) {
-			return false;
-		}
+	const result = db.prepare("DELETE FROM projects WHERE id = ?").run(projectId);
 
-		const { [projectId]: _removed, ...remainingProjects } = registry.projects;
+	if (result.changes === 0) return false;
 
-		const updatedRegistry: ProjectRegistry = {
-			...registry,
-			lastInvoked:
-				registry.lastInvoked === projectId ? null : registry.lastInvoked,
-			projects: remainingProjects,
-		};
+	const meta = db
+		.prepare(
+			"SELECT value FROM project_registry_meta WHERE key = 'last_invoked_project_id'",
+		)
+		.get() as { value: string | null } | null;
 
-		await saveRegistry(updatedRegistry);
-		return true;
-	});
+	if (meta?.value === projectId) {
+		db.prepare(
+			"DELETE FROM project_registry_meta WHERE key = 'last_invoked_project_id'",
+		).run();
+	}
+
+	return true;
 }
 
 /**
  * Get a project by ID.
  */
 export async function getProject(
+	db: Database,
 	projectId: string,
 ): Promise<ProjectEntry | null> {
-	const registry = await loadRegistry();
-	return registry.projects[projectId] ?? null;
+	await ensureHydrated(db);
+
+	const row = db
+		.prepare("SELECT * FROM projects WHERE id = ?")
+		.get(projectId) as ProjectRow | null;
+
+	return row ? rowToEntry(row) : null;
 }
 
 /**
  * Get all registered projects.
  */
-export async function getAllProjects(): Promise<ProjectEntry[]> {
-	const registry = await loadRegistry();
-	return Object.values(registry.projects);
+export async function getAllProjects(db: Database): Promise<ProjectEntry[]> {
+	await ensureHydrated(db);
+
+	const rows = db.prepare("SELECT * FROM projects").all() as ProjectRow[];
+
+	return rows.map(rowToEntry);
 }
 
 /**
  * Get the last invoked project ID.
  */
-export async function getLastInvokedProjectId(): Promise<string | null> {
-	const registry = await loadRegistry();
-	return registry.lastInvoked;
+export async function getLastInvokedProjectId(
+	db: Database,
+): Promise<string | null> {
+	await ensureHydrated(db);
+
+	const row = db
+		.prepare(
+			"SELECT value FROM project_registry_meta WHERE key = 'last_invoked_project_id'",
+		)
+		.get() as { value: string | null } | null;
+
+	return row?.value ?? null;
 }
 
 /**
  * Update availability status for all projects.
  * Marks projects as unavailable if their .rp1/ directory is missing.
  */
-export async function refreshProjectAvailability(): Promise<void> {
-	return withRegistryLock(async () => {
-		const registry = await loadRegistry();
-		const updates: Record<string, ProjectEntry> = {};
-		let hasChanges = false;
+export async function refreshProjectAvailability(db: Database): Promise<void> {
+	await ensureHydrated(db);
 
-		for (const project of Object.values(registry.projects)) {
-			const available = await isValidProject(project.path);
-			if (available !== project.available) {
-				updates[project.id] = { ...project, available };
-				hasChanges = true;
-			} else {
-				updates[project.id] = project;
-			}
-		}
+	const rows = db.prepare("SELECT * FROM projects").all() as ProjectRow[];
 
-		if (hasChanges) {
-			await saveRegistry({
-				...registry,
-				projects: updates,
-			});
+	for (const row of rows) {
+		const available = await isValidProject(row.path);
+		const currentAvailable = row.available === 1;
+
+		if (available !== currentAvailable) {
+			db.prepare("UPDATE projects SET available = ? WHERE path = ?").run(
+				available ? 1 : 0,
+				row.path,
+			);
 		}
-	});
+	}
 }
 
 /**
  * Prune projects whose paths no longer exist on disk.
  * Returns the number of projects removed.
  */
-export async function pruneStaleProjects(): Promise<number> {
-	return withRegistryLock(async () => {
-		const registry = await loadRegistry();
-		const remaining: Record<string, ProjectEntry> = {};
-		let pruned = 0;
+export async function pruneStaleProjects(db: Database): Promise<number> {
+	await ensureHydrated(db);
 
-		for (const [id, project] of Object.entries(registry.projects)) {
-			const available = await isValidProject(project.path);
-			if (available) {
-				remaining[id] = project;
-			} else {
-				pruned++;
-			}
+	const rows = db.prepare("SELECT * FROM projects").all() as ProjectRow[];
+
+	let pruned = 0;
+	const prunedIds = new Set<string>();
+
+	for (const row of rows) {
+		const available = await isValidProject(row.path);
+		if (!available) {
+			db.prepare("DELETE FROM projects WHERE path = ?").run(row.path);
+			prunedIds.add(row.id);
+			pruned++;
 		}
+	}
 
-		if (pruned > 0) {
-			await saveRegistry({
-				...registry,
-				lastInvoked:
-					registry.lastInvoked && remaining[registry.lastInvoked]
-						? registry.lastInvoked
-						: null,
-				projects: remaining,
-			});
+	if (pruned > 0) {
+		const meta = db
+			.prepare(
+				"SELECT value FROM project_registry_meta WHERE key = 'last_invoked_project_id'",
+			)
+			.get() as { value: string | null } | null;
+
+		if (meta?.value && prunedIds.has(meta.value)) {
+			db.prepare(
+				"DELETE FROM project_registry_meta WHERE key = 'last_invoked_project_id'",
+			).run();
 		}
+	}
 
-		return pruned;
-	});
+	return pruned;
 }
 
 /**
  * Set a project as the last invoked.
  */
-export async function setLastInvoked(projectId: string): Promise<void> {
-	return withRegistryLock(async () => {
-		const registry = await loadRegistry();
+export async function setLastInvoked(
+	db: Database,
+	projectId: string,
+): Promise<void> {
+	await ensureHydrated(db);
 
-		if (!registry.projects[projectId]) {
-			throw new Error(`Project ${projectId} not found in registry`);
-		}
+	const exists = db
+		.prepare("SELECT id FROM projects WHERE id = ?")
+		.get(projectId) as { id: string } | null;
 
-		const now = new Date().toISOString();
-		const project = registry.projects[projectId];
+	if (!exists) {
+		throw new Error(`Project ${projectId} not found in registry`);
+	}
 
-		await saveRegistry({
-			...registry,
-			lastInvoked: projectId,
-			projects: {
-				...registry.projects,
-				[projectId]: {
-					...project,
-					lastAccessedAt: now,
-				},
-			},
-		});
-	});
+	const now = new Date().toISOString();
+
+	db.prepare(
+		"INSERT OR REPLACE INTO project_registry_meta (key, value) VALUES ('last_invoked_project_id', ?)",
+	).run(projectId);
+
+	db.prepare("UPDATE projects SET last_accessed_at = ? WHERE id = ?").run(
+		now,
+		projectId,
+	);
+}
+
+/**
+ * Get the total number of registered projects.
+ * Synchronous helper for the health endpoint.
+ */
+export function getProjectCount(db: Database): number {
+	const row = db.prepare("SELECT COUNT(*) as count FROM projects").get() as {
+		count: number;
+	};
+
+	return row.count;
 }

--- a/cli/web-ui/src/server/routes/artifacts-api.ts
+++ b/cli/web-ui/src/server/routes/artifacts-api.ts
@@ -307,7 +307,7 @@ export async function handleArtifactSaveRequest(
 			return errorResponse(`Run not found: ${runId}`, 404);
 		}
 
-		const projects = await dependencies.getAllProjects();
+		const projects = await dependencies.getAllProjects(db);
 		const project = findProjectByPathSet(
 			projects,
 			getEffectiveProjectPath(record),
@@ -496,7 +496,7 @@ export async function handleArtifactPatchRequest(
 			apiContext?.websocketHub &&
 			resolveArtifactAbsolutePath(directories, artifactRecord) !== resolvedPath
 		) {
-			const projects = await dependencies.getAllProjects();
+			const projects = await dependencies.getAllProjects(db);
 			const project = run
 				? findProjectByPathSet(
 						projects,

--- a/cli/web-ui/src/server/routes/v2-api.ts
+++ b/cli/web-ui/src/server/routes/v2-api.ts
@@ -1722,7 +1722,7 @@ export async function handleV2HealthRequest(
 	}
 
 	const db = await getDb();
-	const projectCount = getProjectCount(db);
+	const projectCount = await getProjectCount(db);
 	const uptime = Math.floor((Date.now() - ctx.startTime) / 1000);
 
 	return jsonResponse({

--- a/cli/web-ui/src/server/routes/v2-api.ts
+++ b/cli/web-ui/src/server/routes/v2-api.ts
@@ -81,8 +81,8 @@ import {
 import {
 	getAllProjects,
 	getProject,
+	getProjectCount,
 	isValidProject,
-	loadRegistry,
 	type ProjectEntry,
 	registerProject,
 	removeProject,
@@ -1136,7 +1136,7 @@ export async function handleV2RunsListRequest(req: Request): Promise<Response> {
 
 	try {
 		const db = await getDb();
-		const projects = await getAllProjects();
+		const projects = await getAllProjects(db);
 		const projectLookup = buildProjectLookup(projects);
 
 		let projectPathFilter: string | undefined;
@@ -1209,7 +1209,7 @@ export async function handleV2RunsListRequest(req: Request): Promise<Response> {
 export async function handleV2RunsAttentionRequest(): Promise<Response> {
 	try {
 		const db = await getDb();
-		const projects = await getAllProjects();
+		const projects = await getAllProjects(db);
 		const projectLookup = buildProjectLookup(projects);
 
 		const attentionRuns = getRunsByAttentionStatus(db);
@@ -1252,7 +1252,7 @@ export async function handleV2RunDetailRequest(
 			return errorResponse(`Run not found: ${runId}`, 404);
 		}
 
-		const projects = await getAllProjects();
+		const projects = await getAllProjects(db);
 		const projectLookup = buildProjectLookup(projects);
 		const project =
 			findProjectByIdentity(projectLookup, record) ??
@@ -1282,7 +1282,7 @@ export async function handleV2ArtifactContentRequest(
 			return errorResponse(`Run not found: ${runId}`, 404);
 		}
 
-		const projects = await getAllProjects();
+		const projects = await getAllProjects(db);
 		const projectLookup = buildProjectLookup(projects);
 		const project =
 			findProjectByIdentity(projectLookup, record) ??
@@ -1412,7 +1412,7 @@ export async function handleV2ArtifactContentRequest(
 export async function handleV2ProjectsListRequest(): Promise<Response> {
 	try {
 		const db = await getDb();
-		const projects = await getAllProjects();
+		const projects = await getAllProjects(db);
 		const projectPaths = projects.map((p) => p.path);
 
 		const statsMap = getEmitProjectRunStats(db, projectPaths);
@@ -1450,13 +1450,13 @@ export async function handleV2ProjectDetailRequest(
 	projectId: string,
 ): Promise<Response> {
 	try {
-		const project = await getProject(projectId);
+		const db = await getDb();
+		const project = await getProject(db, projectId);
 
 		if (!project) {
 			return errorResponse(`Project not found: ${projectId}`, 404);
 		}
 
-		const db = await getDb();
 		const statsMap = getEmitProjectRunStats(db, [project.path]);
 		const stats = statsMap.get(project.path);
 
@@ -1564,7 +1564,8 @@ export async function handleV2ProjectFilesRequest(
 	projectId: string,
 ): Promise<Response> {
 	try {
-		const project = await getProject(projectId);
+		const db = await getDb();
+		const project = await getProject(db, projectId);
 
 		if (!project) {
 			return errorResponse(`Project not found: ${projectId}`, 404);
@@ -1599,7 +1600,8 @@ export async function handleV2ProjectContentRequest(
 	filePath: string,
 ): Promise<Response> {
 	try {
-		const project = await getProject(projectId);
+		const db = await getDb();
+		const project = await getProject(db, projectId);
 
 		if (!project) {
 			return errorResponse(`Project not found: ${projectId}`, 404);
@@ -1657,7 +1659,8 @@ export async function handleV2ProjectContentSaveRequest(
 	req: Request,
 ): Promise<Response> {
 	try {
-		const project = await getProject(projectId);
+		const db = await getDb();
+		const project = await getProject(db, projectId);
 
 		if (!project) {
 			return errorResponse(`Project not found: ${projectId}`, 404);
@@ -1718,8 +1721,8 @@ export async function handleV2HealthRequest(
 		}
 	}
 
-	const registry = await loadRegistry();
-	const projectCount = Object.keys(registry.projects).length;
+	const db = await getDb();
+	const projectCount = getProjectCount(db);
 	const uptime = Math.floor((Date.now() - ctx.startTime) / 1000);
 
 	return jsonResponse({
@@ -1809,7 +1812,8 @@ export async function handleV2StatusNotifyRequest(
 			);
 		}
 
-		const projects = await getAllProjects();
+		const db = await getDb();
+		const projects = await getAllProjects(db);
 		const projectLookup = buildProjectLookup(projects);
 		const project = findProjectByIdentity(projectLookup, {
 			projectId,
@@ -1868,7 +1872,8 @@ export async function handleV2ProjectRegisterRequest(
 			);
 		}
 
-		const project = await registerProject(projectPath);
+		const db = await getDb();
+		const project = await registerProject(db, projectPath);
 		ctx.websocketHub?.broadcastProjectsChanged();
 
 		const url = `http://127.0.0.1:${ctx.port}/projects/${project.id}`;
@@ -1887,7 +1892,8 @@ export async function handleV2ProjectDeleteRequest(
 	ctx: ApiContext,
 ): Promise<Response> {
 	try {
-		const removed = await removeProject(projectId);
+		const db = await getDb();
+		const removed = await removeProject(db, projectId);
 
 		if (!removed) {
 			return errorResponse(`Project not found: ${projectId}`, 404);
@@ -1916,7 +1922,7 @@ export async function handleV2NotificationsListRequest(
 
 		const db = await getDb();
 		const result = listNotifications(db, { projectId, limit, offset });
-		const projects = await getAllProjects();
+		const projects = await getAllProjects(db);
 		const projectLookup = buildProjectLookup(projects);
 
 		const summaryRecords =
@@ -2032,7 +2038,7 @@ export async function handleV2FeedRequest(req: Request): Promise<Response> {
 		const offset = Number.parseInt(params.get("offset") ?? "0", 10);
 
 		const db = await getDb();
-		const projects = await getAllProjects();
+		const projects = await getAllProjects(db);
 		const projectLookup = buildProjectLookup(projects);
 		const skillMetadataLookup = await getRuntimeSkillMetadataLookup();
 


### PR DESCRIPTION
## Summary

- Migrates Arcade's project registry from file-backed `projects.json` to DB-backed SQLite storage in `rp1.db`
- Adds schema migration v12 with `projects` and `project_registry_meta` tables, bootstrap hydration from existing JSON, and automatic file cleanup
- Updates all API consumers (`v2-api.ts`, `server.ts`, `artifacts-api.ts`) to pass `Database` as first parameter to registry functions
- Removes file-backed persistence (`loadRegistry`, `saveRegistry`, `withRegistryLock`), eval guards (`isEvalContext`), and the `getRegistryPath` barrel re-export
- Preserves `isInsideWorkTree` check and main work tree registration in `registerProject`
- Adds 36-test registry DB test suite covering schema, CRUD, hydration, pruning, worktree resolution, and fresh startup

## Changes

| File | Change |
|------|--------|
| `cli/src/agent-tools/emit/database.ts` | Schema migration v12 (projects + meta tables) |
| `cli/web-ui/src/server/registry.ts` | Full rewrite: SQL ops, hydration, file cleanup |
| `cli/web-ui/src/server/routes/v2-api.ts` | Pass `db` to all registry calls |
| `cli/web-ui/src/server.ts` | Pass `db` to startup registry calls |
| `cli/web-ui/src/server/routes/artifacts-api.ts` | Pass `db` to `getAllProjects` |
| `cli/web-ui/src/daemon/config-dir.ts` | Remove `getRegistryPath()` |
| `cli/web-ui/src/daemon/index.ts` | Remove barrel re-export |
| `cli/web-ui/src/__tests__/server/registry.test.ts` | New 36-test suite |
| 3 test files | Update mocks from file-based to DB-based setup |

## Test plan

- [x] All 36 registry DB tests pass (schema, CRUD, hydration, pruning, worktree)
- [x] 2214/2214 unit tests pass
- [x] TypeScript compiles cleanly (`tsc --noEmit` for both cli and web-ui)
- [x] Biome lint and format pass
- [x] 33/33 feature acceptance criteria verified
- [ ] Manual: start Arcade daemon, verify projects register and persist across restarts
- [ ] Manual: verify `projects.json` migration and deletion on first startup