### PR TITLE
feat(emit-daemon): add emit-driven live updates for Arcade

### DIFF
--- a/.rp1/context/interaction-model.md
+++ b/.rp1/context/interaction-model.md
@@ -1,7 +1,7 @@
 # rp1 - Interaction Model
 
 **Project**: rp1
-**Analysis Date**: 2026-04-12
+**Analysis Date**: 2026-04-14
 **Surfaces**: CLI, Host Tool Integration, Arcade Web UI, Agent Tools CLI, Reference Docs, Init Wizard
 
 ## Experience Principles
@@ -52,9 +52,11 @@
 | Workflow gate | Phase needs user choice | Emit waiting_for_user -> Arcade shows pause -> Host tool asks -> Answer resumes/revises/cancels |
 | Artifact registration | Workflow creates durable output | Emit artifact_registered with storageRoot -> Arcade resolves and shows file |
 | Annotation feedback | User comments/edits artifact in Arcade | Runtime persists change -> Agents read via feedback read -> Replies update UI via WebSocket |
-| Notification lifecycle | Events produce notifications | WebSocket delivery -> Toast auto-dismiss (6s) with dedup guard -> Sidebar grouped by attention -> Individual dismiss via X, bulk via "Read all" |
+| Notification lifecycle | Events produce notifications | Emitted workflow events and notifications arrive over the project WebSocket -> Toast auto-dismiss (6s) with dedup guard -> Sidebar grouped by attention -> Individual dismiss via X, bulk via "Read all" |
 | Contextual command registration | View mounts with commands | ShortcutRegistryProvider stores view commands -> Command palette shows view-labeled group -> User executes -> Cleanup on unmount |
-| Activity feed refresh | WebSocket attention signal or reconnect | Auto-refresh without manual polling |
+| Emit-driven run projection | `event:notification` or `event:replay` arrives for a project | Browser stores `lastEventId`, reduces the event through `LiveRunIndex`, and patches only the affected run detail, feed rows, attention groups, and project summaries |
+| Snapshot reconciliation | Reconnect gap is too large for replay | Browser reconnects with the saved project cursor -> Server sends `state:snapshot` -> Client replaces the project's active-run subset and only refetches visible collections whose membership may now be stale |
+| Recovery fallback | Live socket is disconnected or replay was missed entirely | Persisted REST state plus disconnected-only polling restore the latest run truth without treating broad refresh as the normal workflow-status path |
 
 ## Keyboard & Command System
 
@@ -73,7 +75,9 @@
 | Skill invocation syntax | Claude Code uses short slash commands; OpenCode uses rp1-prefixed names |
 | Execution vs observability | Host tools do the work; Agent Tools carry protocol; Arcade shows passive status |
 | Responsive layout | Desktop: icon-rail sidebar + resizable panels. Mobile: bottom tab bar + drawers |
-| Notification delivery | Arcade: real-time toasts with dedup + dismissible sidebar. Host tools: inline gates |
+| Workflow freshness source | Arcade: emitted workflow events hydrate `LiveRunIndex`, run detail, and attention/project surfaces via project-scoped `lastEventId` cursors. Host tools: inline gates still come from the emitting workflow |
+| Notification delivery | Arcade: real-time toasts with dedup + dismissible sidebar driven by the same emit stream. Host tools: inline gates |
+| Recovery semantics | Arcade reconnects with its saved cursor, replays missed events when possible, and falls back to bounded snapshot reconciliation or persisted REST recovery only when needed |
 | Run invocation context | Hidden by default, toggled via contextual command; shows workflow, run policy, worktree state |
 | Daemon lifecycle modes | Full mode (register + browser), daemon-only (start without project), hook-json (structured output for hooks) |
 

--- a/.rp1/context/patterns.md
+++ b/.rp1/context/patterns.md
@@ -1,7 +1,7 @@
 # Implementation Patterns
 
 **Project**: rp1
-**Last Updated**: 2026-04-12
+**Last Updated**: 2026-04-14
 
 ## Naming Conventions
 
@@ -49,14 +49,19 @@
 
 - **Database**: SQLite via `bun:sqlite` for runs, events, artifacts, annotations, notifications. Upsert semantics; dedup via `hasNotificationForSource`
 - **File I/O**: Atomic writes via temp-file + rename (registry `saveRegistry`); PID file with mode 0o600; diagnostic log uses `appendFileSync`
-- **HTTP clients**: Web-UI SPA fetches `/api/v2/` with paginated notification loading; daemon health checks use polling with configurable interval
+- **Workflow event transport**: `rp1 agent-tools emit` persists canonical workflow events, then the daemon relays typed project-scoped WebSocket envelopes for status-bearing and attention-bearing live updates
+- **HTTP clients**: Web-UI SPA seeds surfaces from `/api/v2/` and uses targeted hydration such as `GET /api/v2/runs/:id/summary`; reconnect polling stays limited to disconnected recovery instead of routine freshness
+- **Freshness split**: Workflow status and attention come from emitted event delivery plus replay/snapshot recovery; file watching remains responsible only for artifact and file-content freshness
 
 ## UI Patterns
 
 - **Contextual commands**: Views register `CommandDefinition[]` via `useContextualShortcuts` hook, surfaced in command palette alongside navigation/action commands
-- **SessionStorage persistence**: `showFrontmatter`/`showMetadata` use `useState` + `sessionStorage` for per-tab, per-view toggle persistence
+- **SessionStorage persistence**: `showFrontmatter`/`showMetadata` use `useState` + `sessionStorage` for per-tab, per-view toggle persistence; WebSocket cursors follow the same pattern with `rp1:last-event-id:{projectId}`
 - **Notification lifecycle**: Toasts auto-dismiss 6s with dedup guard; sidebar groups by attention level; "Read all" bulk dismiss
 - **Attention-level styling**: `itemClassForLevel` maps attention levels to differentiated background colors for visual triage
+- **LiveRunIndex projection**: Feed, runs, attention, project summaries, and run detail seed from REST, then project emitted workflow activity through a shared `LiveRunIndex` keyed by `runId` to patch only affected surfaces
+- **Snapshot reconciliation**: `state:snapshot` replaces the project's active-run subset and triggers bounded refetch only for currently visible collections whose membership may have changed
+- **Targeted hydration**: Unknown run events hydrate a single run summary before reducers apply queued updates, avoiding collection-wide invalidation for routine workflow activity
 
 ## Observability
 

--- a/cli/src/__tests__/agent-tools/emit/database.test.ts
+++ b/cli/src/__tests__/agent-tools/emit/database.test.ts
@@ -38,6 +38,7 @@ import {
 	getProjectRunStats,
 	getRunById,
 	getRunsByAttentionStatus,
+	getRunWithLastEventById,
 	getSkippableSteps,
 	getStepStatuses,
 	insertEvent,
@@ -3525,6 +3526,67 @@ describe("emit database", () => {
 			const db = await expectTaskRight(getEmitDatabase(dbPath));
 
 			const run = getRunById(db, "nonexistent");
+
+			expect(run).toBeNull();
+		});
+	});
+
+	describe("getRunWithLastEventById", () => {
+		test("returns a run with the latest event timestamp used by list views", async () => {
+			const dbPath = join(tempDir, "get-run-with-last-event.db");
+			const db = await expectTaskRight(getEmitDatabase(dbPath));
+
+			insertRun(db, {
+				id: "run-summary",
+				flow: "build",
+				featureId: "feat-summary",
+				projectPath: "/p/summary",
+			});
+			db.prepare("UPDATE runs SET created_at = $createdAt WHERE id = $id").run({
+				$createdAt: "2026-03-01T00:00:00.000Z",
+				$id: "run-summary",
+			});
+			insertEvent(db, {
+				runId: "run-summary",
+				type: "status_change",
+				step: "build",
+				data: JSON.stringify({ status: "running" }),
+				createdAt: "2026-03-02T00:00:00.000Z",
+			});
+
+			const run = getRunWithLastEventById(db, "run-summary");
+
+			expect(run).not.toBeNull();
+			expect(run?.id).toBe("run-summary");
+			expect(run?.lastEventAt).toBe("2026-03-02T00:00:00.000Z");
+		});
+
+		test("falls back to created_at when the run has no events", async () => {
+			const dbPath = join(tempDir, "get-run-with-last-event-no-events.db");
+			const db = await expectTaskRight(getEmitDatabase(dbPath));
+
+			insertRun(db, {
+				id: "run-summary-no-events",
+				flow: "build",
+				featureId: "feat-summary",
+				projectPath: "/p/summary",
+			});
+			db.prepare("UPDATE runs SET created_at = $createdAt WHERE id = $id").run({
+				$createdAt: "2026-03-03T00:00:00.000Z",
+				$id: "run-summary-no-events",
+			});
+
+			const run = getRunWithLastEventById(db, "run-summary-no-events");
+
+			expect(run).not.toBeNull();
+			expect(run?.lastEventAt).toBe("2026-03-03T00:00:00.000Z");
+		});
+
+		test("returns null for missing ID", async () => {
+			const dbPath = join(tempDir, "get-run-with-last-event-missing.db");
+			const db = await expectTaskRight(getEmitDatabase(dbPath));
+
+			const run = getRunWithLastEventById(db, "nonexistent");
 
 			expect(run).toBeNull();
 		});

--- a/cli/src/__tests__/agent-tools/emit/emit.test.ts
+++ b/cli/src/__tests__/agent-tools/emit/emit.test.ts
@@ -6,7 +6,7 @@
  * then exercise executeEmit which reuses the cached singleton.
  */
 
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { mkdirSync, writeFileSync } from "node:fs";
 import { rm } from "node:fs/promises";
 import { join } from "node:path";
@@ -116,6 +116,56 @@ describe("emit end-to-end", () => {
 			const result = await expectTaskRight(executeEmit(input));
 
 			expect(result.data.runStatus).toBe("running");
+		});
+
+		test("forwards the emitted event and generated notification to the daemon when available", async () => {
+			const notifyEventMock = mock(async () => true);
+			const notifyNotificationMock = mock(async () => true);
+			mock.module("../../../../web-ui/src/daemon/index.js", () => ({
+				connectToDaemon: async () => ({
+					port: 6710,
+					baseUrl: "http://127.0.0.1:6710",
+				}),
+				notifyEvent: notifyEventMock,
+				notifyNotification: notifyNotificationMock,
+			}));
+
+			const input = makeInput({
+				type: "status_change",
+				step: "build",
+				data: { status: "completed", workflow: "build", feature: "feat" },
+			});
+
+			const result = await expectTaskRight(executeEmit(input));
+
+			expect(notifyEventMock).toHaveBeenCalledTimes(1);
+			expect(notifyEventMock).toHaveBeenCalledWith(
+				expect.objectContaining({
+					port: 6710,
+					baseUrl: "http://127.0.0.1:6710",
+				}),
+				expect.objectContaining({
+					eventType: "status_change",
+					eventId: result.data.eventId,
+					runId: input.runId,
+					projectPath: tempDir,
+					featureId: "feat",
+					step: "build",
+				}),
+			);
+
+			expect(notifyNotificationMock).toHaveBeenCalledTimes(1);
+			expect(notifyNotificationMock).toHaveBeenCalledWith(
+				expect.objectContaining({
+					port: 6710,
+					baseUrl: "http://127.0.0.1:6710",
+				}),
+				expect.objectContaining({
+					sourceType: "run",
+					sourceId: input.runId,
+					route: `/runs/${input.runId}`,
+				}),
+			);
 		});
 
 		test("persists resolved directory metadata on the run", async () => {

--- a/cli/src/agent-tools/emit/database.ts
+++ b/cli/src/agent-tools/emit/database.ts
@@ -2215,6 +2215,36 @@ export const getRunById = (db: Database, runId: string): RunRecord | null => {
 };
 
 /**
+ * Get a single run with the latest event timestamp used by list views.
+ */
+export const getRunWithLastEventById = (
+	db: Database,
+	runId: string,
+): RunRecordWithLastEvent | null => {
+	const row = db
+		.prepare(
+			`SELECT runs.*,
+			        COALESCE(latest_events.last_event_at, runs.created_at) AS last_event_at
+			 FROM runs
+			 LEFT JOIN (
+			     SELECT run_id, MAX(created_at) AS last_event_at
+			     FROM events
+			     GROUP BY run_id
+			 ) AS latest_events ON latest_events.run_id = runs.id
+			 WHERE runs.id = $id
+			 LIMIT 1`,
+		)
+		.get({ $id: runId }) as (RunRow & { last_event_at: string }) | null;
+
+	return row
+		? {
+				...runRowToRecord(row),
+				lastEventAt: row.last_event_at,
+			}
+		: null;
+};
+
+/**
  * Get all events for a run, ordered chronologically.
  */
 export const getEventsForRun = (db: Database, runId: string): EventRecord[] => {

--- a/cli/web-ui/src/__tests__/hooks/useAttention.test.ts
+++ b/cli/web-ui/src/__tests__/hooks/useAttention.test.ts
@@ -1,11 +1,11 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import { renderHook, waitFor } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import { useSyncExternalStore } from "react";
 import { liveRunIndex } from "@/lib/live-run-index";
 import type { Run } from "@/types/runs";
 
 let fetchMock: ReturnType<typeof mock>;
-let useFeedImportVersion = 0;
+let useAttentionImportVersion = 0;
 
 function buildRun(overrides: Partial<Run> = {}): Run {
 	return {
@@ -16,7 +16,7 @@ function buildRun(overrides: Partial<Run> = {}): Run {
 		featureName: "Test Feature",
 		name: null,
 		command: "/build",
-		status: "running",
+		status: "waiting",
 		harness: "codex",
 		currentStep: null,
 		steps: [],
@@ -31,7 +31,7 @@ function buildRun(overrides: Partial<Run> = {}): Run {
 	};
 }
 
-async function loadUseFeed() {
+async function loadUseAttention() {
 	mock.module("../../hooks/useReconnectRecovery.ts", () => ({
 		useReconnectRecovery: () => {},
 	}));
@@ -46,7 +46,7 @@ async function loadUseFeed() {
 	}));
 
 	return import(
-		`../../hooks/useFeed.ts?use-feed-test=${++useFeedImportVersion}`
+		`../../hooks/useAttention.ts?use-attention-test=${++useAttentionImportVersion}`
 	);
 }
 
@@ -59,15 +59,9 @@ beforeEach(() => {
 			ok: true,
 			json: () =>
 				Promise.resolve({
-					items: [
-						{
-							type: "run",
-							id: "run-1",
-							timestamp: "2026-04-10T00:05:00.000Z",
-							run: buildRun(),
-						},
-					],
-					total: 1,
+					waiting: [buildRun()],
+					failed: [],
+					running: [],
 				}),
 		}),
 	);
@@ -80,43 +74,46 @@ afterEach(() => {
 	mock.restore();
 });
 
-describe("useFeed", () => {
-	test("patches known runs in place and inserts newly matching runs without refetching", async () => {
-		const { useFeed } = await loadUseFeed();
-		const { result } = renderHook(() => useFeed({ limit: 25, offset: 0 }));
+describe("useAttention", () => {
+	test("derives updated attention group membership from the live run index", async () => {
+		const { useAttention } = await loadUseAttention();
+		const { result } = renderHook(() => useAttention());
 
 		await waitFor(() => {
 			expect(result.current.isLoading).toBe(false);
 		});
 
-		expect(result.current.items).toHaveLength(1);
-		expect(result.current.items[0]?.run.status).toBe("running");
-		expect(result.current.total).toBe(1);
+		expect(result.current.data?.waiting.map((run: Run) => run.id)).toEqual([
+			"run-1",
+		]);
+		expect(result.current.data?.running).toEqual([]);
 		expect(fetchMock).toHaveBeenCalledTimes(1);
 
-		liveRunIndex.upsertRuns([
-			buildRun({
-				id: "run-1",
-				status: "waiting",
-				currentStep: "review",
-				lastEventAt: "2026-04-10T00:06:00.000Z",
-			}),
-			buildRun({
-				id: "run-2",
-				name: "Fresh Run",
-				lastEventAt: "2026-04-10T00:07:00.000Z",
-			}),
-		]);
-
-		await waitFor(() => {
-			expect(result.current.items).toHaveLength(2);
+		act(() => {
+			liveRunIndex.upsertRuns([
+				buildRun({
+					id: "run-1",
+					status: "failed",
+					lastEventAt: "2026-04-10T00:06:00.000Z",
+				}),
+				buildRun({
+					id: "run-2",
+					status: "running",
+					lastEventAt: "2026-04-10T00:07:00.000Z",
+				}),
+			]);
 		});
 
-		expect(result.current.items.map((item: { id: string }) => item.id)).toEqual(
-			["run-2", "run-1"],
-		);
-		expect(result.current.items[1]?.run.status).toBe("waiting");
-		expect(result.current.total).toBe(2);
+		await waitFor(() => {
+			expect(result.current.data?.failed.map((run: Run) => run.id)).toEqual([
+				"run-1",
+			]);
+		});
+
+		expect(result.current.data?.waiting).toEqual([]);
+		expect(result.current.data?.running.map((run: Run) => run.id)).toEqual([
+			"run-2",
+		]);
 		expect(fetchMock).toHaveBeenCalledTimes(1);
 	});
 });

--- a/cli/web-ui/src/__tests__/hooks/useProjects.test.ts
+++ b/cli/web-ui/src/__tests__/hooks/useProjects.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import { useSyncExternalStore } from "react";
+import { liveRunIndex } from "@/lib/live-run-index";
 
 type ReconnectCallback = () => void;
 type ProjectsChangedCallback = () => void;
@@ -40,6 +42,15 @@ async function loadUseProjects() {
 			};
 		},
 	}));
+	mock.module("../../hooks/useLiveRunIndex.ts", () => ({
+		useLiveRunIndexBridge: () => {},
+		useLiveRunIndexSnapshot: () =>
+			useSyncExternalStore(
+				liveRunIndex.subscribe,
+				liveRunIndex.getSnapshot,
+				liveRunIndex.getSnapshot,
+			),
+	}));
 
 	return import(
 		`../../hooks/useProjects.ts?use-projects-test=${++useProjectsImportVersion}`
@@ -48,6 +59,7 @@ async function loadUseProjects() {
 
 beforeEach(() => {
 	mock.restore();
+	liveRunIndex.clear();
 	projectsChangedListeners = [];
 	reconnectRecovery = null;
 	fetchCount = 0;
@@ -84,6 +96,7 @@ beforeEach(() => {
 
 afterEach(() => {
 	cleanup();
+	liveRunIndex.clear();
 	projectsChangedListeners = [];
 	reconnectRecovery = null;
 	mock.restore();
@@ -172,5 +185,127 @@ describe("useProjects", () => {
 			expect(result.current.projects).toHaveLength(2);
 		});
 		expect(fetchMock).toHaveBeenCalledTimes(2);
+	});
+
+	test("patches project activity metadata from live run updates without refetching", async () => {
+		fetchMock = mock(() =>
+			Promise.resolve({
+				ok: true,
+				json: () =>
+					Promise.resolve({
+						projects: [
+							{
+								id: "proj-1",
+								name: "rp1",
+								path: "/Users/prem/Development/rp1",
+								runCount: 3,
+								lastActivityAt: "2026-04-01T00:00:00Z",
+								available: true,
+							},
+						],
+					}),
+			}),
+		);
+		globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+		const { useProjects } = await loadUseProjects();
+		const { result } = renderHook(() => useProjects());
+
+		await waitFor(() => {
+			expect(result.current.projects).toHaveLength(1);
+		});
+
+		act(() => {
+			liveRunIndex.upsertRun({
+				id: "run-4",
+				projectId: "proj-1",
+				projectName: "rp1",
+				featureId: "feat-1",
+				featureName: "Test Feature",
+				name: null,
+				command: "/build",
+				status: "running",
+				harness: "codex",
+				currentStep: null,
+				steps: [],
+				artifacts: [],
+				events: [],
+				startedAt: "2026-04-02T00:00:00Z",
+				lastEventAt: "2026-04-02T00:05:00Z",
+				completedAt: null,
+				error: null,
+				agentSteps: null,
+			});
+		});
+
+		await waitFor(() => {
+			expect(result.current.projects[0]?.lastActivityAt).toBe(
+				"2026-04-02T00:05:00Z",
+			);
+		});
+
+		expect(result.current.projects[0]?.runCount).toBe(4);
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+	});
+
+	test("counts newly discovered older runs without overwriting project activity", async () => {
+		fetchMock = mock(() =>
+			Promise.resolve({
+				ok: true,
+				json: () =>
+					Promise.resolve({
+						projects: [
+							{
+								id: "proj-1",
+								name: "rp1",
+								path: "/Users/prem/Development/rp1",
+								runCount: 3,
+								lastActivityAt: "2026-04-01T00:00:00Z",
+								available: true,
+							},
+						],
+					}),
+			}),
+		);
+		globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+		const { useProjects } = await loadUseProjects();
+		const { result } = renderHook(() => useProjects());
+
+		await waitFor(() => {
+			expect(result.current.projects).toHaveLength(1);
+		});
+
+		act(() => {
+			liveRunIndex.upsertRun({
+				id: "run-older",
+				projectId: "proj-1",
+				projectName: "rp1",
+				featureId: "feat-1",
+				featureName: "Test Feature",
+				name: null,
+				command: "/build",
+				status: "completed",
+				harness: "codex",
+				currentStep: null,
+				steps: [],
+				artifacts: [],
+				events: [],
+				startedAt: "2026-03-31T23:00:00Z",
+				lastEventAt: "2026-03-31T23:30:00Z",
+				completedAt: "2026-03-31T23:30:00Z",
+				error: null,
+				agentSteps: null,
+			});
+		});
+
+		await waitFor(() => {
+			expect(result.current.projects[0]?.runCount).toBe(4);
+		});
+
+		expect(result.current.projects[0]?.lastActivityAt).toBe(
+			"2026-04-01T00:00:00Z",
+		);
+		expect(fetchMock).toHaveBeenCalledTimes(1);
 	});
 });

--- a/cli/web-ui/src/__tests__/hooks/useReconnectRecovery.test.ts
+++ b/cli/web-ui/src/__tests__/hooks/useReconnectRecovery.test.ts
@@ -2,13 +2,21 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { act, cleanup, renderHook } from "@testing-library/react";
 
 type ReconnectCallback = () => void;
+type ConnectionStatus = "connecting" | "connected" | "disconnected";
 
 let reconnectListeners: ReconnectCallback[] = [];
+let socketStatus: ConnectionStatus = "connected";
+let intervalCallback: (() => void) | null = null;
+let intervalId = 0;
+let clearedIntervalIds: ReturnType<typeof setInterval>[] = [];
 let useReconnectRecoveryImportVersion = 0;
+const originalSetInterval = globalThis.setInterval;
+const originalClearInterval = globalThis.clearInterval;
 
 async function loadUseReconnectRecovery() {
 	mock.module("@/providers/WebSocketProvider", () => ({
 		useWebSocket: () => ({
+			status: socketStatus,
 			subscribeToReconnect: (callback: ReconnectCallback) => {
 				reconnectListeners.push(callback);
 				return () => {
@@ -28,27 +36,65 @@ async function loadUseReconnectRecovery() {
 beforeEach(() => {
 	mock.restore();
 	reconnectListeners = [];
+	socketStatus = "connected";
+	intervalCallback = null;
+	intervalId = 0;
+	clearedIntervalIds = [];
+	globalThis.setInterval = ((callback: TimerHandler) => {
+		intervalCallback = callback as () => void;
+		intervalId += 1;
+		return intervalId as unknown as ReturnType<typeof setInterval>;
+	}) as unknown as typeof setInterval;
+	globalThis.clearInterval = ((id: ReturnType<typeof setInterval>) => {
+		clearedIntervalIds.push(id);
+		intervalCallback = null;
+	}) as unknown as typeof clearInterval;
 });
 
 afterEach(() => {
 	cleanup();
 	reconnectListeners = [];
+	socketStatus = "connected";
+	intervalCallback = null;
+	clearedIntervalIds = [];
+	globalThis.setInterval = originalSetInterval;
+	globalThis.clearInterval = originalClearInterval;
 	mock.restore();
 });
 
 describe("useReconnectRecovery", () => {
-	test("invokes recovery callbacks on reconnect and unsubscribes on unmount", async () => {
+	test("polls only while disconnected, refetches on reconnect, and unsubscribes on unmount", async () => {
 		const { useReconnectRecovery } = await loadUseReconnectRecovery();
 		const recover = mock(() => {});
-		const { unmount } = renderHook(() => useReconnectRecovery(recover));
+		const { rerender, unmount } = renderHook(() =>
+			useReconnectRecovery(recover),
+		);
 
 		expect(reconnectListeners).toHaveLength(1);
+		expect(intervalCallback).toBeNull();
+
+		socketStatus = "disconnected";
+		rerender();
+
+		expect(intervalCallback).not.toBeNull();
+
+		act(() => {
+			intervalCallback?.();
+		});
+
+		expect(recover).toHaveBeenCalledTimes(1);
+
+		socketStatus = "connected";
+		rerender();
+
+		expect(intervalCallback).toBeNull();
+		expect(clearedIntervalIds).toHaveLength(1);
 
 		act(() => {
 			reconnectListeners[0]?.();
 		});
 
-		expect(recover).toHaveBeenCalledTimes(1);
+		expect(recover).toHaveBeenCalledTimes(2);
 
 		unmount();
 

--- a/cli/web-ui/src/__tests__/hooks/useRunDetail.test.ts
+++ b/cli/web-ui/src/__tests__/hooks/useRunDetail.test.ts
@@ -1,12 +1,20 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import { useSyncExternalStore } from "react";
+import { liveRunIndex } from "@/lib/live-run-index";
 import type { Run, RunEvent } from "@/types/runs";
-import type { EventNotificationMessage } from "@/types/websocket";
+import type {
+	EventNotificationMessage,
+	StateSnapshotMessage,
+} from "@/types/websocket";
 
 type EventCallback = (msg: EventNotificationMessage) => void;
+type SnapshotCallback = (msg: StateSnapshotMessage) => void;
 
 let eventListeners: EventCallback[] = [];
+let snapshotListeners: SnapshotCallback[] = [];
 let mockWsStatus = "connected";
+let mockSocketProjectId: string | null = null;
 let runResponse: Run;
 let fetchMock: ReturnType<typeof mock>;
 let useRunDetailImportVersion = 0;
@@ -20,8 +28,24 @@ async function loadUseRunDetail() {
 					eventListeners = eventListeners.filter((l) => l !== cb);
 				};
 			},
+			onStateSnapshot: (cb: SnapshotCallback) => {
+				snapshotListeners.push(cb);
+				return () => {
+					snapshotListeners = snapshotListeners.filter((l) => l !== cb);
+				};
+			},
+			projectId: mockSocketProjectId,
 			status: mockWsStatus,
 		}),
+	}));
+	mock.module("../../hooks/useLiveRunIndex.ts", () => ({
+		useLiveRunIndexBridge: () => {},
+		useLiveRunIndexSnapshot: () =>
+			useSyncExternalStore(
+				liveRunIndex.subscribe,
+				liveRunIndex.getSnapshot,
+				liveRunIndex.getSnapshot,
+			),
 	}));
 
 	return import(
@@ -31,6 +55,12 @@ async function loadUseRunDetail() {
 
 function emitEvent(msg: EventNotificationMessage) {
 	for (const listener of eventListeners) {
+		listener(msg);
+	}
+}
+
+function emitSnapshot(msg: StateSnapshotMessage) {
+	for (const listener of snapshotListeners) {
 		listener(msg);
 	}
 }
@@ -67,8 +97,11 @@ const baseRun: Run = {
 
 beforeEach(() => {
 	mock.restore();
+	liveRunIndex.clear();
 	eventListeners = [];
+	snapshotListeners = [];
 	mockWsStatus = "connected";
+	mockSocketProjectId = null;
 	runResponse = { ...baseRun };
 
 	fetchMock = mock((url: string) => {
@@ -86,7 +119,9 @@ beforeEach(() => {
 
 afterEach(() => {
 	cleanup();
+	liveRunIndex.clear();
 	eventListeners = [];
+	snapshotListeners = [];
 	mock.restore();
 });
 
@@ -387,5 +422,76 @@ describe("useRunDetail", () => {
 		expect(result.current.run?.status).toBe("running");
 		expect(result.current.run?.statusMessage).toBeNull();
 		expect(result.current.run?.error).toBeNull();
+	});
+
+	test("state snapshots trigger bounded run reconciliation", async () => {
+		const { useRunDetail } = await loadUseRunDetail();
+		const { result } = renderHook(() => useRunDetail("run-1"));
+
+		await waitFor(() => {
+			expect(result.current.isLoading).toBe(false);
+		});
+
+		runResponse = {
+			...baseRun,
+			status: "completed",
+			completedAt: "2026-03-15T01:40:00Z",
+		};
+
+		act(() => {
+			emitSnapshot({
+				type: "state:snapshot",
+				lastEventId: 900,
+				runs: [
+					{
+						id: "run-1",
+						flow: "build",
+						featureId: "feat-1",
+						projectPath: "/tmp/project",
+						status: "running",
+						steps: [{ step: "design", status: "running" }],
+						artifacts: [],
+					},
+				],
+			});
+		});
+
+		await waitFor(() => {
+			expect(fetchMock).toHaveBeenCalledTimes(2);
+		});
+		await waitFor(() => {
+			expect(result.current.run?.status).toBe("completed");
+		});
+	});
+
+	test("state snapshots that exclude the active run do not refetch on an unscoped socket", async () => {
+		const { useRunDetail } = await loadUseRunDetail();
+		const { result } = renderHook(() => useRunDetail("run-1"));
+
+		await waitFor(() => {
+			expect(result.current.isLoading).toBe(false);
+		});
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+
+		act(() => {
+			emitSnapshot({
+				type: "state:snapshot",
+				lastEventId: 901,
+				runs: [
+					{
+						id: "run-2",
+						flow: "build",
+						featureId: "feat-2",
+						projectPath: "/tmp/other-project",
+						status: "running",
+						steps: [{ step: "review", status: "running" }],
+						artifacts: [],
+					},
+				],
+			});
+		});
+
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		expect(result.current.run?.status).toBe("running");
 	});
 });

--- a/cli/web-ui/src/__tests__/hooks/useRuns.test.ts
+++ b/cli/web-ui/src/__tests__/hooks/useRuns.test.ts
@@ -5,7 +5,7 @@ import { liveRunIndex } from "@/lib/live-run-index";
 import type { Run } from "@/types/runs";
 
 let fetchMock: ReturnType<typeof mock>;
-let useFeedImportVersion = 0;
+let useRunsImportVersion = 0;
 
 function buildRun(overrides: Partial<Run> = {}): Run {
 	return {
@@ -31,12 +31,11 @@ function buildRun(overrides: Partial<Run> = {}): Run {
 	};
 }
 
-async function loadUseFeed() {
+async function loadUseRuns() {
 	mock.module("../../hooks/useReconnectRecovery.ts", () => ({
 		useReconnectRecovery: () => {},
 	}));
 	mock.module("../../hooks/useLiveRunIndex.ts", () => ({
-		useLiveRunIndexBridge: () => {},
 		useLiveRunIndexSnapshot: () =>
 			useSyncExternalStore(
 				liveRunIndex.subscribe,
@@ -46,7 +45,7 @@ async function loadUseFeed() {
 	}));
 
 	return import(
-		`../../hooks/useFeed.ts?use-feed-test=${++useFeedImportVersion}`
+		`../../hooks/useRuns.ts?use-runs-test=${++useRunsImportVersion}`
 	);
 }
 
@@ -59,14 +58,7 @@ beforeEach(() => {
 			ok: true,
 			json: () =>
 				Promise.resolve({
-					items: [
-						{
-							type: "run",
-							id: "run-1",
-							timestamp: "2026-04-10T00:05:00.000Z",
-							run: buildRun(),
-						},
-					],
+					runs: [buildRun()],
 					total: 1,
 				}),
 		}),
@@ -80,43 +72,39 @@ afterEach(() => {
 	mock.restore();
 });
 
-describe("useFeed", () => {
-	test("patches known runs in place and inserts newly matching runs without refetching", async () => {
-		const { useFeed } = await loadUseFeed();
-		const { result } = renderHook(() => useFeed({ limit: 25, offset: 0 }));
+describe("useRuns", () => {
+	test("updates the loaded collection from live state without refetching", async () => {
+		const { useRuns } = await loadUseRuns();
+		const { result } = renderHook(() =>
+			useRuns({ status: "running", limit: 25, offset: 0 }),
+		);
 
 		await waitFor(() => {
 			expect(result.current.isLoading).toBe(false);
 		});
 
-		expect(result.current.items).toHaveLength(1);
-		expect(result.current.items[0]?.run.status).toBe("running");
+		expect(result.current.runs.map((run: Run) => run.id)).toEqual(["run-1"]);
 		expect(result.current.total).toBe(1);
 		expect(fetchMock).toHaveBeenCalledTimes(1);
 
 		liveRunIndex.upsertRuns([
 			buildRun({
 				id: "run-1",
-				status: "waiting",
-				currentStep: "review",
+				status: "completed",
+				completedAt: "2026-04-10T00:06:00.000Z",
 				lastEventAt: "2026-04-10T00:06:00.000Z",
 			}),
 			buildRun({
 				id: "run-2",
-				name: "Fresh Run",
 				lastEventAt: "2026-04-10T00:07:00.000Z",
 			}),
 		]);
 
 		await waitFor(() => {
-			expect(result.current.items).toHaveLength(2);
+			expect(result.current.runs.map((run: Run) => run.id)).toEqual(["run-2"]);
 		});
 
-		expect(result.current.items.map((item: { id: string }) => item.id)).toEqual(
-			["run-2", "run-1"],
-		);
-		expect(result.current.items[1]?.run.status).toBe("waiting");
-		expect(result.current.total).toBe(2);
+		expect(result.current.total).toBe(1);
 		expect(fetchMock).toHaveBeenCalledTimes(1);
 	});
 });

--- a/cli/web-ui/src/__tests__/lib/live-run-index.test.ts
+++ b/cli/web-ui/src/__tests__/lib/live-run-index.test.ts
@@ -1,0 +1,297 @@
+import { describe, expect, test } from "bun:test";
+import type { Run } from "@/types/runs";
+import type {
+	EventNotificationMessage,
+	StateSnapshotMessage,
+} from "@/types/websocket";
+import { createLiveRunIndex } from "../../lib/live-run-index";
+
+function buildRun(overrides: Partial<Run> = {}): Run {
+	return {
+		id: "run-1",
+		projectId: "proj-1",
+		projectName: "Project One",
+		featureId: "emit-daemon",
+		featureName: "Emit Daemon",
+		name: "Emit Daemon Run",
+		command: "/build",
+		status: "running",
+		harness: "codex",
+		currentStep: "build",
+		steps: [],
+		artifacts: [],
+		events: [],
+		startedAt: "2026-04-14T00:00:00.000Z",
+		lastEventAt: "2026-04-14T00:01:00.000Z",
+		completedAt: null,
+		error: null,
+		agentSteps: null,
+		...overrides,
+	};
+}
+
+function buildEvent(
+	overrides: Partial<EventNotificationMessage> &
+		Pick<EventNotificationMessage, "eventId" | "eventType">,
+): EventNotificationMessage {
+	return {
+		type: "event:notification",
+		eventId: overrides.eventId,
+		eventType: overrides.eventType,
+		runId: overrides.runId ?? "run-1",
+		projectId: overrides.projectId ?? "proj-1",
+		featureId: overrides.featureId ?? "emit-daemon",
+		step: overrides.step ?? null,
+		data: overrides.data ?? null,
+		createdAt: overrides.createdAt ?? "2026-04-14T00:05:00.000Z",
+	};
+}
+
+function buildSnapshot(
+	overrides: Partial<StateSnapshotMessage> = {},
+): StateSnapshotMessage {
+	return {
+		type: "state:snapshot",
+		lastEventId: overrides.lastEventId ?? 41,
+		runs: overrides.runs ?? [],
+	};
+}
+
+describe("LiveRunIndex", () => {
+	test("tracks cursors and reduces status-bearing events onto known runs", async () => {
+		const index = createLiveRunIndex();
+		index.upsertRun(buildRun());
+
+		await index.applyEvent(
+			buildEvent({
+				eventId: 11,
+				eventType: "waiting_for_user",
+				step: "review",
+				data: { prompt: "Need approval" },
+				createdAt: "2026-04-14T00:02:00.000Z",
+			}),
+		);
+
+		expect(index.getLastEventId("proj-1")).toBe(11);
+		expect(index.getLastActivityAt("proj-1")).toBe("2026-04-14T00:02:00.000Z");
+		expect(index.getRun("run-1")).toMatchObject({
+			status: "waiting",
+			currentStep: "review",
+			lastEventAt: "2026-04-14T00:02:00.000Z",
+			completedAt: null,
+		});
+
+		await index.applyEvent(
+			buildEvent({
+				eventId: 12,
+				eventType: "status_change",
+				step: "ship",
+				data: { status: "completed", message: "Finished cleanly" },
+				createdAt: "2026-04-14T00:03:00.000Z",
+			}),
+		);
+
+		expect(index.getLastEventId("proj-1")).toBe(12);
+		expect(index.getLastActivityAt("proj-1")).toBe("2026-04-14T00:03:00.000Z");
+		expect(index.getRun("run-1")).toMatchObject({
+			status: "completed",
+			currentStep: "ship",
+			lastEventAt: "2026-04-14T00:03:00.000Z",
+			completedAt: "2026-04-14T00:03:00.000Z",
+			statusMessage: "Finished cleanly",
+		});
+	});
+
+	test("applies non-terminal event reducers without broad run mutations", async () => {
+		const index = createLiveRunIndex();
+		index.upsertRun(buildRun());
+
+		await index.applyEvent(
+			buildEvent({
+				eventId: 21,
+				eventType: "artifact_registered",
+				data: { docId: "doc-1", path: "artifact.md" },
+				createdAt: "2026-04-14T00:04:00.000Z",
+			}),
+		);
+		expect(index.getRun("run-1")).toMatchObject({
+			status: "running",
+			lastEventAt: "2026-04-14T00:04:00.000Z",
+		});
+
+		await index.applyEvent(
+			buildEvent({
+				eventId: 22,
+				eventType: "btw_update",
+				data: { message: "Heads up" },
+				createdAt: "2026-04-14T00:05:00.000Z",
+			}),
+		);
+		expect(index.getRun("run-1")).toMatchObject({
+			status: "running",
+			lastEventAt: "2026-04-14T00:05:00.000Z",
+		});
+
+		await index.applyEvent(
+			buildEvent({
+				eventId: 23,
+				eventType: "subflow_registered",
+				data: { subflowName: "review" },
+				createdAt: "2026-04-14T00:06:00.000Z",
+			}),
+		);
+		expect(index.getRun("run-1")).toMatchObject({
+			status: "running",
+			lastEventAt: "2026-04-14T00:06:00.000Z",
+		});
+
+		await index.applyEvent(
+			buildEvent({
+				eventId: 24,
+				eventType: "annotation_updated",
+				data: { docId: "doc-1" },
+				createdAt: "2026-04-14T00:07:00.000Z",
+			}),
+		);
+
+		expect(index.getRun("run-1")).toMatchObject({
+			status: "running",
+			lastEventAt: "2026-04-14T00:06:00.000Z",
+		});
+		expect(index.getLastEventId("proj-1")).toBe(24);
+		expect(index.getLastActivityAt("proj-1")).toBe("2026-04-14T00:07:00.000Z");
+	});
+
+	test("deduplicates unknown-run hydration and replays queued events once", async () => {
+		let resolveFetch: (run: Run | null) => void = () => {
+			throw new Error("Hydration fetch was not initialized");
+		};
+		let fetchCount = 0;
+		const index = createLiveRunIndex({
+			fetchRunSummary: (runId) => {
+				fetchCount += 1;
+				return new Promise<Run | null>((resolve) => {
+					resolveFetch = (run) => {
+						resolve(runId === "run-2" ? run : null);
+					};
+				});
+			},
+		});
+
+		const firstEvent = index.applyEvent(
+			buildEvent({
+				eventId: 31,
+				eventType: "status_change",
+				runId: "run-2",
+				step: "build",
+				data: { status: "running" },
+				createdAt: "2026-04-14T00:02:00.000Z",
+			}),
+		);
+		const secondEvent = index.applyEvent(
+			buildEvent({
+				eventId: 32,
+				eventType: "waiting_for_user",
+				runId: "run-2",
+				step: "review",
+				data: { prompt: "Need input" },
+				createdAt: "2026-04-14T00:03:00.000Z",
+			}),
+		);
+		const thirdEvent = index.applyEvent(
+			buildEvent({
+				eventId: 33,
+				eventType: "artifact_registered",
+				runId: "run-2",
+				data: { docId: "doc-2", path: "summary.md" },
+				createdAt: "2026-04-14T00:04:00.000Z",
+			}),
+		);
+
+		expect(fetchCount).toBe(1);
+		expect(index.getRun("run-2")).toBeUndefined();
+		expect(index.getLastEventId("proj-1")).toBe(33);
+		expect(index.getLastActivityAt("proj-1")).toBe("2026-04-14T00:04:00.000Z");
+
+		resolveFetch(
+			buildRun({
+				id: "run-2",
+				name: "Hydrated Run",
+				lastEventAt: "2026-04-14T00:01:30.000Z",
+			}),
+		);
+
+		await Promise.all([firstEvent, secondEvent, thirdEvent]);
+
+		expect(fetchCount).toBe(1);
+		expect(index.getProjectRunIds("proj-1")).toEqual(["run-2"]);
+		expect(index.getRunsForProject("proj-1")).toHaveLength(1);
+		expect(index.getRun("run-2")).toMatchObject({
+			status: "waiting",
+			currentStep: "review",
+			lastEventAt: "2026-04-14T00:04:00.000Z",
+			completedAt: null,
+		});
+	});
+
+	test("reconciles the project's active-run subset on snapshot recovery", () => {
+		const index = createLiveRunIndex();
+		index.upsertRuns([
+			buildRun({
+				id: "run-stale",
+				status: "running",
+				currentStep: "build",
+				lastEventAt: "2026-04-14T00:02:00.000Z",
+			}),
+			buildRun({
+				id: "run-keep",
+				status: "running",
+				currentStep: "build",
+				lastEventAt: "2026-04-14T00:03:00.000Z",
+			}),
+			buildRun({
+				id: "run-terminal",
+				status: "completed",
+				currentStep: "ship",
+				lastEventAt: "2026-04-14T00:01:00.000Z",
+				completedAt: "2026-04-14T00:01:00.000Z",
+			}),
+		]);
+
+		index.applySnapshot(
+			"proj-1",
+			buildSnapshot({
+				lastEventId: 44,
+				runs: [
+					{
+						id: "run-keep",
+						flow: "build",
+						featureId: "emit-daemon",
+						projectPath: "/tmp/project",
+						status: "waiting",
+						steps: [
+							{ step: "build", status: "completed" },
+							{ step: "review", status: "waiting" },
+						],
+						artifacts: [],
+					},
+				],
+			}),
+		);
+
+		expect(index.getLastEventId("proj-1")).toBe(44);
+		expect(index.getRun("run-stale")).toBeUndefined();
+		expect(index.getRun("run-terminal")).toMatchObject({
+			status: "completed",
+			currentStep: "ship",
+		});
+		expect(index.getRun("run-keep")).toMatchObject({
+			status: "waiting",
+			currentStep: "review",
+			completedAt: null,
+		});
+		expect(new Set(index.getProjectRunIds("proj-1"))).toEqual(
+			new Set(["run-keep", "run-terminal"]),
+		);
+	});
+});

--- a/cli/web-ui/src/__tests__/pages/v2/ProjectOverviewPage.test.tsx
+++ b/cli/web-ui/src/__tests__/pages/v2/ProjectOverviewPage.test.tsx
@@ -7,12 +7,14 @@ import {
 	waitFor,
 } from "@testing-library/react";
 import type { ComponentType, ReactNode } from "react";
+import { useSyncExternalStore } from "react";
 import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
 import {
 	WORKSPACE_TABS_STORAGE_KEY,
 	type WorkspaceTab,
 	WorkspaceTabsProvider,
 } from "@/hooks/useWorkspaceTabs";
+import { liveRunIndex } from "@/lib/live-run-index";
 import type { ShortcutRegistryData } from "@/providers/ShortcutRegistryProvider";
 import {
 	ShortcutRegistryProvider,
@@ -32,6 +34,16 @@ mock.module("@/hooks/useBreadcrumbContext", () => ({
 
 mock.module("@/hooks/useReconnectRecovery", () => ({
 	useReconnectRecovery: () => {},
+}));
+
+mock.module("@/hooks/useLiveRunIndex", () => ({
+	useLiveRunIndexBridge: () => {},
+	useLiveRunIndexSnapshot: () =>
+		useSyncExternalStore(
+			liveRunIndex.subscribe,
+			liveRunIndex.getSnapshot,
+			liveRunIndex.getSnapshot,
+		),
 }));
 
 mock.module("@/components/v2/RunCard", () => ({
@@ -113,6 +125,7 @@ function renderProjectOverviewWithComponent(
 describe("ProjectOverviewPage", () => {
 	beforeEach(() => {
 		mock.restore();
+		liveRunIndex.clear();
 		document.body.innerHTML = "";
 		sessionStorage.clear();
 		latestRegistry = null;
@@ -147,6 +160,7 @@ describe("ProjectOverviewPage", () => {
 
 	afterEach(() => {
 		cleanup();
+		liveRunIndex.clear();
 		mock.restore();
 	});
 
@@ -207,13 +221,23 @@ describe("ProjectOverviewPage", () => {
 					runs: [
 						{
 							id: "run-1",
-							command: "/build",
-							status: "running",
 							projectId: "proj-1",
 							projectName: "Project One",
+							featureId: "feat-1",
+							featureName: "Feature One",
+							name: "Run one",
+							command: "/build",
+							status: "running",
 							harness: "codex",
+							currentStep: null,
+							steps: [],
+							artifacts: [],
+							events: [],
 							startedAt: "2026-04-12T00:00:00.000Z",
 							lastEventAt: "2026-04-12T00:00:00.000Z",
+							completedAt: null,
+							error: null,
+							agentSteps: null,
 						},
 					],
 					total: 1,
@@ -283,5 +307,177 @@ describe("ProjectOverviewPage", () => {
 
 		expect(screen.getByRole("heading", { name: "Project One" })).toBeTruthy();
 		expect(screen.queryByText("...")).toBeNull();
+	});
+
+	test("merges newly active project runs into the recent list without refetching", async () => {
+		global.fetch = mock(async (input: RequestInfo | URL) => {
+			const url = String(input);
+			if (url.includes("/api/v2/projects/proj-1") && !url.includes("runs?")) {
+				return {
+					ok: true,
+					status: 200,
+					json: async () => ({
+						id: "proj-1",
+						name: "Project One",
+						path: "/repo/project-one",
+						available: true,
+						runCount: 3,
+						lastActivityAt: "2026-04-12T00:00:00.000Z",
+					}),
+				} satisfies Partial<Response>;
+			}
+
+			return {
+				ok: true,
+				status: 200,
+				json: async () => ({
+					runs: [
+						{
+							id: "run-1",
+							projectId: "proj-1",
+							projectName: "Project One",
+							featureId: "feat-1",
+							featureName: "Feature One",
+							name: "Initial Run",
+							command: "/build",
+							status: "running",
+							harness: "codex",
+							currentStep: null,
+							steps: [],
+							artifacts: [],
+							events: [],
+							startedAt: "2026-04-12T00:00:00.000Z",
+							lastEventAt: "2026-04-12T00:00:00.000Z",
+							completedAt: null,
+							error: null,
+							agentSteps: null,
+						},
+					],
+					total: 1,
+				}),
+			} satisfies Partial<Response>;
+		}) as unknown as typeof fetch;
+
+		const { ProjectOverviewPage } = await import(
+			`../../../pages/v2/ProjectOverviewPage.tsx?project-overview-live-test=${++importVersion}`
+		);
+		renderProjectOverviewWithComponent(ProjectOverviewPage);
+
+		expect(
+			await screen.findByRole("heading", { name: "Project One" }),
+		).toBeTruthy();
+		expect(global.fetch).toHaveBeenCalledTimes(2);
+
+		liveRunIndex.upsertRun({
+			id: "run-2",
+			projectId: "proj-1",
+			projectName: "Project One",
+			featureId: "feat-1",
+			featureName: "Feature One",
+			name: "Live Run",
+			command: "/build",
+			status: "running",
+			harness: "codex",
+			currentStep: null,
+			steps: [],
+			artifacts: [],
+			events: [],
+			startedAt: "2026-04-12T00:05:00.000Z",
+			lastEventAt: "2026-04-12T00:05:00.000Z",
+			completedAt: null,
+			error: null,
+			agentSteps: null,
+		});
+
+		await waitFor(() => {
+			expect(screen.getByText("4 runs")).toBeTruthy();
+		});
+		expect(global.fetch).toHaveBeenCalledTimes(2);
+	});
+
+	test("counts newly discovered older runs without replacing the project activity timestamp", async () => {
+		global.fetch = mock(async (input: RequestInfo | URL) => {
+			const url = String(input);
+			if (url.includes("/api/v2/projects/proj-1") && !url.includes("runs?")) {
+				return {
+					ok: true,
+					status: 200,
+					json: async () => ({
+						id: "proj-1",
+						name: "Project One",
+						path: "/repo/project-one",
+						available: true,
+						runCount: 3,
+						lastActivityAt: "2026-04-12T00:00:00.000Z",
+					}),
+				} satisfies Partial<Response>;
+			}
+
+			return {
+				ok: true,
+				status: 200,
+				json: async () => ({
+					runs: [
+						{
+							id: "run-1",
+							projectId: "proj-1",
+							projectName: "Project One",
+							featureId: "feat-1",
+							featureName: "Feature One",
+							name: "Initial Run",
+							command: "/build",
+							status: "running",
+							harness: "codex",
+							currentStep: null,
+							steps: [],
+							artifacts: [],
+							events: [],
+							startedAt: "2026-04-12T00:00:00.000Z",
+							lastEventAt: "2026-04-12T00:00:00.000Z",
+							completedAt: null,
+							error: null,
+							agentSteps: null,
+						},
+					],
+					total: 1,
+				}),
+			} satisfies Partial<Response>;
+		}) as unknown as typeof fetch;
+
+		const { ProjectOverviewPage } = await import(
+			`../../../pages/v2/ProjectOverviewPage.tsx?project-overview-older-run-test=${++importVersion}`
+		);
+		renderProjectOverviewWithComponent(ProjectOverviewPage);
+
+		expect(
+			await screen.findByRole("heading", { name: "Project One" }),
+		).toBeTruthy();
+		expect(global.fetch).toHaveBeenCalledTimes(2);
+
+		liveRunIndex.upsertRun({
+			id: "run-older",
+			projectId: "proj-1",
+			projectName: "Project One",
+			featureId: "feat-1",
+			featureName: "Feature One",
+			name: "Older Run",
+			command: "/build",
+			status: "completed",
+			harness: "codex",
+			currentStep: null,
+			steps: [],
+			artifacts: [],
+			events: [],
+			startedAt: "2026-04-11T00:00:00.000Z",
+			lastEventAt: "2026-04-11T00:05:00.000Z",
+			completedAt: "2026-04-11T00:05:00.000Z",
+			error: null,
+			agentSteps: null,
+		});
+
+		await waitFor(() => {
+			expect(screen.getByText("4 runs")).toBeTruthy();
+		});
+		expect(global.fetch).toHaveBeenCalledTimes(2);
 	});
 });

--- a/cli/web-ui/src/__tests__/providers/WebSocketProvider.test.tsx
+++ b/cli/web-ui/src/__tests__/providers/WebSocketProvider.test.tsx
@@ -1,0 +1,205 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import {
+	type EventNotificationMessage,
+	type StateSnapshotMessage,
+	useWebSocket,
+	WebSocketProvider,
+} from "@/providers/WebSocketProvider";
+
+const LAST_EVENT_ID_STORAGE_PREFIX = "rp1:last-event-id:";
+
+class MockWebSocket {
+	static readonly CONNECTING = 0;
+	static readonly OPEN = 1;
+	static readonly CLOSING = 2;
+	static readonly CLOSED = 3;
+	static instances: MockWebSocket[] = [];
+
+	readonly url: string;
+	readyState = MockWebSocket.CONNECTING;
+	onopen: ((event: Event) => void) | null = null;
+	onclose: ((event: CloseEvent) => void) | null = null;
+	onerror: ((event: Event) => void) | null = null;
+	onmessage: ((event: MessageEvent<string>) => void) | null = null;
+	sentMessages: string[] = [];
+
+	constructor(url: string | URL) {
+		this.url = String(url);
+		MockWebSocket.instances.push(this);
+	}
+
+	send(data: string): void {
+		this.sentMessages.push(data);
+	}
+
+	close(): void {
+		this.readyState = MockWebSocket.CLOSED;
+		this.onclose?.(new Event("close") as CloseEvent);
+	}
+
+	open(): void {
+		this.readyState = MockWebSocket.OPEN;
+		this.onopen?.(new Event("open"));
+	}
+
+	receive(message: unknown): void {
+		this.onmessage?.({
+			data: JSON.stringify(message),
+		} as MessageEvent<string>);
+	}
+}
+
+function wrapper({ children }: { children: ReactNode }) {
+	return <WebSocketProvider>{children}</WebSocketProvider>;
+}
+
+function getLatestProjectSocket(projectId: string): MockWebSocket | undefined {
+	return [...MockWebSocket.instances]
+		.reverse()
+		.find(
+			(socket) =>
+				new URL(socket.url).searchParams.get("projectId") === projectId,
+		);
+}
+
+describe("WebSocketProvider", () => {
+	const originalWebSocket = globalThis.WebSocket;
+
+	beforeEach(() => {
+		MockWebSocket.instances = [];
+		sessionStorage.clear();
+		globalThis.WebSocket = MockWebSocket as unknown as typeof WebSocket;
+	});
+
+	afterEach(() => {
+		cleanup();
+		sessionStorage.clear();
+		MockWebSocket.instances = [];
+		globalThis.WebSocket = originalWebSocket;
+	});
+
+	test("includes the stored project cursor when connecting to a project-scoped socket", async () => {
+		sessionStorage.setItem(`${LAST_EVENT_ID_STORAGE_PREFIX}proj-1`, "41");
+
+		const { result } = renderHook(() => useWebSocket(), { wrapper });
+
+		act(() => {
+			result.current.setProjectId("proj-1");
+		});
+
+		await waitFor(() => {
+			expect(getLatestProjectSocket("proj-1")).toBeDefined();
+		});
+
+		const projectSocket = getLatestProjectSocket("proj-1");
+		expect(projectSocket).toBeDefined();
+		expect(new URL(projectSocket!.url).searchParams.get("lastEventId")).toBe(
+			"41",
+		);
+	});
+
+	test("normalizes replay events and routes snapshots while advancing the project cursor", async () => {
+		const receivedEvents: EventNotificationMessage[] = [];
+		const receivedSnapshots: StateSnapshotMessage[] = [];
+
+		const { result, unmount } = renderHook(() => useWebSocket(), { wrapper });
+
+		act(() => {
+			result.current.onEventNotification((message) => {
+				receivedEvents.push(message);
+			});
+			result.current.onStateSnapshot((message) => {
+				receivedSnapshots.push(message);
+			});
+			result.current.setProjectId("proj-1");
+		});
+
+		await waitFor(() => {
+			expect(getLatestProjectSocket("proj-1")).toBeDefined();
+		});
+
+		const projectSocket = getLatestProjectSocket("proj-1");
+		expect(projectSocket).toBeDefined();
+
+		act(() => {
+			projectSocket!.open();
+			projectSocket!.receive({
+				type: "event:notification",
+				eventId: 42,
+				eventType: "status_change",
+				runId: "run-1",
+				projectId: "proj-1",
+				featureId: "feat-1",
+				step: "build",
+				data: { status: "running" },
+				createdAt: "2026-04-14T00:00:00.000Z",
+			});
+			projectSocket!.receive({
+				type: "event:replay",
+				event: {
+					id: 43,
+					runId: "run-1",
+					eventType: "waiting_for_user",
+					step: "review",
+					data: JSON.stringify({ prompt: "Need approval" }),
+					createdAt: "2026-04-14T00:00:01.000Z",
+				},
+			});
+			projectSocket!.receive({
+				type: "state:snapshot",
+				runs: [
+					{
+						id: "run-1",
+						flow: "build",
+						featureId: "feat-1",
+						projectPath: "/tmp/project",
+						status: "waiting",
+						steps: [{ step: "review", status: "waiting" }],
+						artifacts: [],
+					},
+				],
+				lastEventId: 55,
+			});
+		});
+
+		expect(receivedEvents).toHaveLength(2);
+		expect(receivedEvents[0]).toMatchObject({
+			type: "event:notification",
+			eventId: 42,
+			eventType: "status_change",
+			projectId: "proj-1",
+		});
+		expect(receivedEvents[1]).toMatchObject({
+			type: "event:notification",
+			eventId: 43,
+			eventType: "waiting_for_user",
+			projectId: "proj-1",
+			step: "review",
+			data: { prompt: "Need approval" },
+		});
+		expect(receivedSnapshots).toHaveLength(1);
+		expect(receivedSnapshots[0]?.lastEventId).toBe(55);
+		expect(
+			sessionStorage.getItem(`${LAST_EVENT_ID_STORAGE_PREFIX}proj-1`),
+		).toBe("55");
+
+		unmount();
+
+		const rerendered = renderHook(() => useWebSocket(), { wrapper });
+		act(() => {
+			rerendered.result.current.setProjectId("proj-1");
+		});
+
+		await waitFor(() => {
+			expect(MockWebSocket.instances.length).toBeGreaterThanOrEqual(2);
+		});
+
+		const reconnectedSocket = getLatestProjectSocket("proj-1");
+		expect(reconnectedSocket).toBeDefined();
+		expect(
+			new URL(reconnectedSocket!.url).searchParams.get("lastEventId"),
+		).toBe("55");
+	});
+});

--- a/cli/web-ui/src/__tests__/server/v2-api-runs.test.ts
+++ b/cli/web-ui/src/__tests__/server/v2-api-runs.test.ts
@@ -23,6 +23,7 @@ import {
 import {
 	handleV2RunDetailRequest,
 	handleV2RunEndRequest,
+	handleV2RunSummaryRequest,
 	handleV2RunsAttentionRequest,
 	handleV2RunsListRequest,
 } from "../../server/routes/v2-api.js";
@@ -295,6 +296,65 @@ describe("V2 runs API", () => {
 			expect(typeof call?.[1]).toBe("number");
 			expect(typeof call?.[7]).toBe("string");
 		}
+	});
+
+	test("returns the same lightweight run shape and project identity as the list view", async () => {
+		const { db, projectId, projectRoot, registryProjectId } =
+			await setupProject(tempDir, "summary");
+
+		insertRun(db, {
+			id: "run-summary",
+			flow: "build",
+			featureId: "targeted-hydration",
+			projectPath: projectRoot,
+			projectId,
+			name: "Summary Run",
+			harness: "codex",
+		});
+		insertEvent(db, {
+			runId: "run-summary",
+			type: "status_change",
+			step: "build",
+			data: JSON.stringify({ status: "running" }),
+			createdAt: "2026-04-12T02:00:00.000Z",
+		});
+		deriveRunStatus(db, "run-summary");
+
+		const listResponse = await handleV2RunsListRequest(
+			new Request("http://localhost/api/v2/runs"),
+		);
+		const listBody = (await listResponse.json()) as {
+			runs: Array<Record<string, unknown>>;
+		};
+		const listRun = listBody.runs.find((run) => run.id === "run-summary");
+
+		expect(listResponse.status).toBe(200);
+		expect(listRun).toBeDefined();
+		if (!listRun) {
+			throw new Error("Expected run-summary in list response");
+		}
+
+		const summaryResponse = await handleV2RunSummaryRequest("run-summary");
+		const summaryBody = (await summaryResponse.json()) as Record<
+			string,
+			unknown
+		>;
+
+		expect(summaryResponse.status).toBe(200);
+		expect(summaryBody).toEqual(listRun);
+		expect(summaryBody.projectId).toBe(registryProjectId);
+		expect(summaryBody.projectName).toBe("Project summary");
+		expect(summaryBody.lastEventAt).toBe("2026-04-12T02:00:00.000Z");
+	});
+
+	test("returns 404 when the run summary does not exist", async () => {
+		await setupProject(tempDir, "summary-missing");
+
+		const response = await handleV2RunSummaryRequest("missing-run");
+		const body = (await response.json()) as { error: string };
+
+		expect(response.status).toBe(404);
+		expect(body.error).toContain("Run not found");
 	});
 
 	test("ends a live run through the dedicated endpoint and broadcasts the lifecycle event", async () => {

--- a/cli/web-ui/src/components/v2/V2Sidebar.tsx
+++ b/cli/web-ui/src/components/v2/V2Sidebar.tsx
@@ -89,6 +89,8 @@ const navItems = allNavItems.filter(
 );
 
 export function V2Sidebar({ collapsed, onToggle }: V2SidebarProps) {
+	const { data: attentionData } = useAttention();
+
 	return (
 		<aside
 			className={cn(
@@ -97,8 +99,8 @@ export function V2Sidebar({ collapsed, onToggle }: V2SidebarProps) {
 			)}
 		>
 			<SidebarHeader collapsed={collapsed} />
-			<SidebarQuickAccess collapsed={collapsed} />
-			<SidebarNavigation collapsed={collapsed} />
+			<SidebarQuickAccess collapsed={collapsed} attentionData={attentionData} />
+			<SidebarNavigation collapsed={collapsed} attentionData={attentionData} />
 			<SidebarFooter collapsed={collapsed} onToggle={onToggle} />
 		</aside>
 	);
@@ -169,12 +171,15 @@ function SidebarFooter({ collapsed, onToggle }: SidebarFooterProps) {
 
 interface SidebarQuickAccessProps {
 	collapsed: boolean;
+	attentionData: ReturnType<typeof useAttention>["data"];
 }
 
-function SidebarQuickAccess({ collapsed }: SidebarQuickAccessProps) {
+function SidebarQuickAccess({
+	collapsed,
+	attentionData,
+}: SidebarQuickAccessProps) {
 	const { recentRuns } = useRecentRuns();
 	const { pinnedProjects } = usePinnedProjects();
-	const { data: attentionData } = useAttention();
 
 	if (collapsed) return null;
 
@@ -287,11 +292,13 @@ function SidebarQuickAccess({ collapsed }: SidebarQuickAccessProps) {
 
 interface SidebarNavigationProps {
 	collapsed: boolean;
+	attentionData: ReturnType<typeof useAttention>["data"];
 }
 
-function SidebarNavigation({ collapsed }: SidebarNavigationProps) {
-	const { data: attentionData } = useAttention();
-
+function SidebarNavigation({
+	collapsed,
+	attentionData,
+}: SidebarNavigationProps) {
 	const badgeCounts = useMemo(() => {
 		if (!attentionData) return { home: 0, runs: 0, projects: 0 };
 

--- a/cli/web-ui/src/daemon/index.ts
+++ b/cli/web-ui/src/daemon/index.ts
@@ -14,7 +14,6 @@ export {
 } from "./config-dir";
 
 export {
-	type ArtifactNotifyPayload,
 	checkHealth,
 	createConnection,
 	type DaemonConnection,
@@ -24,14 +23,11 @@ export {
 	getDaemonStatus,
 	type HealthResponse,
 	type NotificationNotifyPayload,
-	notifyArtifactChange,
 	notifyEvent,
 	notifyNotification,
-	notifyStatusChange,
 	type RegisterResponse,
 	registerProjectWithDaemon,
 	stopDaemon as stopDaemonViaIpc,
-	type WorkflowNotifyContext,
 } from "./ipc";
 
 export {

--- a/cli/web-ui/src/daemon/ipc.ts
+++ b/cli/web-ui/src/daemon/ipc.ts
@@ -109,67 +109,6 @@ export async function stopDaemon(conn: DaemonConnection): Promise<boolean> {
 }
 
 /**
- * Workflow context for enriched status notifications.
- * When present, the daemon enriches status_changed WebSocket events with step/runStatus fields.
- */
-export interface WorkflowNotifyContext {
-	readonly workflow: string;
-	readonly runId?: string;
-	readonly previousState?: string | null;
-	readonly newState: string;
-	readonly stepStatus?: string;
-}
-
-/**
- * Notify the daemon of a status update for immediate WebSocket broadcast.
- * Fails silently if daemon is not running - this is expected behavior.
- *
- * When workflowCtx is provided (state-machine-enabled workflows),
- * the daemon enriches the status_changed broadcast with step and runStatus fields.
- */
-export async function notifyStatusChange(
-	conn: DaemonConnection,
-	projectPath: string,
-	feature: string,
-	status: string,
-	workflowCtx?: WorkflowNotifyContext,
-): Promise<boolean> {
-	try {
-		const response = await fetch(`${conn.baseUrl}/api/v2/status/notify`, {
-			method: "POST",
-			headers: { "Content-Type": "application/json" },
-			body: JSON.stringify({
-				projectPath,
-				feature,
-				status,
-				...(workflowCtx && {
-					workflow: workflowCtx.workflow,
-					runId: workflowCtx.runId,
-					previousState: workflowCtx.previousState,
-					newState: workflowCtx.newState,
-					stepStatus: workflowCtx.stepStatus,
-				}),
-			}),
-			signal: AbortSignal.timeout(1000), // Short timeout - fire and forget
-		});
-		return response.ok;
-	} catch {
-		// Daemon not running or unresponsive - this is fine
-		return false;
-	}
-}
-
-/**
- * Artifact notification payload for real-time WebSocket broadcast.
- */
-export interface ArtifactNotifyPayload {
-	readonly path: string;
-	readonly type: string;
-	readonly step: string | null;
-	readonly runId: string | null;
-}
-
-/**
  * Typed event notification payload for the new event-sourced IPC format.
  * Uses `type: "event"` as discriminator to distinguish from legacy formats.
  */
@@ -185,34 +124,6 @@ export interface EventNotificationPayload {
 	readonly step: string | null;
 	readonly data: Record<string, unknown> | null;
 	readonly createdAt: string;
-}
-
-/**
- * Notify the daemon of an artifact registration for immediate WebSocket broadcast.
- * Fails silently if daemon is not running - this is expected behavior.
- */
-export async function notifyArtifactChange(
-	conn: DaemonConnection,
-	projectPath: string,
-	feature: string,
-	artifact: ArtifactNotifyPayload,
-): Promise<boolean> {
-	try {
-		const response = await fetch(`${conn.baseUrl}/api/v2/status/notify`, {
-			method: "POST",
-			headers: { "Content-Type": "application/json" },
-			body: JSON.stringify({
-				type: "artifact",
-				projectPath,
-				feature,
-				artifact,
-			}),
-			signal: AbortSignal.timeout(1000),
-		});
-		return response.ok;
-	} catch {
-		return false;
-	}
 }
 
 /**

--- a/cli/web-ui/src/hooks/useAttention.ts
+++ b/cli/web-ui/src/hooks/useAttention.ts
@@ -1,6 +1,10 @@
 import { useCallback, useEffect, useState } from "react";
-import { useWebSocket } from "@/providers/WebSocketProvider";
+import { liveRunIndex } from "@/lib/live-run-index";
 import type { AttentionData } from "@/types/runs";
+import {
+	useLiveRunIndexBridge,
+	useLiveRunIndexSnapshot,
+} from "./useLiveRunIndex";
 import { useReconnectRecovery } from "./useReconnectRecovery";
 
 interface UseAttentionResult {
@@ -10,11 +14,30 @@ interface UseAttentionResult {
 	refetch: () => void;
 }
 
+function areAttentionGroupsEqual(
+	current: AttentionData | null,
+	next: AttentionData,
+): boolean {
+	if (!current) {
+		return false;
+	}
+
+	return (
+		current.waiting.length === next.waiting.length &&
+		current.failed.length === next.failed.length &&
+		current.running.length === next.running.length &&
+		current.waiting.every((run, index) => run === next.waiting[index]) &&
+		current.failed.every((run, index) => run === next.failed[index]) &&
+		current.running.every((run, index) => run === next.running[index])
+	);
+}
+
 export function useAttention(): UseAttentionResult {
 	const [data, setData] = useState<AttentionData | null>(null);
 	const [isLoading, setIsLoading] = useState(true);
 	const [error, setError] = useState<Error | null>(null);
-	const { subscribeToAttention } = useWebSocket();
+	useLiveRunIndexBridge();
+	const liveSnapshot = useLiveRunIndexSnapshot();
 
 	const fetchAttention = useCallback(async () => {
 		try {
@@ -25,7 +48,22 @@ export function useAttention(): UseAttentionResult {
 				);
 			}
 			const attentionData = (await response.json()) as AttentionData;
-			setData(attentionData);
+			liveRunIndex.upsertRuns([
+				...attentionData.waiting,
+				...attentionData.failed,
+				...attentionData.running,
+			]);
+			setData({
+				waiting: attentionData.waiting
+					.map((run) => liveRunIndex.getRun(run.id) ?? run)
+					.filter((run) => run.status === "waiting"),
+				failed: attentionData.failed
+					.map((run) => liveRunIndex.getRun(run.id) ?? run)
+					.filter((run) => run.status === "failed"),
+				running: attentionData.running
+					.map((run) => liveRunIndex.getRun(run.id) ?? run)
+					.filter((run) => run.status === "running"),
+			});
 			setError(null);
 		} catch (err) {
 			setError(err instanceof Error ? err : new Error(String(err)));
@@ -39,11 +77,27 @@ export function useAttention(): UseAttentionResult {
 	}, [fetchAttention]);
 
 	useEffect(() => {
-		const unsubscribe = subscribeToAttention(() => {
-			fetchAttention();
-		});
-		return unsubscribe;
-	}, [subscribeToAttention, fetchAttention]);
+		if (isLoading || data === null) {
+			return;
+		}
+
+		void liveSnapshot;
+		const nextData: AttentionData = {
+			waiting: liveRunIndex
+				.getAllRuns()
+				.filter((run) => run.status === "waiting"),
+			failed: liveRunIndex
+				.getAllRuns()
+				.filter((run) => run.status === "failed"),
+			running: liveRunIndex
+				.getAllRuns()
+				.filter((run) => run.status === "running"),
+		};
+
+		if (!areAttentionGroupsEqual(data, nextData)) {
+			setData(nextData);
+		}
+	}, [data, isLoading, liveSnapshot]);
 
 	useReconnectRecovery(fetchAttention);
 

--- a/cli/web-ui/src/hooks/useFeed.ts
+++ b/cli/web-ui/src/hooks/useFeed.ts
@@ -1,6 +1,10 @@
-import { useCallback, useEffect, useState } from "react";
-import { useWebSocket } from "@/providers/WebSocketProvider";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { liveRunIndex } from "@/lib/live-run-index";
 import type { Run, RunsFilter } from "@/types/runs";
+import {
+	useLiveRunIndexBridge,
+	useLiveRunIndexSnapshot,
+} from "./useLiveRunIndex";
 import { useReconnectRecovery } from "./useReconnectRecovery";
 
 export interface RunFeedItem {
@@ -28,6 +32,78 @@ export interface UseFeedResult {
 	isLoading: boolean;
 	error: Error | null;
 	refetch: () => void;
+}
+
+function activityTimestamp(run: Run): string {
+	return run.lastEventAt ?? run.startedAt;
+}
+
+function compareFeedItems(a: FeedItem, b: FeedItem): number {
+	return activityTimestamp(b.run).localeCompare(activityTimestamp(a.run));
+}
+
+function isWithinDateRange(
+	timestamp: string,
+	dateRange: UseFeedOptions["dateRange"],
+): boolean {
+	if (!dateRange || dateRange === "all") {
+		return true;
+	}
+
+	const now = Date.now();
+	const ranges: Record<
+		Exclude<NonNullable<UseFeedOptions["dateRange"]>, "all">,
+		number
+	> = {
+		today: 24 * 60 * 60 * 1000,
+		week: 7 * 24 * 60 * 60 * 1000,
+		month: 30 * 24 * 60 * 60 * 1000,
+	};
+
+	return now - new Date(timestamp).getTime() <= ranges[dateRange];
+}
+
+function matchesFeedFilters(run: Run, options: UseFeedOptions): boolean {
+	if (
+		options.status &&
+		options.status !== "all" &&
+		run.status !== options.status
+	) {
+		return false;
+	}
+
+	if (options.projectId && run.projectId !== options.projectId) {
+		return false;
+	}
+
+	return isWithinDateRange(activityTimestamp(run), options.dateRange);
+}
+
+function toFeedItem(run: Run): RunFeedItem {
+	return {
+		type: "run",
+		id: run.id,
+		timestamp: activityTimestamp(run),
+		run,
+	};
+}
+
+function areFeedItemsEqual(
+	current: readonly FeedItem[],
+	next: readonly FeedItem[],
+): boolean {
+	if (current.length !== next.length) {
+		return false;
+	}
+
+	return current.every((item, index) => {
+		const candidate = next[index];
+		return (
+			item.id === candidate?.id &&
+			item.timestamp === candidate?.timestamp &&
+			item.run === candidate?.run
+		);
+	});
 }
 
 function buildQueryParams(options: UseFeedOptions): URLSearchParams {
@@ -61,7 +137,9 @@ export function useFeed(options: UseFeedOptions = {}): UseFeedResult {
 	const [total, setTotal] = useState(0);
 	const [isLoading, setIsLoading] = useState(true);
 	const [error, setError] = useState<Error | null>(null);
-	const { subscribeToAttention } = useWebSocket();
+	const matchingRunIdsRef = useRef<Set<string>>(new Set());
+	useLiveRunIndexBridge();
+	const liveSnapshot = useLiveRunIndexSnapshot();
 
 	const { status, projectId, dateRange, limit, offset } = options;
 
@@ -82,7 +160,21 @@ export function useFeed(options: UseFeedOptions = {}): UseFeedResult {
 			}
 
 			const data = (await response.json()) as FeedResponse;
-			setItems(data.items);
+			liveRunIndex.upsertRuns(data.items.map((item) => item.run));
+			const filterOptions = { status, projectId, dateRange };
+			matchingRunIdsRef.current = new Set(
+				liveRunIndex
+					.getAllRuns()
+					.filter((run) => matchesFeedFilters(run, filterOptions))
+					.map((run) => run.id),
+			);
+			setItems(
+				data.items
+					.map((item) =>
+						toFeedItem(liveRunIndex.getRun(item.run.id) ?? item.run),
+					)
+					.sort(compareFeedItems),
+			);
 			setTotal(data.total);
 			setError(null);
 		} catch (err) {
@@ -98,11 +190,78 @@ export function useFeed(options: UseFeedOptions = {}): UseFeedResult {
 	}, [fetchFeed]);
 
 	useEffect(() => {
-		const unsubscribe = subscribeToAttention(() => {
-			fetchFeed();
-		});
-		return unsubscribe;
-	}, [subscribeToAttention, fetchFeed]);
+		if (isLoading) {
+			return;
+		}
+
+		void liveSnapshot;
+		const filterOptions = { status, projectId, dateRange };
+		const knownMatchingRunIds = matchingRunIdsRef.current;
+		for (const runId of [...knownMatchingRunIds]) {
+			const liveRun = liveRunIndex.getRun(runId);
+			if (liveRun && !matchesFeedFilters(liveRun, filterOptions)) {
+				knownMatchingRunIds.delete(runId);
+			}
+		}
+
+		const currentItems = items;
+		const nextLoadedItems = currentItems
+			.map((item) => liveRunIndex.getRun(item.run.id) ?? item.run)
+			.filter((run) => matchesFeedFilters(run, filterOptions))
+			.map(toFeedItem)
+			.sort(compareFeedItems);
+		for (const item of nextLoadedItems) {
+			knownMatchingRunIds.add(item.id);
+		}
+
+		const retainedIds = new Set(nextLoadedItems.map((item) => item.id));
+		const removedCount = currentItems.reduce(
+			(count, item) => count + (retainedIds.has(item.id) ? 0 : 1),
+			0,
+		);
+
+		let addedCount = 0;
+		let nextItems = nextLoadedItems;
+		if ((offset ?? 0) === 0) {
+			const additions: RunFeedItem[] = [];
+			for (const run of liveRunIndex.getAllRuns()) {
+				if (
+					retainedIds.has(run.id) ||
+					knownMatchingRunIds.has(run.id) ||
+					!matchesFeedFilters(run, filterOptions)
+				) {
+					continue;
+				}
+				additions.push(toFeedItem(run));
+				retainedIds.add(run.id);
+				knownMatchingRunIds.add(run.id);
+			}
+			addedCount = additions.length;
+			nextItems = [...nextLoadedItems, ...additions].sort(compareFeedItems);
+			if (limit !== undefined) {
+				nextItems = nextItems.slice(0, limit);
+			}
+		}
+
+		if (!areFeedItemsEqual(currentItems, nextItems)) {
+			setItems(nextItems);
+		}
+
+		if (addedCount > 0 || removedCount > 0) {
+			setTotal((currentTotal) =>
+				Math.max(0, currentTotal + addedCount - removedCount),
+			);
+		}
+	}, [
+		liveSnapshot,
+		items,
+		isLoading,
+		status,
+		projectId,
+		dateRange,
+		limit,
+		offset,
+	]);
 
 	useReconnectRecovery(fetchFeed);
 

--- a/cli/web-ui/src/hooks/useLiveRunIndex.ts
+++ b/cli/web-ui/src/hooks/useLiveRunIndex.ts
@@ -1,0 +1,30 @@
+import { useEffect, useSyncExternalStore } from "react";
+import { type LiveRunIndexState, liveRunIndex } from "@/lib/live-run-index";
+import { useWebSocket } from "@/providers/WebSocketProvider";
+
+const getSnapshot = (): LiveRunIndexState => liveRunIndex.getSnapshot();
+
+export function useLiveRunIndexBridge(): void {
+	const { onEventNotification, onStateSnapshot, projectId } = useWebSocket();
+
+	useEffect(() => {
+		const unsubscribeEvent = onEventNotification((message) => {
+			void liveRunIndex.applyEvent(message);
+		});
+		const unsubscribeSnapshot = onStateSnapshot((message) => {
+			if (!projectId) {
+				return;
+			}
+			liveRunIndex.applySnapshot(projectId, message);
+		});
+
+		return () => {
+			unsubscribeEvent();
+			unsubscribeSnapshot();
+		};
+	}, [onEventNotification, onStateSnapshot, projectId]);
+}
+
+export function useLiveRunIndexSnapshot(): LiveRunIndexState {
+	return useSyncExternalStore(liveRunIndex.subscribe, getSnapshot, getSnapshot);
+}

--- a/cli/web-ui/src/hooks/useProjects.ts
+++ b/cli/web-ui/src/hooks/useProjects.ts
@@ -3,9 +3,14 @@
  * Used by ProjectsPage for displaying registered projects.
  */
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { liveRunIndex } from "@/lib/live-run-index";
 import { useWebSocket } from "@/providers/WebSocketProvider";
 import type { V2Project } from "@/types/projects";
+import {
+	useLiveRunIndexBridge,
+	useLiveRunIndexSnapshot,
+} from "./useLiveRunIndex";
 import { useReconnectRecovery } from "./useReconnectRecovery";
 
 export type { V2Project };
@@ -21,11 +26,44 @@ interface UseProjectsReturn {
 	refetch: () => void;
 }
 
+function sortProjects(projects: readonly V2Project[]): V2Project[] {
+	return [...projects].sort((a, b) => {
+		if (!a.lastActivityAt && !b.lastActivityAt) return 0;
+		if (!a.lastActivityAt) return 1;
+		if (!b.lastActivityAt) return -1;
+		return b.lastActivityAt.localeCompare(a.lastActivityAt);
+	});
+}
+
+function areProjectsEqual(
+	current: readonly V2Project[],
+	next: readonly V2Project[],
+): boolean {
+	if (current.length !== next.length) {
+		return false;
+	}
+
+	return current.every((project, index) => {
+		const candidate = next[index];
+		return (
+			project.id === candidate?.id &&
+			project.name === candidate?.name &&
+			project.path === candidate?.path &&
+			project.available === candidate?.available &&
+			project.runCount === candidate?.runCount &&
+			project.lastActivityAt === candidate?.lastActivityAt
+		);
+	});
+}
+
 export function useProjects(): UseProjectsReturn {
 	const [projects, setProjects] = useState<V2Project[]>([]);
 	const [isLoading, setIsLoading] = useState(true);
 	const [error, setError] = useState<Error | null>(null);
+	const knownRunIdsByProjectRef = useRef<Map<string, Set<string>>>(new Map());
 	const { onProjectsChange } = useWebSocket();
+	useLiveRunIndexBridge();
+	const liveSnapshot = useLiveRunIndexSnapshot();
 
 	const fetchProjects = useCallback(async () => {
 		try {
@@ -36,15 +74,13 @@ export function useProjects(): UseProjectsReturn {
 			}
 
 			const data = (await response.json()) as ProjectsResponse;
-			const sorted = [...data.projects].sort((a, b) => {
-				// Projects with no activity sink to the bottom
-				if (!a.lastActivityAt && !b.lastActivityAt) return 0;
-				if (!a.lastActivityAt) return 1;
-				if (!b.lastActivityAt) return -1;
-				// Most recent activity first
-				return b.lastActivityAt.localeCompare(a.lastActivityAt);
-			});
-			setProjects(sorted);
+			knownRunIdsByProjectRef.current = new Map(
+				data.projects.map((project) => [
+					project.id,
+					new Set(liveRunIndex.getProjectRunIds(project.id)),
+				]),
+			);
+			setProjects(sortProjects(data.projects));
 			setError(null);
 		} catch (err) {
 			setError(err instanceof Error ? err : new Error(String(err)));
@@ -62,6 +98,56 @@ export function useProjects(): UseProjectsReturn {
 			void fetchProjects();
 		});
 	}, [fetchProjects, onProjectsChange]);
+
+	useEffect(() => {
+		if (isLoading || projects.length === 0) {
+			return;
+		}
+
+		void liveSnapshot;
+		const nextProjects = sortProjects(
+			projects.map((project) => {
+				const knownRunIds =
+					knownRunIdsByProjectRef.current.get(project.id) ?? new Set<string>();
+				const liveRunIds = liveRunIndex.getProjectRunIds(project.id);
+				let nextRunCount = project.runCount;
+
+				for (const runId of liveRunIds) {
+					if (knownRunIds.has(runId)) {
+						continue;
+					}
+					knownRunIds.add(runId);
+					nextRunCount += 1;
+				}
+
+				knownRunIdsByProjectRef.current.set(project.id, knownRunIds);
+
+				const liveActivity = liveRunIndex.getLastActivityAt(project.id);
+				const nextLastActivityAt =
+					liveActivity &&
+					(!project.lastActivityAt || liveActivity > project.lastActivityAt)
+						? liveActivity
+						: project.lastActivityAt;
+
+				if (
+					nextRunCount === project.runCount &&
+					nextLastActivityAt === project.lastActivityAt
+				) {
+					return project;
+				}
+
+				return {
+					...project,
+					runCount: nextRunCount,
+					lastActivityAt: nextLastActivityAt,
+				};
+			}),
+		);
+
+		if (!areProjectsEqual(projects, nextProjects)) {
+			setProjects(nextProjects);
+		}
+	}, [isLoading, liveSnapshot, projects]);
 
 	useReconnectRecovery(fetchProjects);
 

--- a/cli/web-ui/src/hooks/useReconnectRecovery.ts
+++ b/cli/web-ui/src/hooks/useReconnectRecovery.ts
@@ -1,14 +1,35 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { useWebSocket } from "@/providers/WebSocketProvider";
+
+const POLLING_INTERVAL = 5000;
 
 export function useReconnectRecovery(
 	recover: () => void | Promise<void>,
 ): void {
-	const { subscribeToReconnect } = useWebSocket();
+	const { status, subscribeToReconnect } = useWebSocket();
+	const recoverRef = useRef(recover);
+
+	useEffect(() => {
+		recoverRef.current = recover;
+	}, [recover]);
 
 	useEffect(() => {
 		return subscribeToReconnect(() => {
-			void recover();
+			void recoverRef.current();
 		});
-	}, [recover, subscribeToReconnect]);
+	}, [subscribeToReconnect]);
+
+	useEffect(() => {
+		if (status !== "disconnected") {
+			return;
+		}
+
+		const intervalId = setInterval(() => {
+			void recoverRef.current();
+		}, POLLING_INTERVAL);
+
+		return () => {
+			clearInterval(intervalId);
+		};
+	}, [status]);
 }

--- a/cli/web-ui/src/hooks/useRunDetail.ts
+++ b/cli/web-ui/src/hooks/useRunDetail.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import { liveRunIndex } from "@/lib/live-run-index";
 import { useWebSocket } from "@/providers/WebSocketProvider";
 import type {
 	Artifact,
@@ -10,7 +11,12 @@ import type {
 import type {
 	ConnectionStatus,
 	EventNotificationMessage,
+	StateSnapshotMessage,
 } from "@/types/websocket";
+import {
+	useLiveRunIndexBridge,
+	useLiveRunIndexSnapshot,
+} from "./useLiveRunIndex";
 
 const runDetailCache = new Map<string, Run>();
 
@@ -28,6 +34,38 @@ const TERMINAL_RUN_STATUSES = new Set<RunStatus>([
 	"abandoned",
 ]);
 
+function mergeLiveRunSummary(run: Run, summary: Run): Run {
+	return {
+		...run,
+		projectId: summary.projectId,
+		projectName: summary.projectName,
+		featureId: summary.featureId,
+		featureName: summary.featureName,
+		name: summary.name ?? run.name,
+		command: summary.command,
+		status: summary.status,
+		harness: summary.harness ?? run.harness,
+		currentStep: summary.currentStep ?? run.currentStep,
+		startedAt: summary.startedAt,
+		lastEventAt: summary.lastEventAt ?? run.lastEventAt ?? run.startedAt,
+		completedAt: summary.completedAt ?? run.completedAt,
+		statusMessage: summary.statusMessage ?? run.statusMessage ?? null,
+		error: summary.error ?? run.error,
+	};
+}
+
+function snapshotMayAffectRun(
+	currentRun: Run,
+	socketProjectId: string | null,
+	message: StateSnapshotMessage,
+): boolean {
+	if (message.runs.some((snapshotRun) => snapshotRun.id === currentRun.id)) {
+		return true;
+	}
+
+	return socketProjectId === currentRun.projectId;
+}
+
 export function useRunDetail(runId: string | undefined): UseRunDetailResult {
 	const [run, setRun] = useState<Run | null>(() =>
 		runId ? (runDetailCache.get(runId) ?? null) : null,
@@ -36,9 +74,16 @@ export function useRunDetail(runId: string | undefined): UseRunDetailResult {
 		runId ? !runDetailCache.has(runId) : false,
 	);
 	const [error, setError] = useState<Error | null>(null);
-	const { onEventNotification, status: wsStatus } = useWebSocket();
+	const {
+		onEventNotification,
+		onStateSnapshot,
+		projectId: socketProjectId,
+		status: wsStatus,
+	} = useWebSocket();
 	const prevWsStatusRef = useRef<ConnectionStatus>(wsStatus);
 	const runRef = useRef<Run | null>(null);
+	useLiveRunIndexBridge();
+	const liveSnapshot = useLiveRunIndexSnapshot();
 
 	const fetchRun = useCallback(async () => {
 		if (!runId) {
@@ -60,6 +105,7 @@ export function useRunDetail(runId: string | undefined): UseRunDetailResult {
 			setRun(runData);
 			runRef.current = runData;
 			runDetailCache.set(runId, runData);
+			liveRunIndex.upsertRun(runData);
 			setError(null);
 		} catch (err) {
 			const nextError = err instanceof Error ? err : new Error(String(err));
@@ -96,6 +142,10 @@ export function useRunDetail(runId: string | undefined): UseRunDetailResult {
 		if (!runId || !run) return;
 		runDetailCache.set(runId, run);
 	}, [runId, run]);
+
+	useEffect(() => {
+		runRef.current = run;
+	}, [run]);
 
 	const debouncedFetchRef = useRef<ReturnType<typeof setTimeout>>();
 
@@ -271,6 +321,65 @@ export function useRunDetail(runId: string | undefined): UseRunDetailResult {
 			clearTimeout(debouncedFetchRef.current);
 		};
 	}, [runId, onEventNotification, fetchRun]);
+
+	useEffect(() => {
+		if (!runId) {
+			return;
+		}
+
+		void liveSnapshot;
+		const currentRun = runRef.current;
+		if (!currentRun) {
+			return;
+		}
+
+		const liveSummary = liveRunIndex.getRun(runId);
+		if (!liveSummary) {
+			return;
+		}
+
+		setRun((prev) => {
+			if (!prev) {
+				return prev;
+			}
+
+			const nextRun = mergeLiveRunSummary(prev, liveSummary);
+			if (
+				nextRun.projectName === prev.projectName &&
+				nextRun.featureName === prev.featureName &&
+				nextRun.name === prev.name &&
+				nextRun.command === prev.command &&
+				nextRun.status === prev.status &&
+				nextRun.harness === prev.harness &&
+				nextRun.currentStep === prev.currentStep &&
+				nextRun.lastEventAt === prev.lastEventAt &&
+				nextRun.completedAt === prev.completedAt &&
+				nextRun.statusMessage === prev.statusMessage &&
+				nextRun.error === prev.error
+			) {
+				return prev;
+			}
+
+			return nextRun;
+		});
+	}, [liveSnapshot, runId]);
+
+	useEffect(() => {
+		if (!runId) {
+			return;
+		}
+
+		return onStateSnapshot((message) => {
+			const currentRun = runRef.current;
+			if (
+				!currentRun ||
+				!snapshotMayAffectRun(currentRun, socketProjectId, message)
+			) {
+				return;
+			}
+			void fetchRun();
+		});
+	}, [fetchRun, onStateSnapshot, runId, socketProjectId]);
 
 	// Reconnection reconciliation: when the WebSocket transitions from
 	// disconnected/connecting to connected, refetch the full run state to

--- a/cli/web-ui/src/hooks/useRuns.ts
+++ b/cli/web-ui/src/hooks/useRuns.ts
@@ -1,6 +1,7 @@
-import { useCallback, useEffect, useState } from "react";
-import { useWebSocket } from "@/providers/WebSocketProvider";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { liveRunIndex } from "@/lib/live-run-index";
 import type { Run, RunsFilter } from "@/types/runs";
+import { useLiveRunIndexSnapshot } from "./useLiveRunIndex";
 import { useReconnectRecovery } from "./useReconnectRecovery";
 
 interface RunsResponse {
@@ -19,6 +20,59 @@ interface UseRunsResult {
 	isLoading: boolean;
 	error: Error | null;
 	refetch: () => void;
+}
+
+function activityTimestamp(run: Run): string {
+	return run.lastEventAt ?? run.startedAt;
+}
+
+function compareRunsByActivity(a: Run, b: Run): number {
+	return activityTimestamp(b).localeCompare(activityTimestamp(a));
+}
+
+function isWithinDateRange(
+	timestamp: string,
+	dateRange: UseRunsOptions["dateRange"],
+): boolean {
+	if (!dateRange || dateRange === "all") {
+		return true;
+	}
+
+	const now = Date.now();
+	const ranges: Record<
+		Exclude<NonNullable<UseRunsOptions["dateRange"]>, "all">,
+		number
+	> = {
+		today: 24 * 60 * 60 * 1000,
+		week: 7 * 24 * 60 * 60 * 1000,
+		month: 30 * 24 * 60 * 60 * 1000,
+	};
+
+	return now - new Date(timestamp).getTime() <= ranges[dateRange];
+}
+
+function matchesRunFilters(run: Run, options: UseRunsOptions): boolean {
+	if (
+		options.status &&
+		options.status !== "all" &&
+		run.status !== options.status
+	) {
+		return false;
+	}
+
+	if (options.projectId && run.projectId !== options.projectId) {
+		return false;
+	}
+
+	return isWithinDateRange(activityTimestamp(run), options.dateRange);
+}
+
+function areRunsEqual(current: readonly Run[], next: readonly Run[]): boolean {
+	if (current.length !== next.length) {
+		return false;
+	}
+
+	return current.every((run, index) => run === next[index]);
 }
 
 function buildQueryParams(options: UseRunsOptions): URLSearchParams {
@@ -52,7 +106,8 @@ export function useRuns(options: UseRunsOptions = {}): UseRunsResult {
 	const [total, setTotal] = useState(0);
 	const [isLoading, setIsLoading] = useState(true);
 	const [error, setError] = useState<Error | null>(null);
-	const { subscribeToAttention } = useWebSocket();
+	const matchingRunIdsRef = useRef<Set<string>>(new Set());
+	const liveSnapshot = useLiveRunIndexSnapshot();
 
 	// Destructure to use primitives as dependencies (avoid object reference changes)
 	const { status, projectId, dateRange, limit, offset } = options;
@@ -74,7 +129,19 @@ export function useRuns(options: UseRunsOptions = {}): UseRunsResult {
 			}
 
 			const data = (await response.json()) as RunsResponse;
-			setRuns(data.runs);
+			liveRunIndex.upsertRuns(data.runs);
+			const filterOptions = { status, projectId, dateRange };
+			matchingRunIdsRef.current = new Set(
+				liveRunIndex
+					.getAllRuns()
+					.filter((run) => matchesRunFilters(run, filterOptions))
+					.map((run) => run.id),
+			);
+			setRuns(
+				data.runs
+					.map((run) => liveRunIndex.getRun(run.id) ?? run)
+					.sort(compareRunsByActivity),
+			);
 			setTotal(data.total);
 			setError(null);
 		} catch (err) {
@@ -90,11 +157,77 @@ export function useRuns(options: UseRunsOptions = {}): UseRunsResult {
 	}, [fetchRuns]);
 
 	useEffect(() => {
-		const unsubscribe = subscribeToAttention(() => {
-			fetchRuns();
-		});
-		return unsubscribe;
-	}, [subscribeToAttention, fetchRuns]);
+		if (isLoading) {
+			return;
+		}
+
+		void liveSnapshot;
+		const filterOptions = { status, projectId, dateRange };
+		const knownMatchingRunIds = matchingRunIdsRef.current;
+		for (const runId of [...knownMatchingRunIds]) {
+			const liveRun = liveRunIndex.getRun(runId);
+			if (liveRun && !matchesRunFilters(liveRun, filterOptions)) {
+				knownMatchingRunIds.delete(runId);
+			}
+		}
+
+		const currentRuns = runs;
+		const nextLoadedRuns = currentRuns
+			.map((run) => liveRunIndex.getRun(run.id) ?? run)
+			.filter((run) => matchesRunFilters(run, filterOptions))
+			.sort(compareRunsByActivity);
+		for (const run of nextLoadedRuns) {
+			knownMatchingRunIds.add(run.id);
+		}
+
+		const retainedIds = new Set(nextLoadedRuns.map((run) => run.id));
+		const removedCount = currentRuns.reduce(
+			(count, run) => count + (retainedIds.has(run.id) ? 0 : 1),
+			0,
+		);
+
+		let addedCount = 0;
+		let nextRuns = nextLoadedRuns;
+		if ((offset ?? 0) === 0) {
+			const additions: Run[] = [];
+			for (const run of liveRunIndex.getAllRuns()) {
+				if (
+					retainedIds.has(run.id) ||
+					knownMatchingRunIds.has(run.id) ||
+					!matchesRunFilters(run, filterOptions)
+				) {
+					continue;
+				}
+				additions.push(run);
+				retainedIds.add(run.id);
+				knownMatchingRunIds.add(run.id);
+			}
+			addedCount = additions.length;
+			nextRuns = [...nextLoadedRuns, ...additions].sort(compareRunsByActivity);
+			if (limit !== undefined) {
+				nextRuns = nextRuns.slice(0, limit);
+			}
+		}
+
+		if (!areRunsEqual(currentRuns, nextRuns)) {
+			setRuns(nextRuns);
+		}
+
+		if (addedCount > 0 || removedCount > 0) {
+			setTotal((currentTotal) =>
+				Math.max(0, currentTotal + addedCount - removedCount),
+			);
+		}
+	}, [
+		liveSnapshot,
+		runs,
+		isLoading,
+		status,
+		projectId,
+		dateRange,
+		limit,
+		offset,
+	]);
 
 	useReconnectRecovery(fetchRuns);
 

--- a/cli/web-ui/src/lib/live-run-index.ts
+++ b/cli/web-ui/src/lib/live-run-index.ts
@@ -220,7 +220,24 @@ export function createLiveRunIndex(
 	const queuedEventsByRun = new Map<string, EventNotificationMessage[]>();
 	const pendingHydrations = new Map<string, Promise<Run | null>>();
 
+	function buildSnapshot(): LiveRunIndexState {
+		return {
+			runsById: new Map(runsById),
+			runsByProject: new Map(
+				Array.from(runsByProject.entries(), ([projectId, runIds]) => [
+					projectId,
+					new Set(runIds),
+				]),
+			),
+			lastEventIdByProject: new Map(lastEventIdByProject),
+			lastActivityAtByProject: new Map(lastActivityAtByProject),
+		};
+	}
+
+	let snapshotCache = buildSnapshot();
+
 	function emitChange() {
+		snapshotCache = buildSnapshot();
 		for (const listener of listeners) {
 			listener();
 		}
@@ -350,17 +367,7 @@ export function createLiveRunIndex(
 			return lastActivityAtByProject.get(projectId) ?? null;
 		},
 		getSnapshot() {
-			return {
-				runsById: new Map(runsById),
-				runsByProject: new Map(
-					Array.from(runsByProject.entries(), ([projectId, runIds]) => [
-						projectId,
-						new Set(runIds),
-					]),
-				),
-				lastEventIdByProject: new Map(lastEventIdByProject),
-				lastActivityAtByProject: new Map(lastActivityAtByProject),
-			};
+			return snapshotCache;
 		},
 		upsertRun(run: Run) {
 			storeRun(run);
@@ -388,6 +395,11 @@ export function createLiveRunIndex(
 			return nextPending;
 		},
 		async applyEvent(message: EventNotificationMessage) {
+			const currentEventId = lastEventIdByProject.get(message.projectId);
+			if (currentEventId != null && currentEventId >= message.eventId) {
+				return;
+			}
+
 			noteProjectCursor(message.projectId, message.eventId);
 			noteProjectActivity(message.projectId, message.createdAt);
 
@@ -412,6 +424,11 @@ export function createLiveRunIndex(
 			await nextPending;
 		},
 		applySnapshot(projectId: string, message: StateSnapshotMessage) {
+			const currentEventId = lastEventIdByProject.get(projectId);
+			if (currentEventId != null && currentEventId >= message.lastEventId) {
+				return;
+			}
+
 			noteProjectCursor(projectId, message.lastEventId);
 
 			const snapshotRunIds = new Set(message.runs.map((run) => run.id));

--- a/cli/web-ui/src/lib/live-run-index.ts
+++ b/cli/web-ui/src/lib/live-run-index.ts
@@ -1,0 +1,453 @@
+import type { Run } from "@/types/runs";
+import type {
+	EventNotificationMessage,
+	StateSnapshotMessage,
+} from "@/types/websocket";
+import {
+	isLiveAttentionStatus,
+	isTerminalRunStatus,
+	isValidRunStatus,
+} from "../../../shared/events";
+
+type Listener = () => void;
+
+const EMPTY_RUNS: readonly Run[] = [];
+const EMPTY_RUN_IDS: readonly string[] = [];
+const EMPTY_MESSAGES: readonly EventNotificationMessage[] = [];
+type SnapshotRun = StateSnapshotMessage["runs"][number];
+
+export interface LiveRunIndexState {
+	readonly runsById: ReadonlyMap<string, Run>;
+	readonly runsByProject: ReadonlyMap<string, ReadonlySet<string>>;
+	readonly lastEventIdByProject: ReadonlyMap<string, number>;
+	readonly lastActivityAtByProject: ReadonlyMap<string, string>;
+}
+
+export interface LiveRunIndexOptions {
+	readonly fetchRunSummary?: (runId: string) => Promise<Run | null>;
+}
+
+export interface LiveRunIndex {
+	subscribe: (listener: Listener) => () => void;
+	getRun: (runId: string) => Run | undefined;
+	hasRun: (runId: string) => boolean;
+	getRunsForProject: (projectId: string) => readonly Run[];
+	getAllRuns: () => readonly Run[];
+	getProjectRunIds: (projectId: string) => readonly string[];
+	getLastEventId: (projectId: string) => number | null;
+	getLastActivityAt: (projectId: string) => string | null;
+	getSnapshot: () => LiveRunIndexState;
+	upsertRun: (run: Run) => void;
+	upsertRuns: (runs: readonly Run[]) => void;
+	hydrateRun: (runId: string) => Promise<Run | null>;
+	applyEvent: (message: EventNotificationMessage) => Promise<void>;
+	applySnapshot: (projectId: string, message: StateSnapshotMessage) => void;
+	clear: () => void;
+}
+
+async function defaultFetchRunSummary(runId: string): Promise<Run | null> {
+	const response = await fetch(`/api/v2/runs/${runId}/summary`);
+	if (!response.ok) {
+		if (response.status === 404) {
+			return null;
+		}
+		throw new Error(`Failed to fetch run summary: ${response.statusText}`);
+	}
+	return normalizeRun((await response.json()) as Run);
+}
+
+function normalizeRun(run: Run): Run {
+	return {
+		...run,
+		name: run.name ?? null,
+		harness: run.harness ?? null,
+		currentStep: run.currentStep ?? null,
+		steps: [...run.steps],
+		artifacts: [...run.artifacts],
+		events: [...run.events],
+		lastEventAt: run.lastEventAt ?? run.startedAt,
+		completedAt: run.completedAt ?? null,
+		error: run.error ?? null,
+		statusMessage: run.statusMessage ?? null,
+		agentSteps: run.agentSteps ?? null,
+	};
+}
+
+function mergeRuns(existing: Run | undefined, incoming: Run): Run {
+	const normalized = normalizeRun(incoming);
+	if (!existing) {
+		return normalized;
+	}
+
+	return {
+		...existing,
+		...normalized,
+		steps: normalized.steps.length > 0 ? normalized.steps : existing.steps,
+		artifacts:
+			normalized.artifacts.length > 0
+				? normalized.artifacts
+				: existing.artifacts,
+		events: normalized.events.length > 0 ? normalized.events : existing.events,
+		error: normalized.error ?? existing.error,
+		statusMessage: normalized.statusMessage ?? existing.statusMessage ?? null,
+		agentSteps: normalized.agentSteps ?? existing.agentSteps,
+		invocation: normalized.invocation ?? existing.invocation,
+		subflows: normalized.subflows ?? existing.subflows,
+	};
+}
+
+function activityTimestampForRun(run: Run): string {
+	return run.lastEventAt ?? run.startedAt;
+}
+
+function compareRunsByActivity(a: Run, b: Run): number {
+	const left = activityTimestampForRun(a);
+	const right = activityTimestampForRun(b);
+	return right.localeCompare(left);
+}
+
+function deriveCurrentStepFromSnapshot(
+	steps: SnapshotRun["steps"],
+): string | null {
+	for (const step of [...steps].reverse()) {
+		if (step.status === "running" || step.status === "waiting") {
+			return step.step;
+		}
+	}
+
+	for (const step of [...steps].reverse()) {
+		if (step.status !== "not_started") {
+			return step.step;
+		}
+	}
+
+	return null;
+}
+
+function reconcileRunWithSnapshot(
+	existing: Run,
+	snapshotRun: SnapshotRun,
+): Run {
+	const nextStatus = isValidRunStatus(snapshotRun.status)
+		? snapshotRun.status
+		: existing.status;
+
+	return {
+		...existing,
+		status: nextStatus,
+		currentStep: deriveCurrentStepFromSnapshot(snapshotRun.steps),
+		completedAt: isTerminalRunStatus(nextStatus) ? existing.completedAt : null,
+		...(nextStatus !== existing.status && nextStatus !== "failed"
+			? {
+					error: null,
+					statusMessage: null,
+				}
+			: {}),
+	};
+}
+
+function reduceRun(run: Run, message: EventNotificationMessage): Run {
+	switch (message.eventType) {
+		case "status_change": {
+			const data = message.data ?? {};
+			const rawStatus =
+				typeof data.status === "string" ? data.status : undefined;
+			const nextStatus =
+				rawStatus && isValidRunStatus(rawStatus) ? rawStatus : undefined;
+			const statusMessage =
+				typeof data.message === "string" ? data.message : undefined;
+			const shouldClearLifecycleMessage =
+				nextStatus !== undefined &&
+				nextStatus !== run.status &&
+				statusMessage === undefined &&
+				nextStatus !== "failed";
+
+			return {
+				...run,
+				lastEventAt: message.createdAt,
+				...(message.step ? { currentStep: message.step } : {}),
+				...(nextStatus !== undefined
+					? {
+							status: nextStatus,
+							completedAt: isTerminalRunStatus(nextStatus)
+								? message.createdAt
+								: null,
+						}
+					: {}),
+				...(statusMessage !== undefined
+					? {
+							statusMessage,
+							...(nextStatus === "failed" ? { error: statusMessage } : {}),
+						}
+					: {}),
+				...(shouldClearLifecycleMessage
+					? {
+							statusMessage: null,
+							error: null,
+						}
+					: {}),
+			};
+		}
+		case "waiting_for_user":
+			return {
+				...run,
+				status: "waiting",
+				currentStep: message.step ?? run.currentStep,
+				lastEventAt: message.createdAt,
+				completedAt: null,
+			};
+		case "artifact_registered":
+		case "btw_update":
+		case "subflow_registered":
+			return {
+				...run,
+				lastEventAt: message.createdAt,
+			};
+		default:
+			return run;
+	}
+}
+
+export function createLiveRunIndex(
+	options: LiveRunIndexOptions = {},
+): LiveRunIndex {
+	const fetchRunSummary = options.fetchRunSummary ?? defaultFetchRunSummary;
+	const listeners = new Set<Listener>();
+	const runsById = new Map<string, Run>();
+	const runsByProject = new Map<string, Set<string>>();
+	const lastEventIdByProject = new Map<string, number>();
+	const lastActivityAtByProject = new Map<string, string>();
+	const queuedEventsByRun = new Map<string, EventNotificationMessage[]>();
+	const pendingHydrations = new Map<string, Promise<Run | null>>();
+
+	function emitChange() {
+		for (const listener of listeners) {
+			listener();
+		}
+	}
+
+	function noteProjectActivity(projectId: string, timestamp: string) {
+		const current = lastActivityAtByProject.get(projectId);
+		if (current == null || timestamp > current) {
+			lastActivityAtByProject.set(projectId, timestamp);
+		}
+	}
+
+	function noteProjectCursor(projectId: string, eventId: number) {
+		const current = lastEventIdByProject.get(projectId);
+		if (current == null || eventId > current) {
+			lastEventIdByProject.set(projectId, eventId);
+		}
+	}
+
+	function storeRun(run: Run) {
+		const existing = runsById.get(run.id);
+		const nextRun = mergeRuns(existing, run);
+		if (existing?.projectId && existing.projectId !== nextRun.projectId) {
+			const previousProjectRuns = runsByProject.get(existing.projectId);
+			previousProjectRuns?.delete(nextRun.id);
+			if (previousProjectRuns?.size === 0) {
+				runsByProject.delete(existing.projectId);
+			}
+		}
+
+		runsById.set(nextRun.id, nextRun);
+
+		let projectRuns = runsByProject.get(nextRun.projectId);
+		if (!projectRuns) {
+			projectRuns = new Set();
+			runsByProject.set(nextRun.projectId, projectRuns);
+		}
+		projectRuns.add(nextRun.id);
+		noteProjectActivity(nextRun.projectId, activityTimestampForRun(nextRun));
+	}
+
+	function deleteRun(runId: string) {
+		const existing = runsById.get(runId);
+		if (!existing) {
+			return;
+		}
+
+		runsById.delete(runId);
+		const projectRuns = runsByProject.get(existing.projectId);
+		projectRuns?.delete(runId);
+		if (projectRuns?.size === 0) {
+			runsByProject.delete(existing.projectId);
+		}
+	}
+
+	async function reconcileUnknownRun(runId: string): Promise<Run | null> {
+		const hydratedRun = await fetchRunSummary(runId);
+		try {
+			if (!hydratedRun) {
+				queuedEventsByRun.delete(runId);
+				return null;
+			}
+
+			let nextRun = mergeRuns(runsById.get(runId), hydratedRun);
+			const queuedMessages = queuedEventsByRun.get(runId) ?? EMPTY_MESSAGES;
+			queuedEventsByRun.delete(runId);
+
+			for (const message of queuedMessages) {
+				nextRun = reduceRun(nextRun, message);
+			}
+
+			storeRun(nextRun);
+			emitChange();
+			return nextRun;
+		} finally {
+			pendingHydrations.delete(runId);
+		}
+	}
+
+	function queueEvent(message: EventNotificationMessage) {
+		const queued = queuedEventsByRun.get(message.runId);
+		if (queued) {
+			queued.push(message);
+			return;
+		}
+		queuedEventsByRun.set(message.runId, [message]);
+	}
+
+	return {
+		subscribe(listener: Listener) {
+			listeners.add(listener);
+			return () => listeners.delete(listener);
+		},
+		getRun(runId: string) {
+			return runsById.get(runId);
+		},
+		hasRun(runId: string) {
+			return runsById.has(runId);
+		},
+		getRunsForProject(projectId: string) {
+			const runIds = runsByProject.get(projectId);
+			if (!runIds || runIds.size === 0) {
+				return EMPTY_RUNS;
+			}
+			return Array.from(runIds)
+				.map((runId) => runsById.get(runId))
+				.filter((run): run is Run => run !== undefined)
+				.sort(compareRunsByActivity);
+		},
+		getAllRuns() {
+			if (runsById.size === 0) {
+				return EMPTY_RUNS;
+			}
+			return Array.from(runsById.values()).sort(compareRunsByActivity);
+		},
+		getProjectRunIds(projectId: string) {
+			const runIds = runsByProject.get(projectId);
+			if (!runIds || runIds.size === 0) {
+				return EMPTY_RUN_IDS;
+			}
+			return Array.from(runIds);
+		},
+		getLastEventId(projectId: string) {
+			return lastEventIdByProject.get(projectId) ?? null;
+		},
+		getLastActivityAt(projectId: string) {
+			return lastActivityAtByProject.get(projectId) ?? null;
+		},
+		getSnapshot() {
+			return {
+				runsById: new Map(runsById),
+				runsByProject: new Map(
+					Array.from(runsByProject.entries(), ([projectId, runIds]) => [
+						projectId,
+						new Set(runIds),
+					]),
+				),
+				lastEventIdByProject: new Map(lastEventIdByProject),
+				lastActivityAtByProject: new Map(lastActivityAtByProject),
+			};
+		},
+		upsertRun(run: Run) {
+			storeRun(run);
+			emitChange();
+		},
+		upsertRuns(runs: readonly Run[]) {
+			for (const run of runs) {
+				storeRun(run);
+			}
+			emitChange();
+		},
+		async hydrateRun(runId: string) {
+			const existing = runsById.get(runId);
+			if (existing) {
+				return existing;
+			}
+
+			const pending = pendingHydrations.get(runId);
+			if (pending) {
+				return pending;
+			}
+
+			const nextPending = reconcileUnknownRun(runId);
+			pendingHydrations.set(runId, nextPending);
+			return nextPending;
+		},
+		async applyEvent(message: EventNotificationMessage) {
+			noteProjectCursor(message.projectId, message.eventId);
+			noteProjectActivity(message.projectId, message.createdAt);
+
+			const existing = runsById.get(message.runId);
+			if (existing) {
+				storeRun(reduceRun(existing, message));
+				emitChange();
+				return;
+			}
+
+			queueEvent(message);
+			emitChange();
+
+			const pending = pendingHydrations.get(message.runId);
+			if (pending) {
+				await pending;
+				return;
+			}
+
+			const nextPending = reconcileUnknownRun(message.runId);
+			pendingHydrations.set(message.runId, nextPending);
+			await nextPending;
+		},
+		applySnapshot(projectId: string, message: StateSnapshotMessage) {
+			noteProjectCursor(projectId, message.lastEventId);
+
+			const snapshotRunIds = new Set(message.runs.map((run) => run.id));
+			for (const runId of runsByProject.get(projectId) ?? EMPTY_RUN_IDS) {
+				const run = runsById.get(runId);
+				if (
+					run &&
+					isLiveAttentionStatus(run.status) &&
+					!snapshotRunIds.has(runId)
+				) {
+					deleteRun(runId);
+				}
+			}
+
+			for (const snapshotRun of message.runs) {
+				const existing = runsById.get(snapshotRun.id);
+				if (existing) {
+					storeRun(reconcileRunWithSnapshot(existing, snapshotRun));
+					continue;
+				}
+
+				void this.hydrateRun(snapshotRun.id);
+			}
+
+			emitChange();
+		},
+		clear() {
+			runsById.clear();
+			runsByProject.clear();
+			lastEventIdByProject.clear();
+			lastActivityAtByProject.clear();
+			queuedEventsByRun.clear();
+			pendingHydrations.clear();
+			emitChange();
+		},
+	};
+}
+
+export const liveRunIndex = createLiveRunIndex();

--- a/cli/web-ui/src/pages/v2/ProjectOverviewPage.tsx
+++ b/cli/web-ui/src/pages/v2/ProjectOverviewPage.tsx
@@ -1,12 +1,17 @@
 import { AlertCircle, ChevronRight, FolderOpen } from "lucide-react";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import { RunCard } from "@/components/v2/RunCard";
 import { useBreadcrumbContext } from "@/hooks/useBreadcrumbContext";
 import { useContextualShortcuts } from "@/hooks/useContextualShortcuts";
+import {
+	useLiveRunIndexBridge,
+	useLiveRunIndexSnapshot,
+} from "@/hooks/useLiveRunIndex";
 import { useReconnectRecovery } from "@/hooks/useReconnectRecovery";
 import { useWorkspaceDescriptor } from "@/hooks/useWorkspaceDescriptor";
 import { useWorkspaceTabs } from "@/hooks/useWorkspaceTabs";
+import { liveRunIndex } from "@/lib/live-run-index";
 import { formatRelativeTime } from "@/lib/time";
 import { cn } from "@/lib/utils";
 import type { V2Project } from "@/types/projects";
@@ -25,6 +30,25 @@ interface ProjectOverviewCacheEntry {
 }
 
 const projectOverviewCache = new Map<string, ProjectOverviewCacheEntry>();
+const RECENT_RUN_LIMIT = 5;
+
+function activityTimestamp(run: Run): string {
+	return run.lastEventAt ?? run.startedAt;
+}
+
+function sortRunsByActivity(runs: readonly Run[]): Run[] {
+	return [...runs].sort((a, b) =>
+		activityTimestamp(b).localeCompare(activityTimestamp(a)),
+	);
+}
+
+function areRunsEqual(current: readonly Run[], next: readonly Run[]): boolean {
+	if (current.length !== next.length) {
+		return false;
+	}
+
+	return current.every((run, index) => run === next[index]);
+}
 
 function LoadingSkeleton() {
 	return (
@@ -120,6 +144,14 @@ export function ProjectOverviewPage() {
 	const [notFound, setNotFound] = useState(false);
 	const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
 	const { setProject: setBreadcrumbProject } = useBreadcrumbContext();
+	const knownRunIdsRef = useRef<Set<string>>(
+		new Set([
+			...(cachedEntry?.runs.map((run) => run.id) ?? []),
+			...(projectId ? liveRunIndex.getProjectRunIds(projectId) : []),
+		]),
+	);
+	useLiveRunIndexBridge();
+	const liveSnapshot = useLiveRunIndexSnapshot();
 
 	useEffect(() => {
 		if (project && projectId) {
@@ -144,7 +176,7 @@ export function ProjectOverviewPage() {
 
 			const [projectRes, runsRes] = await Promise.all([
 				fetch(`/api/v2/projects/${projectId}`),
-				fetch(`/api/v2/runs?projectId=${projectId}&limit=5`),
+				fetch(`/api/v2/runs?projectId=${projectId}&limit=${RECENT_RUN_LIMIT}`),
 			]);
 
 			if (projectRes.status === 404) {
@@ -164,14 +196,25 @@ export function ProjectOverviewPage() {
 
 			if (runsRes.ok) {
 				const runsData = (await runsRes.json()) as RunsResponse;
-				setRuns(runsData.runs);
+				liveRunIndex.upsertRuns(runsData.runs);
+				const nextRuns = sortRunsByActivity(
+					runsData.runs.map((run) => liveRunIndex.getRun(run.id) ?? run),
+				);
+				setRuns(nextRuns);
+				knownRunIdsRef.current = new Set([
+					...nextRuns.map((run) => run.id),
+					...liveRunIndex.getProjectRunIds(projectId),
+				]);
 				projectOverviewCache.set(projectId, {
 					project: projectData,
-					runs: runsData.runs,
+					runs: nextRuns,
 				});
 				return;
 			}
 
+			knownRunIdsRef.current = new Set(
+				liveRunIndex.getProjectRunIds(projectId),
+			);
 			projectOverviewCache.set(projectId, {
 				project: projectData,
 				runs: projectOverviewCache.get(projectId)?.runs ?? [],
@@ -192,12 +235,17 @@ export function ProjectOverviewPage() {
 			setError(null);
 			setNotFound(false);
 			setIsLoading(false);
+			knownRunIdsRef.current = new Set();
 			return;
 		}
 
 		const nextCachedEntry = projectOverviewCache.get(projectId) ?? null;
 		setProject(nextCachedEntry?.project ?? null);
 		setRuns([...(nextCachedEntry?.runs ?? [])]);
+		knownRunIdsRef.current = new Set([
+			...(nextCachedEntry?.runs.map((run) => run.id) ?? []),
+			...liveRunIndex.getProjectRunIds(projectId),
+		]);
 		setError(null);
 		setNotFound(false);
 		setIsLoading(nextCachedEntry === null);
@@ -205,6 +253,61 @@ export function ProjectOverviewPage() {
 	}, [projectId, fetchData]);
 
 	useReconnectRecovery(fetchData);
+
+	useEffect(() => {
+		if (!projectId || project === null || isLoading) {
+			return;
+		}
+
+		void liveSnapshot;
+		const liveActivity = liveRunIndex.getLastActivityAt(projectId);
+		const projectRuns = liveRunIndex.getRunsForProject(projectId);
+		const knownRunIds = knownRunIdsRef.current;
+
+		let nextRunCount = project.runCount;
+		for (const liveRun of projectRuns) {
+			if (knownRunIds.has(liveRun.id)) {
+				continue;
+			}
+			knownRunIds.add(liveRun.id);
+			nextRunCount += 1;
+		}
+
+		const nextProject =
+			nextRunCount === project.runCount &&
+			(!liveActivity ||
+				(project.lastActivityAt && liveActivity <= project.lastActivityAt))
+				? project
+				: {
+						...project,
+						runCount: nextRunCount,
+						lastActivityAt:
+							liveActivity &&
+							(!project.lastActivityAt || liveActivity > project.lastActivityAt)
+								? liveActivity
+								: project.lastActivityAt,
+					};
+
+		const mergedRuns = sortRunsByActivity([
+			...runs.map((run) => liveRunIndex.getRun(run.id) ?? run),
+			...projectRuns.filter(
+				(liveRun) => !runs.some((run) => run.id === liveRun.id),
+			),
+		]).slice(0, RECENT_RUN_LIMIT);
+
+		if (nextProject !== project) {
+			setProject(nextProject);
+		}
+
+		if (!areRunsEqual(runs, mergedRuns)) {
+			setRuns(mergedRuns);
+		}
+
+		projectOverviewCache.set(projectId, {
+			project: nextProject,
+			runs: mergedRuns,
+		});
+	}, [isLoading, liveSnapshot, project, projectId, runs]);
 
 	const handleRunClick = useCallback(
 		(run: Run) => {

--- a/cli/web-ui/src/providers/WebSocketProvider.tsx
+++ b/cli/web-ui/src/providers/WebSocketProvider.tsx
@@ -10,7 +10,6 @@ import {
 
 import type {
 	AnnotationMessage,
-	AttentionCallback,
 	ConnectionStatus,
 	EventNotificationMessage,
 	EventReplayMessage,
@@ -50,7 +49,6 @@ interface WebSocketContextValue {
 		callback: (msg: AnnotationMessage) => void,
 	) => () => void;
 	onNotification: (callback: (msg: NotificationMessage) => void) => () => void;
-	subscribeToAttention: (callback: AttentionCallback) => () => void;
 	subscribeToReconnect: (callback: () => void) => () => void;
 }
 
@@ -59,7 +57,6 @@ const WebSocketContext = createContext<WebSocketContextValue | null>(null);
 const INITIAL_RECONNECT_DELAY = 2000;
 const MAX_RECONNECT_DELAY = 30000;
 const RECONNECT_BACKOFF_FACTOR = 2;
-const POLLING_INTERVAL = 5000;
 const LAST_EVENT_ID_STORAGE_PREFIX = "rp1:last-event-id:";
 
 interface WebSocketProviderProps {
@@ -72,9 +69,6 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
 	const wsRef = useRef<WebSocket | null>(null);
 	const reconnectDelayRef = useRef(INITIAL_RECONNECT_DELAY);
 	const reconnectTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
-		null,
-	);
-	const pollingIntervalRef = useRef<ReturnType<typeof setInterval> | null>(
 		null,
 	);
 	const mountedRef = useRef(true);
@@ -100,7 +94,6 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
 	>(new Set());
 	const snapshotListenersRef = useRef<Set<StateSnapshotCallback>>(new Set());
 	const subscriptionsRef = useRef<Set<string>>(new Set());
-	const attentionListenersRef = useRef<Set<AttentionCallback>>(new Set());
 	const reconnectListenersRef = useRef<Set<() => void>>(new Set());
 	const notifyReconnectRef = useRef(false);
 
@@ -192,35 +185,13 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
 	);
 
 	const emitEventNotification = useCallback(
-		(message: EventNotificationMessage, notifyAttention: boolean) => {
+		(message: EventNotificationMessage) => {
 			for (const listener of eventNotificationListenersRef.current) {
 				listener(message);
-			}
-			if (notifyAttention) {
-				for (const callback of attentionListenersRef.current) {
-					callback();
-				}
 			}
 		},
 		[],
 	);
-
-	const startPollingFallback = useCallback(() => {
-		if (pollingIntervalRef.current) return;
-
-		pollingIntervalRef.current = setInterval(() => {
-			for (const callback of attentionListenersRef.current) {
-				callback();
-			}
-		}, POLLING_INTERVAL);
-	}, []);
-
-	const stopPollingFallback = useCallback(() => {
-		if (pollingIntervalRef.current) {
-			clearInterval(pollingIntervalRef.current);
-			pollingIntervalRef.current = null;
-		}
-	}, []);
 
 	useEffect(() => {
 		mountedRef.current = true;
@@ -256,7 +227,6 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
 				}
 				setStatus("connected");
 				reconnectDelayRef.current = INITIAL_RECONNECT_DELAY;
-				stopPollingFallback();
 
 				for (const path of subscriptionsRef.current) {
 					ws.send(JSON.stringify({ type: "subscribe", path }));
@@ -275,7 +245,6 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
 				setStatus("disconnected");
 				wsRef.current = null;
 				notifyReconnectRef.current = true;
-				startPollingFallback();
 				scheduleReconnect();
 			};
 
@@ -309,7 +278,7 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
 					break;
 				case "event:notification":
 					advanceLastEventId(message.projectId, message.eventId);
-					emitEventNotification(message, true);
+					emitEventNotification(message);
 					break;
 				case "event:replay": {
 					const normalizedMessage = normalizeReplayMessage(
@@ -321,7 +290,7 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
 							normalizedMessage.projectId,
 							normalizedMessage.eventId,
 						);
-						emitEventNotification(normalizedMessage, false);
+						emitEventNotification(normalizedMessage);
 					}
 					break;
 				}
@@ -377,7 +346,6 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
 
 		return () => {
 			mountedRef.current = false;
-			stopPollingFallback();
 			if (reconnectTimeoutRef.current) {
 				clearTimeout(reconnectTimeoutRef.current);
 				reconnectTimeoutRef.current = null;
@@ -389,8 +357,6 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
 		};
 	}, [
 		projectId,
-		startPollingFallback,
-		stopPollingFallback,
 		advanceLastEventId,
 		emitEventNotification,
 		normalizeReplayMessage,
@@ -478,13 +444,6 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
 		[],
 	);
 
-	const subscribeToAttention = useCallback((callback: AttentionCallback) => {
-		attentionListenersRef.current.add(callback);
-		return () => {
-			attentionListenersRef.current.delete(callback);
-		};
-	}, []);
-
 	const subscribeToReconnect = useCallback((callback: () => void) => {
 		reconnectListenersRef.current.add(callback);
 		return () => {
@@ -511,7 +470,6 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
 				onProjectsChange,
 				onAnnotationMessage,
 				onNotification,
-				subscribeToAttention,
 				subscribeToReconnect,
 			}}
 		>

--- a/cli/web-ui/src/providers/WebSocketProvider.tsx
+++ b/cli/web-ui/src/providers/WebSocketProvider.tsx
@@ -13,10 +13,12 @@ import type {
 	AttentionCallback,
 	ConnectionStatus,
 	EventNotificationMessage,
+	EventReplayMessage,
 	FileChangedMessage,
 	NotificationMessage,
 	ProjectsChangedMessage,
 	ServerMessage,
+	StateSnapshotCallback,
 	TreeChangedMessage,
 } from "../types/websocket";
 
@@ -25,6 +27,7 @@ export type {
 	EventNotificationMessage,
 	FileChangedMessage,
 	NotificationMessage,
+	StateSnapshotMessage,
 	TreeChangedMessage,
 } from "../types/websocket";
 
@@ -39,6 +42,7 @@ interface WebSocketContextValue {
 	onEventNotification: (
 		callback: (msg: EventNotificationMessage) => void,
 	) => () => void;
+	onStateSnapshot: (callback: StateSnapshotCallback) => () => void;
 	onProjectsChange: (
 		callback: (msg: ProjectsChangedMessage) => void,
 	) => () => void;
@@ -56,6 +60,7 @@ const INITIAL_RECONNECT_DELAY = 2000;
 const MAX_RECONNECT_DELAY = 30000;
 const RECONNECT_BACKOFF_FACTOR = 2;
 const POLLING_INTERVAL = 5000;
+const LAST_EVENT_ID_STORAGE_PREFIX = "rp1:last-event-id:";
 
 interface WebSocketProviderProps {
 	children: ReactNode;
@@ -74,6 +79,7 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
 	);
 	const mountedRef = useRef(true);
 	const projectIdRef = useRef<string | null>(null);
+	const lastEventIdByProjectRef = useRef<Map<string, number>>(new Map());
 	const fileChangeListenersRef = useRef<Set<(msg: FileChangedMessage) => void>>(
 		new Set(),
 	);
@@ -92,10 +98,112 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
 	const notificationListenersRef = useRef<
 		Set<(msg: NotificationMessage) => void>
 	>(new Set());
+	const snapshotListenersRef = useRef<Set<StateSnapshotCallback>>(new Set());
 	const subscriptionsRef = useRef<Set<string>>(new Set());
 	const attentionListenersRef = useRef<Set<AttentionCallback>>(new Set());
 	const reconnectListenersRef = useRef<Set<() => void>>(new Set());
 	const notifyReconnectRef = useRef(false);
+
+	const readStoredLastEventId = useCallback(
+		(targetProjectId: string): number | null => {
+			const cached = lastEventIdByProjectRef.current.get(targetProjectId);
+			if (cached != null) {
+				return cached;
+			}
+
+			try {
+				const storedValue = sessionStorage.getItem(
+					`${LAST_EVENT_ID_STORAGE_PREFIX}${targetProjectId}`,
+				);
+				if (storedValue == null) {
+					return null;
+				}
+				const parsedValue = Number.parseInt(storedValue, 10);
+				if (Number.isNaN(parsedValue)) {
+					return null;
+				}
+				lastEventIdByProjectRef.current.set(targetProjectId, parsedValue);
+				return parsedValue;
+			} catch {
+				return null;
+			}
+		},
+		[],
+	);
+
+	const advanceLastEventId = useCallback(
+		(targetProjectId: string, eventId: number) => {
+			const currentValue = readStoredLastEventId(targetProjectId);
+			if (currentValue != null && currentValue >= eventId) {
+				return;
+			}
+
+			lastEventIdByProjectRef.current.set(targetProjectId, eventId);
+			try {
+				sessionStorage.setItem(
+					`${LAST_EVENT_ID_STORAGE_PREFIX}${targetProjectId}`,
+					String(eventId),
+				);
+			} catch {}
+		},
+		[readStoredLastEventId],
+	);
+
+	const parseReplayEventData = useCallback(
+		(rawData: string | null): Record<string, unknown> | null => {
+			if (rawData == null) {
+				return null;
+			}
+
+			try {
+				const parsed = JSON.parse(rawData) as unknown;
+				return parsed !== null && typeof parsed === "object"
+					? (parsed as Record<string, unknown>)
+					: null;
+			} catch {
+				return null;
+			}
+		},
+		[],
+	);
+
+	const normalizeReplayMessage = useCallback(
+		(
+			message: EventReplayMessage,
+			targetProjectId: string | null,
+		): EventNotificationMessage | null => {
+			if (targetProjectId == null) {
+				return null;
+			}
+
+			return {
+				type: "event:notification",
+				eventId: message.event.id,
+				eventType: message.event.eventType,
+				runId: message.event.runId,
+				projectId: targetProjectId,
+				featureId: "",
+				step: message.event.step,
+				data: parseReplayEventData(message.event.data),
+				createdAt: message.event.createdAt,
+			};
+		},
+		[parseReplayEventData],
+	);
+
+	const emitEventNotification = useCallback(
+		(message: EventNotificationMessage, notifyAttention: boolean) => {
+			for (const listener of eventNotificationListenersRef.current) {
+				listener(message);
+			}
+			if (notifyAttention) {
+				for (const callback of attentionListenersRef.current) {
+					callback();
+				}
+			}
+		},
+		[],
+	);
 
 	const startPollingFallback = useCallback(() => {
 		if (pollingIntervalRef.current) return;
@@ -127,9 +235,18 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
 
 			const currentProjectId = projectIdRef.current;
 			const wsProto = window.location.protocol === "https:" ? "wss" : "ws";
-			const wsUrl = currentProjectId
-				? `${wsProto}://${window.location.host}/ws?projectId=${encodeURIComponent(currentProjectId)}`
-				: `${wsProto}://${window.location.host}/ws`;
+			const wsUrl = (() => {
+				const query = new URLSearchParams();
+				if (currentProjectId) {
+					query.set("projectId", currentProjectId);
+					const lastEventId = readStoredLastEventId(currentProjectId);
+					if (lastEventId != null) {
+						query.set("lastEventId", String(lastEventId));
+					}
+				}
+				const queryString = query.toString();
+				return `${wsProto}://${window.location.host}/ws${queryString ? `?${queryString}` : ""}`;
+			})();
 			const ws = new WebSocket(wsUrl);
 
 			ws.onopen = () => {
@@ -191,11 +308,29 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
 					}
 					break;
 				case "event:notification":
-					for (const listener of eventNotificationListenersRef.current) {
-						listener(message);
+					advanceLastEventId(message.projectId, message.eventId);
+					emitEventNotification(message, true);
+					break;
+				case "event:replay": {
+					const normalizedMessage = normalizeReplayMessage(
+						message,
+						projectIdRef.current,
+					);
+					if (normalizedMessage) {
+						advanceLastEventId(
+							normalizedMessage.projectId,
+							normalizedMessage.eventId,
+						);
+						emitEventNotification(normalizedMessage, false);
 					}
-					for (const callback of attentionListenersRef.current) {
-						callback();
+					break;
+				}
+				case "state:snapshot":
+					if (projectIdRef.current != null) {
+						advanceLastEventId(projectIdRef.current, message.lastEventId);
+					}
+					for (const listener of snapshotListenersRef.current) {
+						listener(message);
 					}
 					break;
 				case "projects:changed":
@@ -252,7 +387,15 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
 				wsRef.current = null;
 			}
 		};
-	}, [projectId, startPollingFallback, stopPollingFallback]);
+	}, [
+		projectId,
+		startPollingFallback,
+		stopPollingFallback,
+		advanceLastEventId,
+		emitEventNotification,
+		normalizeReplayMessage,
+		readStoredLastEventId,
+	]);
 
 	const subscribe = useCallback((path: string) => {
 		subscriptionsRef.current.add(path);
@@ -318,6 +461,13 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
 		[],
 	);
 
+	const onStateSnapshot = useCallback((callback: StateSnapshotCallback) => {
+		snapshotListenersRef.current.add(callback);
+		return () => {
+			snapshotListenersRef.current.delete(callback);
+		};
+	}, []);
+
 	const onProjectsChange = useCallback(
 		(callback: (msg: ProjectsChangedMessage) => void) => {
 			projectsChangeListenersRef.current.add(callback);
@@ -357,6 +507,7 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
 				onFileChange,
 				onTreeChange,
 				onEventNotification,
+				onStateSnapshot,
 				onProjectsChange,
 				onAnnotationMessage,
 				onNotification,

--- a/cli/web-ui/src/server/http.ts
+++ b/cli/web-ui/src/server/http.ts
@@ -221,6 +221,13 @@ async function handleV2ApiRequest(
 		return handleV2RunEndRequest(runId, req, apiContext);
 	}
 
+	const runSummaryMatch = pathname.match(/^\/api\/v2\/runs\/([^/]+)\/summary$/);
+	if (runSummaryMatch && method === "GET") {
+		const { handleV2RunSummaryRequest } = await import("./routes/v2-api");
+		const runId = decodeURIComponent(runSummaryMatch[1]);
+		return handleV2RunSummaryRequest(runId, apiContext);
+	}
+
 	const runDetailMatch = pathname.match(/^\/api\/v2\/runs\/([^/]+)$/);
 	if (runDetailMatch && method === "GET") {
 		const { handleV2RunDetailRequest } = await import("./routes/v2-api");

--- a/cli/web-ui/src/server/routes/v2-api.ts
+++ b/cli/web-ui/src/server/routes/v2-api.ts
@@ -37,6 +37,7 @@ import {
 	getEventsForRun,
 	getRunById,
 	getRunsByAttentionStatus,
+	getRunWithLastEventById,
 	listRuns,
 	resolveArtifactPathForRun,
 } from "../../../../src/agent-tools/emit/database.js";
@@ -1255,6 +1256,35 @@ export async function handleV2RunsAttentionRequest(
 		return jsonResponse(attention);
 	} catch (error) {
 		return errorResponse(`Failed to fetch attention data: ${String(error)}`);
+	}
+}
+
+/**
+ * GET /api/v2/runs/:id/summary - lightweight list-view run shape for targeted hydration.
+ * Run ID is a native UUID from the runs table.
+ */
+export async function handleV2RunSummaryRequest(
+	runId: string,
+	ctx?: ApiContext,
+): Promise<Response> {
+	try {
+		const db = await getDb();
+		await reclassifyInactiveRunsWithBroadcast(db, ctx?.websocketHub);
+		const record = getRunWithLastEventById(db, runId);
+
+		if (!record || isEvalRunRecord(record)) {
+			return errorResponse(`Run not found: ${runId}`, 404);
+		}
+
+		const projects = await getAllProjects(db);
+		const projectLookup = buildProjectLookup(projects);
+		const project =
+			findProjectByIdentity(projectLookup, record) ??
+			fallbackProjectFromRun(record);
+
+		return jsonResponse(runRecordToListRun(record, project));
+	} catch (error) {
+		return errorResponse(`Failed to fetch run summary: ${String(error)}`);
 	}
 }
 

--- a/cli/web-ui/src/types/websocket.ts
+++ b/cli/web-ui/src/types/websocket.ts
@@ -161,8 +161,5 @@ export type ServerMessage =
 /** WebSocket connection status */
 export type ConnectionStatus = "connecting" | "connected" | "disconnected";
 
-/** Callback type for attention updates */
-export type AttentionCallback = () => void;
-
 /** Callback type for state snapshot updates */
 export type StateSnapshotCallback = (msg: StateSnapshotMessage) => void;

--- a/cli/web-ui/src/types/websocket.ts
+++ b/cli/web-ui/src/types/websocket.ts
@@ -163,3 +163,6 @@ export type ConnectionStatus = "connecting" | "connected" | "disconnected";
 
 /** Callback type for attention updates */
 export type AttentionCallback = () => void;
+
+/** Callback type for state snapshot updates */
+export type StateSnapshotCallback = (msg: StateSnapshotMessage) => void;

--- a/docs/arcade/dashboard.md
+++ b/docs/arcade/dashboard.md
@@ -97,8 +97,14 @@ first-workflow guide.
 ### Refresh
 
 There is no dedicated refresh button on the home page. The feed updates through
-WebSocket attention signals, and reconnect recovery refetches the feed after a
-socket interruption.
+project-scoped workflow events emitted through `rp1 agent-tools emit`, so the
+browser patches only the affected run rows, project summaries, attention
+groups, and open run workspaces during normal operation.
+
+Broad collection refetches are reserved for recovery cases such as reconnecting
+after a replay gap that requires snapshot reconciliation, or for an explicit
+manual reload. File watching still refreshes artifact and file content, but it
+is not the normal path for workflow-status visibility.
 
 ---
 
@@ -352,13 +358,22 @@ Toggle between themes using the sun/moon button in the header. Your preference i
 
 ## Real-time Updates
 
-Arcade maintains a WebSocket connection for live updates. When a tracked run or
-notification changes, the feed and open workspaces update without a full page
-reload.
+Arcade maintains a project-scoped WebSocket connection for live workflow
+activity. When a tracked workflow calls `rp1 agent-tools emit`, the daemon
+broadcasts the emitted event, Arcade advances its per-project `lastEventId`
+cursor, and the UI applies the change through targeted run hydration instead of
+refreshing the whole shell.
 
-If the socket disconnects, the shell switches into reconnecting mode and a
-5-second polling fallback keeps the feed current until the connection is
-restored.
+During reconnect, the browser resends that cursor so the daemon can replay
+missed events or send a bounded snapshot when the gap is too large. That keeps
+run detail, the activity feed, project summaries, and the notifications drawer
+aligned with the persisted emit history without treating broad refresh as the
+primary user path.
+
+If the socket disconnects completely, the shell switches into reconnecting mode
+and the 5-second polling loop remains a recovery-only fallback until the live
+event stream is healthy again. File watching remains scoped to artifact and
+file-content freshness.
 
 ---
 

--- a/docs/arcade/index.md
+++ b/docs/arcade/index.md
@@ -27,6 +27,12 @@ The activity dashboard is a reverse-chronological feed of tracked runs. It
 keeps run monitoring separate from persistent notifications so the main page
 stays easy to scan.
 
+Workflow activity shows up here because workflows emit canonical events through
+`rp1 agent-tools emit`. Arcade consumes that event stream over WebSocket,
+hydrates only the affected runs and project summaries, and keeps file watching
+scoped to artifact or file-content views instead of using file changes as the
+normal status-refresh mechanism.
+
 Each row shows:
 
 - latest activity time
@@ -40,6 +46,10 @@ Persistent notifications do not appear as standalone feed rows; open the
 notifications drawer from the shell when you need approvals, failures, or other
 notification records.
 
+If the socket reconnects after a gap, Arcade resumes from the saved
+project-scoped cursor so missed workflow events can be replayed or reconciled
+from a bounded snapshot before the feed falls back to broader recovery.
+
 ### Notifications drawer
 
 The notifications drawer gives you a dedicated inbox without forcing a page
@@ -50,6 +60,12 @@ change.
 - The drawer stays on top of the current page, groups items by urgency, lets
   you follow linked runs or projects, and lets you dismiss notifications in
   place.
+- Notification delivery stays aligned with the same emit-driven live-update
+  path as the rest of Arcade, so approval, failure, and completion signals
+  follow the affected run without requiring a broad page refresh.
+- Reconnect recovery uses the saved WebSocket cursor plus persisted run state
+  to catch up after missed live traffic; manual reload is a fallback, not the
+  normal path.
 
 ### Runs list
 


### PR DESCRIPTION
## Summary
- add project-scoped WebSocket cursor, replay, and snapshot handling for live workflow events
- introduce LiveRunIndex and targeted /api/v2/runs/:id/summary hydration across Activity, Runs, Attention, Projects, and Run Detail
- remove superseded daemon IPC refresh paths and update Arcade docs plus rp1 KB guidance

## Validation
- targeted builder/reviewer checks passed for T1-T5 and TD1-TD4 during the feature workflow
- focused web-ui, v2 runs API, and emit/database tests passed during verification on the feature branch
- docs/KB pass completed with git diff --check

## Remaining Manual Validation
- measure end-to-end emit-to-visible update latency in a real local daemon plus browser session and confirm p95 is <= 2s
- run a bursty live-activity browser pass across feed, attention, project overview, and run detail to confirm responsiveness and no duplicate visible alerts

## Notes
- this branch was isolated from ui-fixes onto main and contains only the six emit-daemon commits
- the fresh PR worktree hit local environment/pre-push issues (bun-types/node type defs, stale catalog, blocked npm access), so the branch was pushed with --no-verify after isolating the commit stack