### PR TITLE
feat(web-ui): sync workspace tabs across browser tabs

### DIFF
--- a/cli/web-ui/src/__tests__/components/v2/NotificationsSidebar.test.tsx
+++ b/cli/web-ui/src/__tests__/components/v2/NotificationsSidebar.test.tsx
@@ -39,7 +39,7 @@ function setStoredState(state: {
 	readonly activeKey: string | null;
 	readonly lastDurableRoute: string;
 }) {
-	sessionStorage.setItem(WORKSPACE_TABS_STORAGE_KEY, JSON.stringify(state));
+	localStorage.setItem(WORKSPACE_TABS_STORAGE_KEY, JSON.stringify(state));
 }
 
 function renderWithWorkspaceTabs(
@@ -57,13 +57,13 @@ describe("NotificationsSidebar", () => {
 	beforeEach(() => {
 		mock.restore();
 		document.body.innerHTML = "";
-		sessionStorage.clear();
+		localStorage.clear();
 	});
 
 	afterEach(() => {
 		cleanup();
 		mock.restore();
-		sessionStorage.clear();
+		localStorage.clear();
 	});
 
 	function LocationProbe() {

--- a/cli/web-ui/src/__tests__/components/v2/NotificationsSidebar.test.tsx
+++ b/cli/web-ui/src/__tests__/components/v2/NotificationsSidebar.test.tsx
@@ -39,7 +39,17 @@ function setStoredState(state: {
 	readonly activeKey: string | null;
 	readonly lastDurableRoute: string;
 }) {
-	localStorage.setItem(WORKSPACE_TABS_STORAGE_KEY, JSON.stringify(state));
+	localStorage.setItem(
+		WORKSPACE_TABS_STORAGE_KEY,
+		JSON.stringify({ tabs: state.tabs }),
+	);
+	sessionStorage.setItem(
+		"rp1-workspace-session:v1",
+		JSON.stringify({
+			activeKey: state.activeKey,
+			lastDurableRoute: state.lastDurableRoute,
+		}),
+	);
 }
 
 function renderWithWorkspaceTabs(
@@ -58,12 +68,14 @@ describe("NotificationsSidebar", () => {
 		mock.restore();
 		document.body.innerHTML = "";
 		localStorage.clear();
+		sessionStorage.clear();
 	});
 
 	afterEach(() => {
 		cleanup();
 		mock.restore();
 		localStorage.clear();
+		sessionStorage.clear();
 	});
 
 	function LocationProbe() {

--- a/cli/web-ui/src/__tests__/components/v2/WorkspaceShellIntegration.test.tsx
+++ b/cli/web-ui/src/__tests__/components/v2/WorkspaceShellIntegration.test.tsx
@@ -30,7 +30,7 @@ function setStoredState(state: {
 	readonly activeKey: string | null;
 	readonly lastDurableRoute: string;
 }) {
-	sessionStorage.setItem(WORKSPACE_TABS_STORAGE_KEY, JSON.stringify(state));
+	localStorage.setItem(WORKSPACE_TABS_STORAGE_KEY, JSON.stringify(state));
 }
 
 function LocationProbe() {
@@ -115,12 +115,12 @@ async function renderShell(initialEntries: readonly string[]) {
 
 describe("workspace shell integration", () => {
 	beforeEach(() => {
-		sessionStorage.clear();
+		localStorage.clear();
 	});
 
 	afterEach(() => {
 		cleanup();
-		sessionStorage.clear();
+		localStorage.clear();
 	});
 
 	test("keeps breadcrumb chrome synchronized with the active workspace tab", async () => {

--- a/cli/web-ui/src/__tests__/components/v2/WorkspaceShellIntegration.test.tsx
+++ b/cli/web-ui/src/__tests__/components/v2/WorkspaceShellIntegration.test.tsx
@@ -30,7 +30,17 @@ function setStoredState(state: {
 	readonly activeKey: string | null;
 	readonly lastDurableRoute: string;
 }) {
-	localStorage.setItem(WORKSPACE_TABS_STORAGE_KEY, JSON.stringify(state));
+	localStorage.setItem(
+		WORKSPACE_TABS_STORAGE_KEY,
+		JSON.stringify({ tabs: state.tabs }),
+	);
+	sessionStorage.setItem(
+		"rp1-workspace-session:v1",
+		JSON.stringify({
+			activeKey: state.activeKey,
+			lastDurableRoute: state.lastDurableRoute,
+		}),
+	);
 }
 
 function LocationProbe() {
@@ -116,11 +126,13 @@ async function renderShell(initialEntries: readonly string[]) {
 describe("workspace shell integration", () => {
 	beforeEach(() => {
 		localStorage.clear();
+		sessionStorage.clear();
 	});
 
 	afterEach(() => {
 		cleanup();
 		localStorage.clear();
+		sessionStorage.clear();
 	});
 
 	test("keeps breadcrumb chrome synchronized with the active workspace tab", async () => {

--- a/cli/web-ui/src/__tests__/components/v2/WorkspaceTabStrip.test.tsx
+++ b/cli/web-ui/src/__tests__/components/v2/WorkspaceTabStrip.test.tsx
@@ -51,7 +51,17 @@ function setStoredState(state: {
 	readonly activeKey: string | null;
 	readonly lastDurableRoute: string;
 }) {
-	localStorage.setItem(WORKSPACE_TABS_STORAGE_KEY, JSON.stringify(state));
+	localStorage.setItem(
+		WORKSPACE_TABS_STORAGE_KEY,
+		JSON.stringify({ tabs: state.tabs }),
+	);
+	sessionStorage.setItem(
+		"rp1-workspace-session:v1",
+		JSON.stringify({
+			activeKey: state.activeKey,
+			lastDurableRoute: state.lastDurableRoute,
+		}),
+	);
 }
 
 function LocationProbe() {
@@ -93,6 +103,7 @@ describe("WorkspaceTabStrip", () => {
 		scrollIntoViewMock.mockClear();
 		prefersReducedMotion = true;
 		localStorage.clear();
+		sessionStorage.clear();
 		HTMLElement.prototype.scrollIntoView =
 			scrollIntoViewMock as typeof HTMLElement.prototype.scrollIntoView;
 		window.requestAnimationFrame = ((callback: FrameRequestCallback) => {
@@ -105,6 +116,7 @@ describe("WorkspaceTabStrip", () => {
 		cleanup();
 		mock.restore();
 		localStorage.clear();
+		sessionStorage.clear();
 		window.requestAnimationFrame = originalRequestAnimationFrame;
 		HTMLElement.prototype.scrollIntoView = originalScrollIntoView;
 	});

--- a/cli/web-ui/src/__tests__/components/v2/WorkspaceTabStrip.test.tsx
+++ b/cli/web-ui/src/__tests__/components/v2/WorkspaceTabStrip.test.tsx
@@ -51,7 +51,7 @@ function setStoredState(state: {
 	readonly activeKey: string | null;
 	readonly lastDurableRoute: string;
 }) {
-	sessionStorage.setItem(WORKSPACE_TABS_STORAGE_KEY, JSON.stringify(state));
+	localStorage.setItem(WORKSPACE_TABS_STORAGE_KEY, JSON.stringify(state));
 }
 
 function LocationProbe() {
@@ -92,7 +92,7 @@ describe("WorkspaceTabStrip", () => {
 		mock.restore();
 		scrollIntoViewMock.mockClear();
 		prefersReducedMotion = true;
-		sessionStorage.clear();
+		localStorage.clear();
 		HTMLElement.prototype.scrollIntoView =
 			scrollIntoViewMock as typeof HTMLElement.prototype.scrollIntoView;
 		window.requestAnimationFrame = ((callback: FrameRequestCallback) => {
@@ -104,7 +104,7 @@ describe("WorkspaceTabStrip", () => {
 	afterEach(() => {
 		cleanup();
 		mock.restore();
-		sessionStorage.clear();
+		localStorage.clear();
 		window.requestAnimationFrame = originalRequestAnimationFrame;
 		HTMLElement.prototype.scrollIntoView = originalScrollIntoView;
 	});

--- a/cli/web-ui/src/__tests__/hooks/useWorkspaceDescriptor.test.tsx
+++ b/cli/web-ui/src/__tests__/hooks/useWorkspaceDescriptor.test.tsx
@@ -21,7 +21,17 @@ function setStoredState(state: {
 	readonly activeKey: string | null;
 	readonly lastDurableRoute: string;
 }) {
-	localStorage.setItem(WORKSPACE_TABS_STORAGE_KEY, JSON.stringify(state));
+	localStorage.setItem(
+		WORKSPACE_TABS_STORAGE_KEY,
+		JSON.stringify({ tabs: state.tabs }),
+	);
+	sessionStorage.setItem(
+		"rp1-workspace-session:v1",
+		JSON.stringify({
+			activeKey: state.activeKey,
+			lastDurableRoute: state.lastDurableRoute,
+		}),
+	);
 }
 
 function DescriptorHarness({
@@ -85,11 +95,13 @@ function renderHarness(
 describe("useWorkspaceDescriptor", () => {
 	beforeEach(() => {
 		localStorage.clear();
+		sessionStorage.clear();
 	});
 
 	afterEach(() => {
 		cleanup();
 		localStorage.clear();
+		sessionStorage.clear();
 	});
 
 	test("publishes metadata and exposes adjacent workspace commands", async () => {

--- a/cli/web-ui/src/__tests__/hooks/useWorkspaceDescriptor.test.tsx
+++ b/cli/web-ui/src/__tests__/hooks/useWorkspaceDescriptor.test.tsx
@@ -21,7 +21,7 @@ function setStoredState(state: {
 	readonly activeKey: string | null;
 	readonly lastDurableRoute: string;
 }) {
-	sessionStorage.setItem(WORKSPACE_TABS_STORAGE_KEY, JSON.stringify(state));
+	localStorage.setItem(WORKSPACE_TABS_STORAGE_KEY, JSON.stringify(state));
 }
 
 function DescriptorHarness({
@@ -84,12 +84,12 @@ function renderHarness(
 
 describe("useWorkspaceDescriptor", () => {
 	beforeEach(() => {
-		sessionStorage.clear();
+		localStorage.clear();
 	});
 
 	afterEach(() => {
 		cleanup();
-		sessionStorage.clear();
+		localStorage.clear();
 	});
 
 	test("publishes metadata and exposes adjacent workspace commands", async () => {

--- a/cli/web-ui/src/__tests__/hooks/useWorkspaceTabs.test.tsx
+++ b/cli/web-ui/src/__tests__/hooks/useWorkspaceTabs.test.tsx
@@ -48,7 +48,7 @@ function setStoredState(state: {
 	readonly activeKey: string | null;
 	readonly lastDurableRoute: string;
 }) {
-	sessionStorage.setItem(WORKSPACE_TABS_STORAGE_KEY, JSON.stringify(state));
+	localStorage.setItem(WORKSPACE_TABS_STORAGE_KEY, JSON.stringify(state));
 }
 
 function parseTabs(): WorkspaceTab[] {
@@ -69,12 +69,12 @@ function renderHarness(initialEntries: readonly string[]) {
 
 describe("useWorkspaceTabs", () => {
 	beforeEach(() => {
-		sessionStorage.clear();
+		localStorage.clear();
 	});
 
 	afterEach(() => {
 		cleanup();
-		sessionStorage.clear();
+		localStorage.clear();
 	});
 
 	test("hydrates and deduplicates stored workspaces", async () => {
@@ -178,7 +178,7 @@ describe("useWorkspaceTabs", () => {
 	});
 
 	test("falls back to the default durable route when stored durable state is invalid", async () => {
-		sessionStorage.setItem(
+		localStorage.setItem(
 			WORKSPACE_TABS_STORAGE_KEY,
 			JSON.stringify({
 				tabs: [],
@@ -307,5 +307,134 @@ describe("useWorkspaceTabs", () => {
 		});
 		expect(parseTabs()).toEqual([]);
 		expect(screen.getByTestId("active-key").textContent).toBe("null");
+	});
+
+	test("merges tabs from a storage event while preserving the local activeKey", async () => {
+		setStoredState({
+			tabs: [
+				{
+					key: "run:run-1",
+					kind: "run",
+					currentPath: "/runs/run-1",
+					rootPath: "/runs/run-1",
+					title: "Run one",
+					subtitle: null,
+					projectId: null,
+					lastVisitedAt: 1,
+				},
+			],
+			activeKey: "run:run-1",
+			lastDurableRoute: "/projects",
+		});
+
+		renderHarness(["/runs/run-1"]);
+
+		await waitFor(() => {
+			expect(screen.getByTestId("active-key").textContent).toBe("run:run-1");
+		});
+
+		act(() => {
+			const remoteState = JSON.stringify({
+				tabs: [
+					{
+						key: "run:run-1",
+						kind: "run",
+						currentPath: "/runs/run-1",
+						rootPath: "/runs/run-1",
+						title: "Run one",
+						subtitle: null,
+						projectId: null,
+						lastVisitedAt: 1,
+					},
+					{
+						key: "run:run-3",
+						kind: "run",
+						currentPath: "/runs/run-3",
+						rootPath: "/runs/run-3",
+						title: "Run three",
+						subtitle: null,
+						projectId: null,
+						lastVisitedAt: 5,
+					},
+				],
+				activeKey: "run:run-3",
+				lastDurableRoute: "/",
+			});
+
+			window.dispatchEvent(
+				new StorageEvent("storage", {
+					key: WORKSPACE_TABS_STORAGE_KEY,
+					newValue: remoteState,
+					storageArea: localStorage,
+				}),
+			);
+		});
+
+		await waitFor(() => {
+			expect(parseTabs()).toHaveLength(2);
+		});
+		expect(parseTabs().map((tab) => tab.key)).toEqual([
+			"run:run-1",
+			"run:run-3",
+		]);
+		expect(screen.getByTestId("active-key").textContent).toBe("run:run-1");
+	});
+
+	test("uses the tab with the higher lastVisitedAt when merging conflicts from storage events", async () => {
+		setStoredState({
+			tabs: [
+				{
+					key: "run:run-1",
+					kind: "run",
+					currentPath: "/runs/run-1/step/build",
+					rootPath: "/runs/run-1",
+					title: "Run one",
+					subtitle: null,
+					projectId: null,
+					lastVisitedAt: 10,
+				},
+			],
+			activeKey: "run:run-1",
+			lastDurableRoute: "/projects",
+		});
+
+		renderHarness(["/runs/run-1/step/build"]);
+
+		await waitFor(() => {
+			expect(parseTabs()[0]?.currentPath).toBe("/runs/run-1/step/build");
+		});
+
+		act(() => {
+			const remoteState = JSON.stringify({
+				tabs: [
+					{
+						key: "run:run-1",
+						kind: "run",
+						currentPath: "/runs/run-1/step/test",
+						rootPath: "/runs/run-1",
+						title: "Run one",
+						subtitle: null,
+						projectId: null,
+						lastVisitedAt: 5,
+					},
+				],
+				activeKey: "run:run-1",
+				lastDurableRoute: "/",
+			});
+
+			window.dispatchEvent(
+				new StorageEvent("storage", {
+					key: WORKSPACE_TABS_STORAGE_KEY,
+					newValue: remoteState,
+					storageArea: localStorage,
+				}),
+			);
+		});
+
+		await waitFor(() => {
+			const tabs = parseTabs();
+			expect(tabs).toHaveLength(1);
+			expect(tabs[0]?.currentPath).toBe("/runs/run-1/step/build");
+		});
 	});
 });

--- a/cli/web-ui/src/__tests__/hooks/useWorkspaceTabs.test.tsx
+++ b/cli/web-ui/src/__tests__/hooks/useWorkspaceTabs.test.tsx
@@ -48,7 +48,17 @@ function setStoredState(state: {
 	readonly activeKey: string | null;
 	readonly lastDurableRoute: string;
 }) {
-	localStorage.setItem(WORKSPACE_TABS_STORAGE_KEY, JSON.stringify(state));
+	localStorage.setItem(
+		WORKSPACE_TABS_STORAGE_KEY,
+		JSON.stringify({ tabs: state.tabs }),
+	);
+	sessionStorage.setItem(
+		"rp1-workspace-session:v1",
+		JSON.stringify({
+			activeKey: state.activeKey,
+			lastDurableRoute: state.lastDurableRoute,
+		}),
+	);
 }
 
 function parseTabs(): WorkspaceTab[] {
@@ -70,11 +80,13 @@ function renderHarness(initialEntries: readonly string[]) {
 describe("useWorkspaceTabs", () => {
 	beforeEach(() => {
 		localStorage.clear();
+		sessionStorage.clear();
 	});
 
 	afterEach(() => {
 		cleanup();
 		localStorage.clear();
+		sessionStorage.clear();
 	});
 
 	test("hydrates and deduplicates stored workspaces", async () => {
@@ -180,8 +192,11 @@ describe("useWorkspaceTabs", () => {
 	test("falls back to the default durable route when stored durable state is invalid", async () => {
 		localStorage.setItem(
 			WORKSPACE_TABS_STORAGE_KEY,
+			JSON.stringify({ tabs: [] }),
+		);
+		sessionStorage.setItem(
+			"rp1-workspace-session:v1",
 			JSON.stringify({
-				tabs: [],
 				activeKey: null,
 				lastDurableRoute: "/settings",
 			}),
@@ -309,7 +324,7 @@ describe("useWorkspaceTabs", () => {
 		expect(screen.getByTestId("active-key").textContent).toBe("null");
 	});
 
-	test("merges tabs from a storage event while preserving the local activeKey", async () => {
+	test("adopts remote tabs from a storage event while preserving the local activeKey", async () => {
 		setStoredState({
 			tabs: [
 				{
@@ -357,8 +372,6 @@ describe("useWorkspaceTabs", () => {
 						lastVisitedAt: 5,
 					},
 				],
-				activeKey: "run:run-3",
-				lastDurableRoute: "/",
 			});
 
 			window.dispatchEvent(
@@ -380,28 +393,38 @@ describe("useWorkspaceTabs", () => {
 		expect(screen.getByTestId("active-key").textContent).toBe("run:run-1");
 	});
 
-	test("uses the tab with the higher lastVisitedAt when merging conflicts from storage events", async () => {
+	test("removes tabs that were closed in another browser tab via storage event", async () => {
 		setStoredState({
 			tabs: [
 				{
 					key: "run:run-1",
 					kind: "run",
-					currentPath: "/runs/run-1/step/build",
+					currentPath: "/runs/run-1",
 					rootPath: "/runs/run-1",
 					title: "Run one",
 					subtitle: null,
 					projectId: null,
-					lastVisitedAt: 10,
+					lastVisitedAt: 1,
+				},
+				{
+					key: "run:run-2",
+					kind: "run",
+					currentPath: "/runs/run-2",
+					rootPath: "/runs/run-2",
+					title: "Run two",
+					subtitle: null,
+					projectId: null,
+					lastVisitedAt: 2,
 				},
 			],
 			activeKey: "run:run-1",
 			lastDurableRoute: "/projects",
 		});
 
-		renderHarness(["/runs/run-1/step/build"]);
+		renderHarness(["/runs/run-1"]);
 
 		await waitFor(() => {
-			expect(parseTabs()[0]?.currentPath).toBe("/runs/run-1/step/build");
+			expect(parseTabs()).toHaveLength(2);
 		});
 
 		act(() => {
@@ -410,16 +433,14 @@ describe("useWorkspaceTabs", () => {
 					{
 						key: "run:run-1",
 						kind: "run",
-						currentPath: "/runs/run-1/step/test",
+						currentPath: "/runs/run-1",
 						rootPath: "/runs/run-1",
 						title: "Run one",
 						subtitle: null,
 						projectId: null,
-						lastVisitedAt: 5,
+						lastVisitedAt: 1,
 					},
 				],
-				activeKey: "run:run-1",
-				lastDurableRoute: "/",
 			});
 
 			window.dispatchEvent(
@@ -432,9 +453,9 @@ describe("useWorkspaceTabs", () => {
 		});
 
 		await waitFor(() => {
-			const tabs = parseTabs();
-			expect(tabs).toHaveLength(1);
-			expect(tabs[0]?.currentPath).toBe("/runs/run-1/step/build");
+			expect(parseTabs()).toHaveLength(1);
 		});
+		expect(parseTabs().map((tab) => tab.key)).toEqual(["run:run-1"]);
+		expect(screen.getByTestId("active-key").textContent).toBe("run:run-1");
 	});
 });

--- a/cli/web-ui/src/__tests__/pages/v2/ArtifactViewerPage.test.tsx
+++ b/cli/web-ui/src/__tests__/pages/v2/ArtifactViewerPage.test.tsx
@@ -214,7 +214,7 @@ function RegistryProbe() {
 }
 
 function readStoredTabs() {
-	const raw = sessionStorage.getItem(WORKSPACE_TABS_STORAGE_KEY);
+	const raw = localStorage.getItem(WORKSPACE_TABS_STORAGE_KEY);
 	return raw
 		? (JSON.parse(raw) as {
 				tabs: Array<{ title: string; subtitle: string | null }>;
@@ -252,7 +252,7 @@ describe("ArtifactViewerPage", () => {
 	beforeEach(() => {
 		mock.restore();
 		document.body.innerHTML = "";
-		sessionStorage.clear();
+		localStorage.clear();
 		latestRegistry = null;
 		breadcrumbApi.setActiveArtifact.mockClear();
 		breadcrumbApi.setProject.mockClear();

--- a/cli/web-ui/src/__tests__/pages/v2/ArtifactViewerPage.test.tsx
+++ b/cli/web-ui/src/__tests__/pages/v2/ArtifactViewerPage.test.tsx
@@ -253,6 +253,7 @@ describe("ArtifactViewerPage", () => {
 		mock.restore();
 		document.body.innerHTML = "";
 		localStorage.clear();
+		sessionStorage.clear();
 		latestRegistry = null;
 		breadcrumbApi.setActiveArtifact.mockClear();
 		breadcrumbApi.setProject.mockClear();

--- a/cli/web-ui/src/__tests__/pages/v2/HomePage.test.tsx
+++ b/cli/web-ui/src/__tests__/pages/v2/HomePage.test.tsx
@@ -74,7 +74,7 @@ function setStoredState(state: {
 	readonly activeKey: string | null;
 	readonly lastDurableRoute: string;
 }) {
-	sessionStorage.setItem(WORKSPACE_TABS_STORAGE_KEY, JSON.stringify(state));
+	localStorage.setItem(WORKSPACE_TABS_STORAGE_KEY, JSON.stringify(state));
 }
 
 function LocationProbe() {
@@ -119,13 +119,13 @@ describe("HomePage", () => {
 	beforeEach(() => {
 		mock.restore();
 		document.body.innerHTML = "";
-		sessionStorage.clear();
+		localStorage.clear();
 	});
 
 	afterEach(() => {
 		cleanup();
 		mock.restore();
-		sessionStorage.clear();
+		localStorage.clear();
 	});
 
 	test("reopens an existing run workspace from the activity feed entry", async () => {

--- a/cli/web-ui/src/__tests__/pages/v2/HomePage.test.tsx
+++ b/cli/web-ui/src/__tests__/pages/v2/HomePage.test.tsx
@@ -74,7 +74,17 @@ function setStoredState(state: {
 	readonly activeKey: string | null;
 	readonly lastDurableRoute: string;
 }) {
-	localStorage.setItem(WORKSPACE_TABS_STORAGE_KEY, JSON.stringify(state));
+	localStorage.setItem(
+		WORKSPACE_TABS_STORAGE_KEY,
+		JSON.stringify({ tabs: state.tabs }),
+	);
+	sessionStorage.setItem(
+		"rp1-workspace-session:v1",
+		JSON.stringify({
+			activeKey: state.activeKey,
+			lastDurableRoute: state.lastDurableRoute,
+		}),
+	);
 }
 
 function LocationProbe() {
@@ -120,12 +130,14 @@ describe("HomePage", () => {
 		mock.restore();
 		document.body.innerHTML = "";
 		localStorage.clear();
+		sessionStorage.clear();
 	});
 
 	afterEach(() => {
 		cleanup();
 		mock.restore();
 		localStorage.clear();
+		sessionStorage.clear();
 	});
 
 	test("reopens an existing run workspace from the activity feed entry", async () => {

--- a/cli/web-ui/src/__tests__/pages/v2/ProjectOverviewPage.test.tsx
+++ b/cli/web-ui/src/__tests__/pages/v2/ProjectOverviewPage.test.tsx
@@ -75,7 +75,17 @@ function setStoredState(state: {
 	readonly activeKey: string | null;
 	readonly lastDurableRoute: string;
 }) {
-	localStorage.setItem(WORKSPACE_TABS_STORAGE_KEY, JSON.stringify(state));
+	localStorage.setItem(
+		WORKSPACE_TABS_STORAGE_KEY,
+		JSON.stringify({ tabs: state.tabs }),
+	);
+	sessionStorage.setItem(
+		"rp1-workspace-session:v1",
+		JSON.stringify({
+			activeKey: state.activeKey,
+			lastDurableRoute: state.lastDurableRoute,
+		}),
+	);
 }
 
 async function renderProjectOverview(
@@ -128,6 +138,7 @@ describe("ProjectOverviewPage", () => {
 		liveRunIndex.clear();
 		document.body.innerHTML = "";
 		localStorage.clear();
+		sessionStorage.clear();
 		latestRegistry = null;
 		breadcrumbApi.setProject.mockClear();
 		global.fetch = mock(async (input: RequestInfo | URL) => {

--- a/cli/web-ui/src/__tests__/pages/v2/ProjectOverviewPage.test.tsx
+++ b/cli/web-ui/src/__tests__/pages/v2/ProjectOverviewPage.test.tsx
@@ -75,7 +75,7 @@ function setStoredState(state: {
 	readonly activeKey: string | null;
 	readonly lastDurableRoute: string;
 }) {
-	sessionStorage.setItem(WORKSPACE_TABS_STORAGE_KEY, JSON.stringify(state));
+	localStorage.setItem(WORKSPACE_TABS_STORAGE_KEY, JSON.stringify(state));
 }
 
 async function renderProjectOverview(
@@ -127,7 +127,7 @@ describe("ProjectOverviewPage", () => {
 		mock.restore();
 		liveRunIndex.clear();
 		document.body.innerHTML = "";
-		sessionStorage.clear();
+		localStorage.clear();
 		latestRegistry = null;
 		breadcrumbApi.setProject.mockClear();
 		global.fetch = mock(async (input: RequestInfo | URL) => {

--- a/cli/web-ui/src/__tests__/pages/v2/ProjectsPage.test.tsx
+++ b/cli/web-ui/src/__tests__/pages/v2/ProjectsPage.test.tsx
@@ -52,7 +52,7 @@ function setStoredState(state: {
 	readonly activeKey: string | null;
 	readonly lastDurableRoute: string;
 }) {
-	sessionStorage.setItem(WORKSPACE_TABS_STORAGE_KEY, JSON.stringify(state));
+	localStorage.setItem(WORKSPACE_TABS_STORAGE_KEY, JSON.stringify(state));
 }
 
 async function renderProjectsPage(
@@ -91,13 +91,13 @@ describe("ProjectsPage", () => {
 	beforeEach(() => {
 		mock.restore();
 		document.body.innerHTML = "";
-		sessionStorage.clear();
+		localStorage.clear();
 	});
 
 	afterEach(() => {
 		cleanup();
 		mock.restore();
-		sessionStorage.clear();
+		localStorage.clear();
 	});
 
 	test("opens the selected project overview from the project row", async () => {

--- a/cli/web-ui/src/__tests__/pages/v2/ProjectsPage.test.tsx
+++ b/cli/web-ui/src/__tests__/pages/v2/ProjectsPage.test.tsx
@@ -52,7 +52,17 @@ function setStoredState(state: {
 	readonly activeKey: string | null;
 	readonly lastDurableRoute: string;
 }) {
-	localStorage.setItem(WORKSPACE_TABS_STORAGE_KEY, JSON.stringify(state));
+	localStorage.setItem(
+		WORKSPACE_TABS_STORAGE_KEY,
+		JSON.stringify({ tabs: state.tabs }),
+	);
+	sessionStorage.setItem(
+		"rp1-workspace-session:v1",
+		JSON.stringify({
+			activeKey: state.activeKey,
+			lastDurableRoute: state.lastDurableRoute,
+		}),
+	);
 }
 
 async function renderProjectsPage(
@@ -92,12 +102,14 @@ describe("ProjectsPage", () => {
 		mock.restore();
 		document.body.innerHTML = "";
 		localStorage.clear();
+		sessionStorage.clear();
 	});
 
 	afterEach(() => {
 		cleanup();
 		mock.restore();
 		localStorage.clear();
+		sessionStorage.clear();
 	});
 
 	test("opens the selected project overview from the project row", async () => {

--- a/cli/web-ui/src/components/v2/WorkspaceTabStrip.tsx
+++ b/cli/web-ui/src/components/v2/WorkspaceTabStrip.tsx
@@ -189,7 +189,7 @@ export function WorkspaceTabStrip({
 					aria-label="Open workspaces"
 					className="min-w-0 flex-1 overflow-x-auto"
 				>
-					<div className="flex min-w-max items-center gap-2">
+					<div className="flex items-center gap-1">
 						{tabs.map((tab) => {
 							const isActive = tab.key === activeKey;
 
@@ -197,7 +197,7 @@ export function WorkspaceTabStrip({
 								<div
 									key={tab.key}
 									className={cn(
-										"group flex max-w-[13rem] shrink-0 items-center gap-1 rounded-md border px-2 py-1 md:max-w-[18rem]",
+										"group flex min-w-[5rem] max-w-[13rem] items-center gap-1 rounded-md border px-2 py-1 md:min-w-[7rem] md:max-w-[18rem]",
 										isActive
 											? "border-border bg-surface text-fg"
 											: "border-transparent bg-transparent text-fg-muted hover:border-border/60 hover:bg-muted/30 hover:text-fg",

--- a/cli/web-ui/src/hooks/useWorkspaceTabs.tsx
+++ b/cli/web-ui/src/hooks/useWorkspaceTabs.tsx
@@ -56,6 +56,7 @@ interface StoredWorkspaceTabsState {
 }
 
 export const WORKSPACE_TABS_STORAGE_KEY = "rp1-workspace-tabs:v1";
+const SESSION_STATE_KEY = "rp1-workspace-session:v1";
 const BROADCAST_CHANNEL_NAME = "rp1-workspace-tabs";
 
 const DEFAULT_STATE: WorkspaceTabsState = {
@@ -142,21 +143,34 @@ function loadWorkspaceTabsState(): WorkspaceTabsState {
 
 	try {
 		const raw = localStorage.getItem(WORKSPACE_TABS_STORAGE_KEY);
-		if (!raw) return DEFAULT_STATE;
-
-		const parsed = JSON.parse(raw) as StoredWorkspaceTabsState;
-		const parsedTabs = Array.isArray(parsed.tabs)
-			? dedupeTabs(parsed.tabs.map(sanitizeStoredTab).filter(isWorkspaceTab))
+		const parsedTabs = raw
+			? (() => {
+					const parsed = JSON.parse(raw) as StoredWorkspaceTabsState;
+					return Array.isArray(parsed.tabs)
+						? dedupeTabs(
+								parsed.tabs.map(sanitizeStoredTab).filter(isWorkspaceTab),
+							)
+						: [];
+				})()
 			: [];
+
+		const sessionRaw = sessionStorage.getItem(SESSION_STATE_KEY);
+		const session = sessionRaw
+			? (JSON.parse(sessionRaw) as {
+					activeKey?: unknown;
+					lastDurableRoute?: unknown;
+				})
+			: {};
+
 		const normalizedDurableRoute =
-			typeof parsed.lastDurableRoute === "string" &&
-			normalizeWorkspaceRoute(parsed.lastDurableRoute).type === "durable"
-				? parsed.lastDurableRoute
+			typeof session.lastDurableRoute === "string" &&
+			normalizeWorkspaceRoute(session.lastDurableRoute).type === "durable"
+				? session.lastDurableRoute
 				: "/";
 		const activeKey =
-			typeof parsed.activeKey === "string" &&
-			parsedTabs.some((tab) => tab.key === parsed.activeKey)
-				? parsed.activeKey
+			typeof session.activeKey === "string" &&
+			parsedTabs.some((tab) => tab.key === session.activeKey)
+				? session.activeKey
 				: null;
 
 		return {
@@ -264,7 +278,17 @@ export function WorkspaceTabsProvider({
 
 	useEffect(() => {
 		if (typeof window === "undefined") return;
-		localStorage.setItem(WORKSPACE_TABS_STORAGE_KEY, JSON.stringify(state));
+		localStorage.setItem(
+			WORKSPACE_TABS_STORAGE_KEY,
+			JSON.stringify({ tabs: state.tabs }),
+		);
+		sessionStorage.setItem(
+			SESSION_STATE_KEY,
+			JSON.stringify({
+				activeKey: state.activeKey,
+				lastDurableRoute: state.lastDurableRoute,
+			}),
+		);
 		channelRef.current?.postMessage(state.tabs);
 	}, [state]);
 
@@ -281,14 +305,13 @@ export function WorkspaceTabsProvider({
 			);
 
 			setState((current) => {
-				const mergedTabs = dedupeTabs([...remoteTabs, ...current.tabs]);
 				if (
-					mergedTabs.length === current.tabs.length &&
-					mergedTabs.every((tab, i) => tab === current.tabs[i])
+					remoteTabs.length === current.tabs.length &&
+					remoteTabs.every((tab, i) => tab.key === current.tabs[i]?.key)
 				) {
 					return current;
 				}
-				return { ...current, tabs: mergedTabs };
+				return { ...current, tabs: remoteTabs };
 			});
 		};
 
@@ -313,14 +336,13 @@ export function WorkspaceTabsProvider({
 					: [];
 
 				setState((current) => {
-					const mergedTabs = dedupeTabs([...remoteTabs, ...current.tabs]);
 					if (
-						mergedTabs.length === current.tabs.length &&
-						mergedTabs.every((tab, i) => tab === current.tabs[i])
+						remoteTabs.length === current.tabs.length &&
+						remoteTabs.every((tab, i) => tab.key === current.tabs[i]?.key)
 					) {
 						return current;
 					}
-					return { ...current, tabs: mergedTabs };
+					return { ...current, tabs: remoteTabs };
 				});
 			} catch {
 				// Ignore malformed storage events

--- a/cli/web-ui/src/hooks/useWorkspaceTabs.tsx
+++ b/cli/web-ui/src/hooks/useWorkspaceTabs.tsx
@@ -56,6 +56,7 @@ interface StoredWorkspaceTabsState {
 }
 
 export const WORKSPACE_TABS_STORAGE_KEY = "rp1-workspace-tabs:v1";
+const BROADCAST_CHANNEL_NAME = "rp1-workspace-tabs";
 
 const DEFAULT_STATE: WorkspaceTabsState = {
 	tabs: [],
@@ -140,7 +141,7 @@ function loadWorkspaceTabsState(): WorkspaceTabsState {
 	if (typeof window === "undefined") return DEFAULT_STATE;
 
 	try {
-		const raw = sessionStorage.getItem(WORKSPACE_TABS_STORAGE_KEY);
+		const raw = localStorage.getItem(WORKSPACE_TABS_STORAGE_KEY);
 		if (!raw) return DEFAULT_STATE;
 
 		const parsed = JSON.parse(raw) as StoredWorkspaceTabsState;
@@ -253,6 +254,7 @@ export function WorkspaceTabsProvider({
 		loadWorkspaceTabsState(),
 	);
 	const stateRef = useRef(state);
+	const channelRef = useRef<BroadcastChannel | null>(null);
 	const location = useLocation();
 	const navigate = useNavigate();
 
@@ -262,8 +264,72 @@ export function WorkspaceTabsProvider({
 
 	useEffect(() => {
 		if (typeof window === "undefined") return;
-		sessionStorage.setItem(WORKSPACE_TABS_STORAGE_KEY, JSON.stringify(state));
+		localStorage.setItem(WORKSPACE_TABS_STORAGE_KEY, JSON.stringify(state));
+		channelRef.current?.postMessage(state.tabs);
 	}, [state]);
+
+	useEffect(() => {
+		if (typeof BroadcastChannel === "undefined") return;
+
+		const channel = new BroadcastChannel(BROADCAST_CHANNEL_NAME);
+		channelRef.current = channel;
+
+		channel.onmessage = (event: MessageEvent) => {
+			if (!Array.isArray(event.data)) return;
+			const remoteTabs = dedupeTabs(
+				(event.data as unknown[]).map(sanitizeStoredTab).filter(isWorkspaceTab),
+			);
+
+			setState((current) => {
+				const mergedTabs = dedupeTabs([...remoteTabs, ...current.tabs]);
+				if (
+					mergedTabs.length === current.tabs.length &&
+					mergedTabs.every((tab, i) => tab === current.tabs[i])
+				) {
+					return current;
+				}
+				return { ...current, tabs: mergedTabs };
+			});
+		};
+
+		return () => {
+			channel.close();
+			channelRef.current = null;
+		};
+	}, []);
+
+	useEffect(() => {
+		if (typeof window === "undefined") return;
+
+		const handleStorage = (event: StorageEvent) => {
+			if (event.key !== WORKSPACE_TABS_STORAGE_KEY || !event.newValue) return;
+
+			try {
+				const parsed = JSON.parse(event.newValue) as StoredWorkspaceTabsState;
+				const remoteTabs = Array.isArray(parsed.tabs)
+					? dedupeTabs(
+							parsed.tabs.map(sanitizeStoredTab).filter(isWorkspaceTab),
+						)
+					: [];
+
+				setState((current) => {
+					const mergedTabs = dedupeTabs([...remoteTabs, ...current.tabs]);
+					if (
+						mergedTabs.length === current.tabs.length &&
+						mergedTabs.every((tab, i) => tab === current.tabs[i])
+					) {
+						return current;
+					}
+					return { ...current, tabs: mergedTabs };
+				});
+			} catch {
+				// Ignore malformed storage events
+			}
+		};
+
+		window.addEventListener("storage", handleStorage);
+		return () => window.removeEventListener("storage", handleStorage);
+	}, []);
 
 	useLayoutEffect(() => {
 		const currentPath = createCurrentPath(


### PR DESCRIPTION
## Summary
- Moves tab persistence from `sessionStorage` to `localStorage` so the tab list is shared across browser tabs of the same origin
- Adds `BroadcastChannel` for real-time cross-tab sync with `storage` event fallback for browsers without BroadcastChannel support
- `activeKey` and `lastDurableRoute` remain in `sessionStorage` (per-session) so each browser tab maintains its own navigation position and durable fallback route
- Remote tab updates are adopted as truth (not merged additively), so closing a tab in one browser tab removes it from all others
- **Tab compression**: Tabs shrink proportionally when there are too many to fit, similar to Chrome. Minimum floor width (5rem mobile / 7rem desktop) prevents tabs from collapsing; horizontal scroll activates when tabs hit the floor

## Test plan
- [x] All 33 workspace-related tests pass with split storage (localStorage for tabs, sessionStorage for session state)
- [x] New test: adopts remote tabs from a storage event while preserving the local activeKey
- [x] New test: removes tabs that were closed in another browser tab via storage event
- [x] Playwright: 10 tabs at 1280px compress equally to 112px each, filling available space
- [x] Playwright: 3 tabs at 1280px display at natural width (226-279px), capped by max-width
- [x] Playwright: 10 tabs at 800px show 7 visible with horizontal scroll for the rest
- [x] Manual: open Arcade in two browser tabs, open a run workspace in one — verify it appears in the other
- [x] Manual: close a tab in one browser tab — verify it disappears in the other
- [x] Manual: verify each browser tab maintains its own active tab selection after reload