### PR TITLE
feat(daemon): add cross-process lifecycle lock and harden daemon mutations

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -294,7 +294,7 @@ install: rm-stable build
         if [ -z "$port" ]; then port=7710; fi; \
         echo ""; \
         echo "Restarting Arcade daemon on port ${port}..."; \
-        ./bin/rp1 arcade --daemon-only --port "$port" --no-open >/dev/null 2>&1 || true; \
+        ./bin/rp1 arcade --daemon-only --port "$port" --no-open 2>&1 || echo "Warning: daemon restart failed (port ${port} may be in use)"; \
         rm -f "$restart_marker"; \
     fi
 

--- a/Justfile
+++ b/Justfile
@@ -136,33 +136,12 @@ build-web-ui:
 
 # Clear web-ui cache (needed when testing local builds)
 
-# Stops the production daemon first if running, since it serves assets from this cache
+# Stops the production daemon first if running, since it serves assets from this cache.
+# Delegates daemon handling to the shared lifecycle manager via a Bun helper script.
 clean-web-ui-cache:
     #!/usr/bin/env bash
     set -e
-    if [ "$(uname)" = "Darwin" ]; then
-        config_dir="${HOME}/Library/Application Support/rp1"
-    else
-        config_dir="${XDG_CONFIG_HOME:-$HOME/.config}/rp1"
-    fi
-    pid_file="${config_dir}/daemon.pid"
-    restart_marker="${config_dir}/restart-arcade-after-install"
-    mkdir -p "$config_dir"
-    rm -f "$restart_marker"
-    if [ -f "$pid_file" ]; then
-        daemon_pid=$(sed -n '2p' "$pid_file")
-        if [ -n "$daemon_pid" ] && kill -0 "$daemon_pid" 2>/dev/null; then
-            echo "Stopping production daemon (PID $daemon_pid) before clearing web-ui cache..."
-            touch "$restart_marker"
-            curl -sf -X POST http://127.0.0.1:7710/api/v2/shutdown >/dev/null 2>&1 || true
-            kill "$daemon_pid" 2>/dev/null || true
-            for i in $(seq 1 30); do
-                kill -0 "$daemon_pid" 2>/dev/null || break
-                sleep 0.1
-            done
-            rm -f "$pid_file"
-        fi
-    fi
+    cd cli && bun run scripts/prepare-local-install-daemon.ts
     rm -rf ~/.rp1/web-ui/
 
 # Build the local binary with -dev version suffix
@@ -311,9 +290,11 @@ install: rm-stable build
     echo ""; \
     ./bin/rp1 install -y; \
     if [ -f "$restart_marker" ]; then \
+        port=$(cat "$restart_marker" 2>/dev/null | tr -d '[:space:]'); \
+        if [ -z "$port" ]; then port=7710; fi; \
         echo ""; \
-        echo "Restarting Arcade daemon..."; \
-        ./bin/rp1 arcade --daemon-only --no-open >/dev/null 2>&1 || true; \
+        echo "Restarting Arcade daemon on port ${port}..."; \
+        ./bin/rp1 arcade --daemon-only --port "$port" --no-open >/dev/null 2>&1 || true; \
         rm -f "$restart_marker"; \
     fi
 

--- a/cli/scripts/prepare-local-install-daemon.ts
+++ b/cli/scripts/prepare-local-install-daemon.ts
@@ -1,0 +1,75 @@
+/**
+ * Prepare daemon state before a local install replaces the rp1 binary.
+ *
+ * This script runs via `bun run` from the Justfile's clean-web-ui-cache recipe,
+ * using the shared daemon manager contract instead of raw PID-file parsing,
+ * curl, and kill commands.
+ *
+ * Behavior:
+ *   - If a daemon is running, stops it through the lifecycle manager and writes
+ *     the prior port to the restart marker so the post-install step can restore
+ *     Arcade on the same port with the newly built binary.
+ *   - If no daemon is running, removes any stale restart marker so the
+ *     post-install step does not start a surprise background daemon.
+ *
+ * Exit codes:
+ *   0 - success (daemon stopped or no daemon was running)
+ *   1 - unexpected error during preparation
+ */
+
+import { existsSync, unlinkSync, writeFileSync } from "node:fs";
+import {
+	ensureConfigDir,
+	getRestartMarkerPath,
+} from "../web-ui/src/daemon/config-dir";
+import { getStatus, stopDaemon } from "../web-ui/src/daemon/manager";
+
+const DEFAULT_PORT = 7710;
+
+async function main(): Promise<void> {
+	await ensureConfigDir();
+
+	const markerPath = getRestartMarkerPath();
+
+	// Detect whether a daemon is currently serving.
+	const status = await getStatus(DEFAULT_PORT);
+
+	if (status.running) {
+		const port = status.port ?? DEFAULT_PORT;
+		console.error(
+			`Stopping production daemon on port ${port} before install...`,
+		);
+
+		const result = await stopDaemon(port);
+
+		if (result.action === "stopped") {
+			// Record the port so the post-install step can restore Arcade.
+			writeFileSync(markerPath, String(port), { mode: 0o600 });
+			console.error(`Daemon stopped. Restart marker written (port ${port}).`);
+		} else {
+			// stopDaemon returned not_running despite getStatus saying running.
+			// Race condition — another process may have stopped it. Clear marker.
+			removeMarker(markerPath);
+			console.error("Daemon was no longer running when stop was attempted.");
+		}
+	} else {
+		// No daemon running — remove any stale marker from a prior interrupted install.
+		removeMarker(markerPath);
+		console.error("No daemon running. Stale marker cleared.");
+	}
+}
+
+function removeMarker(path: string): void {
+	try {
+		if (existsSync(path)) {
+			unlinkSync(path);
+		}
+	} catch {
+		// Best-effort cleanup.
+	}
+}
+
+main().catch((err) => {
+	console.error("prepare-local-install-daemon failed:", err);
+	process.exit(1);
+});

--- a/cli/scripts/prepare-local-install-daemon.ts
+++ b/cli/scripts/prepare-local-install-daemon.ts
@@ -6,10 +6,11 @@
  * curl, and kill commands.
  *
  * Behavior:
- *   - If a daemon is running, stops it through the lifecycle manager and writes
- *     the prior port to the restart marker so the post-install step can restore
- *     Arcade on the same port with the newly built binary.
- *   - If no daemon is running, removes any stale restart marker so the
+ *   - Calls stopDaemon() (which acquires the lifecycle lock internally) to
+ *     cleanly shut down any running daemon.
+ *   - If the daemon was stopped, writes the prior port to the restart marker
+ *     so the post-install step can restore Arcade on the same port.
+ *   - If no daemon was running, removes any stale restart marker so the
  *     post-install step does not start a surprise background daemon.
  *
  * Exit codes:
@@ -17,12 +18,13 @@
  *   1 - unexpected error during preparation
  */
 
-import { existsSync, unlinkSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import {
 	ensureConfigDir,
+	getPidFilePath,
 	getRestartMarkerPath,
 } from "../web-ui/src/daemon/config-dir";
-import { getStatus, stopDaemon } from "../web-ui/src/daemon/manager";
+import { stopDaemon } from "../web-ui/src/daemon/manager";
 
 const DEFAULT_PORT = 7710;
 
@@ -31,29 +33,26 @@ async function main(): Promise<void> {
 
 	const markerPath = getRestartMarkerPath();
 
-	// Detect whether a daemon is currently serving.
-	const status = await getStatus(DEFAULT_PORT);
+	// Read the port from the PID file before stopping so we know which port
+	// to restore after install.  This read is unlocked — the subsequent
+	// stopDaemon() call re-checks under the lifecycle lock.
+	let port = DEFAULT_PORT;
+	try {
+		const pidContent = readFileSync(getPidFilePath(), "utf-8");
+		const parsed = Number.parseInt(pidContent.trim().split("\n")[0], 10);
+		if (!Number.isNaN(parsed)) port = parsed;
+	} catch {
+		// No PID file or unreadable — use default port.
+	}
 
-	if (status.running) {
-		const port = status.port ?? DEFAULT_PORT;
-		console.error(
-			`Stopping production daemon on port ${port} before install...`,
-		);
+	// stopDaemon() acquires the lifecycle lock internally, so the entire
+	// probe-and-stop sequence is atomic with respect to other callers.
+	const result = await stopDaemon(port);
 
-		const result = await stopDaemon(port);
-
-		if (result.action === "stopped") {
-			// Record the port so the post-install step can restore Arcade.
-			writeFileSync(markerPath, String(port), { mode: 0o600 });
-			console.error(`Daemon stopped. Restart marker written (port ${port}).`);
-		} else {
-			// stopDaemon returned not_running despite getStatus saying running.
-			// Race condition — another process may have stopped it. Clear marker.
-			removeMarker(markerPath);
-			console.error("Daemon was no longer running when stop was attempted.");
-		}
+	if (result.action === "stopped") {
+		writeFileSync(markerPath, String(port), { mode: 0o600 });
+		console.error(`Daemon stopped. Restart marker written (port ${port}).`);
 	} else {
-		// No daemon running — remove any stale marker from a prior interrupted install.
 		removeMarker(markerPath);
 		console.error("No daemon running. Stale marker cleared.");
 	}

--- a/cli/src/__tests__/commands/arcade.test.ts
+++ b/cli/src/__tests__/commands/arcade.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
 	arcadeCommand,
 	formatArcadeHookPayload,
+	formatLifecycleAction,
 } from "../../commands/arcade.js";
 
 describe("arcade command", () => {
@@ -23,6 +24,60 @@ describe("arcade command", () => {
 				systemMessage:
 					"🕹️ rp1 Arcade is live at http://127.0.0.1:7710/projects/test-id",
 			}),
+		);
+	});
+});
+
+describe("formatLifecycleAction", () => {
+	test("reports reused daemon on the given port", () => {
+		expect(formatLifecycleAction("reused", 7710)).toBe(
+			"Reused daemon on port 7710",
+		);
+	});
+
+	test("reports started daemon on the given port", () => {
+		expect(formatLifecycleAction("started", 8080)).toBe(
+			"Started daemon on port 8080",
+		);
+	});
+
+	test("reports replaced daemon with no reason", () => {
+		expect(formatLifecycleAction("replaced", 7710)).toBe(
+			"Replaced daemon on port 7710",
+		);
+	});
+
+	test("reports replaced daemon with version_mismatch reason", () => {
+		expect(formatLifecycleAction("replaced", 7710, "version_mismatch")).toBe(
+			"Replaced daemon on port 7710 (reason: version mismatch)",
+		);
+	});
+
+	test("reports replaced daemon with unhealthy_daemon reason", () => {
+		expect(formatLifecycleAction("replaced", 9090, "unhealthy_daemon")).toBe(
+			"Replaced daemon on port 9090 (reason: unhealthy daemon)",
+		);
+	});
+
+	test("reports replaced daemon with stale_pid reason", () => {
+		expect(formatLifecycleAction("replaced", 7710, "stale_pid")).toBe(
+			"Replaced daemon on port 7710 (reason: stale pid)",
+		);
+	});
+
+	test("reason underscores are replaced with spaces for readability", () => {
+		const msg = formatLifecycleAction("replaced", 7710, "missing_pid");
+		expect(msg).toContain("missing pid");
+		expect(msg).not.toContain("missing_pid");
+	});
+
+	test("reason is ignored for reused and started actions", () => {
+		// formatLifecycleAction only appends reason for "replaced".
+		expect(formatLifecycleAction("reused", 7710, "stale_pid")).toBe(
+			"Reused daemon on port 7710",
+		);
+		expect(formatLifecycleAction("started", 7710, "missing_pid")).toBe(
+			"Started daemon on port 7710",
 		);
 	});
 });

--- a/cli/src/__tests__/commands/arcade.test.ts
+++ b/cli/src/__tests__/commands/arcade.test.ts
@@ -49,19 +49,19 @@ describe("formatLifecycleAction", () => {
 
 	test("reports replaced daemon with version_mismatch reason", () => {
 		expect(formatLifecycleAction("replaced", 7710, "version_mismatch")).toBe(
-			"Replaced daemon on port 7710 (reason: version mismatch)",
+			"Replaced daemon on port 7710 (version mismatch)",
 		);
 	});
 
 	test("reports replaced daemon with unhealthy_daemon reason", () => {
 		expect(formatLifecycleAction("replaced", 9090, "unhealthy_daemon")).toBe(
-			"Replaced daemon on port 9090 (reason: unhealthy daemon)",
+			"Replaced daemon on port 9090 (unhealthy daemon)",
 		);
 	});
 
 	test("reports replaced daemon with stale_pid reason", () => {
 		expect(formatLifecycleAction("replaced", 7710, "stale_pid")).toBe(
-			"Replaced daemon on port 7710 (reason: stale pid)",
+			"Replaced daemon on port 7710 (stale pid)",
 		);
 	});
 
@@ -71,11 +71,16 @@ describe("formatLifecycleAction", () => {
 		expect(msg).not.toContain("missing_pid");
 	});
 
-	test("reason is ignored for reused and started actions", () => {
-		// formatLifecycleAction only appends reason for "replaced".
-		expect(formatLifecycleAction("reused", 7710, "stale_pid")).toBe(
-			"Reused daemon on port 7710",
+	test("reused action includes reason when present", () => {
+		expect(formatLifecycleAction("reused", 7710, "missing_pid")).toBe(
+			"Reused daemon on port 7710 (missing pid)",
 		);
+		expect(formatLifecycleAction("reused", 7710, "stale_pid")).toBe(
+			"Reused daemon on port 7710 (stale pid)",
+		);
+	});
+
+	test("started action never includes reason", () => {
 		expect(formatLifecycleAction("started", 7710, "missing_pid")).toBe(
 			"Started daemon on port 7710",
 		);

--- a/cli/src/__tests__/daemon/install-preparation.test.ts
+++ b/cli/src/__tests__/daemon/install-preparation.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Install preparation contract tests.
+ * Verifies the restart-marker file behavior that the Justfile depends on:
+ * marker written with port when daemon was running, cleared when not,
+ * and legacy empty markers default to port 7710.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { cleanupTempDir, createTempDir } from "../helpers/index.js";
+
+describe("install preparation restart marker contract", () => {
+	let tempDir: string;
+	let markerPath: string;
+
+	beforeEach(async () => {
+		tempDir = await createTempDir("install-prep");
+		markerPath = join(tempDir, "restart-arcade-after-install");
+	});
+
+	afterEach(async () => {
+		await cleanupTempDir(tempDir);
+	});
+
+	test("marker written with port number records the daemon port for post-install restart", () => {
+		const port = 7710;
+		writeFileSync(markerPath, String(port), { mode: 0o600 });
+
+		expect(existsSync(markerPath)).toBe(true);
+		const content = readFileSync(markerPath, "utf-8").trim();
+		expect(content).toBe("7710");
+		expect(Number.parseInt(content, 10)).toBe(7710);
+	});
+
+	test("marker with custom port preserves non-default port across install", () => {
+		const port = 8080;
+		writeFileSync(markerPath, String(port), { mode: 0o600 });
+
+		const content = readFileSync(markerPath, "utf-8").trim();
+		expect(Number.parseInt(content, 10)).toBe(8080);
+	});
+
+	test("empty marker file defaults to port 7710 for legacy compatibility", () => {
+		// Legacy behavior: an empty marker from an older build should still work.
+		writeFileSync(markerPath, "", { mode: 0o600 });
+
+		const content = readFileSync(markerPath, "utf-8").trim();
+		// The Justfile reads: port=$(cat "$restart_marker" | tr -d '[:space:]')
+		// if [ -z "$port" ]; then port=7710; fi
+		const port = content === "" ? 7710 : Number.parseInt(content, 10);
+		expect(port).toBe(7710);
+	});
+
+	test("marker removal prevents post-install daemon restart", () => {
+		writeFileSync(markerPath, "7710", { mode: 0o600 });
+		expect(existsSync(markerPath)).toBe(true);
+
+		const { unlinkSync } = require("node:fs");
+		unlinkSync(markerPath);
+		expect(existsSync(markerPath)).toBe(false);
+	});
+
+	test("stale marker from prior interrupted install is safe to remove", () => {
+		writeFileSync(markerPath, "9090", { mode: 0o600 });
+
+		try {
+			if (existsSync(markerPath)) {
+				const { unlinkSync } = require("node:fs");
+				unlinkSync(markerPath);
+			}
+		} catch {
+			// Best-effort cleanup should not throw
+		}
+
+		expect(existsSync(markerPath)).toBe(false);
+	});
+
+	test("marker does not exist when no daemon was running", () => {
+		// Verify that absence of marker means no restart should occur.
+		expect(existsSync(markerPath)).toBe(false);
+	});
+
+	test("post-install restart reads the recorded port from marker content", () => {
+		// Simulates the Justfile read pattern.
+		writeFileSync(markerPath, "7720", { mode: 0o600 });
+
+		if (existsSync(markerPath)) {
+			const rawContent = readFileSync(markerPath, "utf-8").replace(/\s/g, "");
+			const port = rawContent === "" ? 7710 : Number.parseInt(rawContent, 10);
+			expect(port).toBe(7720);
+			expect(Number.isNaN(port)).toBe(false);
+		}
+	});
+});

--- a/cli/src/__tests__/daemon/lifecycle-lock.test.ts
+++ b/cli/src/__tests__/daemon/lifecycle-lock.test.ts
@@ -1,0 +1,316 @@
+/**
+ * Lifecycle lock tests.
+ * Verifies lock acquisition, waiting, stale-lock recovery, and concurrent serialization.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+	existsSync,
+	mkdirSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+import { cleanupTempDir, createTempDir } from "../helpers/index.js";
+
+let testConfigDir: string;
+let lockPath: string;
+
+mock.module("../../../web-ui/src/daemon/config-dir.js", () => ({
+	getConfigDir: () => testConfigDir,
+	getLifecycleLockPath: () => lockPath,
+	getRestartMarkerPath: () =>
+		join(testConfigDir, "restart-arcade-after-install"),
+	ensureConfigDir: async () => {
+		mkdirSync(testConfigDir, { recursive: true, mode: 0o700 });
+		return testConfigDir;
+	},
+	getPidFilePath: () => join(testConfigDir, "daemon.pid"),
+	getDaemonStatePath: () => join(testConfigDir, "daemon-state.json"),
+	readDaemonState: () => null,
+	writeDaemonState: () => {},
+}));
+
+mock.module("../../../web-ui/src/daemon/diagnostics.js", () => ({
+	logDaemonEvent: () => {},
+	logDaemonError: () => {},
+}));
+
+const { acquireLifecycleLock, withLifecycleLock } = await import(
+	"../../../web-ui/src/daemon/lifecycle-lock.js"
+);
+
+describe("lifecycle lock", () => {
+	beforeEach(async () => {
+		testConfigDir = await createTempDir("lifecycle-lock");
+		lockPath = join(testConfigDir, "daemon.lifecycle.lock");
+	});
+
+	afterEach(async () => {
+		// Clean up any leftover lock dirs before removing temp dir.
+		if (existsSync(lockPath)) {
+			rmSync(lockPath, { recursive: true, force: true });
+		}
+		await cleanupTempDir(testConfigDir);
+	});
+
+	describe("acquireLifecycleLock", () => {
+		test("creates lock directory and writes owner metadata", async () => {
+			const release = await acquireLifecycleLock({
+				operation: "ensureDaemon",
+				port: 7710,
+				cliVersion: "1.0.0",
+				waitTimeoutMs: 1000,
+			});
+
+			expect(existsSync(lockPath)).toBe(true);
+
+			const metadataPath = join(lockPath, "owner.json");
+			expect(existsSync(metadataPath)).toBe(true);
+
+			const metadata = JSON.parse(readFileSync(metadataPath, "utf-8"));
+			expect(metadata.ownerPid).toBe(process.pid);
+			expect(metadata.operation).toBe("ensureDaemon");
+			expect(metadata.port).toBe(7710);
+			expect(metadata.cliVersion).toBe("1.0.0");
+			expect(typeof metadata.acquiredAt).toBe("string");
+
+			release();
+		});
+
+		test("release function removes lock directory", async () => {
+			const release = await acquireLifecycleLock({
+				operation: "stopDaemon",
+				port: 7710,
+				cliVersion: "1.0.0",
+				waitTimeoutMs: 1000,
+			});
+
+			expect(existsSync(lockPath)).toBe(true);
+			release();
+			expect(existsSync(lockPath)).toBe(false);
+		});
+
+		test("release is idempotent", async () => {
+			const release = await acquireLifecycleLock({
+				operation: "ensureDaemon",
+				port: 7710,
+				cliVersion: "1.0.0",
+				waitTimeoutMs: 1000,
+			});
+
+			release();
+			expect(() => release()).not.toThrow();
+			expect(existsSync(lockPath)).toBe(false);
+		});
+
+		test("recovers stale lock left by dead process", async () => {
+			// Simulate a lock left by a dead process (PID 99999999 should not exist).
+			mkdirSync(lockPath, { recursive: false, mode: 0o700 });
+			writeFileSync(
+				join(lockPath, "owner.json"),
+				JSON.stringify({
+					ownerPid: 99999999,
+					operation: "ensureDaemon",
+					port: 7710,
+					cliVersion: "0.9.0",
+					acquiredAt: new Date().toISOString(),
+				}),
+			);
+
+			// Should recover the stale lock and acquire.
+			const release = await acquireLifecycleLock({
+				operation: "ensureDaemon",
+				port: 7710,
+				cliVersion: "1.0.0",
+				waitTimeoutMs: 2000,
+			});
+
+			const metadata = JSON.parse(
+				readFileSync(join(lockPath, "owner.json"), "utf-8"),
+			);
+			expect(metadata.ownerPid).toBe(process.pid);
+			expect(metadata.cliVersion).toBe("1.0.0");
+
+			release();
+		});
+
+		test("recovers corrupted lock with missing metadata", async () => {
+			// Simulate a lock directory that exists but has no owner.json.
+			mkdirSync(lockPath, { recursive: false, mode: 0o700 });
+
+			const release = await acquireLifecycleLock({
+				operation: "restartDaemon",
+				port: 7710,
+				cliVersion: "1.0.0",
+				waitTimeoutMs: 2000,
+			});
+
+			const metadata = JSON.parse(
+				readFileSync(join(lockPath, "owner.json"), "utf-8"),
+			);
+			expect(metadata.ownerPid).toBe(process.pid);
+			expect(metadata.operation).toBe("restartDaemon");
+
+			release();
+		});
+
+		test("recovers aged-out lock even when owner PID is alive", async () => {
+			// Simulate a lock held by the current process but acquired far in the past.
+			mkdirSync(lockPath, { recursive: false, mode: 0o700 });
+			writeFileSync(
+				join(lockPath, "owner.json"),
+				JSON.stringify({
+					ownerPid: process.pid,
+					operation: "ensureDaemon",
+					port: 7710,
+					cliVersion: "1.0.0",
+					acquiredAt: new Date(Date.now() - 120_000).toISOString(),
+				}),
+			);
+
+			// staleLockTimeoutMs is set to 100ms so the 120s-old lock is stale.
+			const release = await acquireLifecycleLock({
+				operation: "stopDaemon",
+				port: 7710,
+				cliVersion: "1.0.0",
+				waitTimeoutMs: 2000,
+				staleLockTimeoutMs: 100,
+			});
+
+			const metadata = JSON.parse(
+				readFileSync(join(lockPath, "owner.json"), "utf-8"),
+			);
+			expect(metadata.operation).toBe("stopDaemon");
+
+			release();
+		});
+
+		test("times out when lock is held by live process within stale threshold", async () => {
+			// Hold the lock with the current PID and a recent timestamp.
+			mkdirSync(lockPath, { recursive: false, mode: 0o700 });
+			writeFileSync(
+				join(lockPath, "owner.json"),
+				JSON.stringify({
+					ownerPid: process.pid,
+					operation: "ensureDaemon",
+					port: 7710,
+					cliVersion: "1.0.0",
+					acquiredAt: new Date().toISOString(),
+				}),
+			);
+
+			await expect(
+				acquireLifecycleLock({
+					operation: "stopDaemon",
+					port: 7710,
+					cliVersion: "1.0.0",
+					waitTimeoutMs: 400,
+					pollIntervalMs: 50,
+					staleLockTimeoutMs: 60_000,
+				}),
+			).rejects.toThrow(/Timed out waiting for daemon lifecycle lock/);
+		});
+
+		test("creates parent config directory if it does not exist", async () => {
+			// Remove the config dir so it must be recreated.
+			rmSync(testConfigDir, { recursive: true, force: true });
+			expect(existsSync(testConfigDir)).toBe(false);
+
+			const release = await acquireLifecycleLock({
+				operation: "ensureDaemon",
+				port: 7710,
+				cliVersion: "1.0.0",
+				waitTimeoutMs: 1000,
+			});
+
+			expect(existsSync(lockPath)).toBe(true);
+			release();
+		});
+	});
+
+	describe("withLifecycleLock", () => {
+		test("releases lock after successful execution", async () => {
+			const result = await withLifecycleLock(
+				{
+					operation: "ensureDaemon",
+					port: 7710,
+					cliVersion: "1.0.0",
+					waitTimeoutMs: 1000,
+				},
+				async () => {
+					expect(existsSync(lockPath)).toBe(true);
+					return "success";
+				},
+			);
+
+			expect(result).toBe("success");
+			expect(existsSync(lockPath)).toBe(false);
+		});
+
+		test("releases lock when function throws", async () => {
+			const error = new Error("operation failed");
+
+			await expect(
+				withLifecycleLock(
+					{
+						operation: "ensureDaemon",
+						port: 7710,
+						cliVersion: "1.0.0",
+						waitTimeoutMs: 1000,
+					},
+					async () => {
+						throw error;
+					},
+				),
+			).rejects.toThrow("operation failed");
+
+			expect(existsSync(lockPath)).toBe(false);
+		});
+	});
+
+	describe("concurrent serialization", () => {
+		test("second caller waits until first releases", async () => {
+			const events: string[] = [];
+
+			const first = withLifecycleLock(
+				{
+					operation: "first",
+					port: 7710,
+					cliVersion: "1.0.0",
+					waitTimeoutMs: 5000,
+					pollIntervalMs: 50,
+				},
+				async () => {
+					events.push("first:start");
+					await new Promise((resolve) => setTimeout(resolve, 200));
+					events.push("first:end");
+				},
+			);
+
+			// Give the first lock a moment to acquire.
+			await new Promise((resolve) => setTimeout(resolve, 50));
+
+			const second = withLifecycleLock(
+				{
+					operation: "second",
+					port: 7710,
+					cliVersion: "1.0.0",
+					waitTimeoutMs: 5000,
+					pollIntervalMs: 50,
+				},
+				async () => {
+					events.push("second:start");
+				},
+			);
+
+			await Promise.all([first, second]);
+
+			// The second operation must start after the first ends.
+			expect(events.indexOf("first:end")).toBeLessThan(
+				events.indexOf("second:start"),
+			);
+		});
+	});
+});

--- a/cli/src/__tests__/daemon/manager.test.ts
+++ b/cli/src/__tests__/daemon/manager.test.ts
@@ -2,6 +2,10 @@ import { afterEach, describe, expect, test } from "bun:test";
 import type { ChildProcess } from "node:child_process";
 import { spawn } from "node:child_process";
 import {
+	type DaemonLifecycleReason,
+	DaemonPortConflictError,
+	type DaemonStartAction,
+	type DaemonStopAction,
 	forceKillProcess,
 	isProcessRunning,
 	waitForProcessExit,
@@ -124,6 +128,60 @@ describe("daemon manager", () => {
 			forceKillProcess(pid);
 			const exited = await waitForProcessExit(pid, 2000);
 			expect(exited).toBe(true);
+		});
+	});
+
+	describe("DaemonPortConflictError", () => {
+		test("extends Error with correct name", () => {
+			const err = new DaemonPortConflictError(8080);
+			expect(err).toBeInstanceOf(Error);
+			expect(err.name).toBe("DaemonPortConflictError");
+		});
+
+		test("stores the conflicting port", () => {
+			const err = new DaemonPortConflictError(9090);
+			expect(err.port).toBe(9090);
+		});
+
+		test("message includes port and remediation guidance", () => {
+			const err = new DaemonPortConflictError(7710);
+			expect(err.message).toContain("7710");
+			expect(err.message).toContain("non-rp1 process");
+			expect(err.message).toContain("Use a different port");
+		});
+
+		test("port value matches constructor argument for any port", () => {
+			for (const port of [80, 443, 3000, 7710, 8080, 49152]) {
+				const err = new DaemonPortConflictError(port);
+				expect(err.port).toBe(port);
+				expect(err.message).toContain(String(port));
+			}
+		});
+	});
+
+	describe("lifecycle action types", () => {
+		test("DaemonStartAction values cover reused, started, replaced", () => {
+			const actions: DaemonStartAction[] = ["reused", "started", "replaced"];
+			expect(actions).toEqual(["reused", "started", "replaced"]);
+		});
+
+		test("DaemonStopAction values cover stopped and not_running", () => {
+			const actions: DaemonStopAction[] = ["stopped", "not_running"];
+			expect(actions).toEqual(["stopped", "not_running"]);
+		});
+
+		test("DaemonLifecycleReason values cover expected reason tags", () => {
+			const reasons: DaemonLifecycleReason[] = [
+				"stale_pid",
+				"missing_pid",
+				"version_mismatch",
+				"unhealthy_daemon",
+			];
+			expect(reasons).toHaveLength(4);
+			expect(reasons).toContain("stale_pid");
+			expect(reasons).toContain("missing_pid");
+			expect(reasons).toContain("version_mismatch");
+			expect(reasons).toContain("unhealthy_daemon");
 		});
 	});
 });

--- a/cli/src/commands/arcade.ts
+++ b/cli/src/commands/arcade.ts
@@ -17,6 +17,7 @@ import {
 	formatError,
 	getExitCode,
 	notFoundError,
+	portInUseError,
 	runtimeError,
 	tryCatchTE,
 } from "../../shared/errors.js";
@@ -29,6 +30,8 @@ interface ArcadeStartResult {
 	readonly projectId: string;
 	readonly projectName: string;
 	readonly url: string;
+	readonly action: "reused" | "started" | "replaced";
+	readonly reason?: string;
 	readonly wasRunning: boolean;
 }
 
@@ -109,7 +112,7 @@ const startArcade = async (
 		"../../web-ui/src/daemon/index.js"
 	);
 
-	const { connection, wasRunning } = await ensureDaemon(
+	const { connection, action, reason, wasRunning } = await ensureDaemon(
 		config.port,
 		cliVersion,
 	);
@@ -122,6 +125,8 @@ const startArcade = async (
 		projectId: project.id,
 		projectName: project.name,
 		url,
+		action,
+		reason,
 		wasRunning,
 	};
 };
@@ -133,6 +138,46 @@ export function formatArcadeHookPayload(url: string): string {
 }
 
 /**
+ * Map daemon errors to CLIErrors, converting port conflicts to PortInUseError.
+ * Uses duck-typing to avoid eager import of the Bun-dependent daemon module.
+ */
+const mapDaemonError =
+	(context: string) =>
+	(e: unknown): CLIError => {
+		if (
+			e instanceof Error &&
+			e.name === "DaemonPortConflictError" &&
+			"port" in e &&
+			typeof (e as Record<string, unknown>).port === "number"
+		) {
+			return portInUseError((e as { port: number }).port);
+		}
+		return runtimeError(`${context}: ${e}`);
+	};
+
+/**
+ * Format a human-readable lifecycle action message for daemon operations.
+ */
+export function formatLifecycleAction(
+	action: "reused" | "started" | "replaced",
+	port: number,
+	reason?: string,
+): string {
+	switch (action) {
+		case "reused":
+			return `Reused daemon on port ${port}`;
+		case "started":
+			return `Started daemon on port ${port}`;
+		case "replaced": {
+			const reasonSuffix = reason
+				? ` (reason: ${reason.replace(/_/g, " ")})`
+				: "";
+			return `Replaced daemon on port ${port}${reasonSuffix}`;
+		}
+	}
+}
+
+/**
  * Execute with daemon support - start daemon if needed, register project, open browser.
  */
 const executeWithDaemon = (
@@ -140,70 +185,51 @@ const executeWithDaemon = (
 	logger: Logger,
 	cliVersion?: string,
 ): TE.TaskEither<CLIError, void> =>
-	tryCatchTE(
-		async () => {
-			logger.debug("Ensuring daemon is running...");
-			const { projectId, projectName, url, wasRunning } = await startArcade(
-				config,
-				cliVersion,
-			);
+	tryCatchTE(async () => {
+		logger.debug("Ensuring daemon is running...");
+		const { projectId, projectName, url, action, reason } = await startArcade(
+			config,
+			cliVersion,
+		);
 
-			if (wasRunning) {
-				logger.debug(`Connected to existing daemon on port ${config.port}`);
-			} else {
-				logger.info(`Started daemon on port ${config.port}`);
-			}
+		logger.info(formatLifecycleAction(action, config.port, reason));
 
-			logger.debug(`Registering project: ${config.rp1Root}`);
-			logger.info(`Project registered: ${projectName} (${projectId})`);
+		logger.debug(`Registering project: ${config.rp1Root}`);
+		logger.info(`Project registered: ${projectName} (${projectId})`);
 
-			if (config.openBrowser) {
-				logger.debug("Opening browser...");
-				await openBrowser(url, logger)();
-				logger.info(`Opened ${url}`);
-			} else {
-				logger.info(`Server running at ${url}`);
-			}
-		},
-		(e) => runtimeError(`Failed to start arcade: ${e}`),
-	);
+		if (config.openBrowser) {
+			logger.debug("Opening browser...");
+			await openBrowser(url, logger)();
+			logger.info(`Opened ${url}`);
+		} else {
+			logger.info(`Server running at ${url}`);
+		}
+	}, mapDaemonError("Failed to start arcade"));
 
 const hookOutputCommand = (
 	config: ArcadeConfig,
 	cliVersion?: string,
 ): TE.TaskEither<CLIError, void> =>
-	tryCatchTE(
-		async () => {
-			// Hook mode should be side-effect-light: if a healthy daemon is already
-			// serving, reuse it instead of forcing the dev-build restart path.
-			const { url } = await startArcade(config, cliVersion);
-			console.log(formatArcadeHookPayload(url));
-		},
-		(e) => runtimeError(`Failed to format arcade hook output: ${e}`),
-	);
+	tryCatchTE(async () => {
+		// Hook mode should be side-effect-light: if a healthy daemon is already
+		// serving, reuse it instead of forcing the dev-build restart path.
+		const { url } = await startArcade(config, cliVersion);
+		console.log(formatArcadeHookPayload(url));
+	}, mapDaemonError("Failed to format arcade hook output"));
 
 const ensureDaemonOnlyCommand = (
 	port: number,
 	logger: Logger,
 	cliVersion?: string,
 ): TE.TaskEither<CLIError, void> =>
-	tryCatchTE(
-		async () => {
-			const { ensureDaemon } = await import("../../web-ui/src/daemon/index.js");
+	tryCatchTE(async () => {
+		const { ensureDaemon } = await import("../../web-ui/src/daemon/index.js");
 
-			logger.debug(
-				"Ensuring daemon is running without project registration...",
-			);
-			const { wasRunning } = await ensureDaemon(port, cliVersion);
+		logger.debug("Ensuring daemon is running without project registration...");
+		const { action, reason } = await ensureDaemon(port, cliVersion);
 
-			if (wasRunning) {
-				logger.info(`Daemon already running on port ${port}`);
-			} else {
-				logger.info(`Started daemon on port ${port}`);
-			}
-		},
-		(e) => runtimeError(`Failed to ensure daemon: ${e}`),
-	);
+		logger.info(formatLifecycleAction(action, port, reason));
+	}, mapDaemonError("Failed to ensure daemon"));
 
 /**
  * Stop the daemon.
@@ -214,9 +240,9 @@ const stopDaemonCommand = (logger: Logger): TE.TaskEither<CLIError, void> =>
 			const { stopDaemon } = await import("../../web-ui/src/daemon/index.js");
 
 			logger.debug("Stopping daemon...");
-			const stopped = await stopDaemon();
+			const result = await stopDaemon();
 
-			if (stopped) {
+			if (result.action === "stopped") {
 				logger.info("Daemon stopped successfully");
 			} else {
 				logger.info("No daemon running");
@@ -266,19 +292,15 @@ const statusCommand = (_logger: Logger): TE.TaskEither<CLIError, void> =>
 const restartDaemonCommand = (
 	port: number,
 	logger: Logger,
+	cliVersion?: string,
 ): TE.TaskEither<CLIError, void> =>
-	tryCatchTE(
-		async () => {
-			const { restartDaemon } = await import(
-				"../../web-ui/src/daemon/index.js"
-			);
+	tryCatchTE(async () => {
+		const { restartDaemon } = await import("../../web-ui/src/daemon/index.js");
 
-			logger.debug("Restarting daemon...");
-			await restartDaemon(port);
-			logger.info(`Daemon restarted on port ${port}`);
-		},
-		(e) => runtimeError(`Failed to restart daemon: ${e}`),
-	);
+		logger.debug("Restarting daemon...");
+		const { action, reason } = await restartDaemon(port, cliVersion);
+		logger.info(formatLifecycleAction(action, port, reason));
+	}, mapDaemonError("Failed to restart daemon"));
 
 const execute = (
 	args: string[],
@@ -304,7 +326,9 @@ const execute = (
 		return pipe(
 			loadArcadeConfig(args),
 			TE.fromEither,
-			TE.chain((config) => restartDaemonCommand(config.port, logger)),
+			TE.chain((config) =>
+				restartDaemonCommand(config.port, logger, cliVersion),
+			),
 		);
 	}
 

--- a/cli/src/commands/arcade.ts
+++ b/cli/src/commands/arcade.ts
@@ -33,6 +33,8 @@ interface ArcadeStartResult {
 	readonly action: "reused" | "started" | "replaced";
 	readonly reason?: string;
 	readonly wasRunning: boolean;
+	/** The port the daemon is actually listening on (may differ from requested). */
+	readonly daemonPort: number;
 }
 
 const directoryExists = (path: string): boolean => {
@@ -128,6 +130,7 @@ const startArcade = async (
 		action,
 		reason,
 		wasRunning,
+		daemonPort: connection.port,
 	};
 };
 
@@ -163,17 +166,14 @@ export function formatLifecycleAction(
 	port: number,
 	reason?: string,
 ): string {
+	const reasonSuffix = reason ? ` (${reason.replace(/_/g, " ")})` : "";
 	switch (action) {
 		case "reused":
-			return `Reused daemon on port ${port}`;
+			return `Reused daemon on port ${port}${reasonSuffix}`;
 		case "started":
 			return `Started daemon on port ${port}`;
-		case "replaced": {
-			const reasonSuffix = reason
-				? ` (reason: ${reason.replace(/_/g, " ")})`
-				: "";
+		case "replaced":
 			return `Replaced daemon on port ${port}${reasonSuffix}`;
-		}
 	}
 }
 
@@ -187,12 +187,10 @@ const executeWithDaemon = (
 ): TE.TaskEither<CLIError, void> =>
 	tryCatchTE(async () => {
 		logger.debug("Ensuring daemon is running...");
-		const { projectId, projectName, url, action, reason } = await startArcade(
-			config,
-			cliVersion,
-		);
+		const { projectId, projectName, url, action, reason, daemonPort } =
+			await startArcade(config, cliVersion);
 
-		logger.info(formatLifecycleAction(action, config.port, reason));
+		logger.info(formatLifecycleAction(action, daemonPort, reason));
 
 		logger.debug(`Registering project: ${config.rp1Root}`);
 		logger.info(`Project registered: ${projectName} (${projectId})`);
@@ -226,9 +224,9 @@ const ensureDaemonOnlyCommand = (
 		const { ensureDaemon } = await import("../../web-ui/src/daemon/index.js");
 
 		logger.debug("Ensuring daemon is running without project registration...");
-		const { action, reason } = await ensureDaemon(port, cliVersion);
+		const { connection, action, reason } = await ensureDaemon(port, cliVersion);
 
-		logger.info(formatLifecycleAction(action, port, reason));
+		logger.info(formatLifecycleAction(action, connection.port, reason));
 	}, mapDaemonError("Failed to ensure daemon"));
 
 /**
@@ -298,8 +296,11 @@ const restartDaemonCommand = (
 		const { restartDaemon } = await import("../../web-ui/src/daemon/index.js");
 
 		logger.debug("Restarting daemon...");
-		const { action, reason } = await restartDaemon(port, cliVersion);
-		logger.info(formatLifecycleAction(action, port, reason));
+		const { connection, action, reason } = await restartDaemon(
+			port,
+			cliVersion,
+		);
+		logger.info(formatLifecycleAction(action, connection.port, reason));
 	}, mapDaemonError("Failed to restart daemon"));
 
 const execute = (

--- a/cli/web-ui/src/daemon/config-dir.ts
+++ b/cli/web-ui/src/daemon/config-dir.ts
@@ -56,6 +56,22 @@ export function getPidFilePath(): string {
 }
 
 /**
+ * Get the path to the lifecycle lock directory.
+ * Used by lifecycle-lock.ts for cross-process daemon mutation serialization.
+ */
+export function getLifecycleLockPath(): string {
+	return join(getConfigDir(), "daemon.lifecycle.lock");
+}
+
+/**
+ * Get the path to the restart-arcade-after-install marker file.
+ * Written by the install preparation helper and read by the post-install flow.
+ */
+export function getRestartMarkerPath(): string {
+	return join(getConfigDir(), "restart-arcade-after-install");
+}
+
+/**
  * Daemon state file shape for tracking recovery state across restarts.
  */
 export interface DaemonState {

--- a/cli/web-ui/src/daemon/index.ts
+++ b/cli/web-ui/src/daemon/index.ts
@@ -8,11 +8,12 @@ export {
 	ensureConfigDir,
 	getConfigDir,
 	getDaemonStatePath,
+	getLifecycleLockPath,
 	getPidFilePath,
+	getRestartMarkerPath,
 	readDaemonState,
 	writeDaemonState,
 } from "./config-dir";
-
 export {
 	checkHealth,
 	createConnection,
@@ -29,10 +30,21 @@ export {
 	registerProjectWithDaemon,
 	stopDaemon as stopDaemonViaIpc,
 } from "./ipc";
+export {
+	acquireLifecycleLock,
+	type LockAcquireOptions,
+	type LockMetadata,
+	withLifecycleLock,
+} from "./lifecycle-lock";
 
 export {
 	connectToDaemon,
+	type DaemonLifecycleReason,
+	DaemonPortConflictError,
+	type DaemonStartAction,
 	type DaemonStartResult,
+	type DaemonStopAction,
+	type DaemonStopResult,
 	ensureDaemon,
 	forceKillProcess,
 	getStatus,

--- a/cli/web-ui/src/daemon/lifecycle-lock.ts
+++ b/cli/web-ui/src/daemon/lifecycle-lock.ts
@@ -48,8 +48,11 @@ export interface LockAcquireOptions {
 
 /**
  * Default timeout for waiting to acquire the lock.
+ * Must exceed the worst-case lifecycle operation time (~10s for stop +
+ * health-wait) so a second caller waiting on a legitimately-held lock
+ * does not time out spuriously.
  */
-const DEFAULT_WAIT_TIMEOUT_MS = 10_000;
+const DEFAULT_WAIT_TIMEOUT_MS = 30_000;
 
 /**
  * Default polling interval when waiting for the lock.

--- a/cli/web-ui/src/daemon/lifecycle-lock.ts
+++ b/cli/web-ui/src/daemon/lifecycle-lock.ts
@@ -9,6 +9,7 @@ import {
 	mkdirSync,
 	readFileSync,
 	rmSync,
+	statSync,
 	writeFileSync,
 } from "node:fs";
 import { join } from "node:path";
@@ -59,6 +60,13 @@ const DEFAULT_POLL_INTERVAL_MS = 200;
  * Default age threshold beyond which a held lock is considered stale.
  */
 const DEFAULT_STALE_LOCK_TIMEOUT_MS = 30_000;
+
+/**
+ * Grace period (ms) for a newly-created lock dir before treating missing
+ * metadata as corruption.  Covers the brief window between the winning
+ * process's mkdir and its owner.json write.
+ */
+const LOCK_METADATA_GRACE_MS = 2_000;
 
 /**
  * Name of the metadata file written inside the lock directory.
@@ -228,7 +236,21 @@ export async function acquireLifecycleLock(
 
 		if (!existing && existsSync(lockPath)) {
 			// Lock directory exists but metadata is missing or unreadable.
-			// Treat as a corrupted lock and recover.
+			// Check whether the directory was just created — the winning
+			// process may still be writing owner.json.
+			try {
+				const stat = statSync(lockPath);
+				const ageMs = Date.now() - (stat.birthtimeMs ?? stat.ctimeMs);
+				if (ageMs < LOCK_METADATA_GRACE_MS) {
+					// Recently created — wait for metadata rather than stealing.
+					await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+					continue;
+				}
+			} catch {
+				// Lock dir removed between existsSync and statSync — retry.
+				continue;
+			}
+			// Old and still no metadata — genuinely corrupted.
 			logDaemonEvent("lifecycle_lock_recovered", {
 				reason: "missing_metadata",
 			});

--- a/cli/web-ui/src/daemon/lifecycle-lock.ts
+++ b/cli/web-ui/src/daemon/lifecycle-lock.ts
@@ -1,0 +1,284 @@
+/**
+ * Cross-process lifecycle lock for serializing daemon mutations.
+ * Uses atomic mkdir semantics with owner metadata and stale-lock recovery.
+ * The lock is held only around lifecycle operations, not for the daemon lifetime.
+ */
+
+import {
+	existsSync,
+	mkdirSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+import { getConfigDir, getLifecycleLockPath } from "./config-dir";
+import { logDaemonEvent } from "./diagnostics";
+import { isProcessRunning } from "./manager";
+
+/**
+ * Metadata written inside the lock directory to identify the current owner.
+ */
+export interface LockMetadata {
+	readonly ownerPid: number;
+	readonly operation: string;
+	readonly port: number;
+	readonly cliVersion: string;
+	readonly acquiredAt: string;
+}
+
+/**
+ * Options for lock acquisition behavior.
+ */
+export interface LockAcquireOptions {
+	/** The lifecycle operation being performed (e.g., "ensureDaemon", "stopDaemon"). */
+	readonly operation: string;
+	/** The port involved in this lifecycle operation. */
+	readonly port: number;
+	/** The CLI version performing the operation. */
+	readonly cliVersion: string;
+	/** Maximum time in milliseconds to wait for a held lock before giving up. Default: 10000. */
+	readonly waitTimeoutMs?: number;
+	/** Interval in milliseconds between lock acquisition polls. Default: 200. */
+	readonly pollIntervalMs?: number;
+	/** Maximum age in milliseconds before a held lock is considered stale. Default: 30000. */
+	readonly staleLockTimeoutMs?: number;
+}
+
+/**
+ * Default timeout for waiting to acquire the lock.
+ */
+const DEFAULT_WAIT_TIMEOUT_MS = 10_000;
+
+/**
+ * Default polling interval when waiting for the lock.
+ */
+const DEFAULT_POLL_INTERVAL_MS = 200;
+
+/**
+ * Default age threshold beyond which a held lock is considered stale.
+ */
+const DEFAULT_STALE_LOCK_TIMEOUT_MS = 30_000;
+
+/**
+ * Name of the metadata file written inside the lock directory.
+ */
+const LOCK_METADATA_FILE = "owner.json";
+
+/**
+ * Read lock metadata from the lock directory.
+ * Returns null if the metadata cannot be read or parsed.
+ */
+function readLockMetadata(lockPath: string): LockMetadata | null {
+	try {
+		const metadataPath = join(lockPath, LOCK_METADATA_FILE);
+		const content = readFileSync(metadataPath, "utf-8");
+		const parsed = JSON.parse(content) as Record<string, unknown>;
+
+		if (
+			typeof parsed.ownerPid === "number" &&
+			typeof parsed.operation === "string" &&
+			typeof parsed.port === "number" &&
+			typeof parsed.cliVersion === "string" &&
+			typeof parsed.acquiredAt === "string"
+		) {
+			return {
+				ownerPid: parsed.ownerPid,
+				operation: parsed.operation,
+				port: parsed.port,
+				cliVersion: parsed.cliVersion,
+				acquiredAt: parsed.acquiredAt,
+			};
+		}
+		return null;
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Write lock metadata into the lock directory.
+ */
+function writeLockMetadata(lockPath: string, metadata: LockMetadata): void {
+	const metadataPath = join(lockPath, LOCK_METADATA_FILE);
+	writeFileSync(metadataPath, JSON.stringify(metadata, null, 2), {
+		mode: 0o600,
+	});
+}
+
+/**
+ * Check whether a held lock is stale based on owner liveness and age.
+ */
+function isLockStale(
+	metadata: LockMetadata,
+	staleLockTimeoutMs: number,
+): boolean {
+	if (!isProcessRunning(metadata.ownerPid)) {
+		return true;
+	}
+
+	const acquiredAt = new Date(metadata.acquiredAt).getTime();
+	if (Number.isNaN(acquiredAt)) {
+		return true;
+	}
+
+	return Date.now() - acquiredAt > staleLockTimeoutMs;
+}
+
+/**
+ * Remove a lock directory and its contents.
+ * Handles partial cleanup gracefully.
+ */
+function removeLockDir(lockPath: string): void {
+	try {
+		rmSync(lockPath, { recursive: true, force: true });
+	} catch {
+		// Best-effort cleanup; the next caller will retry recovery.
+	}
+}
+
+/**
+ * Try to acquire the lock directory atomically via mkdir.
+ * Returns true if the lock was acquired, false if it already exists.
+ * Throws on unexpected filesystem errors.
+ */
+function tryAcquireLockDir(lockPath: string): boolean {
+	try {
+		mkdirSync(lockPath, { recursive: false, mode: 0o700 });
+		return true;
+	} catch (err: unknown) {
+		if (
+			err instanceof Error &&
+			"code" in err &&
+			(err as NodeJS.ErrnoException).code === "EEXIST"
+		) {
+			return false;
+		}
+		throw err;
+	}
+}
+
+/**
+ * Acquire the lifecycle lock, blocking with polling until available or timeout.
+ * Automatically recovers stale locks left by dead or timed-out owners.
+ *
+ * @returns A release function that must be called when the lifecycle operation completes.
+ * @throws Error if the lock cannot be acquired within the wait timeout.
+ */
+export async function acquireLifecycleLock(
+	options: LockAcquireOptions,
+): Promise<() => void> {
+	const lockPath = getLifecycleLockPath();
+	const waitTimeoutMs = options.waitTimeoutMs ?? DEFAULT_WAIT_TIMEOUT_MS;
+	const pollIntervalMs = options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+	const staleLockTimeoutMs =
+		options.staleLockTimeoutMs ?? DEFAULT_STALE_LOCK_TIMEOUT_MS;
+
+	const metadata: LockMetadata = {
+		ownerPid: process.pid,
+		operation: options.operation,
+		port: options.port,
+		cliVersion: options.cliVersion,
+		acquiredAt: new Date().toISOString(),
+	};
+
+	const startTime = Date.now();
+
+	while (true) {
+		// Ensure the parent config directory exists before attempting to create the lock.
+		const configDir = getConfigDir();
+		if (!existsSync(configDir)) {
+			mkdirSync(configDir, { recursive: true, mode: 0o700 });
+		}
+
+		if (tryAcquireLockDir(lockPath)) {
+			writeLockMetadata(lockPath, metadata);
+			logDaemonEvent("lifecycle_lock_acquired", {
+				operation: options.operation,
+				port: options.port,
+				cliVersion: options.cliVersion,
+			});
+
+			let released = false;
+			return () => {
+				if (released) return;
+				released = true;
+				removeLockDir(lockPath);
+				logDaemonEvent("lifecycle_lock_released", {
+					operation: options.operation,
+					port: options.port,
+				});
+			};
+		}
+
+		// Lock already exists -- check for staleness.
+		const existing = readLockMetadata(lockPath);
+
+		if (existing && isLockStale(existing, staleLockTimeoutMs)) {
+			logDaemonEvent("lifecycle_lock_recovered", {
+				stalePid: existing.ownerPid,
+				staleOperation: existing.operation,
+				staleAcquiredAt: existing.acquiredAt,
+				reason: isProcessRunning(existing.ownerPid) ? "timeout" : "dead_owner",
+			});
+			removeLockDir(lockPath);
+			// Retry immediately after recovery rather than sleeping.
+			continue;
+		}
+
+		if (!existing && existsSync(lockPath)) {
+			// Lock directory exists but metadata is missing or unreadable.
+			// Treat as a corrupted lock and recover.
+			logDaemonEvent("lifecycle_lock_recovered", {
+				reason: "missing_metadata",
+			});
+			removeLockDir(lockPath);
+			continue;
+		}
+
+		// Check wait timeout.
+		if (Date.now() - startTime >= waitTimeoutMs) {
+			logDaemonEvent("lifecycle_lock_timeout", {
+				waitedMs: Date.now() - startTime,
+				heldBy: existing
+					? {
+							ownerPid: existing.ownerPid,
+							operation: existing.operation,
+						}
+					: null,
+			});
+			const holderInfo = existing
+				? ` (held by PID ${existing.ownerPid} for "${existing.operation}")`
+				: "";
+			throw new Error(
+				`Timed out waiting for daemon lifecycle lock${holderInfo}. ` +
+					"Another rp1 lifecycle operation may be in progress. " +
+					`If this persists, remove ${lockPath} manually.`,
+			);
+		}
+
+		logDaemonEvent("lifecycle_lock_wait", {
+			heldBy: existing?.ownerPid,
+			heldForOperation: existing?.operation,
+			waitedMs: Date.now() - startTime,
+		});
+
+		await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+	}
+}
+
+/**
+ * Execute a function while holding the lifecycle lock.
+ * The lock is always released when the function completes or throws.
+ */
+export async function withLifecycleLock<T>(
+	options: LockAcquireOptions,
+	fn: () => Promise<T>,
+): Promise<T> {
+	const release = await acquireLifecycleLock(options);
+	try {
+		return await fn();
+	} finally {
+		release();
+	}
+}

--- a/cli/web-ui/src/daemon/manager.ts
+++ b/cli/web-ui/src/daemon/manager.ts
@@ -254,6 +254,37 @@ async function isPortAvailable(port: number): Promise<boolean> {
 }
 
 /**
+ * Wait for a port to become free by polling isPortAvailable.
+ * Returns true if the port became available within the timeout.
+ */
+async function waitForPortFree(
+	port: number,
+	timeoutMs: number,
+): Promise<boolean> {
+	const start = Date.now();
+	while (Date.now() - start < timeoutMs) {
+		if (await isPortAvailable(port)) return true;
+		await new Promise((resolve) =>
+			setTimeout(resolve, PROCESS_EXIT_POLL_INTERVAL_MS),
+		);
+	}
+	return isPortAvailable(port);
+}
+
+/**
+ * Stop an untracked daemon via IPC and wait for the port to free.
+ * Used when resolvePortOwnerPid returns null (Windows, no lsof).
+ * Returns true if the port became free within the grace period.
+ */
+async function stopUntrackedDaemon(
+	conn: DaemonConnection,
+	port: number,
+): Promise<boolean> {
+	await stopDaemonIpc(conn);
+	return waitForPortFree(port, STOP_GRACEFUL_TIMEOUT_MS);
+}
+
+/**
  * Wait for the daemon to become healthy.
  */
 async function waitForHealth(
@@ -478,6 +509,14 @@ export async function ensureDaemon(
 							const realPid = resolvePortOwnerPid(port);
 							if (realPid) {
 								await stopDaemonProcess({ port, pid: realPid });
+							} else {
+								// No PID available — IPC shutdown + wait for port to free.
+								const freed = await stopUntrackedDaemon(conn, port);
+								if (!freed) {
+									throw new Error(
+										`Failed to stop untracked daemon on port ${port} for version replacement`,
+									);
+								}
 							}
 							reason = "version_mismatch";
 							replacing = true;
@@ -573,8 +612,11 @@ export async function stopDaemon(
 					await stopDaemonProcess({ port, pid: realPid });
 					return { action: "stopped" as const };
 				}
-				// Could not resolve PID — attempt IPC shutdown only.
-				await stopDaemonIpc(conn);
+				// Could not resolve PID — IPC shutdown + wait for port to free.
+				const freed = await stopUntrackedDaemon(conn, port);
+				if (!freed) {
+					logDaemonEvent("stop_port_still_occupied", { port });
+				}
 				return { action: "stopped" as const };
 			}
 
@@ -661,7 +703,12 @@ export async function restartDaemon(
 					if (realPid) {
 						await stopDaemonProcess({ port, pid: realPid });
 					} else {
-						await stopDaemonIpc(conn);
+						const freed = await stopUntrackedDaemon(conn, port);
+						if (!freed) {
+							throw new Error(
+								`Failed to stop untracked daemon on port ${port} for restart`,
+							);
+						}
 					}
 				}
 			}

--- a/cli/web-ui/src/daemon/manager.ts
+++ b/cli/web-ui/src/daemon/manager.ts
@@ -1,6 +1,7 @@
 /**
  * Daemon lifecycle manager.
  * Handles starting, stopping, and connecting to the background daemon service.
+ * All lifecycle mutations execute under the config-dir lifecycle lock.
  */
 
 import { execSync, spawn } from "node:child_process";
@@ -16,6 +17,7 @@ import {
 	type HealthResponse,
 	stopDaemon as stopDaemonIpc,
 } from "./ipc";
+import { withLifecycleLock } from "./lifecycle-lock";
 
 /**
  * Check if a running daemon needs restart based on version.
@@ -40,11 +42,57 @@ interface PidFileData {
 }
 
 /**
- * Result of daemon start operation.
+ * Explicit lifecycle action for daemon start operations.
+ */
+export type DaemonStartAction = "reused" | "started" | "replaced";
+
+/**
+ * Explicit lifecycle action for daemon stop operations.
+ */
+export type DaemonStopAction = "stopped" | "not_running";
+
+/**
+ * Reason tag explaining why a lifecycle action was taken.
+ */
+export type DaemonLifecycleReason =
+	| "stale_pid"
+	| "missing_pid"
+	| "version_mismatch"
+	| "unhealthy_daemon";
+
+/**
+ * Result of daemon start operation with explicit lifecycle action.
  */
 export interface DaemonStartResult {
 	readonly connection: DaemonConnection;
+	readonly action: DaemonStartAction;
+	readonly reason?: DaemonLifecycleReason;
+	/** Derived from action for backward compatibility: true when action is "reused" or "replaced". */
 	readonly wasRunning: boolean;
+}
+
+/**
+ * Result of daemon stop operation with explicit lifecycle action.
+ */
+export interface DaemonStopResult {
+	readonly action: DaemonStopAction;
+}
+
+/**
+ * Error thrown when the requested port is occupied by a non-rp1 process.
+ * Arcade command converts this to a PortInUseError CLIError for user-facing output.
+ */
+export class DaemonPortConflictError extends Error {
+	readonly port: number;
+
+	constructor(port: number) {
+		super(
+			`Port ${port} is in use by a non-rp1 process. ` +
+				`Use a different port or stop the process occupying port ${port}.`,
+		);
+		this.name = "DaemonPortConflictError";
+		this.port = port;
+	}
 }
 
 /**
@@ -270,132 +318,10 @@ async function spawnDaemon(port: number): Promise<number> {
 }
 
 /**
- * Ensure daemon is running, starting it if necessary.
- * Restarts the daemon if the version has changed or if running a dev build.
- * Returns connection to the daemon.
+ * Stop a daemon process using IPC shutdown then signal escalation.
+ * Used internally for replacement and stop flows.
  */
-export async function ensureDaemon(
-	port: number = DEFAULT_PORT,
-	cliVersion?: string,
-): Promise<DaemonStartResult> {
-	const pidData = await readPidFile();
-
-	if (pidData) {
-		if (isProcessRunning(pidData.pid)) {
-			const conn = createConnection(pidData.port);
-			const health = await checkHealth(conn);
-
-			if (health) {
-				if (cliVersion && shouldRestartForVersion(health, cliVersion)) {
-					logDaemonEvent("restart_for_version", {
-						requestedPort: port,
-						daemonPort: pidData.port,
-						daemonPid: pidData.pid,
-						daemonVersion: health.version,
-						cliVersion,
-					});
-					console.error(
-						`[rp1] Daemon version ${health.version} differs from CLI ${cliVersion}. Restarting...`,
-					);
-					await stopDaemon();
-				} else {
-					if (pidData.port !== port) {
-						console.error(
-							`[rp1] Daemon already running on port ${pidData.port} (requested ${port}). Using existing daemon.`,
-						);
-					}
-					return { connection: conn, wasRunning: true };
-				}
-			} else {
-				const healthy = await waitForHealth(conn, 2000);
-				if (healthy) {
-					if (pidData.port !== port) {
-						console.error(
-							`[rp1] Daemon already running on port ${pidData.port} (requested ${port}). Using existing daemon.`,
-						);
-					}
-					return { connection: conn, wasRunning: true };
-				}
-			}
-		}
-
-		await removePidFile();
-	}
-
-	const portAvailable = await isPortAvailable(port);
-	if (!portAvailable) {
-		const conn = createConnection(port);
-		const health = await checkHealth(conn);
-		if (health) {
-			const realPid = resolvePortOwnerPid(port);
-			if (realPid) {
-				await writePidFile({ port, pid: realPid });
-			}
-			return { connection: conn, wasRunning: true };
-		}
-
-		// Port occupied by non-daemon process — kill it and reclaim
-		const ownerPid = resolvePortOwnerPid(port);
-		if (ownerPid) {
-			logDaemonEvent("reclaiming_port", {
-				port,
-				ownerPid,
-				reason: "health_check_failed",
-			});
-			try {
-				process.kill(ownerPid, "SIGTERM");
-			} catch {
-				// Process may have already exited
-			}
-			const exited = await waitForProcessExit(
-				ownerPid,
-				STOP_GRACEFUL_TIMEOUT_MS,
-			);
-			if (!exited) {
-				forceKillProcess(ownerPid);
-				await waitForProcessExit(ownerPid, STOP_KILL_TIMEOUT_MS);
-			}
-		}
-
-		const portFreed = await isPortAvailable(port);
-		if (!portFreed) {
-			throw new Error(
-				`Port ${port} is in use and could not be reclaimed. Try a different port.`,
-			);
-		}
-	}
-
-	const pid = await spawnDaemon(port);
-	await writePidFile({ port, pid });
-
-	const conn = createConnection(port);
-	const healthy = await waitForHealth(conn);
-
-	if (!healthy) {
-		await removePidFile();
-		throw new Error(
-			"Daemon started but failed to become healthy within timeout",
-		);
-	}
-
-	return { connection: conn, wasRunning: false };
-}
-
-/**
- * Stop the running daemon with SIGTERM -> SIGKILL escalation.
- */
-export async function stopDaemon(): Promise<boolean> {
-	const pidData = await readPidFile();
-
-	if (!pidData) {
-		return false;
-	}
-
-	logDaemonEvent("stop_requested", {
-		port: pidData.port,
-		daemonPid: pidData.pid,
-	});
-
+async function stopDaemonProcess(pidData: PidFileData): Promise<void> {
 	const conn = createConnection(pidData.port);
 	await stopDaemonIpc(conn);
 
@@ -418,43 +344,360 @@ export async function stopDaemon(): Promise<boolean> {
 	}
 
 	await removePidFile();
-	return true;
+}
+
+/**
+ * Build a DaemonStartResult with derived wasRunning field.
+ */
+function makeStartResult(
+	connection: DaemonConnection,
+	action: DaemonStartAction,
+	reason?: DaemonLifecycleReason,
+): DaemonStartResult {
+	return {
+		connection,
+		action,
+		reason,
+		wasRunning: action !== "started",
+	};
+}
+
+/**
+ * Resolve the default CLI version for lock metadata when not provided.
+ */
+function resolveLockVersion(cliVersion?: string): string {
+	return cliVersion ?? "unknown";
+}
+
+/**
+ * Ensure daemon is running, starting it if necessary.
+ * Executes under the lifecycle lock so all state reads happen after acquisition.
+ * Restarts the daemon if the version has changed or if running a dev build.
+ * Returns connection to the daemon with explicit lifecycle action.
+ */
+export async function ensureDaemon(
+	port: number = DEFAULT_PORT,
+	cliVersion?: string,
+): Promise<DaemonStartResult> {
+	return withLifecycleLock(
+		{
+			operation: "ensureDaemon",
+			port,
+			cliVersion: resolveLockVersion(cliVersion),
+		},
+		async () => {
+			// Step 1: Read PID file under lock and probe health.
+			const pidData = await readPidFile();
+			let reason: DaemonLifecycleReason | undefined;
+			let replacing = false;
+
+			if (pidData) {
+				if (isProcessRunning(pidData.pid)) {
+					const conn = createConnection(pidData.port);
+					const health = await checkHealth(conn);
+
+					if (health) {
+						// Step 2: Healthy and tracked daemon found.
+						if (cliVersion && shouldRestartForVersion(health, cliVersion)) {
+							logDaemonEvent("restart_for_version", {
+								requestedPort: port,
+								daemonPort: pidData.port,
+								daemonPid: pidData.pid,
+								daemonVersion: health.version,
+								cliVersion,
+							});
+							console.error(
+								`[rp1] Daemon version ${health.version} differs from CLI ${cliVersion}. Replacing...`,
+							);
+							await stopDaemonProcess(pidData);
+							reason = "version_mismatch";
+							replacing = true;
+						} else {
+							// Compatible and healthy → reuse.
+							if (pidData.port !== port) {
+								console.error(
+									`[rp1] Daemon already running on port ${pidData.port} (requested ${port}). Using existing daemon.`,
+								);
+							}
+							logDaemonEvent("daemon_reused", {
+								port: pidData.port,
+								pid: pidData.pid,
+							});
+							return makeStartResult(conn, "reused");
+						}
+					} else {
+						// Process running but health check failed — wait briefly.
+						const healthy = await waitForHealth(conn, 2000);
+						if (healthy) {
+							if (pidData.port !== port) {
+								console.error(
+									`[rp1] Daemon already running on port ${pidData.port} (requested ${port}). Using existing daemon.`,
+								);
+							}
+							logDaemonEvent("daemon_reused", {
+								port: pidData.port,
+								pid: pidData.pid,
+								afterWait: true,
+							});
+							return makeStartResult(conn, "reused");
+						}
+						// Still unhealthy → stop and replace.
+						logDaemonEvent("replacing_unhealthy_daemon", {
+							port: pidData.port,
+							pid: pidData.pid,
+						});
+						await stopDaemonProcess(pidData);
+						reason = "unhealthy_daemon";
+						replacing = true;
+					}
+				} else {
+					// PID file exists but process is gone → stale PID.
+					logDaemonEvent("stale_pid_cleanup", {
+						port: pidData.port,
+						pid: pidData.pid,
+					});
+					await removePidFile();
+					reason = "stale_pid";
+				}
+			}
+
+			// Step 3: If not replacing, check whether the port is available.
+			if (!replacing) {
+				const portFree = await isPortAvailable(port);
+				if (!portFree) {
+					// Port is occupied — check if a healthy rp1 daemon is on it.
+					const conn = createConnection(port);
+					const health = await checkHealth(conn);
+
+					if (health) {
+						// Step 3a: Healthy rp1 daemon on port without PID tracking → repair ownership.
+						const repairReason = reason ?? "missing_pid";
+
+						if (cliVersion && shouldRestartForVersion(health, cliVersion)) {
+							// Incompatible version — stop the untracked daemon and replace.
+							const realPid = resolvePortOwnerPid(port);
+							if (realPid) {
+								await stopDaemonProcess({ port, pid: realPid });
+							}
+							reason = "version_mismatch";
+							replacing = true;
+						} else {
+							// Compatible — repair PID file and reuse.
+							const realPid = resolvePortOwnerPid(port);
+							if (realPid) {
+								await writePidFile({ port, pid: realPid });
+								logDaemonEvent("pid_repaired", {
+									port,
+									pid: realPid,
+									reason: repairReason,
+								});
+							}
+							logDaemonEvent("daemon_reused", {
+								port,
+								reason: repairReason,
+								repaired: true,
+							});
+							return makeStartResult(conn, "reused", repairReason);
+						}
+					} else {
+						// Step 5: Port occupied by a non-rp1 process → raise PortInUseError.
+						logDaemonEvent("foreign_port_conflict", { port });
+						throw new DaemonPortConflictError(port);
+					}
+				}
+			}
+
+			// Step 6: Spawn a new daemon, wait for health, and write the PID file.
+			const pid = await spawnDaemon(port);
+			await writePidFile({ port, pid });
+
+			const conn = createConnection(port);
+			const healthy = await waitForHealth(conn);
+
+			if (!healthy) {
+				await removePidFile();
+				throw new Error(
+					"Daemon started but failed to become healthy within timeout",
+				);
+			}
+
+			const action: DaemonStartAction = replacing ? "replaced" : "started";
+			logDaemonEvent(replacing ? "daemon_replaced" : "daemon_started", {
+				port,
+				pid,
+				reason,
+			});
+			return makeStartResult(conn, action, reason);
+		},
+	);
+}
+
+/**
+ * Stop the running daemon with SIGTERM -> SIGKILL escalation.
+ * Executes under the lifecycle lock. Recovers from stale or missing PID state
+ * by probing the default port for a live rp1 daemon.
+ */
+export async function stopDaemon(
+	port: number = DEFAULT_PORT,
+): Promise<DaemonStopResult> {
+	return withLifecycleLock(
+		{
+			operation: "stopDaemon",
+			port,
+			cliVersion: "unknown",
+		},
+		async () => {
+			const pidData = await readPidFile();
+
+			if (pidData) {
+				logDaemonEvent("stop_requested", {
+					port: pidData.port,
+					daemonPid: pidData.pid,
+				});
+				await stopDaemonProcess(pidData);
+				return { action: "stopped" as const };
+			}
+
+			// No PID file — attempt recovery by probing the port for a live rp1 daemon.
+			const conn = createConnection(port);
+			const health = await checkHealth(conn);
+
+			if (health) {
+				const realPid = resolvePortOwnerPid(port);
+				if (realPid) {
+					logDaemonEvent("stop_requested", {
+						port,
+						daemonPid: realPid,
+						recoveredFromMissingPid: true,
+					});
+					await stopDaemonProcess({ port, pid: realPid });
+					return { action: "stopped" as const };
+				}
+				// Could not resolve PID — attempt IPC shutdown only.
+				await stopDaemonIpc(conn);
+				return { action: "stopped" as const };
+			}
+
+			return { action: "not_running" as const };
+		},
+	);
 }
 
 /**
  * Get status of the daemon.
+ * Recovers from stale or missing PID state by probing the port for a live daemon.
  */
-export async function getStatus(): Promise<DaemonStatus> {
+export async function getStatus(
+	port: number = DEFAULT_PORT,
+): Promise<DaemonStatus> {
 	const pidData = await readPidFile();
 
-	if (!pidData) {
-		return { running: false };
+	if (pidData) {
+		if (!isProcessRunning(pidData.pid)) {
+			await removePidFile();
+			// Fall through to port-based recovery below.
+		} else {
+			const conn = createConnection(pidData.port);
+			return getDaemonStatus(conn);
+		}
 	}
 
-	if (!isProcessRunning(pidData.pid)) {
-		await removePidFile();
-		return { running: false };
+	// Recovery fallback: probe the port for a live rp1 daemon.
+	const conn = createConnection(port);
+	const health = await checkHealth(conn);
+
+	if (health) {
+		// Repair PID file so subsequent calls have accurate tracking.
+		const realPid = resolvePortOwnerPid(port);
+		if (realPid) {
+			await writePidFile({ port, pid: realPid });
+			logDaemonEvent("pid_repaired", {
+				port,
+				pid: realPid,
+				reason: "status_recovery",
+			});
+		}
+		return getDaemonStatus(conn);
 	}
 
-	const conn = createConnection(pidData.port);
-	return getDaemonStatus(conn);
+	return { running: false };
 }
 
 /**
  * Restart the daemon. Ensures old process is fully terminated before starting new one.
+ * Executes under the lifecycle lock.
  */
 export async function restartDaemon(
 	port: number = DEFAULT_PORT,
 	cliVersion?: string,
 ): Promise<DaemonStartResult> {
-	const pidData = await readPidFile();
-	await stopDaemon();
+	return withLifecycleLock(
+		{
+			operation: "restartDaemon",
+			port,
+			cliVersion: resolveLockVersion(cliVersion),
+		},
+		async () => {
+			const pidData = await readPidFile();
 
-	if (pidData && isProcessRunning(pidData.pid)) {
-		await waitForProcessExit(pidData.pid, STOP_KILL_TIMEOUT_MS);
-	}
+			if (pidData) {
+				logDaemonEvent("stop_requested", {
+					port: pidData.port,
+					daemonPid: pidData.pid,
+					reason: "restart",
+				});
+				await stopDaemonProcess(pidData);
 
-	return ensureDaemon(port, cliVersion);
+				if (isProcessRunning(pidData.pid)) {
+					await waitForProcessExit(pidData.pid, STOP_KILL_TIMEOUT_MS);
+				}
+			} else {
+				// Recovery: probe the port for an untracked daemon.
+				const conn = createConnection(port);
+				const health = await checkHealth(conn);
+
+				if (health) {
+					const realPid = resolvePortOwnerPid(port);
+					if (realPid) {
+						await stopDaemonProcess({ port, pid: realPid });
+					} else {
+						await stopDaemonIpc(conn);
+					}
+				}
+			}
+
+			// Spawn new daemon directly (no nested lock via ensureDaemon).
+			const portFree = await isPortAvailable(port);
+			if (!portFree) {
+				const conn = createConnection(port);
+				const health = await checkHealth(conn);
+				if (!health) {
+					throw new DaemonPortConflictError(port);
+				}
+				// If somehow still a healthy rp1 daemon, treat as replacement.
+			}
+
+			const pid = await spawnDaemon(port);
+			await writePidFile({ port, pid });
+
+			const conn = createConnection(port);
+			const healthy = await waitForHealth(conn);
+
+			if (!healthy) {
+				await removePidFile();
+				throw new Error(
+					"Daemon started but failed to become healthy within timeout",
+				);
+			}
+
+			logDaemonEvent("daemon_replaced", {
+				port,
+				pid,
+				reason: "restart",
+			});
+			return makeStartResult(conn, "replaced");
+		},
+	);
 }
 
 /**

--- a/docs/arcade/index.md
+++ b/docs/arcade/index.md
@@ -17,6 +17,61 @@ rp1 arcade
 Run that from any project directory. By default it opens the browser on
 `http://localhost:7710`.
 
+### Daemon lifecycle
+
+Arcade runs as a single background daemon per user environment. Every launch
+path -- `rp1 arcade`, hooks, `just install` -- converges on one authoritative
+daemon rather than allowing duplicates. You do not need to worry about
+leftover processes or manual cleanup during normal use.
+
+When you run `rp1 arcade`, the daemon manager resolves the current state and
+reports one of three outcomes:
+
+| Outcome | When it happens | CLI feedback |
+|---------|-----------------|--------------|
+| **Reused** | A healthy, compatible daemon is already running on the requested port | `Reused daemon on port 7710` |
+| **Started** | No daemon was running; a new one is launched | `Started daemon on port 7710` |
+| **Replaced** | A daemon was running but is unhealthy or from an incompatible version | `Replaced daemon on port 7710 (reason: version mismatch)` |
+
+Replacement reasons include `version mismatch`, `unhealthy daemon`,
+`stale pid`, and `missing pid`. These appear in the CLI output and in
+`daemon.log` so you can verify exactly what happened without inspecting PID
+files or process tables.
+
+### Port conflicts
+
+If the requested port is occupied by a non-rp1 process, Arcade raises an
+actionable error instead of terminating the other process:
+
+```
+Port 7710 is in use by a non-rp1 process.
+Use a different port or stop the process occupying port 7710.
+```
+
+Use `--port` to pick a different port:
+
+```bash
+rp1 arcade --port 8080
+```
+
+### Stale state recovery
+
+If a previous daemon crashed or its PID file became stale, the next launch
+detects and repairs the ownership state automatically. You do not need to
+delete PID files or restart markers manually -- the daemon manager handles
+recovery as part of normal startup.
+
+### Other lifecycle commands
+
+```bash
+rp1 arcade --status     # Show whether the daemon is running
+rp1 arcade --stop       # Stop the daemon
+rp1 arcade --restart    # Restart the daemon
+```
+
+These commands are idempotent. Repeating them does not accumulate extra
+processes or stale state.
+
 ---
 
 ## Main Surfaces

--- a/docs/reference/cli/install.md
+++ b/docs/reference/cli/install.md
@@ -111,6 +111,38 @@ rp1 install codex --dry-run
 rp1 install copilot --dry-run
 ```
 
+## Contributor Local Install (`just install`)
+
+Contributors building rp1 locally use `just install` to compile and install a
+fresh binary and its assets. When Arcade is already running, the install flow
+handles daemon replacement automatically:
+
+1. **Before build** -- the install recipe stops the active daemon through the
+   shared lifecycle manager and records the port it was serving on.
+2. **Build and install** -- the web UI cache is cleared and the new binary is
+   compiled and installed to all detected host tools.
+3. **After install** -- if Arcade was running before the install, the new
+   `./bin/rp1` binary restarts the daemon on the previously recorded port.
+   If Arcade was not running, no daemon is started as a side effect.
+
+This means you do not need to manually stop and restart Arcade around
+`just install`. The flow preserves the prior port so browser tabs and
+bookmarks continue to work.
+
+### What you should see
+
+| Before install | After install |
+|----------------|---------------|
+| Arcade was running on port 7710 | Arcade is restarted on port 7710 using the new build |
+| Arcade was running on port 8080 | Arcade is restarted on port 8080 using the new build |
+| Arcade was not running | No daemon is started; the install completes cleanly |
+
+### Manual recovery
+
+Under normal conditions no manual steps are needed. If an install is
+interrupted mid-flow, the next `just install` or `rp1 arcade` call detects
+and cleans up stale restart markers and daemon state automatically.
+
 ## Verification
 
 After installation, verify the target host:


### PR DESCRIPTION
## Summary

- Introduce a config-dir lifecycle lock (`lifecycle-lock.ts`) using atomic `mkdir` with owner metadata, bounded wait, and stale-lock recovery — all daemon lifecycle operations (`ensureDaemon`, `stopDaemon`, `restartDaemon`) now execute under lock
- Replace boolean `wasRunning` with explicit `DaemonStartAction`/`DaemonStopAction`/`DaemonLifecycleReason` types; foreign port conflicts raise `DaemonPortConflictError` instead of killing the occupant
- Replace shell-level PID-file parsing in the Justfile with a shared Bun helper (`prepare-local-install-daemon.ts`) that uses the daemon manager contract, with restart-marker port awareness for post-install restoration
- Add 45 new tests across 4 files and user-facing documentation for the daemon lifecycle contract and contributor install flow

## Test plan

- [x] All 2550 tests pass (including 45 new tests)
- [x] TypeScript checks clean (CLI + web-ui)
- [x] Biome lint/format clean
- [x] 30/30 acceptance criteria verified by feature-verifier
- [ ] Manual: run `just install` with a running daemon and verify stop → build → restore cycle
- [ ] Manual: verify `rp1 arcade` on a port occupied by a non-rp1 process shows a clear error