### PR TITLE
fix(web-ui): viewer overflow, clickable links, and debug args display

### DIFF
--- a/cli/src/agent-tools/workflow-bootstrap/index.ts
+++ b/cli/src/agent-tools/workflow-bootstrap/index.ts
@@ -352,6 +352,7 @@ const buildBootstrapContext = (params: {
 	readonly directories: ReturnType<typeof resolveDirectories>;
 	readonly trace: WorkflowBootstrapTrace;
 	readonly decision: string;
+	readonly arguments?: Readonly<Record<string, string | boolean>>;
 }): string =>
 	JSON.stringify({
 		workflow: {
@@ -379,6 +380,10 @@ const buildBootstrapContext = (params: {
 		run: {
 			decision: params.decision,
 		},
+		...(params.arguments &&
+			Object.keys(params.arguments).length > 0 && {
+				arguments: params.arguments,
+			}),
 	});
 
 export const execute = (
@@ -463,6 +468,7 @@ export const execute = (
 					directories,
 					trace,
 					decision: "pending",
+					arguments: resolvedArgs.arguments,
 				});
 
 				const featureId = deriveFeatureId(resolvedArgs.arguments);
@@ -485,6 +491,7 @@ export const execute = (
 					directories,
 					trace,
 					decision: runResult.decision,
+					arguments: resolvedArgs.arguments,
 				});
 
 				insertRun(db, {

--- a/cli/web-ui/src/__tests__/components/v2/RunInvocationCard.test.tsx
+++ b/cli/web-ui/src/__tests__/components/v2/RunInvocationCard.test.tsx
@@ -16,6 +16,11 @@ const baseInvocation: RunInvocationContext = {
 	workIdentity: "FEATURE_ID=feat-ui",
 	identityValues: { FEATURE_ID: "feat-ui" },
 	harness: "codex",
+	arguments: {
+		FEATURE_ID: "feat-ui",
+		AFK: true,
+		API_TOKEN: "[redacted]",
+	},
 };
 
 afterEach(() => {
@@ -34,11 +39,27 @@ describe("RunInvocationCard", () => {
 		expect(screen.getByText("/repo/worktrees/feature")).toBeTruthy();
 		expect(screen.getByText("Linked worktree (feature)")).toBeTruthy();
 		expect(screen.getByText("FEATURE_ID=feat-ui")).toBeTruthy();
+
+		expect(screen.getByText("Arguments")).toBeTruthy();
+		expect(screen.getByText("FEATURE_ID")).toBeTruthy();
+		expect(screen.getByText("feat-ui")).toBeTruthy();
+		expect(screen.getByText("AFK")).toBeTruthy();
+		expect(screen.getByText("true")).toBeTruthy();
+		expect(screen.getByText("API_TOKEN")).toBeTruthy();
+		expect(screen.getByText("[redacted]")).toBeTruthy();
 	});
 
 	test("omits the invocation card when no context exists", () => {
 		render(createElement(RunInvocationCard, { invocation: undefined }));
 
 		expect(screen.queryByText("Invocation")).toBeNull();
+	});
+
+	test("omits the arguments section when arguments is undefined", () => {
+		const { arguments: _, ...noArgs } = baseInvocation;
+		render(createElement(RunInvocationCard, { invocation: noArgs }));
+
+		expect(screen.getByText("Invocation")).toBeTruthy();
+		expect(screen.queryByText("Arguments")).toBeNull();
 	});
 });

--- a/cli/web-ui/src/components/MarkdownViewer/MarkdownViewer.tsx
+++ b/cli/web-ui/src/components/MarkdownViewer/MarkdownViewer.tsx
@@ -342,7 +342,7 @@ export function MarkdownViewer({
 	}, [headingIdPrefix]);
 
 	return (
-		<div className="relative flex gap-3">
+		<div className="relative flex gap-3 min-w-0 max-w-full">
 			{/* Annotation gutter - visual column for indicators */}
 			<div
 				ref={gutterRef}

--- a/cli/web-ui/src/components/MilkdownEditor/MilkdownEditor.tsx
+++ b/cli/web-ui/src/components/MilkdownEditor/MilkdownEditor.tsx
@@ -30,6 +30,7 @@ import {
 	useState,
 } from "react";
 import { getHighlighter, normalizeLanguage } from "../../lib/shiki";
+import { createLinkClickPlugin } from "./link-click-plugin";
 import { createMermaidPlugin } from "./mermaid-plugin";
 
 import "@milkdown/kit/prose/view/style/prosemirror.css";
@@ -163,7 +164,8 @@ function MilkdownEditorInner({
 				.use(gfm)
 				.use(history)
 				.use(listener)
-				.use(createMermaidPlugin());
+				.use(createMermaidPlugin())
+				.use(createLinkClickPlugin());
 
 			// Note: mermaid NodeView must come after commonmark (needs code_block schema)
 

--- a/cli/web-ui/src/components/MilkdownEditor/link-click-plugin.ts
+++ b/cli/web-ui/src/components/MilkdownEditor/link-click-plugin.ts
@@ -1,0 +1,42 @@
+import { Plugin, PluginKey } from "@milkdown/kit/prose/state";
+import type { EditorView } from "@milkdown/kit/prose/view";
+import { $prose } from "@milkdown/kit/utils";
+
+const linkClickPluginKey = new PluginKey("linkClick");
+
+/**
+ * Finds the closest `<a>` element from a click target within the editor.
+ * Returns the href if it's a valid external/internal link, otherwise null.
+ */
+function findLinkHref(
+	target: EventTarget | null,
+	view: EditorView,
+): string | null {
+	if (!(target instanceof HTMLElement)) return null;
+	const anchor = target.closest("a");
+	if (!anchor) return null;
+	// Only handle links that are inside the editor DOM
+	if (!view.dom.contains(anchor)) return null;
+	return anchor.href || null;
+}
+
+/**
+ * ProseMirror plugin that makes hyperlinks clickable in the Milkdown editor.
+ * Opens links in a new tab on click.
+ */
+export const createLinkClickPlugin = () =>
+	$prose(() => {
+		return new Plugin({
+			key: linkClickPluginKey,
+			props: {
+				handleClick(view: EditorView, _pos: number, event: MouseEvent) {
+					const href = findLinkHref(event.target, view);
+					if (!href) return false;
+					// Open in a new tab
+					window.open(href, "_blank", "noopener,noreferrer");
+					event.preventDefault();
+					return true;
+				},
+			},
+		});
+	});

--- a/cli/web-ui/src/components/v2/ArtifactViewerPanel.tsx
+++ b/cli/web-ui/src/components/v2/ArtifactViewerPanel.tsx
@@ -212,7 +212,7 @@ function ArtifactViewerInner({
 	const showTocToggle = headings.length > 0 && !tocOpen;
 
 	return (
-		<div className="flex h-full flex-col overflow-hidden">
+		<div className="flex h-full flex-col overflow-hidden min-w-0">
 			<div className="shrink-0 px-4 md:px-[40px] pt-[24px] pb-[16px]">
 				<div className="flex items-center justify-between">
 					<h2 className="type-secondary text-fg-muted">{step.name}</h2>
@@ -303,10 +303,10 @@ function ArtifactViewerInner({
 				)}
 			</div>
 
-			<div className="flex flex-1 min-h-0 overflow-hidden">
+			<div className="flex flex-1 min-h-0 min-w-0 overflow-hidden">
 				{showSubflow && hasSubflow ? (
 					<ScrollArea
-						className="flex-1 min-h-0 max-w-full overflow-hidden"
+						className="flex-1 min-h-0 min-w-0"
 						viewportRef={scrollViewportRef}
 					>
 						<div className="px-4 md:px-[40px] py-4">
@@ -318,7 +318,7 @@ function ArtifactViewerInner({
 					</ScrollArea>
 				) : (
 					<ScrollArea
-						className="flex-1 min-h-0 max-w-full overflow-hidden"
+						className="flex-1 min-h-0 min-w-0"
 						viewportRef={scrollViewportRef}
 					>
 						<ContentPanel

--- a/cli/web-ui/src/components/v2/ContentPanel.tsx
+++ b/cli/web-ui/src/components/v2/ContentPanel.tsx
@@ -43,7 +43,7 @@ export function ContentPanel({
 }: ContentPanelProps) {
 	return (
 		<div
-			className="artifact-viewer-content max-w-full overflow-hidden break-words px-4 md:px-[40px]"
+			className="artifact-viewer-content max-w-full min-w-0 break-words px-4 md:px-[40px]"
 			style={{
 				paddingTop: "16px",
 				paddingBottom: "40px",

--- a/cli/web-ui/src/components/v2/RunInvocationCard.tsx
+++ b/cli/web-ui/src/components/v2/RunInvocationCard.tsx
@@ -98,6 +98,24 @@ export function RunInvocationCard({
 						monospace
 					/>
 				</dl>
+				{invocation.arguments &&
+					Object.keys(invocation.arguments).length > 0 && (
+						<>
+							<h3 className="mt-md type-secondary text-fg-muted tracking-wider uppercase">
+								Arguments
+							</h3>
+							<dl className="mt-md grid gap-x-lg gap-y-md md:grid-cols-2 xl:grid-cols-3">
+								{Object.entries(invocation.arguments).map(([key, value]) => (
+									<InvocationField
+										key={key}
+										label={key}
+										value={String(value)}
+										monospace
+									/>
+								))}
+							</dl>
+						</>
+					)}
 			</div>
 		</section>
 	);

--- a/cli/web-ui/src/components/v2/UnifiedContentRenderer.tsx
+++ b/cli/web-ui/src/components/v2/UnifiedContentRenderer.tsx
@@ -260,7 +260,7 @@ function MarkdownEditorWithSave({
 	}, []);
 
 	return (
-		<div className="relative flex gap-3">
+		<div className="relative flex gap-3 min-w-0 max-w-full">
 			<div
 				ref={gutterRef}
 				className="w-5 flex-shrink-0 relative"

--- a/cli/web-ui/src/pages/v2/ArtifactViewerPage.tsx
+++ b/cli/web-ui/src/pages/v2/ArtifactViewerPage.tsx
@@ -971,7 +971,7 @@ export function ArtifactViewerPage() {
 				<ResizableHandle withHandle aria-label="Resize sidebar" />
 
 				<ResizablePanel defaultSize={55} minSize={40}>
-					<main className="relative flex h-full flex-col overflow-hidden">
+					<main className="relative flex h-full flex-col overflow-hidden min-w-0">
 						<div
 							className="flex h-10 items-center justify-end gap-2 border-b px-4"
 							role="toolbar"
@@ -1014,7 +1014,7 @@ export function ArtifactViewerPage() {
 							viewportRef={scrollViewportRef}
 						>
 							<article
-								className="p-6"
+								className="p-6 min-w-0 max-w-full"
 								onScroll={handleScroll as unknown as React.UIEventHandler}
 								aria-label={
 									selectedArtifactPath

--- a/cli/web-ui/src/pages/v2/FileBrowserPage.tsx
+++ b/cli/web-ui/src/pages/v2/FileBrowserPage.tsx
@@ -623,7 +623,7 @@ export function FileBrowserPage() {
 				<ResizableHandle aria-label="Resize file tree" />
 
 				<ResizablePanel defaultSize={isMarkdown ? 55 : 67} minSize={40}>
-					<main className="relative flex h-full flex-col overflow-hidden">
+					<main className="relative flex h-full flex-col overflow-hidden min-w-0">
 						<div
 							className="flex h-10 items-center justify-end gap-2 px-4"
 							role="toolbar"

--- a/cli/web-ui/src/server/routes/v2-api.ts
+++ b/cli/web-ui/src/server/routes/v2-api.ts
@@ -306,6 +306,32 @@ function sanitizeInvocationIdentityValues(
 	return Object.keys(sanitized).length > 0 ? sanitized : undefined;
 }
 
+function sanitizeInvocationArguments(
+	rawArguments: unknown,
+): Readonly<Record<string, string | boolean>> | undefined {
+	const args = asObject(rawArguments);
+	if (!args) return undefined;
+
+	const sanitized = Object.fromEntries(
+		Object.entries(args).flatMap(([key, value]) => {
+			if (typeof value !== "string" && typeof value !== "boolean") {
+				return [];
+			}
+
+			return [
+				[
+					key,
+					typeof value === "string" && isSensitiveInvocationKey(key)
+						? "[redacted]"
+						: value,
+				],
+			];
+		}),
+	) as Record<string, string | boolean>;
+
+	return Object.keys(sanitized).length > 0 ? sanitized : undefined;
+}
+
 function buildDisplayWorkIdentity(
 	identityArgs: readonly string[],
 	identityValues: Readonly<Record<string, string | boolean>> | undefined,
@@ -396,6 +422,9 @@ function parseRunInvocationContext(
 		typeof trace.harness === "string" && trace.harness.length > 0
 			? trace.harness
 			: record.harness;
+	const sanitizedArguments = sanitizeInvocationArguments(
+		bootstrapContext.arguments,
+	);
 
 	return {
 		workflowName,
@@ -413,6 +442,7 @@ function parseRunInvocationContext(
 		...(workIdentity ? { workIdentity } : {}),
 		...(identityValues ? { identityValues } : {}),
 		...(harness ? { harness } : {}),
+		...(sanitizedArguments ? { arguments: sanitizedArguments } : {}),
 	};
 }
 

--- a/cli/web-ui/src/styles/globals.css
+++ b/cli/web-ui/src/styles/globals.css
@@ -148,6 +148,8 @@
   /* Markdown content styles */
   .markdown-content {
     @apply max-w-none;
+    overflow-wrap: break-word;
+    word-break: break-word;
   }
 
   .markdown-content > *:first-child {
@@ -393,6 +395,9 @@
     padding: 16px;
     outline: none;
     min-height: 200px;
+    max-width: 100%;
+    overflow-wrap: break-word;
+    word-break: break-word;
   }
 
   .milkdown-editor-root .ProseMirror-selectednode {
@@ -679,6 +684,8 @@
     border-collapse: collapse;
     min-width: 100%;
     margin: 16px 0;
+    display: block;
+    overflow-x: auto;
   }
 
   .milkdown-editor-root .ProseMirror thead {

--- a/cli/web-ui/src/styles/globals.css
+++ b/cli/web-ui/src/styles/globals.css
@@ -739,6 +739,11 @@
 
 }
 
+/* Override contenteditable cursor: text for links in the Milkdown editor */
+.milkdown-editor-root .ProseMirror a {
+  cursor: pointer !important;
+}
+
 /* Active annotation highlight via CSS Custom Highlight API */
 ::highlight(active-annotation) {
   background-color: hsl(var(--accent) / 0.15);

--- a/cli/web-ui/src/types/runs.ts
+++ b/cli/web-ui/src/types/runs.ts
@@ -82,6 +82,7 @@ export interface RunInvocationContext {
 	readonly workIdentity?: string;
 	readonly identityValues?: Readonly<Record<string, string | boolean>>;
 	readonly harness?: string | null;
+	readonly arguments?: Readonly<Record<string, string | boolean>>;
 }
 
 /** An agent run with all associated data */


### PR DESCRIPTION
## Summary
- **Content overflow fix**: Add `min-w-0` to flex containers in artifact/file viewer so panels shrink properly on resize instead of clipping content
- **Clickable hyperlinks**: Add ProseMirror plugin to intercept link clicks in Milkdown editor and open them in new tabs, with `cursor: pointer` override for contenteditable
- **Debug args display**: Persist full resolved workflow arguments in `bootstrap_context` DB column and render them in the Arcade debug panel's RunInvocationCard with sensitive key redaction

## Test plan
- [x] Resize artifact viewer panel narrower — tables should scroll horizontally, text should wrap
- [x] Click a hyperlink in artifact/file viewer — should open in new tab, cursor shows pointer on hover
- [x] Open a run's debug info (Cmd+K → "Show Debug Info") — should show "Arguments" section with key/value pairs
- [x] Sensitive argument keys (token, secret, password) should show `[redacted]` values