### PR TITLE
fix(init): prompt when ancestor directory has an rp1 project

### DIFF
--- a/cli/src/__tests__/init/directory-model.test.ts
+++ b/cli/src/__tests__/init/directory-model.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import {
+	detectAncestorProject,
 	detectReinitState,
 	resolveInitDirectoryModel,
 } from "../../init/directory-model.js";
@@ -65,6 +66,48 @@ describe("init directory model", () => {
 				process.env.HOME = originalHome;
 			}
 		}
+	});
+
+	test("detectAncestorProject returns isAncestor when parent has project_id", async () => {
+		const nestedDir = join(tempDir, "packages", "app");
+		await mkdir(join(tempDir, ".rp1"), { recursive: true });
+		await writeFile(join(tempDir, ".rp1", "project_id"), "project-123");
+		await mkdir(nestedDir, { recursive: true });
+
+		const result = detectAncestorProject(nestedDir);
+
+		expect(result.isAncestor).toBe(true);
+		expect(result.ancestorRoot).toBe(tempDir);
+	});
+
+	test("detectAncestorProject returns false when cwd is the project root", async () => {
+		await mkdir(join(tempDir, ".rp1"), { recursive: true });
+		await writeFile(join(tempDir, ".rp1", "project_id"), "project-123");
+
+		const result = detectAncestorProject(tempDir);
+
+		expect(result.isAncestor).toBe(false);
+		expect(result.ancestorRoot).toBeUndefined();
+	});
+
+	test("detectAncestorProject returns false when no ancestor project exists", () => {
+		const result = detectAncestorProject(tempDir);
+
+		expect(result.isAncestor).toBe(false);
+		expect(result.ancestorRoot).toBeUndefined();
+	});
+
+	test("detectAncestorProject ignores ancestor with .rp1 dir but no project_id", async () => {
+		const nestedDir = join(tempDir, "packages", "app");
+		// Create .rp1/ directory without project_id (stale/legacy)
+		await mkdir(join(tempDir, ".rp1"), { recursive: true });
+		await mkdir(nestedDir, { recursive: true });
+
+		const result = detectAncestorProject(nestedDir);
+
+		// A stale .rp1/ dir without project_id should NOT trigger the ancestor prompt
+		expect(result.isAncestor).toBe(false);
+		expect(result.ancestorRoot).toBeUndefined();
 	});
 
 	test("detects work content from .rp1/work directory", async () => {

--- a/cli/src/__tests__/init/directory-model.test.ts
+++ b/cli/src/__tests__/init/directory-model.test.ts
@@ -1,7 +1,9 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { execFileSync } from "node:child_process";
 import { mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import {
+	defaultInitDirectoryModel,
 	detectAncestorProject,
 	detectReinitState,
 	resolveInitDirectoryModel,
@@ -108,6 +110,90 @@ describe("init directory model", () => {
 		// A stale .rp1/ dir without project_id should NOT trigger the ancestor prompt
 		expect(result.isAncestor).toBe(false);
 		expect(result.ancestorRoot).toBeUndefined();
+	});
+
+	test("detectAncestorProject does not flag a linked git worktree as an ancestor", async () => {
+		// Set up a main repo with a project_id, then create a linked worktree
+		// whose main repo is a *sibling* path rather than an ancestor. The
+		// resolver maps the worktree back to the main repo, but that is not a
+		// real ancestor of the worktree cwd, so the prompt must not fire.
+		const mainRepo = join(tempDir, "main-repo");
+		await mkdir(mainRepo, { recursive: true });
+		const gitEnv = {
+			...process.env,
+			GIT_AUTHOR_NAME: "rp1-test",
+			GIT_AUTHOR_EMAIL: "rp1-test@example.com",
+			GIT_COMMITTER_NAME: "rp1-test",
+			GIT_COMMITTER_EMAIL: "rp1-test@example.com",
+		};
+		const runGit = (cwd: string, args: string[]): void => {
+			execFileSync("git", args, { cwd, env: gitEnv, stdio: "ignore" });
+		};
+
+		runGit(mainRepo, ["init", "-q", "-b", "main"]);
+		await writeFile(join(mainRepo, "README.md"), "# main\n", "utf-8");
+		runGit(mainRepo, ["add", "README.md"]);
+		runGit(mainRepo, ["commit", "-q", "-m", "initial"]);
+
+		await mkdir(join(mainRepo, ".rp1"), { recursive: true });
+		await writeFile(join(mainRepo, ".rp1", "project_id"), "main-project-id");
+
+		const worktreePath = join(tempDir, "worktrees", "feature-x");
+		runGit(mainRepo, [
+			"worktree",
+			"add",
+			"-b",
+			"feature-x",
+			worktreePath,
+			"main",
+		]);
+
+		try {
+			const result = detectAncestorProject(worktreePath);
+			expect(result.isAncestor).toBe(false);
+			expect(result.ancestorRoot).toBeUndefined();
+		} finally {
+			// Best-effort cleanup of the linked worktree before the temp dir rm
+			try {
+				runGit(mainRepo, ["worktree", "remove", "--force", worktreePath]);
+			} catch {
+				// ignore
+			}
+		}
+	});
+
+	test("defaultInitDirectoryModel always targets cwd even inside a nested project", async () => {
+		const nestedDir = join(tempDir, "packages", "app");
+		await mkdir(join(tempDir, ".rp1"), { recursive: true });
+		await writeFile(join(tempDir, ".rp1", "project_id"), "project-123");
+		await mkdir(nestedDir, { recursive: true });
+
+		const directories = defaultInitDirectoryModel(nestedDir);
+
+		expect(directories.projectRoot).toBe(nestedDir);
+		expect(directories.rp1Dir).toBe(join(nestedDir, ".rp1"));
+	});
+
+	test("detectReinitState honors a forced-local directory model", async () => {
+		const nestedDir = join(tempDir, "packages", "app");
+		// Parent has an rp1 project, but the nested dir is empty.
+		await mkdir(join(tempDir, ".rp1"), { recursive: true });
+		await writeFile(join(tempDir, ".rp1", "project_id"), "project-123");
+		await mkdir(nestedDir, { recursive: true });
+
+		// Without override: climbs to parent and reports existing rp1 dir.
+		const climbed = await detectReinitState(nestedDir, null);
+		expect(climbed.hasRp1Dir).toBe(true);
+
+		// With forced-local override: must only look at the nested dir.
+		const local = await detectReinitState(
+			nestedDir,
+			null,
+			defaultInitDirectoryModel(nestedDir),
+		);
+		expect(local.hasRp1Dir).toBe(false);
+		expect(local.hasKBContent).toBe(false);
+		expect(local.hasWorkContent).toBe(false);
 	});
 
 	test("detects work content from .rp1/work directory", async () => {

--- a/cli/src/__tests__/init/ui/components/FinalSummary.test.tsx
+++ b/cli/src/__tests__/init/ui/components/FinalSummary.test.tsx
@@ -91,6 +91,7 @@ function createTestWizardState(
 		phase: "complete",
 		error: null,
 		pluginInstallError: null,
+		cancellationReason: null,
 		...overrides,
 	};
 }

--- a/cli/src/__tests__/init/ui/hooks/useWizardState.test.ts
+++ b/cli/src/__tests__/init/ui/hooks/useWizardState.test.ts
@@ -39,6 +39,7 @@ function createTestState(overrides: Partial<WizardState> = {}): WizardState {
 		phase: "running",
 		error: null,
 		pluginInstallError: null,
+		cancellationReason: null,
 		...overrides,
 	};
 }

--- a/cli/src/commands/init.ts
+++ b/cli/src/commands/init.ts
@@ -40,6 +40,10 @@ export const initCommand = new Command("init")
 		"-i, --interactive",
 		"Force interactive mode even without TTY (overrides --yes)",
 	)
+	.option(
+		"--force-nested",
+		"Create a nested project even when a parent directory has an rp1 project",
+	)
 	.addHelpText(
 		"after",
 		`
@@ -54,10 +58,16 @@ Non-interactive mode (--yes) behaviors:
   - Refreshes rp1 configuration idempotently (fenced content, directories, settings)
   - Silent operation except for errors and final summary
 
+Ancestor project detection:
+  When run in a subdirectory of an existing rp1 project, prompts whether to
+  use the existing project or create a nested one. In non-interactive mode,
+  defaults to using the existing project. Use --force-nested to override.
+
 Examples:
   rp1 init                    Interactive setup with prompts
   rp1 init --yes              Non-interactive with defaults (CI/automation)
   rp1 init --interactive      Force prompts even without TTY
+  rp1 init --force-nested     Create nested project under an existing one
 
 Exit codes:
   0    Success (including with warnings)
@@ -82,6 +92,7 @@ Exit codes:
 					{
 						yes: options.yes,
 						interactive: options.interactive,
+						forceNested: options.forceNested,
 					},
 					registry,
 				);
@@ -95,6 +106,7 @@ Exit codes:
 				{
 					yes: options.yes,
 					interactive: options.interactive,
+					forceNested: options.forceNested,
 				},
 				logger,
 			)();

--- a/cli/src/init/directory-model.ts
+++ b/cli/src/init/directory-model.ts
@@ -13,7 +13,7 @@ export interface InitDirectoryModel {
 	readonly workDir: string;
 }
 
-const defaultInitDirectoryModel = (cwd: string): InitDirectoryModel => {
+export const defaultInitDirectoryModel = (cwd: string): InitDirectoryModel => {
 	const projectRoot = path.resolve(cwd);
 	const rp1Dir = path.resolve(projectRoot, ".rp1");
 	return {
@@ -23,6 +23,13 @@ const defaultInitDirectoryModel = (cwd: string): InitDirectoryModel => {
 		workDir: path.join(rp1Dir, "work"),
 	};
 };
+
+export interface AncestorProjectInfo {
+	/** Whether the resolved project root is an ancestor directory (not cwd itself) */
+	readonly isAncestor: boolean;
+	/** The ancestor project root path (only meaningful when isAncestor is true) */
+	readonly ancestorRoot: string | undefined;
+}
 
 export const resolveInitDirectoryModel = (cwd: string): InitDirectoryModel => {
 	const result = resolveDirectorySet(cwd);
@@ -36,6 +43,36 @@ export const resolveInitDirectoryModel = (cwd: string): InitDirectoryModel => {
 		contextDir: path.resolve(result.right.kbRoot),
 		workDir: path.resolve(result.right.workRoot),
 	};
+};
+
+/**
+ * Detect whether an ancestor directory (not cwd itself) has an rp1 project with a project_id.
+ * Used by init to prompt when running in a subdirectory of an existing project.
+ *
+ * Only flags as ancestor when the resolved project root has a project_id file.
+ * A stale .rp1/ directory without project_id does not trigger the ancestor prompt.
+ */
+export const detectAncestorProject = (cwd: string): AncestorProjectInfo => {
+	const resolvedCwd = path.resolve(cwd);
+	const result = resolveDirectorySet(cwd);
+
+	if (E.isLeft(result)) {
+		return { isAncestor: false, ancestorRoot: undefined };
+	}
+
+	const resolvedProjectRoot = path.resolve(result.right.projectRoot);
+
+	// Only flag as ancestor if:
+	// 1. The resolved root is genuinely a parent, not cwd itself
+	// 2. The ancestor has a project_id (not just a stale .rp1/ dir)
+	if (
+		resolvedProjectRoot !== resolvedCwd &&
+		result.right.projectId !== undefined
+	) {
+		return { isAncestor: true, ancestorRoot: resolvedProjectRoot };
+	}
+
+	return { isAncestor: false, ancestorRoot: undefined };
 };
 
 async function fileExists(filePath: string): Promise<boolean> {

--- a/cli/src/init/directory-model.ts
+++ b/cli/src/init/directory-model.ts
@@ -49,8 +49,10 @@ export const resolveInitDirectoryModel = (cwd: string): InitDirectoryModel => {
  * Detect whether an ancestor directory (not cwd itself) has an rp1 project with a project_id.
  * Used by init to prompt when running in a subdirectory of an existing project.
  *
- * Only flags as ancestor when the resolved project root has a project_id file.
- * A stale .rp1/ directory without project_id does not trigger the ancestor prompt.
+ * Only flags as ancestor when:
+ * - The resolved project root is a true ancestor directory of cwd (not a sibling).
+ * - The ancestor has a project_id file (stale .rp1/ dirs alone do not count).
+ * - cwd is not inside a linked git worktree whose main repo resolves to a sibling path.
  */
 export const detectAncestorProject = (cwd: string): AncestorProjectInfo => {
 	const resolvedCwd = path.resolve(cwd);
@@ -60,20 +62,43 @@ export const detectAncestorProject = (cwd: string): AncestorProjectInfo => {
 		return { isAncestor: false, ancestorRoot: undefined };
 	}
 
-	const resolvedProjectRoot = path.resolve(result.right.projectRoot);
-
-	// Only flag as ancestor if:
-	// 1. The resolved root is genuinely a parent, not cwd itself
-	// 2. The ancestor has a project_id (not just a stale .rp1/ dir)
-	if (
-		resolvedProjectRoot !== resolvedCwd &&
-		result.right.projectId !== undefined
-	) {
-		return { isAncestor: true, ancestorRoot: resolvedProjectRoot };
+	// Linked git worktrees resolve to the main repo root, which can be a sibling
+	// path rather than an ancestor. Skip the prompt in that case.
+	if (result.right.isWorktree) {
+		return { isAncestor: false, ancestorRoot: undefined };
 	}
 
-	return { isAncestor: false, ancestorRoot: undefined };
+	const resolvedProjectRoot = path.resolve(result.right.projectRoot);
+
+	if (result.right.projectId === undefined) {
+		return { isAncestor: false, ancestorRoot: undefined };
+	}
+
+	// Require a true parent-of relationship: cwd must live inside projectRoot,
+	// not just be path-inequal to it.
+	const rootWithSep = resolvedProjectRoot.endsWith(path.sep)
+		? resolvedProjectRoot
+		: resolvedProjectRoot + path.sep;
+	if (!resolvedCwd.startsWith(rootWithSep)) {
+		return { isAncestor: false, ancestorRoot: undefined };
+	}
+
+	return { isAncestor: true, ancestorRoot: resolvedProjectRoot };
 };
+
+/**
+ * Return the InitDirectoryModel to use for a given init invocation.
+ * When forceLocalProject is true, always treat cwd as the project root
+ * (used after the user opts into a nested init). Otherwise use the
+ * ancestor-climbing resolver as before.
+ */
+export const chooseInitDirectoryModel = (
+	cwd: string,
+	forceLocalProject: boolean,
+): InitDirectoryModel =>
+	forceLocalProject
+		? defaultInitDirectoryModel(cwd)
+		: resolveInitDirectoryModel(cwd);
 
 async function fileExists(filePath: string): Promise<boolean> {
 	try {
@@ -124,8 +149,9 @@ async function hasAnyFiles(dirPath: string): Promise<boolean> {
 export async function detectReinitState(
 	cwd: string,
 	detectedTool: DetectedTool | null,
+	directoriesOverride?: InitDirectoryModel,
 ): Promise<ReinitState> {
-	const directories = resolveInitDirectoryModel(cwd);
+	const directories = directoriesOverride ?? resolveInitDirectoryModel(cwd);
 	const hasRp1Dir = await directoryExists(directories.rp1Dir);
 
 	let hasFenced = false;

--- a/cli/src/init/index.ts
+++ b/cli/src/init/index.ts
@@ -23,10 +23,10 @@ import {
 	detectProjectContext,
 } from "./context-detector.js";
 import {
-	defaultInitDirectoryModel,
+	chooseInitDirectoryModel,
 	detectAncestorProject,
 	detectReinitState as detectSharedReinitState,
-	resolveInitDirectoryModel,
+	type InitDirectoryModel,
 } from "./directory-model.js";
 import { detectGitRoot, type GitRootResult } from "./git-root.js";
 import type {
@@ -262,12 +262,17 @@ async function handleAncestorProjectCheck(
 export async function detectReinitState(
 	cwd: string,
 	detectedToolInstructionFile: string | null,
+	directories?: InitDirectoryModel,
 ): Promise<ReinitState> {
-	return detectSharedReinitState(cwd, {
-		tool: {
-			instruction_file: detectedToolInstructionFile,
-		},
-	} as DetectedTool | null);
+	return detectSharedReinitState(
+		cwd,
+		{
+			tool: {
+				instruction_file: detectedToolInstructionFile,
+			},
+		} as DetectedTool | null,
+		directories,
+	);
 }
 
 /**
@@ -552,6 +557,11 @@ export function executeInit(
 					cwd = gitCheck.cwd;
 				}
 
+				// Resolve directories once, respecting forceLocalProject, and pass
+				// this through to every downstream helper so they don't re-resolve
+				// (and accidentally climb back to an ancestor project).
+				const directories = chooseInitDirectoryModel(cwd, forceLocalProject);
+
 				const contextResultEither = await detectProjectContext(cwd)();
 				const contextResult: ContextDetectionResult = E.isRight(
 					contextResultEither,
@@ -569,7 +579,7 @@ export function executeInit(
 				);
 
 				progress.startStep("reinit-check");
-				const reinitState = await detectReinitState(cwd, null);
+				const reinitState = await detectReinitState(cwd, null, directories);
 				const reinitCheck = await handleReinitCheck(
 					reinitState,
 					promptOptions,
@@ -600,7 +610,7 @@ export function executeInit(
 
 				const [toolResultEither, readinessResult] = await Promise.all([
 					detectTools(registry)(),
-					checkRp1Readiness(cwd),
+					checkRp1Readiness(cwd, undefined, directories),
 				]);
 
 				const toolDetectionResult = E.isRight(toolResultEither)
@@ -778,16 +788,21 @@ export function executeInit(
 
 				// --- Project setup ---
 				progress.startStep("directory-setup");
-				const directories = forceLocalProject
-					? defaultInitDirectoryModel(cwd)
-					: resolveInitDirectoryModel(cwd);
-				const dirActions = await createDirectoryStructure(cwd, logger);
+				const dirActions = await createDirectoryStructure(
+					cwd,
+					logger,
+					directories,
+				);
 				allActions.push(...dirActions);
 				await ensureProjectId(directories.projectRoot);
 				progress.completeStep();
 
 				progress.startStep("settings-setup");
-				const settingsActions = await createSettingsFiles(cwd, logger);
+				const settingsActions = await createSettingsFiles(
+					cwd,
+					logger,
+					directories,
+				);
 				allActions.push(...settingsActions);
 				progress.completeStep();
 
@@ -831,6 +846,8 @@ export function executeInit(
 						cwd,
 						pluginStatus,
 						readinessResult,
+						undefined,
+						directories,
 					);
 
 					if (healthReport.issues.length === 0) {

--- a/cli/src/init/index.ts
+++ b/cli/src/init/index.ts
@@ -23,6 +23,8 @@ import {
 	detectProjectContext,
 } from "./context-detector.js";
 import {
+	defaultInitDirectoryModel,
+	detectAncestorProject,
 	detectReinitState as detectSharedReinitState,
 	resolveInitDirectoryModel,
 } from "./directory-model.js";
@@ -182,6 +184,75 @@ async function handleGitRootCheck(
 			);
 			return { proceed: false, cwd: gitResult.currentDir };
 	}
+}
+
+type AncestorProjectChoice = "use-existing" | "create-nested";
+
+/**
+ * Handle the case where an ancestor directory already has an rp1 project.
+ * Prompts the user to choose between using the existing project or creating a nested one.
+ *
+ * Non-interactive default: Uses existing project. The user can override with --force-nested.
+ */
+async function handleAncestorProjectCheck(
+	cwd: string,
+	ancestorRoot: string,
+	options: InitOptions,
+	promptOptions: PromptOptions,
+	logger: Logger,
+	progress: InitProgress,
+): Promise<{ proceed: boolean; forceLocal: boolean }> {
+	// --force-nested bypasses the prompt entirely
+	if (options.forceNested) {
+		logger.info(
+			`Ancestor rp1 project found at ${ancestorRoot}. Creating nested project here (--force-nested).`,
+		);
+		return { proceed: true, forceLocal: true };
+	}
+
+	// Non-interactive mode: default to using the existing project
+	if (!promptOptions.isTTY) {
+		logger.info(
+			`Ancestor rp1 project found at ${ancestorRoot}. Using existing project (non-interactive mode).`,
+		);
+		logger.info(
+			"To create a nested project here instead, re-run with --force-nested.",
+		);
+		return { proceed: false, forceLocal: false };
+	}
+
+	// Interactive mode: prompt the user
+	progress.pauseStep();
+
+	const choice = await selectOption<AncestorProjectChoice>(
+		`An rp1 project already exists at ${ancestorRoot}. What would you like to do?`,
+		[
+			{
+				value: "use-existing",
+				name: "Use existing project",
+				description: `Keep using the rp1 project at ${ancestorRoot}`,
+			},
+			{
+				value: "create-nested",
+				name: "Create nested project here",
+				description: `Initialize a new rp1 project in ${cwd}`,
+			},
+		],
+		promptOptions,
+	);
+
+	if (choice === null) {
+		// Prompt cancelled or non-interactive fallback
+		return { proceed: false, forceLocal: false };
+	}
+
+	if (choice === "use-existing") {
+		logger.info(`Using existing rp1 project at ${ancestorRoot}.`);
+		return { proceed: false, forceLocal: false };
+	}
+
+	// create-nested
+	return { proceed: true, forceLocal: true };
 }
 
 /**
@@ -439,9 +510,46 @@ export function executeInit(
 					};
 				}
 
-				const cwd = gitCheck.cwd;
+				let cwd = gitCheck.cwd;
+				let forceLocalProject = false;
 				if (gitCheck.warning) {
 					allWarnings.push(gitCheck.warning);
+				}
+
+				// Check if an ancestor directory has an rp1 project
+				const ancestorInfo = detectAncestorProject(cwd);
+				if (ancestorInfo.isAncestor && ancestorInfo.ancestorRoot) {
+					const ancestorCheck = await handleAncestorProjectCheck(
+						cwd,
+						ancestorInfo.ancestorRoot,
+						options,
+						promptOptions,
+						logger,
+						progress,
+					);
+
+					if (!ancestorCheck.proceed) {
+						return {
+							actions: [
+								{
+									type: "skipped",
+									reason: `Using existing rp1 project at ${ancestorInfo.ancestorRoot}`,
+								},
+							],
+							detectedTool: null,
+							warnings: [],
+							healthReport: null,
+							nextSteps: [],
+						};
+					}
+
+					forceLocalProject = ancestorCheck.forceLocal;
+				}
+
+				// If user chose to create a nested project, override cwd resolution
+				// so the rest of init operates on the local directory
+				if (forceLocalProject) {
+					cwd = gitCheck.cwd;
 				}
 
 				const contextResultEither = await detectProjectContext(cwd)();
@@ -670,7 +778,9 @@ export function executeInit(
 
 				// --- Project setup ---
 				progress.startStep("directory-setup");
-				const directories = resolveInitDirectoryModel(cwd);
+				const directories = forceLocalProject
+					? defaultInitDirectoryModel(cwd)
+					: resolveInitDirectoryModel(cwd);
 				const dirActions = await createDirectoryStructure(cwd, logger);
 				allActions.push(...dirActions);
 				await ensureProjectId(directories.projectRoot);

--- a/cli/src/init/models.ts
+++ b/cli/src/init/models.ts
@@ -179,6 +179,8 @@ export interface InitOptions {
 	readonly yes?: boolean;
 	/** Force interactive mode even without TTY (--interactive flag) */
 	readonly interactive?: boolean;
+	/** Force creating a nested project even when an ancestor project exists */
+	readonly forceNested?: boolean;
 }
 
 /**
@@ -259,6 +261,12 @@ export interface UserChoices {
 	 * - "exit": Cancel and let user navigate to correct project first
 	 */
 	readonly gitRootChoice?: "continue" | "exit";
+	/**
+	 * Choice for handling ancestor project detection.
+	 * - "use-existing": Use the ancestor project, do not init in cwd
+	 * - "create-nested": Create a nested project in cwd
+	 */
+	readonly ancestorProjectChoice?: "use-existing" | "create-nested";
 	/** Choice for re-initialization behavior */
 	readonly reinitChoice?: ReinitChoice;
 	/** Selected gitignore preset */

--- a/cli/src/init/steps/health-check.ts
+++ b/cli/src/init/steps/health-check.ts
@@ -6,7 +6,10 @@
 import { readFile, stat } from "node:fs/promises";
 import { resolve } from "node:path";
 import { hasFencedContent } from "../comment-fence.js";
-import { resolveInitDirectoryModel } from "../directory-model.js";
+import {
+	type InitDirectoryModel,
+	resolveInitDirectoryModel,
+} from "../directory-model.js";
 import type { HealthReport, PluginStatus, StepCallbacks } from "../models.js";
 import { hasShellFencedContent } from "../shell-fence.js";
 import type { ReadinessResult } from "./readiness.js";
@@ -113,8 +116,9 @@ export async function performHealthCheck(
 	plugins: readonly PluginStatus[],
 	readiness?: ReadinessResult,
 	callbacks?: StepCallbacks,
+	directoriesOverride?: InitDirectoryModel,
 ): Promise<HealthReport> {
-	const directories = resolveInitDirectoryModel(cwd);
+	const directories = directoriesOverride ?? resolveInitDirectoryModel(cwd);
 	const rp1Dir = directories.rp1Dir;
 	const issues: string[] = [];
 

--- a/cli/src/init/steps/project-setup.ts
+++ b/cli/src/init/steps/project-setup.ts
@@ -24,7 +24,10 @@ import {
 	validateFencing,
 	wrapWithFence,
 } from "../comment-fence.js";
-import { resolveInitDirectoryModel } from "../directory-model.js";
+import {
+	type InitDirectoryModel,
+	resolveInitDirectoryModel,
+} from "../directory-model.js";
 import { buildManagedGitignoreContent } from "../gitignore.js";
 import type { GitignorePreset, InitAction } from "../models.js";
 import type { InitProgress } from "../progress.js";
@@ -96,9 +99,10 @@ function countLines(content: string): number {
 export async function createDirectoryStructure(
 	cwd: string,
 	logger: Logger,
+	directoriesOverride?: InitDirectoryModel,
 ): Promise<InitAction[]> {
 	const actions: InitAction[] = [];
-	const directories = resolveInitDirectoryModel(cwd);
+	const directories = directoriesOverride ?? resolveInitDirectoryModel(cwd);
 	const { rp1Dir, contextDir, workDir } = directories;
 
 	if (!(await directoryExists(rp1Dir))) {
@@ -137,8 +141,12 @@ function resolveGlobalSettingsPath(): string {
 /**
  * Resolve the local settings file path.
  */
-function resolveLocalSettingsPath(cwd: string): string {
-	return path.join(resolveInitDirectoryModel(cwd).rp1Dir, "settings.toml");
+function resolveLocalSettingsPath(
+	cwd: string,
+	directoriesOverride?: InitDirectoryModel,
+): string {
+	const directories = directoriesOverride ?? resolveInitDirectoryModel(cwd);
+	return path.join(directories.rp1Dir, "settings.toml");
 }
 
 /**
@@ -173,6 +181,7 @@ async function createOrUpdateSettingsFile(
 export async function createSettingsFiles(
 	cwd: string,
 	logger: Logger,
+	directoriesOverride?: InitDirectoryModel,
 ): Promise<InitAction[]> {
 	const actions: InitAction[] = [];
 
@@ -196,7 +205,7 @@ export async function createSettingsFiles(
 	}
 
 	// Process local settings file
-	const localPath = resolveLocalSettingsPath(cwd);
+	const localPath = resolveLocalSettingsPath(cwd, directoriesOverride);
 	const localResult = await createOrUpdateSettingsFile(localPath);
 	actions.push(localResult.action);
 

--- a/cli/src/init/steps/readiness.ts
+++ b/cli/src/init/steps/readiness.ts
@@ -5,7 +5,10 @@
 
 import { stat } from "node:fs/promises";
 import { join } from "node:path";
-import { resolveInitDirectoryModel } from "../directory-model.js";
+import {
+	type InitDirectoryModel,
+	resolveInitDirectoryModel,
+} from "../directory-model.js";
 import type { StepCallbacks } from "../models.js";
 
 /**
@@ -63,10 +66,11 @@ async function isDirectory(dirPath: string): Promise<boolean> {
 export async function checkRp1Readiness(
 	cwd: string,
 	callbacks?: StepCallbacks,
+	directoriesOverride?: InitDirectoryModel,
 ): Promise<ReadinessResult> {
 	callbacks?.onActivity("Checking existing rp1 configuration", "info");
 
-	const directories = resolveInitDirectoryModel(cwd);
+	const directories = directoriesOverride ?? resolveInitDirectoryModel(cwd);
 	const rp1Dir = directories.rp1Dir;
 	const contextDir = directories.contextDir;
 	const kbFile = join(contextDir, "index.md");

--- a/cli/src/init/ui/InitWizard.tsx
+++ b/cli/src/init/ui/InitWizard.tsx
@@ -313,14 +313,25 @@ export const InitWizard: React.FC<InitWizardProps> = ({
 		if (state.phase === "complete") {
 			completedRef.current = true;
 
-			// Build the InitResult from wizard state
-			const result: InitResult = {
-				actions: [],
-				detectedTool: state.detectedTools[0] ?? null,
-				warnings: [],
-				healthReport: state.healthReport,
-				nextSteps: [],
-			};
+			// Build the InitResult from wizard state. If the wizard was
+			// cancelled gracefully (e.g. user reused an ancestor project),
+			// report a single `skipped` action instead of a blank result so
+			// the outer CLI can log why nothing was installed.
+			const result: InitResult = state.cancellationReason
+				? {
+						actions: [{ type: "skipped", reason: state.cancellationReason }],
+						detectedTool: null,
+						warnings: [],
+						healthReport: null,
+						nextSteps: [],
+					}
+				: {
+						actions: [],
+						detectedTool: state.detectedTools[0] ?? null,
+						warnings: [],
+						healthReport: state.healthReport,
+						nextSteps: [],
+					};
 
 			onComplete(result);
 
@@ -342,13 +353,36 @@ export const InitWizard: React.FC<InitWizardProps> = ({
 		state.error,
 		state.detectedTools,
 		state.healthReport,
+		state.cancellationReason,
 		onComplete,
 		onError,
 		exit,
 	]);
 
-	// Render completion state using FinalSummary component
+	// Render completion state. A cancelled wizard (e.g. the user chose to
+	// reuse an ancestor project) renders a short notice instead of the
+	// normal FinalSummary, since no install actions took place.
 	if (state.phase === "complete") {
+		if (state.cancellationReason) {
+			return (
+				<Box flexDirection="column" paddingY={spacing.small}>
+					<WizardHeader
+						currentStep={state.currentStepIndex + 1}
+						totalSteps={state.steps.length}
+					/>
+					<StepList steps={state.steps} currentIndex={state.currentStepIndex} />
+					<Box
+						borderStyle="round"
+						borderColor={colors.info}
+						paddingX={spacing.medium}
+						paddingY={spacing.small}
+						marginTop={spacing.small}
+					>
+						<Text color={colors.info}>{state.cancellationReason}</Text>
+					</Box>
+				</Box>
+			);
+		}
 		return <FinalSummary state={state} />;
 	}
 

--- a/cli/src/init/ui/InitWizard.tsx
+++ b/cli/src/init/ui/InitWizard.tsx
@@ -18,6 +18,7 @@ import type {
 } from "../models.js";
 import { FinalSummary } from "./components/FinalSummary.js";
 import {
+	ancestorProjectOptions,
 	gitignorePresetOptions,
 	gitRootOptions,
 	reinitOptions,
@@ -46,7 +47,12 @@ export interface InitWizardProps {
 /**
  * Type of prompt currently being displayed.
  */
-type PromptType = "git-root" | "reinit" | "gitignore" | null;
+type PromptType =
+	| "git-root"
+	| "reinit"
+	| "gitignore"
+	| "ancestor-project"
+	| null;
 
 /**
  * Steps that may require user prompts.
@@ -102,10 +108,19 @@ export const InitWizard: React.FC<InitWizardProps> = ({
 	 * Handle prompt requests from step execution.
 	 * This allows steps to trigger prompts dynamically based on their results.
 	 */
+	const [promptAncestorRoot, setPromptAncestorRoot] = useState<
+		string | undefined
+	>(undefined);
+
 	const handlePromptRequest = useCallback(
-		(request: { type: "git-root" | "reinit" | "gitignore"; cwd?: string }) => {
+		(request: {
+			type: "git-root" | "reinit" | "gitignore" | "ancestor-project";
+			cwd?: string;
+			ancestorRoot?: string;
+		}) => {
 			setActivePrompt(request.type);
 			setPromptCwd(request.cwd);
+			setPromptAncestorRoot(request.ancestorRoot);
 			dispatch({ type: "SET_PHASE", phase: "prompting" });
 		},
 		[dispatch],
@@ -167,6 +182,9 @@ export const InitWizard: React.FC<InitWizardProps> = ({
 			switch (activePrompt) {
 				case "git-root":
 					key = "gitRootChoice";
+					break;
+				case "ancestor-project":
+					key = "ancestorProjectChoice";
 					break;
 				case "reinit":
 					key = "reinitChoice";
@@ -376,6 +394,29 @@ export const InitWizard: React.FC<InitWizardProps> = ({
 							message={`Initialize rp1 in ${promptCwd ?? process.cwd()}?`}
 							options={gitRootOptions}
 							onSelect={handleChoice as (value: "continue" | "exit") => void}
+						/>
+					</Box>
+				);
+			case "ancestor-project":
+				return (
+					<Box flexDirection="column">
+						<Box marginBottom={spacing.small}>
+							<Text color={colors.dim}>
+								An rp1 project already exists at{" "}
+								{promptAncestorRoot ?? "an ancestor directory"}.
+							</Text>
+						</Box>
+						<SelectPrompt
+							message="What would you like to do?"
+							options={ancestorProjectOptions(
+								promptAncestorRoot ?? "ancestor",
+								promptCwd ?? process.cwd(),
+							)}
+							onSelect={
+								handleChoice as (
+									value: "use-existing" | "create-nested",
+								) => void
+							}
 						/>
 					</Box>
 				);

--- a/cli/src/init/ui/components/SelectPrompt.tsx
+++ b/cli/src/init/ui/components/SelectPrompt.tsx
@@ -124,6 +124,26 @@ export const gitRootOptions: readonly SelectOption<"continue" | "exit">[] = [
 ];
 
 /**
+ * Options for ancestor project detection.
+ * Used when an ancestor directory already has an rp1 project.
+ */
+export const ancestorProjectOptions = (
+	ancestorRoot: string,
+	cwd: string,
+): readonly SelectOption<"use-existing" | "create-nested">[] => [
+	{
+		value: "use-existing",
+		label: "Use existing project",
+		description: `Keep using the rp1 project at ${ancestorRoot}`,
+	},
+	{
+		value: "create-nested",
+		label: "Create nested project here",
+		description: `Initialize a new rp1 project in ${cwd}`,
+	},
+];
+
+/**
  * Options for re-initialization behavior.
  * Used when rp1 is already configured in the project.
  */

--- a/cli/src/init/ui/hooks/useStepExecution.ts
+++ b/cli/src/init/ui/hooks/useStepExecution.ts
@@ -35,6 +35,8 @@ import {
 	type ProjectContext,
 } from "../../context-detector.js";
 import {
+	defaultInitDirectoryModel,
+	detectAncestorProject,
 	detectReinitState,
 	resolveInitDirectoryModel,
 } from "../../directory-model.js";
@@ -133,8 +135,10 @@ interface ExecutionContext {
 	readinessResult: ReadinessResult | null;
 	pluginStatus: readonly PluginStatus[];
 	healthReport: HealthReport | null;
+	forceLocalProject: boolean;
 	userChoices: {
 		gitRootChoice?: "continue" | "exit";
+		ancestorProjectChoice?: "use-existing" | "create-nested";
 		reinitChoice?: ReinitChoice;
 		gitignorePreset?: GitignorePreset;
 	};
@@ -145,10 +149,12 @@ interface ExecutionContext {
  * When a step needs user input, it sets this in the context.
  */
 export interface PromptRequest {
-	readonly type: "git-root" | "reinit" | "gitignore";
+	readonly type: "git-root" | "reinit" | "gitignore" | "ancestor-project";
 	readonly resolve: (value: string) => void;
-	/** Current working directory (for git-root prompt) */
+	/** Current working directory (for git-root and ancestor-project prompts) */
 	readonly cwd?: string;
+	/** Ancestor project root (for ancestor-project prompt) */
+	readonly ancestorRoot?: string;
 }
 
 /**
@@ -221,6 +227,7 @@ export const useStepExecution = ({
 		readinessResult: null,
 		pluginStatus: [],
 		healthReport: null,
+		forceLocalProject: false,
 		userChoices: {},
 	});
 
@@ -321,8 +328,64 @@ export const useStepExecution = ({
 				// Default (continue): user confirmed this is the right directory
 				addAct("git-check", "Project root confirmed", "success");
 			}
+
+			// Check if an ancestor directory has an rp1 project
+			const ancestorInfo = detectAncestorProject(ctx.cwd);
+			if (ancestorInfo.isAncestor && ancestorInfo.ancestorRoot) {
+				// --force-nested bypasses the prompt entirely
+				if (options.forceNested) {
+					addAct(
+						"git-check",
+						`Ancestor project at ${ancestorInfo.ancestorRoot} (creating nested project via --force-nested)`,
+						"info",
+					);
+					ctx.forceLocalProject = true;
+				} else {
+					const ancestorChoice = state.userChoices.ancestorProjectChoice;
+
+					if (ancestorChoice === undefined && !options.yes && onPromptRequest) {
+						promptRequestedRef.current = true;
+						onPromptRequest({
+							type: "ancestor-project",
+							resolve: () => {},
+							cwd: ctx.cwd,
+							ancestorRoot: ancestorInfo.ancestorRoot,
+						});
+						return;
+					}
+
+					if (ancestorChoice === undefined && options.yes) {
+						// Non-interactive default: use existing project
+						throw new Error(
+							`An rp1 project already exists at ${ancestorInfo.ancestorRoot}. ` +
+								"Using existing project (non-interactive mode). " +
+								"To create a nested project here instead, re-run with --force-nested.",
+						);
+					}
+
+					if (ancestorChoice === "use-existing") {
+						throw new Error(
+							`Using existing rp1 project at ${ancestorInfo.ancestorRoot}.`,
+						);
+					}
+
+					// create-nested
+					addAct(
+						"git-check",
+						`Creating nested project (ancestor at ${ancestorInfo.ancestorRoot})`,
+						"info",
+					);
+					ctx.forceLocalProject = true;
+				}
+			}
 		},
-		[state.userChoices.gitRootChoice, options.yes, onPromptRequest],
+		[
+			state.userChoices.gitRootChoice,
+			state.userChoices.ancestorProjectChoice,
+			options.yes,
+			options.forceNested,
+			onPromptRequest,
+		],
 	);
 
 	/**
@@ -408,7 +471,9 @@ export const useStepExecution = ({
 	const executeDirectorySetup = useCallback(
 		async (addAct: AddActivityFn): Promise<void> => {
 			const ctx = contextRef.current;
-			const directories = resolveInitDirectoryModel(ctx.cwd);
+			const directories = ctx.forceLocalProject
+				? defaultInitDirectoryModel(ctx.cwd)
+				: resolveInitDirectoryModel(ctx.cwd);
 
 			let created = 0;
 

--- a/cli/src/init/ui/hooks/useStepExecution.ts
+++ b/cli/src/init/ui/hooks/useStepExecution.ts
@@ -35,9 +35,10 @@ import {
 	type ProjectContext,
 } from "../../context-detector.js";
 import {
-	defaultInitDirectoryModel,
+	chooseInitDirectoryModel,
 	detectAncestorProject,
 	detectReinitState,
+	type InitDirectoryModel,
 	resolveInitDirectoryModel,
 } from "../../directory-model.js";
 import { detectGitRoot, type GitRootResult } from "../../git-root.js";
@@ -102,8 +103,12 @@ function resolveGlobalSettingsPath(): string {
 /**
  * Resolve the local settings file path.
  */
-function resolveLocalSettingsPath(cwd: string): string {
-	return path.join(resolveInitDirectoryModel(cwd).rp1Dir, "settings.toml");
+function resolveLocalSettingsPath(
+	cwd: string,
+	directoriesOverride?: InitDirectoryModel,
+): string {
+	const directories = directoriesOverride ?? resolveInitDirectoryModel(cwd);
+	return path.join(directories.rp1Dir, "settings.toml");
 }
 
 /**
@@ -136,6 +141,12 @@ interface ExecutionContext {
 	pluginStatus: readonly PluginStatus[];
 	healthReport: HealthReport | null;
 	forceLocalProject: boolean;
+	/**
+	 * Resolved directory model for this init run. Populated at the end of the
+	 * git-check step after any ancestor-project decision is made, so all
+	 * downstream helpers operate on the same project root.
+	 */
+	directories: InitDirectoryModel | null;
 	userChoices: {
 		gitRootChoice?: "continue" | "exit";
 		ancestorProjectChoice?: "use-existing" | "create-nested";
@@ -228,6 +239,7 @@ export const useStepExecution = ({
 		pluginStatus: [],
 		healthReport: null,
 		forceLocalProject: false,
+		directories: null,
 		userChoices: {},
 	});
 
@@ -355,18 +367,28 @@ export const useStepExecution = ({
 					}
 
 					if (ancestorChoice === undefined && options.yes) {
-						// Non-interactive default: use existing project
-						throw new Error(
-							`An rp1 project already exists at ${ancestorInfo.ancestorRoot}. ` +
+						// Non-interactive default: use existing project. This is a
+						// valid outcome, not a failure -- exit the wizard cleanly.
+						promptRequestedRef.current = true;
+						dispatch({
+							type: "CANCEL_WIZARD",
+							reason:
+								`An rp1 project already exists at ${ancestorInfo.ancestorRoot}. ` +
 								"Using existing project (non-interactive mode). " +
 								"To create a nested project here instead, re-run with --force-nested.",
-						);
+						});
+						return;
 					}
 
 					if (ancestorChoice === "use-existing") {
-						throw new Error(
-							`Using existing rp1 project at ${ancestorInfo.ancestorRoot}.`,
-						);
+						// User picked the valid "reuse ancestor" option -- this is a
+						// successful early exit, not an error.
+						promptRequestedRef.current = true;
+						dispatch({
+							type: "CANCEL_WIZARD",
+							reason: `Using existing rp1 project at ${ancestorInfo.ancestorRoot}.`,
+						});
+						return;
 					}
 
 					// create-nested
@@ -378,8 +400,17 @@ export const useStepExecution = ({
 					ctx.forceLocalProject = true;
 				}
 			}
+
+			// Finalize the directory model for the rest of the wizard. All
+			// downstream steps must use this instead of re-resolving from cwd,
+			// which would climb back to an ancestor project.
+			ctx.directories = chooseInitDirectoryModel(
+				ctx.cwd,
+				ctx.forceLocalProject,
+			);
 		},
 		[
+			dispatch,
 			state.userChoices.gitRootChoice,
 			state.userChoices.ancestorProjectChoice,
 			options.yes,
@@ -410,7 +441,11 @@ export const useStepExecution = ({
 				context: ctx.projectContext,
 			});
 
-			const reinitState = await detectReinitState(ctx.cwd, ctx.primaryTool);
+			const reinitState = await detectReinitState(
+				ctx.cwd,
+				ctx.primaryTool,
+				ctx.directories ?? undefined,
+			);
 			ctx.reinitState = reinitState;
 
 			if (!reinitState.hasRp1Dir && !reinitState.hasFencedContent) {
@@ -471,9 +506,10 @@ export const useStepExecution = ({
 	const executeDirectorySetup = useCallback(
 		async (addAct: AddActivityFn): Promise<void> => {
 			const ctx = contextRef.current;
-			const directories = ctx.forceLocalProject
-				? defaultInitDirectoryModel(ctx.cwd)
-				: resolveInitDirectoryModel(ctx.cwd);
+			const directories =
+				ctx.directories ??
+				chooseInitDirectoryModel(ctx.cwd, ctx.forceLocalProject);
+			ctx.directories = directories;
 
 			let created = 0;
 
@@ -541,7 +577,10 @@ export const useStepExecution = ({
 			}
 
 			// Create or merge local settings file
-			const localPath = resolveLocalSettingsPath(ctx.cwd);
+			const localPath = resolveLocalSettingsPath(
+				ctx.cwd,
+				ctx.directories ?? undefined,
+			);
 			if (!(await fileExists(localPath))) {
 				await writeFileContent(localPath, DEFAULT_SETTINGS_TEMPLATE);
 				addAct("settings-setup", "Created local settings file", "success");
@@ -572,7 +611,7 @@ export const useStepExecution = ({
 			// Run tool detection and readiness check in parallel
 			const [toolResultEither, readinessResult] = await Promise.all([
 				detectTools(ctx.registry)(),
-				checkRp1Readiness(ctx.cwd),
+				checkRp1Readiness(ctx.cwd, undefined, ctx.directories ?? undefined),
 			]);
 
 			const toolResult = E.isRight(toolResultEither)
@@ -948,6 +987,8 @@ export const useStepExecution = ({
 				ctx.cwd,
 				ctx.pluginStatus,
 				ctx.readinessResult ?? undefined,
+				undefined,
+				ctx.directories ?? undefined,
 			);
 
 			ctx.healthReport = healthReport;

--- a/cli/src/init/ui/hooks/useWizardState.ts
+++ b/cli/src/init/ui/hooks/useWizardState.ts
@@ -46,6 +46,8 @@ export interface WizardState {
 	readonly error: string | null;
 	/** Plugin installation error message (if installation failed) */
 	readonly pluginInstallError: string | null;
+	/** Non-error cancellation reason (e.g. user chose to reuse an ancestor project). */
+	readonly cancellationReason: string | null;
 }
 
 /**
@@ -87,6 +89,10 @@ export type WizardAction =
 	| {
 			readonly type: "SET_PLUGIN_INSTALL_ERROR";
 			readonly error: string;
+	  }
+	| {
+			readonly type: "CANCEL_WIZARD";
+			readonly reason: string;
 	  };
 
 /**
@@ -172,6 +178,7 @@ const createInitialState = (): WizardState => ({
 	phase: "running",
 	error: null,
 	pluginInstallError: null,
+	cancellationReason: null,
 });
 
 /**
@@ -327,6 +334,36 @@ const wizardReducer = (
 			return {
 				...state,
 				pluginInstallError: action.error,
+			};
+		}
+
+		case "CANCEL_WIZARD": {
+			// Graceful early exit (e.g. user chose to reuse an ancestor project).
+			// Mark any still-pending steps as skipped so the UI renders cleanly
+			// and transition straight to the complete phase.
+			const cancelActivity: Activity = {
+				id: `cancel-${Date.now()}`,
+				message: action.reason,
+				type: "info",
+				timestamp: Date.now(),
+			};
+
+			const stepsAfterCancel = state.steps.map((step) => {
+				if (step.status === "pending" || step.status === "running") {
+					return {
+						...step,
+						status: "skipped" as StepStatus,
+						activities: [...step.activities, cancelActivity],
+					};
+				}
+				return step;
+			});
+
+			return {
+				...state,
+				steps: stepsAfterCancel,
+				phase: "complete",
+				cancellationReason: action.reason,
 			};
 		}
 

--- a/cli/src/init/ui/index.tsx
+++ b/cli/src/init/ui/index.tsx
@@ -111,6 +111,7 @@ export const buildStateFromResult = (result: InitResult): WizardState => {
 		phase: "complete",
 		error: null,
 		pluginInstallError: null,
+		cancellationReason: null,
 	};
 };
 


### PR DESCRIPTION
## Summary
- `rp1 init` in a subdirectory of an existing rp1 project silently operated on the ancestor (via `resolveDirectorySet()`'s ancestor-climbing resolver), leaving the subdirectory without its own `project_id` and unregistered.
- Now detects when the resolved project root differs from cwd AND the ancestor has a `project_id` file; prompts the user to **use existing** or **create a nested project here**.
- Non-interactive mode defaults to *use existing* and surfaces the new `--force-nested` flag to opt into nested init.

## Behavior
- Prompt fires based on ancestor `project_id` presence, not local `.rp1/` presence — a stale `.rp1/` dir from older rp1 versions does not suppress the prompt.
- Interactive Ink wizard path and non-UI `executeInit` path both implement the new check.
- `--force-nested` bypasses the prompt and forces `projectRoot = cwd` unconditionally.

## Test plan
- [x] `just check-cli` — lint + typecheck clean
- [x] `bun test src/__tests__/init/` — 389 tests pass (4 new tests for `detectAncestorProject`)
- [x] Manual: run `rp1 init` inside a subdir of an rp1-initialized repo → confirm prompt appears
- [x] Manual: run `rp1 init --force-nested` inside such a subdir → confirm new `.rp1/project_id` is created locally without prompt
- [x] Manual: run `rp1 init` in a non-TTY context inside a subdir → confirm default "use existing" message mentions `--force-nested`

Investigation report: `.rp1/work/issues/project-init/investigation_report.md`