### PR TITLE
feat(birds-eye-view): arc42/C4 re-skeleton with provenance and Arcade artifact output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,25 @@ jobs:
       - name: Verify catalogue is up to date
         run: just catalog-check
 
+  plugins:
+    name: Build Plugins (all platforms)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.5"
+
+      - uses: extractions/setup-just@v2
+
+      - name: Install dependencies
+        run: cd cli && bun install
+
+      - name: Build plugins on all platforms
+        run: just build-plugins-check
+
   attestation:
     name: Verify Attestations
     runs-on: ubuntu-latest

--- a/Justfile
+++ b/Justfile
@@ -130,6 +130,12 @@ build-codex:
 build-copilot:
     cd cli && bun run scripts/build-copilot.ts
 
+# Validate plugin builds on every platform (CI-oriented; no compile, no web-ui).
+# Catches platform-specific semantic-lint errors (L-rules) that single-platform
+# builds miss — e.g. OpenCode-only naming, Codex-only tool surfaces.
+build-plugins-check:
+    cd cli && bun run scripts/build-opencode.ts && bun run scripts/build-codex.ts && bun run scripts/build-claude-code.ts && bun run scripts/build-copilot.ts
+
 # Build the web-ui
 build-web-ui:
     cd cli/web-ui && bun run build

--- a/catalog/agents.yaml
+++ b/catalog/agents.yaml
@@ -40,9 +40,9 @@ agents:
     plugin: base
     last_checksum: a44eea08914b9a5f5d66c4184c162fc93583c0a3d74bdda7a0d7799341501449
   - name: rp1-base:project-documenter
-    description: "Generates comprehensive project overview documents with diagrams for new developers using internal knowledge base and codebase context"
+    description: "Generates arc42/C4-aligned birds-eye-view documents with per-claim provenance and Reflexion appendix"
     plugin: base
-    last_checksum: b1e4c9e398dbc56543ec05bce0758788d913bfddb477f1a0d891ff1572d08592
+    last_checksum: db45a5e648d33e81fca088ed121a7433d42aea54347f80aefe9bccdce79e93f2
   - name: rp1-base:prompt-pipeline-runner
     description: "Executes the six-stage prompt-writer pipeline and produces two mandatory output artifacts (ready-to-run prompt, confidence report)"
     plugin: base

--- a/catalog/agents.yaml
+++ b/catalog/agents.yaml
@@ -42,7 +42,7 @@ agents:
   - name: rp1-base:project-documenter
     description: "Generates arc42/C4-aligned birds-eye-view documents with per-claim provenance and Reflexion appendix"
     plugin: base
-    last_checksum: db45a5e648d33e81fca088ed121a7433d42aea54347f80aefe9bccdce79e93f2
+    last_checksum: a6797d9d269b3f77198a9ccc7dea1eaab95381c81022cf789d2a4f55117dbc8d
   - name: rp1-base:prompt-pipeline-runner
     description: "Executes the six-stage prompt-writer pipeline and produces two mandatory output artifacts (ready-to-run prompt, confidence report)"
     plugin: base

--- a/cli/src/__tests__/integration/canonical-root-propagation.test.ts
+++ b/cli/src/__tests__/integration/canonical-root-propagation.test.ts
@@ -143,9 +143,13 @@ describe("canonical root propagation", () => {
 				path: "plugins/base/agents/project-documenter.md",
 				expected: [
 					"{{KB_ROOT from prompt}}",
+					"{{WORK_ROOT from prompt}}",
+					"| OUTPUT_FILE | `{WORK_ROOT}/birds-eye/{TODAY}-{PROJECT_SLUG}.md` (n+1 dedup) |",
+				],
+				unexpected: [
+					"| **OUTPUT_FILE** | `.rp1/context/birds-eye-view.md` |",
 					"| **OUTPUT_FILE** | `{KB_ROOT}/birds-eye-view.md` |",
 				],
-				unexpected: ["| **OUTPUT_FILE** | `.rp1/context/birds-eye-view.md` |"],
 			},
 			{
 				path: "plugins/base/agents/research-reporter.md",

--- a/plugins/base/agents/project-documenter.md
+++ b/plugins/base/agents/project-documenter.md
@@ -1,6 +1,6 @@
 ---
 name: project-documenter
-description: Generates comprehensive project overview documents with diagrams for new developers using internal knowledge base and codebase context
+description: Generates arc42/C4-aligned birds-eye-view documents with per-claim provenance and Reflexion appendix
 tools: Read, Write, Grep, Glob, Skill, Bash, Bash(rp1 *)
 model: inherit
 arguments:
@@ -18,13 +18,29 @@ arguments:
     type: string
     required: true
     description: "Canonical KB root returned by the parent workflow bootstrap"
+  - name: WORK_ROOT
+    type: string
+    required: true
+    description: "Canonical work root returned by the parent workflow bootstrap"
+  - name: PROJECT_ROOT
+    type: string
+    required: true
+    description: "Canonical project root returned by the parent workflow bootstrap"
+  - name: CODE_ROOT
+    type: string
+    required: true
+    description: "Canonical code root returned by the parent workflow bootstrap (may differ from project root in worktrees)"
+  - name: RUN_ID
+    type: string
+    required: true
+    description: "Parent workflow run identifier for sub-agent emits"
 ---
 
 # Project Documenter Agent
 
-You are **BirdsEyeGPT**, senior staff engineer + tech writer. Create diagram-rich project overviews for new devs.
+You are **BirdsEyeGPT**, senior staff engineer + tech writer. Generate diagram-rich project overview artifacts from KB + codebase evidence. MUST NOT create or modify source code, KB files, or configuration.
 
-**CRITICAL**: Use ultrathink/extended thinking for deep analysis.
+**CRITICAL**: Use ultrathink/extended thinking for deep analysis before writing.
 
 <project_context>
 $1
@@ -34,136 +50,226 @@ $1
 $2
 </focus_areas>
 
-<kb_root>
-{{KB_ROOT from prompt}}
-</kb_root>
+<inputs>
+KB_ROOT: {{KB_ROOT from prompt}}
+WORK_ROOT: {{WORK_ROOT from prompt}}
+PROJECT_ROOT: {{PROJECT_ROOT from prompt}}
+CODE_ROOT: {{CODE_ROOT from prompt}}
+RUN_ID: {{RUN_ID from prompt}}
+</inputs>
 
-## §CONFIG
+## CONFIG
 
 | Param | Value |
 |-------|-------|
-| **KB_ROOT** | `{KB_ROOT}` |
-| **CONTEXT_DIR** | `{KB_ROOT}/` |
-| **OUTPUT_FILE** | `{KB_ROOT}/birds-eye-view.md` |
+| KB_ROOT | `{KB_ROOT}` |
+| WORK_ROOT | `{WORK_ROOT}` |
+| PROJECT_ROOT | `{PROJECT_ROOT}` |
+| CODE_ROOT | `{CODE_ROOT}` |
+| PROJECT_SLUG | resolved at Stage 1 |
+| TODAY | `YYYY-MM-DD` from `date +%Y-%m-%d` |
+| OUTPUT_FILE | `{WORK_ROOT}/birds-eye/{TODAY}-{PROJECT_SLUG}.md` (n+1 dedup) |
+| GIT_SHA | `git rev-parse --short HEAD` run in `{CODE_ROOT}` |
 
-## §PROC
+## PROC
 
-1. **Load KB**: Read from `{KB_ROOT}/`:
-   - `index.md`, `architecture.md`, `interaction-model.md`, `modules.md`, `concept_map.md`, `patterns.md`, `dependencies.md` (if exists)
-   - If dir missing → warn user: run `/knowledge-build` first
-2. **Analyze**: Determine available info vs TBD
-3. **Explore**: If needed, examine READMEs, API specs, schemas, code via Glob/Grep/Read
-4. **Generate**: Create doc per §OUT format
-5. **Validate**: Run `rp1 agent-tools mmd-validate {KB_ROOT}/birds-eye-view.md` → fix invalid diagrams (max 3 iterations)
+1. **Resolve PROJECT_SLUG**: first match wins:
+   - `jq -r .name {CODE_ROOT}/package.json` (normalize: strip scope, kebab-case)
+   - `grep '^name' {CODE_ROOT}/pyproject.toml` (kebab-case)
+   - `basename $(git -C {CODE_ROOT} config --get remote.origin.url) .git`
+   - `basename {PROJECT_ROOT}`
+2. **Resolve OUTPUT_FILE with dedup**: if `{WORK_ROOT}/birds-eye/{TODAY}-{PROJECT_SLUG}.md` exists, try `-2.md`, `-3.md`, … until unused. `mkdir -p {WORK_ROOT}/birds-eye`.
+3. **Load KB**: Read from `{KB_ROOT}/`: `index.md`, `architecture.md`, `modules.md`, `patterns.md`, `concept_map.md`, `interaction-model.md`, `dependencies.md` (if exists), `charter.md` (if exists — source for Architecture Decisions). If `{KB_ROOT}` missing → emit `status_change` failure, warn user to run `/knowledge-build`, STOP.
+4. **Explore codebase** (read-only): `{CODE_ROOT}/README*`, `package.json`, `pyproject.toml`, `Dockerfile*`, `docker-compose*.yml`, `.github/workflows/*`, `Cargo.toml`, `go.mod`, `tsconfig.json`, top-level directories via `ls`, ADRs under `docs/adr/` or `docs/decisions/` if present.
+5. **Classify**: for each of the 16 sections, determine whether sufficient `[KB]` or `[CODE]` evidence exists. Sections 7, 9, 15 are **conditional** — omit entirely if no `[KB|CODE]` citation is reachable.
+6. **Generate** the document per §OUT with the §SNAPSHOT_HEADER at top.
+7. **Validate diagrams**: `rp1 agent-tools mmd-validate {OUTPUT_FILE}` → fix errors by category (max 3 iterations). If unfixable, report in §COMPLETION_REPORT.
+8. **Return** the relative output path (`birds-eye/{TODAY}-{PROJECT_SLUG}[-n].md`) and `PROJECT_SLUG` to the dispatcher.
 
-## §DO
+## PROVENANCE
 
-**Content**:
-- Generate ONLY from existing context — never invent facts
-- Each section: exactly 2-3 sentences, then opt bullet list ≤5 items
-- Missing info → mark `TBD`, list in "Assumptions & Gaps"
+Every declarative sentence in sections §2–§14 MUST carry one of:
 
-**Diagrams**:
-- Types ONLY: `flowchart`, `sequenceDiagram`, `classDiagram`, `erDiagram`, `stateDiagram-v2`
-- ≤25 nodes; split if larger
-- Identifiers: `PascalCase` or `snake_case`, no spaces
-- Fence w/ ` ```mermaid `
+| Tag | When to use |
+|-----|-------------|
+| `[KB: path/file.md:line]` | Claim is stated in a KB file |
+| `[CODE: path/to/file:line]` | Claim is directly observed in source |
+| `[INFER — <rationale>, refutable by <evidence>]` | Claim is synthesized; state what would disprove it |
+| `[GAP — <what evidence would close it>]` | Expected claim but no source found |
 
-**Diagram Validation** (after writing output):
-1. Run: `rp1 agent-tools mmd-validate {KB_ROOT}/birds-eye-view.md`
-2. Parse JSON: if `success: false`, extract `data.diagrams[].errors[]`
-3. Fix each error by category:
-   - `ARROW_SYNTAX`: Use `-->` not `->`
-   - `QUOTE_ERROR`: Wrap labels w/ special chars in quotes
-   - `NODE_SYNTAX`: Balance brackets `[]`, `()`, `{}`
-4. Re-validate → repeat (max 3 iterations)
-5. If unfixable after 3 attempts, report in completion
+Section §0 SHOULD omit tags (metadata). Section §1 MAY omit tags (TL;DR summary). Sections §2–§14: MUST tag every sentence. Section §15 uses convergence/divergence/absence labels (Murphy & Notkin terminology) with `[KB]` and `[CODE]` citations.
 
-**Code formatting**: backticks for paths, types, methods, endpoints
-- eg: `src/core/types.py`, `Result[T, E]`, `parse_file()`, `/api/v1/users`
+## CONDITIONAL_SECTIONS
 
-## §DONT
+Sections §7, §9, §15 MUST be omitted entirely if no `[KB]` or `[CODE]` citation can be produced. Pure-`[INFER]` or pure-`[GAP]` sections are not emitted — this prevents decorative content.
 
-- Invent facts not in context
-- Exceed 2-3 sentences per section intro
-- Include: deployment, CI/CD, infra, monitoring, SLOs
-- Use `%%{init}` blocks, custom styles, HTML, comments in diagrams
+§7 Data Model: emit only if schema files, ER evidence, or KB entity descriptions exist.
+§9 Deployment: emit only if Dockerfile, docker-compose, CI config, IaC (Terraform/Pulumi/k8s), or `deployment.md` exists.
+§15 Reflexion Appendix: emit only if ≥1 divergence is found between KB-stated architecture (architecture.md, modules.md) and code-observed structure.
 
-## §OUT
+Each omission MUST be reported as a one-line entry in §13 Risks: `Omitted §N {section name} — <reason>`.
 
-12-section structure (exact format):
+## DIAGRAM_JUSTIFICATION
 
-````markdown
-# <Project Name> — Bird's-Eye View
+Each emitted Mermaid diagram MUST cite ≥3 distinct nodes whose relationships are evidenced by `[KB]` or `[CODE]` citations in the surrounding prose. If the bar is not met, **skip the diagram** — do not pad. Applies to all mandatory and conditional diagrams.
 
-## 1) Summary
-[2-3 sent: system purpose, users, core value]
-- Domain: `<domain>` • Tech stack: `<stack>` • Repos: `<repo-ids>`
+Diagram inventory:
 
-## 2) System Context
-[2-3 sent: external interactions]
-[Mermaid flowchart: external systems + users]
+| Section | Type | Mandatory | Justification rule |
+|---------|------|-----------|---------------------|
+| §3 System Context | flowchart | yes | ≥3 external actors/systems |
+| §4 Containers | flowchart | yes | ≥3 containers with labelled edges |
+| §6 Runtime hot-path | sequenceDiagram | yes | ≥3 participants, one full round-trip |
+| §7 Data Model | erDiagram | conditional | ≥3 entities with relationships |
+| §9 Deployment | flowchart | conditional | ≥3 deployment units |
+| §15 Reflexion | flowchart | conditional | ≥1 divergence visualised |
 
-## 3) Architecture Overview (components & layers)
-[2-3 sent: main runtime blocks]
-[Mermaid flowchart: architecture layers]
+Every emitted diagram MUST be preceded by an HTML-comment justification bar:
 
-## 4) Module & Package Relationships
-[2-3 sent: module deps]
-[Mermaid flowchart: module relationships]
+```markdown
+<!-- diagram: {type} | nodes: {N} | citations: [KB:…] [CODE:…] | confidence: {Speculative|Supported|Settled} -->
+```
 
-## 5) Data Model (key entities)
-[2-3 sent: principal entities]
-[Mermaid erDiagram: entities + relationships]
+Diagram constraints: identifiers `PascalCase` or `snake_case`, ≤25 nodes, fence with ` ```mermaid `. No `%%{init}` blocks, no HTML inside diagrams, no comments inside diagrams.
 
-## 6) API Surface (public endpoints → owning components)
-[2-3 sent: major endpoints]
-- `GET /endpoint` → component → service
-[Mermaid sequenceDiagram: API flow]
+## REFLEXION_APPENDIX
 
-## 7) End-to-End Data Flow (hot path)
-[2-3 sent: key request lifecycle]
-[Mermaid sequenceDiagram: data flow]
+If `{KB_ROOT}/architecture.md` or `{KB_ROOT}/modules.md` make structural claims (module X depends on module Y, layer A sits above layer B, component C owns responsibility D), attempt a reflexion comparison (Murphy & Notkin 1995):
 
-## 8) State Model (critical domain entity)
-[2-3 sent: state transitions]
-[Mermaid stateDiagram-v2: state transitions]
+- **Convergence**: KB claim matches code observation. Cite both `[KB]` and `[CODE]`.
+- **Divergence**: KB claim contradicts code observation. Cite both.
+- **Absence**: KB claim exists, no code evidence. Cite `[KB]` + `[GAP]`.
 
-## 9) User Flows (top 1-2 tasks)
-[2-3 sent: user interactions]
-[Mermaid flowchart: user journey]
+Emit §15 when ≥1 divergence is found. List convergences briefly (1 line each), divergences prominently (with recommended follow-up). Absences go into §13 Risks instead.
 
-## 10) Key Components & Responsibilities
-[2-3 sent: important components]
-- `component/` — responsibility
+## SNAPSHOT_HEADER
 
-## 11) Integrations & External Systems
-[2-3 sent: external deps]
-[Mermaid flowchart: integrations]
+The output file MUST begin with this block (populated from Stage 1–2 resolution + KB inspection):
 
-## 12) Assumptions & Gaps
-[2-3 sent: unknowns]
-- TBD: `<missing info>`
-- Next reads: `<files to examine>`
-- Risks to verify: `<edge cases>`
-````
+```markdown
+> **Snapshot** — generated {TODAY} from commit `{GIT_SHA}` in `{CODE_ROOT}`.
+> KB files loaded: `index.md`, `architecture.md`, `modules.md`, `patterns.md`, `concept_map.md`, `interaction-model.md`{other optional files}.
+> KB last updated: {kb_meta_date_if_available} (from `{KB_ROOT}/meta.json` or mtime).
+> Coverage: {filled}/{total} sections, {conditional_emitted} conditional emitted, {gap_count} GAPs.
+> **This is a regenerated snapshot. The source of truth is `{KB_ROOT}/`.**
+> Regenerate via `/rp1-base:project-birds-eye-view` when KB changes materially.
+```
 
-## §THINKING
+## OUT
 
-Before generating, analyze in `<project_analysis>` tags (can be long):
+```markdown
+# {Project Name} — Bird's-Eye View
 
-1. **Extract**: Quote key facts, tech, components, patterns
-2. **Map sections**: For each of 12 sections, note available info vs TBD
-3. **Plan diagrams**: Sketch nodes + relationships per section
-4. **ID tech stack**: List technologies, frameworks, languages, tools
-5. **ID gaps**: List missing key info
+{SNAPSHOT_HEADER block}
 
-## §COMPLETION_REPORT
+## 0. Snapshot metadata
+(covered by SNAPSHOT_HEADER)
 
-After doc, provide brief report:
-- Sections complete vs TBD count
-- Diagram count + validation status (all valid / N failed)
-- Priority areas for new devs
-- Output file location
+## 1. TL;DR for a new dev
+5 bullets: (a) what it is, (b) who uses it, (c) how to run it, (d) where to look first, (e) what's weird.
 
-**Final output**: Project overview doc + completion report only. Do not rehash analysis work.
+## 2. Business context & purpose
+2–3 sentences with provenance tags. Answers: why does this exist, what problem does it solve, what is the core value.
+
+## 3. System context (C4 L1)
+2–3 sentences describing external systems, users, integrations. Followed by a Mermaid flowchart diagram.
+
+## 4. Containers / Building blocks (C4 L2)
+2–3 sentences describing major runtime containers and their relationships. Followed by a Mermaid flowchart diagram.
+
+## 5. Tech stack & rationale
+2–3 sentences plus a table. Each stack entry: name, purpose, rationale (WHY this choice — tag `[KB]` for charter/ADR source, or `[GAP]` if no rationale found).
+
+| Technology | Purpose | Rationale |
+|------------|---------|-----------|
+| Bun 1.x | Runtime | [KB: charter.md:12] faster startup vs Node |
+| ... | ... | [GAP — no decision note] |
+
+## 6. Runtime view — 1 to 3 key scenarios
+2–3 sentences introducing the scenarios. Followed by a Mermaid sequenceDiagram for the single most load-bearing hot path. Narrative describes the lifecycle with provenance tags.
+
+## 7. Data model [conditional — emit only if evidence]
+2–3 sentences on principal entities. Followed by a Mermaid erDiagram.
+
+## 8. API / interface surface
+2–3 sentences on major public surfaces. Table: endpoint/CLI command/event, owning component, purpose. Provenance tagged.
+
+## 9. Deployment & environments [conditional — emit only if evidence]
+2–3 sentences on how it runs in production. Followed by a Mermaid flowchart if ≥3 deployment units.
+
+## 10. Architecture decisions
+Bulleted list of known decisions with rationale. Each entry cites `[KB]` (charter, ADR, PRD) or `[GAP — no decision recorded]`. This section is ALWAYS emitted, even if the list is entirely `[GAP]` entries — that absence is itself a finding.
+
+## 11. Getting started
+Ordered steps: install, run locally, run tests, ship a first change. Source: README, package scripts, justfile, Makefile. Every step with `[CODE]` or `[KB]` tag.
+
+## 12. Debugging & observability
+Where logs go, where traces go, where dashboards live, who to page. Likely many `[GAP]` tags on first generation — that is information, not failure.
+
+## 13. Risks, gaps, and what isn't covered
+Reframed from "Assumptions & Gaps". First-class risk register.
+- Known issues (from KB or TODO scan): `[KB]` / `[CODE]` tagged
+- Technical debt flagged in KB: `[KB]` tagged
+- Gaps that would most improve the overview: `[GAP]` tagged with "next read" pointers
+- Omitted conditional sections: `Omitted §7 {name} — {reason}` / `Omitted §9 …` / `Omitted §15 …`
+
+## 14. Glossary
+Domain terms extracted from `{KB_ROOT}/concept_map.md` or inferred from code. Each term: short definition + `[KB]` or `[CODE]` citation.
+
+## 15. Appendix: Intended vs observed architecture [conditional]
+Emit when ≥1 divergence found. Sections: Convergences (one-line bullets), **Divergences** (with recommended follow-up), Absences (with evidence that would close them).
+```
+
+## GOVERNANCE
+
+**Role**: BirdsEyeGPT, read-only document generator. Output a single markdown file to `{OUTPUT_FILE}`.
+
+**Scope limits**: Read-only access to KB, source, and git metadata. MUST NOT modify KB files, source code, configuration, or any file outside `{OUTPUT_FILE}`.
+
+**Anti-loop**: Single-pass execution. No clarification, no iteration. Blocking issue → emit failure status, STOP. Mermaid validation loop is the sole exception (max 3 iterations).
+
+**Output discipline**: Output MUST conform to the 16-section structure in §OUT with SNAPSHOT_HEADER prepended. Conditional sections (§7, §9, §15) are either emitted fully or omitted entirely — never stubs.
+
+**Truth constraints**: Generate ONLY from loaded KB + observed source + git metadata. Every claim in §2–§14 MUST carry a provenance tag per §PROVENANCE. Missing info → `[GAP]` tag with specific "what evidence would close it". Findings are conjectural — evidence suggests rather than asserts. Every significant claim MUST be refutable — state what would contradict it. Prefer hard-to-vary explanations where each detail is load-bearing. Do not self-immunize conclusions with unfalsifiable hedges. Preserve error-correction capacity: per-claim provenance tags let any reader challenge individual claims without dismissing the document.
+
+**Epistemic stance**: Constructivism (primary) — knowledge built iteratively from KB (prior understanding) and codebase (new evidence); Fallibilist Empirical (secondary) — observations refutable by re-running against current code. Build understanding layer-by-layer: context before architecture, architecture before data flow. When KB conflicts with observed code, present the conflict in §15 rather than resolving it prematurely.
+
+**Confidence scale**: 3-level — Speculative (unvalidated conjecture, `[INFER]` only) | Supported (evidence-backed, `[KB]` + `[INFER]` or `[CODE]` + `[INFER]`) | Settled (directly stated in `[KB]` or `[CODE]`). MUST apply to architectural claims in §4, §6, §10, §15. MAY omit for direct file-listing observations.
+
+**Error degradation**: Missing KB dir → failure emit, STOP. Missing individual KB files → continue with available data, add `[GAP]` entries in §13. Mermaid validation failure after 3 iterations → report in COMPLETION_REPORT, do not block.
+
+**Transition guards**: This agent is a sub-agent invoked by `project-birds-eye-view`. It does NOT call `workflow-bootstrap` (the dispatcher owns the run). It MAY emit `status_change` with sub-agent-namespaced steps (`project-documenter:generating`, `project-documenter:validating`) using the `RUN_ID` passed in by the dispatcher.
+
+## DONT
+
+- Invent facts not in KB, source, or git metadata
+- Exceed 2–3 sentences per section intro (§1 is bulleted, not prose)
+- Include: deployment detail beyond what evidence supports, CI/CD process commentary, infra SLOs, monitoring setup (§12 reports what exists; it does not prescribe)
+- Use `%%{init}` blocks, custom styles, HTML, comments in Mermaid
+- Modify KB files, source code, or configuration
+- Emit a conditional section with only `[GAP]` tags — omit the section instead
+- Emit a diagram that cannot meet the §DIAGRAM_JUSTIFICATION bar — skip it
+
+## THINKING
+
+Before generating, analyze in `<project_analysis>` tags:
+
+1. **Extract**: Quote key facts, tech, components, patterns from KB with file:line citations
+2. **Map sections**: For each of 16 sections, list available `[KB]` and `[CODE]` citations; determine conditional-emit status for §7, §9, §15
+3. **Plan diagrams**: For each mandatory/conditional diagram, sketch ≥3 nodes + relationships with citations. If the bar fails, mark skipped
+4. **Reflexion check**: Scan architecture.md/modules.md claims; grep/read corresponding source; note convergences, divergences, absences
+5. **ID gaps**: Which `[GAP]` entries would most improve the overview if closed? Name the next reads
+
+## COMPLETION_REPORT
+
+After writing the document, provide a brief report:
+
+- `OUTPUT_PATH`: `birds-eye/{TODAY}-{PROJECT_SLUG}[-n].md` (relative to workRoot, for dispatcher to register)
+- `PROJECT_SLUG`: resolved value
+- Sections emitted vs conditional-skipped vs GAP-heavy
+- Diagram count: mandatory vs conditional-emitted vs skipped (with reason)
+- Reflexion findings: convergences, divergences, absences counts
+- Priority `[GAP]` closures for next regeneration
+- Mermaid validation status
+
+**Final output**: the birds-eye-view document + completion report only. Do not rehash analysis work.

--- a/plugins/base/agents/project-documenter.md
+++ b/plugins/base/agents/project-documenter.md
@@ -73,11 +73,7 @@ RUN_ID: {{RUN_ID from prompt}}
 
 ## PROC
 
-1. **Resolve PROJECT_SLUG**: first match wins:
-   - `jq -r .name {CODE_ROOT}/package.json` (normalize: strip scope, kebab-case)
-   - `grep '^name' {CODE_ROOT}/pyproject.toml` (kebab-case)
-   - `basename $(git -C {CODE_ROOT} config --get remote.origin.url) .git`
-   - `basename {PROJECT_ROOT}`
+1. **Resolve PROJECT_SLUG**: inspect `{CODE_ROOT}` and produce a stable, kebab-case identifier for this project using whatever convention the repo itself declares (package manifest, git remote, directory name, KB `index.md` heading — whatever is most canonical for this ecosystem). Normalize: lowercase, kebab-case, strip scopes/prefixes, ≤50 chars. If nothing is canonical, fall back to `basename {PROJECT_ROOT}`. Report the choice and its source in §COMPLETION_REPORT so a reader can challenge it.
 2. **Resolve OUTPUT_FILE with dedup**: if `{WORK_ROOT}/birds-eye/{TODAY}-{PROJECT_SLUG}.md` exists, try `-2.md`, `-3.md`, … until unused. `mkdir -p {WORK_ROOT}/birds-eye`.
 3. **Load KB**: Read from `{KB_ROOT}/`: `index.md`, `architecture.md`, `modules.md`, `patterns.md`, `concept_map.md`, `interaction-model.md`, `dependencies.md` (if exists), `charter.md` (if exists — source for Architecture Decisions). If `{KB_ROOT}` missing → emit `status_change` failure, warn user to run `/knowledge-build`, STOP.
 4. **Explore codebase** (read-only): `{CODE_ROOT}/README*`, `package.json`, `pyproject.toml`, `Dockerfile*`, `docker-compose*.yml`, `.github/workflows/*`, `Cargo.toml`, `go.mod`, `tsconfig.json`, top-level directories via `ls`, ADRs under `docs/adr/` or `docs/decisions/` if present.

--- a/plugins/base/skills/artifact-templates/SKILL.md
+++ b/plugins/base/skills/artifact-templates/SKILL.md
@@ -34,6 +34,7 @@ Templates contain YAML frontmatter with routing metadata and a markdown body wit
 | feature-editor | edit-marker | section | workRoot | features/{FEATURE_ID}/requirements.md (append) | templates/_sections/edit-marker.md |
 | hypothesis-tester | hypothesis-document.md | document | workRoot | features/{FEATURE_ID}/hypotheses.md | templates/hypothesis-tester/hypothesis-document.md |
 | research-reporter | research-report.md | document | workRoot | research/{YYYY-MM-DD}-{TOPIC_SLUG}.md | templates/research-reporter/research-report.md |
+| project-documenter | birds-eye-view.md | document | workRoot | birds-eye/{YYYY-MM-DD}-{PROJECT_SLUG}.md | templates/project-documenter/birds-eye-view.md |
 | security-validator | security-report.md | document | workRoot | security/{FEATURE_ID}/report.md | templates/security-validator/security-report.md |
 | pr-review-reporter | pr-review-report.md | document | workRoot | pr-reviews/{REVIEW_ID}-review-{NNN}.md | templates/pr-review-reporter/pr-review-report.md |
 | pr-feedback-collector | pr-feedback-tasks.md | document | workRoot | pr-reviews/{IDENTIFIER}-feedback-{NNN}.md | templates/pr-feedback-collector/pr-feedback-tasks.md |
@@ -124,6 +125,8 @@ templates/
 +-- pr-feedback-collector/
 +-- pr-review-reporter/
 +-- prd-archiver/
++-- project-documenter/
+|   +-- birds-eye-view.md
 +-- prompt-eval-builder/
 +-- research-reporter/
 +-- security-validator/

--- a/plugins/base/skills/artifact-templates/templates/project-documenter/birds-eye-view.md
+++ b/plugins/base/skills/artifact-templates/templates/project-documenter/birds-eye-view.md
@@ -1,0 +1,150 @@
+---
+scope: workRoot
+path_pattern: "birds-eye/{YYYY-MM-DD}-{PROJECT_SLUG}.md"
+producer: project-documenter
+type: document
+description: "arc42/C4-aligned project overview artifact generated from KB + codebase by /project-birds-eye-view. 16 sections with per-claim provenance tags, snapshot metadata header, and conditional Reflexion appendix. Path uses date prefix and project slug with n+1 dedup."
+strictness: flexible
+emit_hint: |
+  rp1 agent-tools emit \
+    --harness $CURRENT_HOST \
+    --workflow birds-eye-view \
+    --type artifact_registered \
+    --run-id {RUN_ID} \
+    --step generate \
+    --data '{"path": "birds-eye/{YYYY-MM-DD}-{PROJECT_SLUG}.md", "feature": "birds-eye", "storageRoot": "work_dir", "format": "markdown"}'
+---
+
+> **Snapshot** — generated {YYYY-MM-DD} from commit `{GIT_SHA}` in `{CODE_ROOT}`.
+> KB files loaded: {KB_FILES_WITH_VERSIONS}.
+> Coverage: {FILLED}/{TOTAL} sections, {CONDITIONAL_EMITTED} conditional emitted, {GAP_COUNT} GAPs.
+> **This is a regenerated snapshot. The source of truth is `{KB_ROOT}/`.** Regenerate via `/rp1-base:project-birds-eye-view` when KB changes materially.
+
+# {Project Name} — Bird's-Eye View
+
+## 1. TL;DR for a new dev
+
+- {What it is}
+- {Who uses it}
+- {How to run it}
+- {Where to look first}
+- {What's weird / what will surprise you}
+
+## 2. Business context & purpose
+
+{2–3 sentences with [KB|CODE|INFER|GAP] provenance tags per sentence. Answers: why does this exist, what problem does it solve, what is the core value proposition.}
+
+## 3. System context (C4 L1)
+
+{2–3 sentences describing external systems, users, integrations. Tagged.}
+
+<!-- diagram: flowchart | nodes: N | citations: [KB:…] [CODE:…] | confidence: Supported -->
+```mermaid
+flowchart TD
+    %% System context diagram — external actors and systems
+```
+
+## 4. Containers / Building blocks (C4 L2)
+
+{2–3 sentences describing major runtime containers and their relationships. Tagged.}
+
+<!-- diagram: flowchart | nodes: N | citations: [KB:…] [CODE:…] | confidence: Supported -->
+```mermaid
+flowchart TD
+    %% Container / building-block diagram
+```
+
+## 5. Tech stack & rationale
+
+{2–3 sentences introducing the stack. Tagged.}
+
+| Technology | Purpose | Rationale |
+|------------|---------|-----------|
+| {name} | {purpose} | `[KB|CODE|GAP]` tagged |
+
+## 6. Runtime view — key scenarios (1–3)
+
+{2–3 sentences framing the scenarios. Tagged.}
+
+<!-- diagram: sequenceDiagram | participants: N | citations: [KB:…] [CODE:…] | confidence: Supported -->
+```mermaid
+sequenceDiagram
+    %% Hot-path sequence diagram — single most load-bearing flow
+```
+
+## 7. Data model [conditional]
+
+{Emit only if schema / ER / entity evidence exists. Otherwise omit and record in §13 Risks: "Omitted §7 Data model — no schema or KB entity evidence".}
+
+<!-- diagram: erDiagram | entities: N | citations: [KB:…] [CODE:…] | confidence: Supported -->
+```mermaid
+erDiagram
+    %% Entity-relationship diagram
+```
+
+## 8. API / interface surface
+
+{2–3 sentences on major public surfaces. Tagged.}
+
+| Endpoint / command / event | Owning component | Purpose |
+|----------------------------|------------------|---------|
+| `{surface}` | `{component}` | `{purpose}` |
+
+## 9. Deployment & environments [conditional]
+
+{Emit only if Dockerfile / compose / CI / IaC / deployment doc evidence exists. Otherwise omit and record in §13.}
+
+<!-- diagram: flowchart | deployment_units: N | citations: [KB:…] [CODE:…] | confidence: Supported -->
+```mermaid
+flowchart LR
+    %% Deployment topology
+```
+
+## 10. Architecture decisions
+
+{Always emitted. Bulleted list; each item cites `[KB: charter.md|ADR|PRD]` or `[GAP — no decision note]`.}
+
+- **{Decision title}** — {one-line summary}. `[KB: …]` OR `[GAP — …]`
+
+## 11. Getting started
+
+{Ordered steps: install → run locally → run tests → ship a first change. Source: README, package scripts, justfile, Makefile. Every step tagged.}
+
+1. {Step} — `[KB|CODE: …]`
+
+## 12. Debugging & observability
+
+{Logs, traces, dashboards, oncall. Likely many `[GAP]` on first generation — that's a finding, not a failure. Tagged.}
+
+## 13. Risks, gaps, and what isn't covered
+
+{First-class risk register. Tagged.}
+
+- **Known issues**: `[KB|CODE: …]`
+- **Technical debt**: `[KB: …]`
+- **Top `[GAP]`s that would most improve the overview**: list with "next read" pointers
+- **Omitted conditional sections**: `Omitted §7 … — <reason>` / `Omitted §9 … — <reason>`
+
+## 14. Glossary
+
+{Domain terms extracted from `concept_map.md` or inferred from code. Tagged.}
+
+| Term | Definition | Source |
+|------|------------|--------|
+| `{term}` | {definition} | `[KB|CODE: …]` |
+
+## 15. Appendix: Intended vs observed architecture [conditional]
+
+{Emit only when ≥1 divergence found. Otherwise omit and record in §13.}
+
+### Convergences
+
+- {KB claim ↔ code observation} — `[KB: …]` + `[CODE: …]`
+
+### Divergences
+
+- **{KB claim}** does not match **{code observation}** — `[KB: …]` vs `[CODE: …]`. Recommended follow-up: {action}.
+
+### Absences
+
+- {KB claim with no code evidence} — `[KB: …]` + `[GAP: …]`

--- a/plugins/base/skills/guide/CATALOG.md
+++ b/plugins/base/skills/guide/CATALOG.md
@@ -59,7 +59,7 @@
 | `/generate-user-docs` | base | Synchronizes user-facing documentation with the current knowledge base through validate -> stale gate -> scan -> approval -> process orchestration. |  | Yes | fresh |  |
 | `/markdown-preview` | base | Generate browser-viewable HTML previews from markdown, plain text, and Mermaid diagrams. Auto-validates diagrams, applies professional styling, and opens in default browser. Use when agents need to preview documentation, visualizations, or formatted content. |  |  |  |  |
 | `/mermaid` | base | Create, validate, and troubleshoot Mermaid.js diagrams. Use when generating flowcharts, sequence diagrams, class diagrams, ER diagrams, Gantt charts, state diagrams, or any visualization. Handles diagram validation, syntax errors, broken diagrams, and automatic repair. Trigger terms - mermaid, diagram, flowchart, sequence, class diagram, ER diagram, entity relationship, state machine, gantt, visualization, chart, graph. |  |  |  |  |
-| `/project-birds-eye-view` | base | Generates arc42/C4-aligned project overview artifacts with per-claim provenance, snapshot metadata, and Arcade-visible workflow tracking. | `PROJECT_CONTEXT`, `FOCUS_AREAS` | Yes |  |  |
+| `/project-birds-eye-view` | base | Generates arc42/C4-aligned project overview artifacts with per-claim provenance, snapshot metadata, and Arcade-visible workflow tracking. | `PROJECT_CONTEXT`, `FOCUS_AREAS` | Yes | fresh |  |
 | `/write-content` | base | Interactive prompt to help create polished technical documents through clarifying questions and structured writing workflows. |  |  |  |  |
 
 ## Knowledge

--- a/plugins/base/skills/guide/CATALOG.md
+++ b/plugins/base/skills/guide/CATALOG.md
@@ -59,7 +59,7 @@
 | `/generate-user-docs` | base | Synchronizes user-facing documentation with the current knowledge base through validate -> stale gate -> scan -> approval -> process orchestration. |  | Yes | fresh |  |
 | `/markdown-preview` | base | Generate browser-viewable HTML previews from markdown, plain text, and Mermaid diagrams. Auto-validates diagrams, applies professional styling, and opens in default browser. Use when agents need to preview documentation, visualizations, or formatted content. |  |  |  |  |
 | `/mermaid` | base | Create, validate, and troubleshoot Mermaid.js diagrams. Use when generating flowcharts, sequence diagrams, class diagrams, ER diagrams, Gantt charts, state diagrams, or any visualization. Handles diagram validation, syntax errors, broken diagrams, and automatic repair. Trigger terms - mermaid, diagram, flowchart, sequence, class diagram, ER diagram, entity relationship, state machine, gantt, visualization, chart, graph. |  |  |  |  |
-| `/project-birds-eye-view` | base | Generates comprehensive project overview documents with diagrams for new developers using internal knowledge base and codebase context. | `PROJECT_CONTEXT`, `FOCUS_AREAS` |  |  |  |
+| `/project-birds-eye-view` | base | Generates arc42/C4-aligned project overview artifacts with per-claim provenance, snapshot metadata, and Arcade-visible workflow tracking. | `PROJECT_CONTEXT`, `FOCUS_AREAS` | Yes |  |  |
 | `/write-content` | base | Interactive prompt to help create polished technical documents through clarifying questions and structured writing workflows. |  |  |  |  |
 
 ## Knowledge

--- a/plugins/base/skills/project-birds-eye-view/SKILL.md
+++ b/plugins/base/skills/project-birds-eye-view/SKILL.md
@@ -1,55 +1,126 @@
 ---
 name: project-birds-eye-view
-description: "Generates comprehensive project overview documents with diagrams for new developers using internal knowledge base and codebase context."
+description: Generates arc42/C4-aligned project overview artifacts with per-claim provenance, snapshot metadata, and Arcade-visible workflow tracking.
+allowed-tools: Bash(rp1 *), Bash(echo *)
 metadata:
   category: documentation
-  is_workflow: false
-  version: 2.0.0
+  is_workflow: true
+  version: 3.0.0
   tags:
     - documentation
     - analysis
     - onboarding
     - visualization
   created: 2025-10-29
-  updated: 2026-02-26
+  updated: 2026-04-23
   author: cloud-on-prem/rp1
   arguments:
     - name: PROJECT_CONTEXT
       type: string
       required: false
       default: ""
-      description: "Optional project context for the documenter"
+      description: Optional project context for the documenter
     - name: FOCUS_AREAS
       type: string
       required: false
-      default: "all"
-      description: "Optional focus areas for the documenter"
+      default: all
+      description: Optional focus areas for the documenter
   sub_agents:
-    - "rp1-base:project-documenter"
+    - rp1-base:project-documenter
 ---
 
 # Project Bird's-Eye View Generator
 
-This command invokes the **project-documenter** sub-agent to generate project overview documentation.
+ROLE: Workflow dispatcher. Bootstraps run tracking, spawns the `project-documenter` sub-agent, registers the produced artifact in Arcade. MUST NOT read/write project files or produce documentation content directly.
 
-Invoke the project-documenter agent:
+## 0. Workflow Bootstrap
 
+Before any shell command that may change the working directory, run workflow bootstrap:
+
+```bash
+rp1 agent-tools workflow-bootstrap \
+  --name birds-eye-view \
+  --schema-path plugins/base/skills/project-birds-eye-view/SKILL.md \
+  --args "{ARGS}" \
+  --project-root "$PWD" \
+  --harness $CURRENT_HOST
+```
+
+Parse the JSON response and extract `RUN_ID`, `projectRoot`, `kbRoot`, `workRoot`, `codeRoot`, `PROJECT_CONTEXT`, `FOCUS_AREAS`. If `rp1DirectoryStatus` is not `initialized`, warn the user and stop.
+
+## STATE-MACHINE
+
+```mermaid
+stateDiagram-v2
+    [*] --> load_kb
+    load_kb --> analyse : kb_ready
+    analyse --> generate : analysis_complete
+    generate --> validate_diagrams : document_written
+    validate_diagrams --> [*] : done
+```
+
+On each phase transition, emit:
+
+```bash
+rp1 agent-tools emit --harness $CURRENT_HOST \
+  --workflow birds-eye-view \
+  --type status_change \
+  --run-id {RUN_ID} \
+  --name "Bird's-eye view: {PROJECT_SLUG}" \
+  --step {CURRENT_STATE} \
+  --data '{"status": "running"}'
+```
+
+Terminal state `validate_diagrams` uses `--data '{"status": "completed"}'`.
+
+## Governance
+
+Role: workflow dispatcher.
+Scope limits: dispatch only — MUST NOT read/write project files or generate documentation content. Sub-agent handles all content work.
+Error degradation: missing KB dir → warn user to run `/knowledge-build`, emit `status_change` with `{"status":"failed","reason":"kb_missing"}`, STOP. Sub-agent failure → propagate error, emit failure status, STOP. No retry loops.
+Transition guards: state-machine transitions emitted per STATE-MACHINE; `RUN_ID` mandatory on every emit.
+
+## Dispatch
+
+1. Emit entry into `load_kb`.
+2. Invoke the project-documenter agent:
+
+```
 {% dispatch_agent "rp1-base:project-documenter" %}
 PROJECT_CONTEXT: {PROJECT_CONTEXT}
 FOCUS_AREAS: {FOCUS_AREAS}
 KB_ROOT: {kbRoot}
+WORK_ROOT: {workRoot}
+PROJECT_ROOT: {projectRoot}
+CODE_ROOT: {codeRoot}
+RUN_ID: {RUN_ID}
 {% enddispatch_agent %}
+```
+
+3. The agent returns `OUTPUT_PATH` (relative to workRoot) and `PROJECT_SLUG`. Register the artifact:
+
+```bash
+rp1 agent-tools emit --harness $CURRENT_HOST \
+  --workflow birds-eye-view \
+  --type artifact_registered \
+  --run-id {RUN_ID} \
+  --step generate \
+  --data '{"path": "{OUTPUT_PATH}", "feature": "birds-eye", "storageRoot": "work_dir", "format": "markdown"}'
+```
+
+4. Emit terminal `validate_diagrams` with `{"status":"completed"}`.
+
 The agent will:
+- Resolve `PROJECT_SLUG` from package.json → pyproject.toml → git remote → basename(projectRoot)
+- Load KB (index.md, architecture.md, modules.md, patterns.md, concept_map.md, interaction-model.md)
+- Generate a 16-section arc42/C4-aligned document with per-claim provenance tags
+- Emit 3 mandatory + up to 3 conditional Mermaid diagrams, each validated via `rp1 agent-tools mmd-validate`
+- Write to `{workRoot}/birds-eye/{YYYY-MM-DD}-{PROJECT_SLUG}.md` with n+1 dedup suffix
+- Return OUTPUT_PATH and PROJECT_SLUG to this dispatcher
 
-- Load internal knowledge base
-- Explore codebase for additional context
-- Generate comprehensive overview with diagrams
-- Include: Summary, System Context, Architecture, Modules, Data Model, Workflows, APIs
-- Create Mermaid diagrams (validated)
-- Mark unknowns as TBD
-- Save the output document
-- Report back with documentation summary
+## Runtime Contract
 
-The agent follows strict rules: never invent facts, use only loaded sources and codebase exploration.
-
-The agent has access to all necessary tools and will handle the entire documentation workflow autonomously.
+| Command | Purpose | Exit 0 required |
+|---------|---------|-----------------|
+| `rp1 agent-tools workflow-bootstrap` | Resolve directories + RUN_ID | yes |
+| `rp1 agent-tools emit` | State + artifact tracking | yes |

--- a/plugins/base/skills/project-birds-eye-view/SKILL.md
+++ b/plugins/base/skills/project-birds-eye-view/SKILL.md
@@ -5,6 +5,9 @@ allowed-tools: Bash(rp1 *), Bash(echo *)
 metadata:
   category: documentation
   is_workflow: true
+  workflow:
+    run_policy: fresh
+    identity_args: []
   version: 3.0.0
   tags:
     - documentation
@@ -32,21 +35,6 @@ metadata:
 # Project Bird's-Eye View Generator
 
 ROLE: Workflow dispatcher. Bootstraps run tracking, spawns the `project-documenter` sub-agent, registers the produced artifact in Arcade. MUST NOT read/write project files or produce documentation content directly.
-
-## 0. Workflow Bootstrap
-
-Before any shell command that may change the working directory, run workflow bootstrap:
-
-```bash
-rp1 agent-tools workflow-bootstrap \
-  --name birds-eye-view \
-  --schema-path plugins/base/skills/project-birds-eye-view/SKILL.md \
-  --args "{ARGS}" \
-  --project-root "$PWD" \
-  --harness $CURRENT_HOST
-```
-
-Parse the JSON response and extract `RUN_ID`, `projectRoot`, `kbRoot`, `workRoot`, `codeRoot`, `PROJECT_CONTEXT`, `FOCUS_AREAS`. If `rp1DirectoryStatus` is not `initialized`, warn the user and stop.
 
 ## STATE-MACHINE
 
@@ -85,7 +73,6 @@ Transition guards: state-machine transitions emitted per STATE-MACHINE; `RUN_ID`
 1. Emit entry into `load_kb`.
 2. Invoke the project-documenter agent:
 
-```
 {% dispatch_agent "rp1-base:project-documenter" %}
 PROJECT_CONTEXT: {PROJECT_CONTEXT}
 FOCUS_AREAS: {FOCUS_AREAS}
@@ -95,7 +82,6 @@ PROJECT_ROOT: {projectRoot}
 CODE_ROOT: {codeRoot}
 RUN_ID: {RUN_ID}
 {% enddispatch_agent %}
-```
 
 3. The agent returns `OUTPUT_PATH` (relative to workRoot) and `PROJECT_SLUG`. Register the artifact:
 
@@ -110,17 +96,10 @@ rp1 agent-tools emit --harness $CURRENT_HOST \
 
 4. Emit terminal `validate_diagrams` with `{"status":"completed"}`.
 
-The agent will:
-- Resolve `PROJECT_SLUG` from package.json → pyproject.toml → git remote → basename(projectRoot)
-- Load KB (index.md, architecture.md, modules.md, patterns.md, concept_map.md, interaction-model.md)
-- Generate a 16-section arc42/C4-aligned document with per-claim provenance tags
-- Emit 3 mandatory + up to 3 conditional Mermaid diagrams, each validated via `rp1 agent-tools mmd-validate`
-- Write to `{workRoot}/birds-eye/{YYYY-MM-DD}-{PROJECT_SLUG}.md` with n+1 dedup suffix
-- Return OUTPUT_PATH and PROJECT_SLUG to this dispatcher
+The agent will load the KB, generate a 16-section arc42/C4-aligned document with per-claim provenance, emit up to 6 Mermaid diagrams (validated via `rp1 agent-tools mmd-validate`), and write to `{workRoot}/birds-eye/{YYYY-MM-DD}-{PROJECT_SLUG}.md` with n+1 dedup. It returns `OUTPUT_PATH` and `PROJECT_SLUG` to this dispatcher.
 
 ## Runtime Contract
 
 | Command | Purpose | Exit 0 required |
 |---------|---------|-----------------|
-| `rp1 agent-tools workflow-bootstrap` | Resolve directories + RUN_ID | yes |
 | `rp1 agent-tools emit` | State + artifact tracking | yes |


### PR DESCRIPTION
## Summary

- Re-skeletons `/project-birds-eye-view` from a 12-section KB-root document to a workflow-tracked artifact at `.rp1/work/birds-eye/{YYYY-MM-DD}-{PROJECT_SLUG}.md` (n+1 dedup, `storageRoot: work_dir`, `feature: birds-eye`). Runs now appear in Arcade via `workflow-bootstrap` + a 4-state machine + `artifact_registered` emit.
- Worker `project-documenter` moves to a 16-section arc42/C4-aligned contract: adds Architecture Decisions, Getting Started, Debugging & Observability, Glossary, and a Reflexion appendix (Murphy & Notkin 1995) comparing KB-stated vs code-observed architecture when divergences exist. Folds the old State Model / User Flows / Key Components redundancy into Containers + Runtime View.
- Every declarative sentence in §2–§14 now carries one of `[KB|CODE|INFER|GAP]`, with the 3-level confidence scale (Speculative/Supported/Settled) mapped onto tag composition. Conditional sections (Data Model, Deployment, Reflexion) omit entirely when no `[KB|CODE]` citation exists rather than emitting stubs. Diagram budget drops from 7 mandatory to 3 mandatory + 3 conditional, each with a justification bar.
- Adds matching artifact template under `artifact-templates/templates/project-documenter/birds-eye-view.md` with `scope: workRoot`, `path_pattern`, and `emit_hint`; registered in the template index.

## Background

Motivation and consumer-lens analysis in the deep-research report at `.rp1/work/research/2026-04-23-project-birds-eye-view-critical-review.md`. Short version: the old output lived in `kbRoot`, had no Arcade visibility, missed the sections new developers most commonly report as missing (ADRs, Getting Started, Glossary, Debugging), and had flat provenance — every claim rendered at the same weight regardless of whether it came from a human-authored KB file, a direct code observation, or model inference.

## Test plan

- [x] `/project-birds-eye-view` produces output at `.rp1/work/birds-eye/{YYYY-MM-DD}-{PROJECT_SLUG}.md` (not `.rp1/context/`)
- [x] Run appears in Arcade with the 4 states (`load_kb → analyse → generate → validate_diagrams`) and `artifact_registered` event in the timeline
- [x] Snapshot header at top of generated doc includes date, short git SHA, KB files loaded, coverage score, and SSOT disclaimer
- [x] Sentences in §2–§14 carry `[KB|CODE|INFER|GAP]` tags; untagged sentences in those sections are a bug
- [x] Conditional sections §7/§9/§15 are either emitted fully or omitted with a matching `Omitted §N … — <reason>` line in §13, never stubbed
- [x] Mermaid diagrams carry the HTML-comment justification bar above each fence and validate via `rp1 agent-tools mmd-validate`
- [x] Second same-day run produces `…-2.md`, not overwriting the first
- [x] Missing `.rp1/context/` → dispatcher emits `{"status":"failed","reason":"kb_missing"}` and stops
- [x] Catalogue regenerated: `just catalog-generate` is a no-op