### PR TITLE
fix(birds-eye-view): address PR #348 review (state emits, template authority, emit_hint)

### DIFF
--- a/catalog/agents.yaml
+++ b/catalog/agents.yaml
@@ -42,7 +42,7 @@ agents:
   - name: rp1-base:project-documenter
     description: "Generates arc42/C4-aligned birds-eye-view documents with per-claim provenance and Reflexion appendix"
     plugin: base
-    last_checksum: a6797d9d269b3f77198a9ccc7dea1eaab95381c81022cf789d2a4f55117dbc8d
+    last_checksum: f9ef93984a4d2fdab723afcac79398aa4a8098a0cdc31970f21a1f5d32157c52
   - name: rp1-base:prompt-pipeline-runner
     description: "Executes the six-stage prompt-writer pipeline and produces two mandatory output artifacts (ready-to-run prompt, confidence report)"
     plugin: base

--- a/plugins/base/agents/project-documenter.md
+++ b/plugins/base/agents/project-documenter.md
@@ -78,7 +78,7 @@ RUN_ID: {{RUN_ID from prompt}}
 3. **Load KB**: Read from `{KB_ROOT}/`: `index.md`, `architecture.md`, `modules.md`, `patterns.md`, `concept_map.md`, `interaction-model.md`, `dependencies.md` (if exists), `charter.md` (if exists — source for Architecture Decisions). If `{KB_ROOT}` missing → emit `status_change` failure, warn user to run `/knowledge-build`, STOP.
 4. **Explore codebase** (read-only): `{CODE_ROOT}/README*`, `package.json`, `pyproject.toml`, `Dockerfile*`, `docker-compose*.yml`, `.github/workflows/*`, `Cargo.toml`, `go.mod`, `tsconfig.json`, top-level directories via `ls`, ADRs under `docs/adr/` or `docs/decisions/` if present.
 5. **Classify**: for each of the 16 sections, determine whether sufficient `[KB]` or `[CODE]` evidence exists. Sections 7, 9, 15 are **conditional** — omit entirely if no `[KB|CODE]` citation is reachable.
-6. **Generate** the document per §OUT with the §SNAPSHOT_HEADER at top.
+6. **Generate** the document per the template loaded from `rp1-base:artifact-templates` (see §Template Loading), filling placeholders per §Content Guidance.
 7. **Validate diagrams**: `rp1 agent-tools mmd-validate {OUTPUT_FILE}` → fix errors by category (max 3 iterations). If unfixable, report in §COMPLETION_REPORT.
 8. **Return** the relative output path (`birds-eye/{TODAY}-{PROJECT_SLUG}[-n].md`) and `PROJECT_SLUG` to the dispatcher.
 
@@ -138,83 +138,23 @@ If `{KB_ROOT}/architecture.md` or `{KB_ROOT}/modules.md` make structural claims 
 
 Emit §15 when ≥1 divergence is found. List convergences briefly (1 line each), divergences prominently (with recommended follow-up). Absences go into §13 Risks instead.
 
-## SNAPSHOT_HEADER
+## Template Loading
 
-The output file MUST begin with this block (populated from Stage 1–2 resolution + KB inspection):
+1. Read `rp1-base:artifact-templates` SKILL.md — locate the row where **Producer** = `project-documenter` and **Artifact** = `birds-eye-view.md`.
+2. Read the template file at the listed **Template Path**.
+3. Use the template structure for output. Fill placeholders per the content guidance below.
 
-```markdown
-> **Snapshot** — generated {TODAY} from commit `{GIT_SHA}` in `{CODE_ROOT}`.
-> KB files loaded: `index.md`, `architecture.md`, `modules.md`, `patterns.md`, `concept_map.md`, `interaction-model.md`{other optional files}.
-> KB last updated: {kb_meta_date_if_available} (from `{KB_ROOT}/meta.json` or mtime).
-> Coverage: {filled}/{total} sections, {conditional_emitted} conditional emitted, {gap_count} GAPs.
-> **This is a regenerated snapshot. The source of truth is `{KB_ROOT}/`.**
-> Regenerate via `/rp1-base:project-birds-eye-view` when KB changes materially.
-```
+The template owns the 16-section structure, the Snapshot-header block at the top, diagram placement, and section ordering. This agent does not duplicate that contract — when they drift, the template wins.
 
-## OUT
+## Content Guidance
 
-```markdown
-# {Project Name} — Bird's-Eye View
-
-{SNAPSHOT_HEADER block}
-
-## 0. Snapshot metadata
-(covered by SNAPSHOT_HEADER)
-
-## 1. TL;DR for a new dev
-5 bullets: (a) what it is, (b) who uses it, (c) how to run it, (d) where to look first, (e) what's weird.
-
-## 2. Business context & purpose
-2–3 sentences with provenance tags. Answers: why does this exist, what problem does it solve, what is the core value.
-
-## 3. System context (C4 L1)
-2–3 sentences describing external systems, users, integrations. Followed by a Mermaid flowchart diagram.
-
-## 4. Containers / Building blocks (C4 L2)
-2–3 sentences describing major runtime containers and their relationships. Followed by a Mermaid flowchart diagram.
-
-## 5. Tech stack & rationale
-2–3 sentences plus a table. Each stack entry: name, purpose, rationale (WHY this choice — tag `[KB]` for charter/ADR source, or `[GAP]` if no rationale found).
-
-| Technology | Purpose | Rationale |
-|------------|---------|-----------|
-| Bun 1.x | Runtime | [KB: charter.md:12] faster startup vs Node |
-| ... | ... | [GAP — no decision note] |
-
-## 6. Runtime view — 1 to 3 key scenarios
-2–3 sentences introducing the scenarios. Followed by a Mermaid sequenceDiagram for the single most load-bearing hot path. Narrative describes the lifecycle with provenance tags.
-
-## 7. Data model [conditional — emit only if evidence]
-2–3 sentences on principal entities. Followed by a Mermaid erDiagram.
-
-## 8. API / interface surface
-2–3 sentences on major public surfaces. Table: endpoint/CLI command/event, owning component, purpose. Provenance tagged.
-
-## 9. Deployment & environments [conditional — emit only if evidence]
-2–3 sentences on how it runs in production. Followed by a Mermaid flowchart if ≥3 deployment units.
-
-## 10. Architecture decisions
-Bulleted list of known decisions with rationale. Each entry cites `[KB]` (charter, ADR, PRD) or `[GAP — no decision recorded]`. This section is ALWAYS emitted, even if the list is entirely `[GAP]` entries — that absence is itself a finding.
-
-## 11. Getting started
-Ordered steps: install, run locally, run tests, ship a first change. Source: README, package scripts, justfile, Makefile. Every step with `[CODE]` or `[KB]` tag.
-
-## 12. Debugging & observability
-Where logs go, where traces go, where dashboards live, who to page. Likely many `[GAP]` tags on first generation — that is information, not failure.
-
-## 13. Risks, gaps, and what isn't covered
-Reframed from "Assumptions & Gaps". First-class risk register.
-- Known issues (from KB or TODO scan): `[KB]` / `[CODE]` tagged
-- Technical debt flagged in KB: `[KB]` tagged
-- Gaps that would most improve the overview: `[GAP]` tagged with "next read" pointers
-- Omitted conditional sections: `Omitted §7 {name} — {reason}` / `Omitted §9 …` / `Omitted §15 …`
-
-## 14. Glossary
-Domain terms extracted from `{KB_ROOT}/concept_map.md` or inferred from code. Each term: short definition + `[KB]` or `[CODE]` citation.
-
-## 15. Appendix: Intended vs observed architecture [conditional]
-Emit when ≥1 divergence found. Sections: Convergences (one-line bullets), **Divergences** (with recommended follow-up), Absences (with evidence that would close them).
-```
+- **Snapshot header** (top of file): populate `{YYYY-MM-DD}`, `{GIT_SHA}` (`git -C {CODE_ROOT} rev-parse --short HEAD`), KB files loaded (from §PROC step 3), KB last-updated date (from `{KB_ROOT}/meta.json` if present, else mtime), and the coverage tuple `{filled}/{total}/{conditional_emitted}/{gap_count}` computed from the classification in §PROC step 5.
+- **§1 TL;DR**: 5 bullets — what it is, who uses it, how to run it, where to look first, what's weird. Untagged.
+- **§2–§14**: every declarative sentence carries a `[KB|CODE|INFER|GAP]` tag per §PROVENANCE.
+- **§5 Tech stack**: name + purpose from `[CODE]` evidence; rationale from `[KB: charter.md|ADR|PRD]` or `[GAP — no decision note]`.
+- **§10 Architecture decisions**: ALWAYS emitted. A list of only `[GAP]` entries is itself a valid finding — do not skip.
+- **§13 Risks**: first-class register, not a footer. Include `Omitted §N … — <reason>` lines for every conditional section that was skipped.
+- **§15 Reflexion appendix**: see §REFLEXION_APPENDIX — emit only when ≥1 divergence is found.
 
 ## GOVERNANCE
 
@@ -224,7 +164,7 @@ Emit when ≥1 divergence found. Sections: Convergences (one-line bullets), **Di
 
 **Anti-loop**: Single-pass execution. No clarification, no iteration. Blocking issue → emit failure status, STOP. Mermaid validation loop is the sole exception (max 3 iterations).
 
-**Output discipline**: Output MUST conform to the 16-section structure in §OUT with SNAPSHOT_HEADER prepended. Conditional sections (§7, §9, §15) are either emitted fully or omitted entirely — never stubs.
+**Output discipline**: Output MUST conform to the 16-section structure defined by the loaded artifact template, with the Snapshot-header block at the top. Conditional sections (§7, §9, §15) are either emitted fully or omitted entirely — never stubs.
 
 **Truth constraints**: Generate ONLY from loaded KB + observed source + git metadata. Every claim in §2–§14 MUST carry a provenance tag per §PROVENANCE. Missing info → `[GAP]` tag with specific "what evidence would close it". Findings are conjectural — evidence suggests rather than asserts. Every significant claim MUST be refutable — state what would contradict it. Prefer hard-to-vary explanations where each detail is load-bearing. Do not self-immunize conclusions with unfalsifiable hedges. Preserve error-correction capacity: per-claim provenance tags let any reader challenge individual claims without dismissing the document.
 

--- a/plugins/base/skills/artifact-templates/templates/project-documenter/birds-eye-view.md
+++ b/plugins/base/skills/artifact-templates/templates/project-documenter/birds-eye-view.md
@@ -3,16 +3,13 @@ scope: workRoot
 path_pattern: "birds-eye/{YYYY-MM-DD}-{PROJECT_SLUG}.md"
 producer: project-documenter
 type: document
-description: "arc42/C4-aligned project overview artifact generated from KB + codebase by /project-birds-eye-view. 16 sections with per-claim provenance tags, snapshot metadata header, and conditional Reflexion appendix. Path uses date prefix and project slug with n+1 dedup."
+description: "arc42/C4-aligned project overview artifact generated from KB + codebase by /project-birds-eye-view. 16 sections with per-claim provenance tags, snapshot metadata header, and conditional Reflexion appendix. Path uses date prefix and project slug with n+1 dedup — registration MUST use the producer's resolved OUTPUT_PATH, not this pattern, because dedup suffixes (-2, -3, …) are assigned at write time."
 strictness: flexible
-emit_hint: |
-  rp1 agent-tools emit \
-    --harness $CURRENT_HOST \
-    --workflow birds-eye-view \
-    --type artifact_registered \
-    --run-id {RUN_ID} \
-    --step generate \
-    --data '{"path": "birds-eye/{YYYY-MM-DD}-{PROJECT_SLUG}.md", "feature": "birds-eye", "storageRoot": "work_dir", "format": "markdown"}'
+# No emit_hint: path_pattern is NOT safe to use directly for registration.
+# The `/project-birds-eye-view` dispatcher (or any caller) MUST register with the
+# OUTPUT_PATH returned by the project-documenter sub-agent, which includes any
+# n+1 dedup suffix that was actually assigned at write time. See
+# plugins/base/skills/project-birds-eye-view/SKILL.md for the canonical call.
 ---
 
 > **Snapshot** — generated {YYYY-MM-DD} from commit `{GIT_SHA}` in `{CODE_ROOT}`.

--- a/plugins/base/skills/project-birds-eye-view/SKILL.md
+++ b/plugins/base/skills/project-birds-eye-view/SKILL.md
@@ -54,10 +54,12 @@ rp1 agent-tools emit --harness $CURRENT_HOST \
   --workflow birds-eye-view \
   --type status_change \
   --run-id {RUN_ID} \
-  --name "Bird's-eye view: {PROJECT_SLUG}" \
+  --name "Bird's-eye view: {RUN_NAME}" \
   --step {CURRENT_STATE} \
   --data '{"status": "running"}'
 ```
+
+`RUN_NAME` is resolved once, up front, from `basename {projectRoot}` — it is stable before the sub-agent runs, so every emit (including the first) can carry it. The sub-agent's resolved `PROJECT_SLUG` is used for the artifact filename, not the run name.
 
 Terminal state `validate_diagrams` uses `--data '{"status": "completed"}'`.
 
@@ -70,8 +72,10 @@ Transition guards: state-machine transitions emitted per STATE-MACHINE; `RUN_ID`
 
 ## Dispatch
 
-1. Emit entry into `load_kb`.
-2. Invoke the project-documenter agent:
+1. Resolve `RUN_NAME` = `basename {projectRoot}`.
+2. Emit entry into `load_kb` with `{"status":"running"}`. Verify `{kbRoot}` exists — if not, emit `{"status":"failed","reason":"kb_missing"}` and STOP.
+3. Emit entry into `analyse` with `{"status":"running"}` — this is the state the sub-agent runs in.
+4. Invoke the project-documenter agent:
 
 {% dispatch_agent "rp1-base:project-documenter" %}
 PROJECT_CONTEXT: {PROJECT_CONTEXT}
@@ -83,7 +87,7 @@ CODE_ROOT: {codeRoot}
 RUN_ID: {RUN_ID}
 {% enddispatch_agent %}
 
-3. The agent returns `OUTPUT_PATH` (relative to workRoot) and `PROJECT_SLUG`. Register the artifact:
+5. The sub-agent returns `OUTPUT_PATH` (relative to workRoot) and `PROJECT_SLUG`. Emit entry into `generate` with `{"status":"running"}`, then register the artifact — `OUTPUT_PATH` is authoritative, including any n+1 dedup suffix:
 
 ```bash
 rp1 agent-tools emit --harness $CURRENT_HOST \
@@ -94,9 +98,9 @@ rp1 agent-tools emit --harness $CURRENT_HOST \
   --data '{"path": "{OUTPUT_PATH}", "feature": "birds-eye", "storageRoot": "work_dir", "format": "markdown"}'
 ```
 
-4. Emit terminal `validate_diagrams` with `{"status":"completed"}`.
+6. Emit terminal `validate_diagrams` with `{"status":"completed"}`.
 
-The agent will load the KB, generate a 16-section arc42/C4-aligned document with per-claim provenance, emit up to 6 Mermaid diagrams (validated via `rp1 agent-tools mmd-validate`), and write to `{workRoot}/birds-eye/{YYYY-MM-DD}-{PROJECT_SLUG}.md` with n+1 dedup. It returns `OUTPUT_PATH` and `PROJECT_SLUG` to this dispatcher.
+The agent loads the KB, generates a 16-section arc42/C4-aligned document with per-claim provenance, emits up to 6 Mermaid diagrams (validated via `rp1 agent-tools mmd-validate`), and writes to `{workRoot}/birds-eye/{YYYY-MM-DD}-{PROJECT_SLUG}.md` with n+1 dedup. It returns the resolved `OUTPUT_PATH` and `PROJECT_SLUG` to this dispatcher.
 
 ## Runtime Contract
 


### PR DESCRIPTION
Follow-up to #348 addressing the three findings from the review at `.rp1/work/pr-reviews/pr-348-review-001.md`.

## Summary

### 1. High — state-machine emits were internally inconsistent (6fba6012)

The dispatcher's `status_change` template referenced `{PROJECT_SLUG}` in the run name, but `PROJECT_SLUG` is produced by the sub-agent and doesn't exist when the first emit fires. The dispatch procedure also only emitted `load_kb` entry and the terminal `validate_diagrams` — `analyse` and `generate` were declared in the state diagram but never actually entered, so the four-step Arcade progression PR #348 advertised could not appear.

- Resolve a stable `RUN_NAME = basename(projectRoot)` before the first emit; use it in every `status_change`. `PROJECT_SLUG` stays in the artifact filename, not the run name.
- Add explicit `status_change` emits for `analyse` (before sub-agent dispatch) and `generate` (after sub-agent return, before `artifact_registered`).
- Clarify the dispatcher treats the sub-agent's returned `OUTPUT_PATH` as authoritative, including any n+1 dedup suffix.

### 2. Medium — producer didn't load the shared template (40a191b5)

PR #348 added the template index row but never switched `project-documenter` to the two-hop template-loading flow (per `plugins/base/README.md:109`). The agent carried a full inline `## OUT` block, so the new template wasn't authoritative and drift was already visible (template puts the snapshot block before the H1; inline example had the opposite order).

- Replace the inline `## OUT` section with the canonical Template Loading instructions used by the other 20 producers.
- Move per-section discipline into a `## Content Guidance` block — the template owns structure, this agent owns how to fill it.
- Update two stale `§OUT` / `§SNAPSHOT_HEADER` pointers in `§PROC` and `GOVERNANCE`.

### 3. Medium — template's `emit_hint` rotted on same-day reruns (d595309a)

The template declared n+1 dedup in its description but `emit_hint` always registered the unsuffixed `birds-eye/{YYYY-MM-DD}-{PROJECT_SLUG}.md`. Any producer that followed the hint literally would register the wrong file on the second same-day run.

- Remove `emit_hint`.
- Add a frontmatter comment + tighten description: registration MUST use the producer's resolved `OUTPUT_PATH`, never reconstruct from `path_pattern`.

## Test plan

- [x] Trigger `/project-birds-eye-view` once; Arcade shows all four states (`load_kb → analyse → generate → validate_diagrams`) as `running` and then `validate_diagrams` as `completed`.
- [x] Run name in Arcade uses the project directory basename, not an unresolved `{PROJECT_SLUG}` placeholder.
- [x] Trigger a second run on the same day; second artifact writes to `…-2.md` and the `artifact_registered` event's `path` carries the `-2` suffix (not the unsuffixed path).
- [x] `project-documenter` reads `rp1-base:artifact-templates` SKILL.md and then the template file at `templates/project-documenter/birds-eye-view.md` before generating (two Read calls visible in the trace).
- [x] `just build-plugins-check` passes.
- [x] `just catalog-check` passes.