### PR TITLE
feat(arcade): replace artifact loading animation

### DIFF
--- a/cli/web-ui/src/__tests__/components/v2/ArtifactEmptyState.test.tsx
+++ b/cli/web-ui/src/__tests__/components/v2/ArtifactEmptyState.test.tsx
@@ -1,19 +1,8 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import { act, cleanup, render, screen } from "@testing-library/react";
+import { cleanup, render, screen } from "@testing-library/react";
 
 let importVersion = 0;
 let prefersReducedMotion = false;
-
-type IntervalCallback = () => void;
-
-const originalWindowSetInterval = window.setInterval;
-const originalWindowClearInterval = window.clearInterval;
-const originalMathRandom = Math.random;
-
-let nextIntervalId = 1;
-let intervalCallbacks: Map<number, IntervalCallback>;
-let intervalDelays: Map<number, number | undefined>;
-let clearedIntervalIds: number[];
 
 mock.module("@/hooks/usePrefersReducedMotion", () => ({
 	usePrefersReducedMotion: () => prefersReducedMotion,
@@ -25,154 +14,60 @@ async function loadComponent() {
 	);
 }
 
-function installIntervalMocks() {
-	nextIntervalId = 1;
-	intervalCallbacks = new Map();
-	intervalDelays = new Map();
-	clearedIntervalIds = [];
-
-	window.setInterval = ((handler: TimerHandler, timeout?: number) => {
-		if (typeof handler !== "function") {
-			throw new Error("ArtifactEmptyState tests expect function intervals");
-		}
-
-		const id = nextIntervalId++;
-		intervalCallbacks.set(id, handler as IntervalCallback);
-		intervalDelays.set(id, timeout);
-		return id;
-	}) as typeof window.setInterval;
-
-	window.clearInterval = ((id?: number) => {
-		if (typeof id !== "number") return;
-		clearedIntervalIds.push(id);
-		intervalCallbacks.delete(id);
-	}) as typeof window.clearInterval;
-}
-
 describe("ArtifactEmptyState", () => {
 	beforeEach(() => {
 		document.body.innerHTML = "";
 		prefersReducedMotion = false;
-		Math.random = () => 0;
-		installIntervalMocks();
 	});
 
 	afterEach(() => {
 		cleanup();
-		window.setInterval = originalWindowSetInterval;
-		window.clearInterval = originalWindowClearInterval;
-		Math.random = originalMathRandom;
 	});
 
-	test("renders a large centered SVG ASCII visual with an accessible label", async () => {
+	test("renders the artifact reconstruction loader with an accessible label", async () => {
 		const { ArtifactEmptyState } = await loadComponent();
 
 		render(<ArtifactEmptyState />);
 
 		const status = screen.getByRole("status", {
-			name: "Waiting for artifacts",
+			name: "Creating artifacts",
 		});
 		const visual = screen.getByTestId("artifact-empty-state-visual");
 
 		expect(status.className).toContain("items-center");
 		expect(status.className).toContain("justify-center");
-		expect(status.className).toContain("h-full");
+		expect(status.className).not.toContain("bg-");
 		expect(visual.tagName.toLowerCase()).toBe("svg");
-		expect(visual.getAttribute("viewBox")).toBe("0 0 680 360");
-		expect(visual.querySelector("rect")).toBeNull();
-		expect(visual.textContent).toContain("artifact_registered");
-		expect(visual.textContent).toContain(
-			"waiting for your workflow to produce an artifact",
+		expect(visual.getAttribute("viewBox")).toBe("0 0 1200 800");
+		expect(visual.getAttribute("class")).toContain(
+			"artifact-reconstruction-loader",
 		);
-		expect(visual.textContent).toContain("watchArtifacts");
-		expect(visual.textContent).not.toContain("Waiting for artifacts");
-		expect(visual.querySelector("text")?.getAttribute("class")).toContain(
-			"text-[4.5px]",
-		);
-		expect(visual.querySelector('[data-segment-tone="cyan"]')).not.toBeNull();
-		expect(visual.querySelector('[data-segment-tone="lime"]')).not.toBeNull();
-		expect(visual.dataset.variantIndex).toBe("0");
-		expect(visual.getAttribute("class")).toContain("w-[90%]");
-		expect(visual.getAttribute("class")).toContain("aspect-[17/9]");
-		expect(visual.getAttribute("class")).toContain("max-w-none");
-		expect(visual.getAttribute("class")).not.toContain("border");
-		expect(visual.getAttribute("class")).not.toContain("bg-muted");
-	});
-
-	test("chooses one of ten code variants on mount", async () => {
-		Math.random = () => 0.999;
-		const { ArtifactEmptyState, ARTIFACT_EMPTY_STATE_VARIANT_COUNT } =
-			await loadComponent();
-
-		render(<ArtifactEmptyState />);
-
-		const visual = screen.getByTestId("artifact-empty-state-visual");
-
-		expect(ARTIFACT_EMPTY_STATE_VARIANT_COUNT).toBe(10);
-		expect(visual.dataset.variantIndex).toBe(
-			String(ARTIFACT_EMPTY_STATE_VARIANT_COUNT - 1),
-		);
-		expect(visual.textContent).toContain("compile artifact groups");
-	});
-
-	test("advances frames and loops continuously", async () => {
-		const {
-			ArtifactEmptyState,
-			ARTIFACT_EMPTY_STATE_FRAME_COUNT,
-			ARTIFACT_EMPTY_STATE_FRAME_INTERVAL_MS,
-		} = await loadComponent();
-
-		render(<ArtifactEmptyState />);
-
-		const [intervalId] = intervalCallbacks.keys();
-		const callback = intervalCallbacks.get(intervalId);
-		const visual = screen.getByTestId("artifact-empty-state-visual");
-
-		expect(callback).toBeTruthy();
-		expect(intervalDelays.get(intervalId)).toBe(
-			ARTIFACT_EMPTY_STATE_FRAME_INTERVAL_MS,
-		);
-		expect(ARTIFACT_EMPTY_STATE_FRAME_INTERVAL_MS).toBe(880);
 		expect(visual.dataset.animationState).toBe("running");
-		expect(visual.dataset.frameIndex).toBe("0");
-
-		for (let i = 0; i < ARTIFACT_EMPTY_STATE_FRAME_COUNT + 2; i += 1) {
-			act(() => {
-				callback?.();
-			});
-		}
-
-		expect(visual.dataset.animationState).toBe("running");
-		expect(visual.dataset.frameIndex).toBe("2");
-		expect(clearedIntervalIds).not.toContain(intervalId);
+		expect(visual.textContent).toContain("CREATING ARTIFACTS");
+		expect(visual.textContent).toContain("⣠⣾⣿⣿⣿⣦⣄");
+		expect(visual.querySelectorAll(".reconstruction-row")).toHaveLength(9);
+		expect(visual.querySelectorAll(".grid-line")).toHaveLength(6);
+		expect(visual.querySelector(".cursor")).not.toBeNull();
+		expect(visual.querySelector("radialGradient")).toBeNull();
+		expect(visual.querySelector(".loader-bg")).toBeNull();
+		expect(visual.querySelector("style")?.textContent).toContain(
+			"html.dark .artifact-reconstruction-loader",
+		);
+		expect(visual.textContent).not.toContain("artifact_registered");
+		expect(visual.textContent).not.toContain("waiting for your workflow");
 	});
 
-	test("shows the final static frame immediately for reduced motion", async () => {
+	test("uses the static SVG state for reduced motion", async () => {
 		prefersReducedMotion = true;
-		const { ArtifactEmptyState, ARTIFACT_EMPTY_STATE_FRAME_COUNT } =
-			await loadComponent();
-
-		render(<ArtifactEmptyState />);
-
-		const visual = screen.getByTestId("artifact-empty-state-visual");
-
-		expect(intervalCallbacks.size).toBe(0);
-		expect(visual.dataset.animationState).toBe("static");
-		expect(visual.dataset.frameIndex).toBe(
-			String(ARTIFACT_EMPTY_STATE_FRAME_COUNT - 1),
-		);
-	});
-
-	test("clears the interval on unmount before animation completion", async () => {
 		const { ArtifactEmptyState } = await loadComponent();
 
-		const { unmount } = render(<ArtifactEmptyState />);
-		const [intervalId] = intervalCallbacks.keys();
+		render(<ArtifactEmptyState />);
 
-		expect(clearedIntervalIds).not.toContain(intervalId);
+		const visual = screen.getByTestId("artifact-empty-state-visual");
+		const style = visual.querySelector("style");
 
-		unmount();
-
-		expect(clearedIntervalIds).toContain(intervalId);
+		expect(visual.dataset.animationState).toBe("static");
+		expect(style?.textContent).toContain('[data-animation-state="static"] *');
+		expect(visual.querySelectorAll(".reconstruction-row")).toHaveLength(9);
 	});
 });

--- a/cli/web-ui/src/components/v2/ArtifactEmptyState.tsx
+++ b/cli/web-ui/src/components/v2/ArtifactEmptyState.tsx
@@ -1,4 +1,3 @@
-import { useEffect, useState } from "react";
 import { usePrefersReducedMotion } from "@/hooks/usePrefersReducedMotion";
 import { cn } from "@/lib/utils";
 
@@ -6,490 +5,313 @@ export interface ArtifactEmptyStateProps {
 	className?: string;
 }
 
-type ArtifactEmptyStateTone = "muted" | "cyan" | "green" | "lime" | "yellow";
+const GRID_LINES = [
+	{
+		x: 600,
+		y: 520,
+		size: 12,
+		className: "grid-line gl1",
+		text: " . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . ",
+	},
+	{
+		x: 600,
+		y: 550,
+		size: 14,
+		className: "grid-line gl2",
+		text: "  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - ",
+	},
+	{
+		x: 600,
+		y: 590,
+		size: 16,
+		className: "grid-line gl3",
+		text: "   .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  ",
+	},
+	{
+		x: 600,
+		y: 640,
+		size: 18,
+		className: "grid-line gl4",
+		text: "    -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   -   - ",
+	},
+	{
+		x: 600,
+		y: 700,
+		size: 20,
+		className: "grid-line gl5",
+		text: "      .    .    .    .    .    .    .    .    .    .    .    .    .    .    .    .    .    .    .    .    .    .    . ",
+	},
+	{
+		x: 600,
+		y: 770,
+		size: 24,
+		className: "grid-line gl6",
+		text: "         -     -     -     -     -     -     -     -     -     -     -     -     -     -     -     -     -     -    ",
+	},
+] as const;
 
-interface ArtifactEmptyStateSegment {
-	readonly text: string;
-	readonly tone: ArtifactEmptyStateTone;
+const GAMEPAD_ROWS = [
+	{
+		className: "reconstruction-row r1",
+		y: 230,
+		text: "⠀⠀⠀⠀⠀⠀⠀⠀⣀⣀⡀⠀⠀⠀⠀⠀⠀⠀⠀⢀⣀⣀⠀⠀⠀⠀⠀⠀⠀⠀",
+	},
+	{
+		className: "reconstruction-row r2",
+		y: 272,
+		text: "⠀⠀⠀⠀⠀⠀⣠⣾⣿⣿⣿⣦⣄⡀⠀⠀⢀⣠⣴⣿⣿⣿⣷⣄⠀⠀⠀⠀⠀⠀",
+	},
+	{
+		className: "reconstruction-row r3",
+		y: 314,
+		text: "⠀⠀⠀⠀⠀⣼⣿⣿⠛⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣏⠉⣹⣿⣧⠀⠀⠀⠀⠀",
+	},
+	{
+		className: "reconstruction-row r4",
+		y: 356,
+		text: "⠀⠀⠀⠀⣼⣿⣉⣉⠀⣉⣙⣿⣿⣿⣿⣿⣿⣿⣟⠁⣹⣿⣏⠀⣹⣧⠀⠀⠀⠀",
+	},
+	{
+		className: "reconstruction-row r5",
+		y: 398,
+		text: "⠀⠀⠀⢠⣿⣿⣿⣿⣀⣿⣿⣿⣉⣉⣿⣿⣉⣹⣿⣿⣏⠀⣹⣿⣿⣿⡄⠀⠀⠀",
+	},
+	{
+		className: "reconstruction-row r6",
+		y: 440,
+		text: "⠀⠀⠀⢸⣿⣿⣿⣿⣿⣿⣿⣿⣿⠿⠿⠿⠿⣿⣿⣿⣿⣿⣿⣿⣿⣿⡇⠀⠀⠀",
+	},
+	{
+		className: "reconstruction-row r7",
+		y: 482,
+		text: "⠀⠀⠀⢸⣿⣿⣿⣿⣿⠟⠉⠀⠀⠀⠀⠀⠀⠀⠀⠉⠻⣿⣿⣿⣿⣿⡇⠀⠀⠀",
+	},
+	{
+		className: "reconstruction-row r8",
+		y: 524,
+		text: "⠀⠀⠀⠸⣿⣿⣿⡟⠁⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠈⢻⣿⣿⣿⠇⠀⠀⠀",
+	},
+	{
+		className: "reconstruction-row r9",
+		y: 566,
+		text: "⠀⠀⠀⠀⠉⠉⠉⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠉⠉⠉⠀⠀⠀⠀",
+	},
+] as const;
+
+const STAR_POINTS = [
+	{ x: 120, y: 150, text: "+" },
+	{ x: 850, y: 90, text: "." },
+	{ x: 350, y: 70, text: "." },
+	{ x: 750, y: 250, text: "+" },
+	{ x: 1050, y: 450, text: "." },
+	{ x: 80, y: 400, text: "." },
+	{ x: 500, y: 380, text: "+" },
+] as const;
+
+const LOADER_CSS = `
+.artifact-reconstruction-loader {
+	--artifact-loader-neon: #1d7f32;
+	--artifact-loader-bright: #2c9b41;
+	--artifact-loader-dim: #72906d;
+	--artifact-loader-radar-low: #a8b8a4;
+	--artifact-loader-flash: #f6fff6;
+	--artifact-loader-shadow: 0 0 1px rgba(29, 127, 50, 0.16), 0 0 5px rgba(29, 127, 50, 0.16);
+	--artifact-loader-shadow-dim: 0 0 1px rgba(29, 127, 50, 0.12);
+	--artifact-loader-shadow-bright: 0 0 5px rgba(44, 155, 65, 0.26);
+	--artifact-loader-shadow-flash: 0 0 10px rgba(44, 155, 65, 0.35);
 }
-
-type ArtifactEmptyStateLine = readonly ArtifactEmptyStateSegment[];
-
-interface CodeStreamVariant {
-	readonly command: string;
-	readonly lines: readonly ArtifactEmptyStateLine[];
+html.dark .artifact-reconstruction-loader {
+	--artifact-loader-neon: #33ff33;
+	--artifact-loader-bright: #44ff44;
+	--artifact-loader-dim: #118811;
+	--artifact-loader-radar-low: #004400;
+	--artifact-loader-flash: #ffffff;
+	--artifact-loader-shadow: 0 0 4px #11aa11, 0 0 12px #005500;
+	--artifact-loader-shadow-dim: 0 0 2px #003300;
+	--artifact-loader-shadow-bright: 0 0 10px #44ff44;
+	--artifact-loader-shadow-flash: 0 0 15px #ffffff;
 }
-
-const ARTIFACT_EMPTY_STATE_TONE_FILL: Record<ArtifactEmptyStateTone, string> = {
-	muted: "currentColor",
-	cyan: "#06b6d4",
-	green: "#16a34a",
-	lime: "#84cc16",
-	yellow: "#ca8a04",
-};
-
-const segment = (
-	text: string,
-	tone: ArtifactEmptyStateTone = "muted",
-): ArtifactEmptyStateSegment => ({ text, tone });
-
-const line = (
-	text: string,
-	tone: ArtifactEmptyStateTone = "muted",
-): ArtifactEmptyStateLine => [segment(text, tone)];
-
-const parts = (
-	...segments: readonly ArtifactEmptyStateSegment[]
-): ArtifactEmptyStateLine => segments;
-
-const kw = (text: string) => segment(text, "cyan");
-const value = (text: string) => segment(text, "yellow");
-const str = (text: string) => segment(text, "green");
-const cursor = (text: string) => segment(text, "lime");
-
-const CODE_STREAM_VARIANTS = [
-	{
-		command: "tail -f run-output --until artifact_registered",
-		lines: [
-			line("  // hydrate the right panel as soon as files appear", "green"),
-			parts(
-				kw("  async "),
-				segment("function "),
-				cursor("watchArtifacts"),
-				segment("(runId: string) {"),
-			),
-			parts(
-				segment("    const stream = "),
-				kw("await "),
-				segment("events.open(runId);"),
-			),
-			parts(
-				segment("    const panel = createArtifactPanel({ "),
-				value("mode"),
-				segment(": "),
-				str('"aggregate"'),
-				segment(" });"),
-			),
-			line(""),
-			parts(segment("    for await (const event of stream) {")),
-			parts(
-				segment("      if (event.type !== "),
-				str('"artifact_registered"'),
-				segment(") continue;"),
-			),
-			parts(
-				segment("      const artifact = resolveArtifactPath(event.payload);"),
-			),
-			parts(segment("      panel.queue(artifact);")),
-			parts(
-				segment("      panel.status = "),
-				str('"visible in right panel"'),
-				segment(";"),
-			),
-			parts(segment("    }")),
-			parts(segment("  }")),
-		],
-	},
-	{
-		command: "grep -R artifact_registered .rp1/work/features/*",
-		lines: [
-			line("  // keep the file strip populated without step hunting", "green"),
-			parts(
-				kw("  export "),
-				segment("function mergeArtifactRegistration(state, event) {"),
-			),
-			parts(
-				segment("    const artifact = "),
-				kw("parseArtifactEvent"),
-				segment("(event);"),
-			),
-			parts(
-				segment(
-					"    const existing = state.files.find((file) => file.docId === artifact.docId);",
-				),
-			),
-			line(""),
-			parts(segment("    if (existing) {")),
-			parts(segment("      existing.path = artifact.path;")),
-			parts(segment("      existing.updatedDuringRun = true;")),
-			parts(segment("      return state.withFocus(existing.docId);")),
-			parts(segment("    }")),
-			parts(
-				segment("    return state.append(artifact).withFocus(artifact.docId);"),
-			),
-			parts(segment("  }")),
-		],
-	},
-	{
-		command: "rp1 agent-tools emit --event artifact_registered ?",
-		lines: [
-			line("  // normalize all run and step outputs into one list", "green"),
-			parts(
-				kw("  const "),
-				segment("groups = new Map<string, ArtifactGroup>();"),
-			),
-			parts(segment("  for (const artifact of run.artifacts) {")),
-			parts(
-				segment("    const groupKey = artifact.step ?? "),
-				str('"run"'),
-				segment(";"),
-			),
-			parts(
-				segment(
-					"    const group = groups.get(groupKey) ?? createArtifactGroup(groupKey);",
-				),
-			),
-			parts(segment("    group.files.push(artifact);")),
-			parts(segment("    groups.set(groupKey, group);")),
-			parts(segment("  }")),
-			line(""),
-			parts(
-				segment(
-					"  return orderBySelectedStep([...groups.values()], currentStep);",
-				),
-			),
-		],
-	},
-	{
-		command: "resolve storageRoot=work_dir path=features/.../*.md",
-		lines: [
-			line(
-				"  // resolve storage roots before the content viewer asks",
-				"green",
-			),
-			parts(kw("  async "), segment("function resolveArtifact(artifact) {")),
-			parts(
-				segment("    const root = artifact.storageRoot ?? "),
-				str('"work_dir"'),
-				segment(";"),
-			),
-			parts(
-				segment(
-					"    const absolutePath = await projectPaths.resolve(root, artifact.path);",
-				),
-			),
-			parts(segment("    return {")),
-			parts(segment("      ...artifact,")),
-			parts(segment("      absolutePath,")),
-			parts(segment("      basename: path.basename(artifact.path),")),
-			parts(segment("      ready: await fileExists(absolutePath),")),
-			parts(segment("    };")),
-			parts(segment("  }")),
-		],
-	},
-	{
-		command: "render aggregate panel",
-		lines: [
-			line("  // render a seamless horizontal file strip", "green"),
-			parts(
-				kw("  function "),
-				segment("ArtifactStrip({ files, selectedDocId }) {"),
-			),
-			parts(segment("    return files.map((file) => (")),
-			parts(segment("      <FileButton")),
-			parts(segment("        key={file.docId}")),
-			parts(segment("        active={file.docId === selectedDocId}")),
-			parts(segment("        icon={FileText}")),
-			parts(segment("        label={file.basename}")),
-			parts(segment("        onClick={() => openArtifact(file)}")),
-			parts(segment("      />")),
-			parts(segment("    ));")),
-			parts(segment("  }")),
-		],
-	},
-	{
-		command: "await next artifact_registered event",
-		lines: [
-			line(
-				"  // socket events patch the current run without a full reload",
-				"green",
-			),
-			parts(
-				kw("  const "),
-				segment("unsubscribe = socket.on("),
-				str('"event:notification"'),
-				segment(", (message) => {"),
-			),
-			parts(
-				segment("    if (message.payload.event !== "),
-				str('"artifact_registered"'),
-				segment(") return;"),
-			),
-			parts(segment("    liveRunIndex.patch(message.runId, (run) => ({")),
-			parts(segment("      ...run,")),
-			parts(
-				segment(
-					"      artifacts: mergeArtifactRegistration(run.artifacts, message.payload),",
-				),
-			),
-			parts(segment("      lastEventAt: message.timestamp,")),
-			parts(segment("    }));")),
-			parts(segment("    hydrateVisibleRun(message.runId);")),
-			parts(segment("  });")),
-		],
-	},
-	{
-		command: "watch .rp1/work --event write --artifact",
-		lines: [
-			line("  // file writes become rows before the agent finishes", "green"),
-			parts(
-				kw("  async "),
-				segment("function indexWorkFile(filePath: string) {"),
-			),
-			parts(segment("    const metadata = await readFrontmatter(filePath);")),
-			parts(segment("    if (!metadata.rp1_doc_id) return null;")),
-			parts(segment("    return {")),
-			parts(segment("      docId: metadata.rp1_doc_id,")),
-			parts(segment("      path: toProjectRelativePath(filePath),")),
-			parts(segment("      type: detectArtifactType(filePath),")),
-			parts(segment("      updatedDuringRun: true,")),
-			parts(segment("    };")),
-			parts(segment("  }")),
-		],
-	},
-	{
-		command: "build artifact index --visible-first",
-		lines: [
-			line(
-				"  // keep the selected artifact first, then preserve run order",
-				"green",
-			),
-			parts(
-				kw("  function "),
-				segment("visibleArtifacts(groups, selectedArtifact) {"),
-			),
-			parts(
-				segment("    const flat = groups.flatMap((group) => group.artifacts);"),
-			),
-			parts(
-				segment(
-					"    const selected = flat.find((item) => item.docId === selectedArtifact?.docId);",
-				),
-			),
-			parts(segment("    if (!selected) return flat;")),
-			line(""),
-			parts(segment("    return [")),
-			parts(segment("      selected,")),
-			parts(
-				segment(
-					"      ...flat.filter((item) => item.docId !== selected.docId),",
-				),
-			),
-			parts(segment("    ];")),
-			parts(segment("  }")),
-		],
-	},
-	{
-		command: "stream markdown drafts into artifact panel",
-		lines: [
-			line(
-				"  // markdown drafts become inspectable as soon as they exist",
-				"green",
-			),
-			parts(
-				kw("  async "),
-				segment("function publishDraft(featureId, name, body) {"),
-			),
-			parts(
-				segment("    const path = "),
-				str('"features/"'),
-				segment(" + featureId + "),
-				str('"/"'),
-				segment(" + name + "),
-				str('".md"'),
-				segment(";"),
-			),
-			parts(segment("    await workDir.write(path, body);")),
-			parts(segment("    await emit({")),
-			parts(
-				segment("      event: "),
-				str('"artifact_registered"'),
-				segment(","),
-			),
-			parts(segment("      storageRoot: "), str('"work_dir"'), segment(",")),
-			parts(segment("      path,")),
-			parts(segment("      type: "), str('"markdown"'), segment(",")),
-			parts(segment("    });")),
-			parts(segment("  }")),
-		],
-	},
-	{
-		command: "compile artifact groups --no-tabs",
-		lines: [
-			line("  // one surface, many files, no step tabs required", "green"),
-			parts(
-				kw("  const "),
-				segment("artifactRows = groups.reduce((rows, group) => {"),
-			),
-			parts(segment("    for (const artifact of group.artifacts) {")),
-			parts(segment("      rows.push({")),
-			parts(segment("        id: artifact.docId,")),
-			parts(segment("        label: basename(artifact.path),")),
-			parts(
-				segment("        sourceStep: group.stepId ?? "),
-				str('"run"'),
-				segment(","),
-			),
-			parts(segment("        open: () => selectArtifact(artifact),")),
-			parts(segment("      });")),
-			parts(segment("    }")),
-			parts(segment("    return rows;")),
-			parts(segment("  }, []);")),
-		],
-	},
-] satisfies readonly CodeStreamVariant[];
-
-const ARTIFACT_EMPTY_STATE_FOOTERS = [
-	[
-		line(" stdout  [:::: scan active ::::]"),
-		line(" emit    [                  ]  waiting for first artifact"),
-		line(" panel   [ empty            ]"),
-	],
-	[
-		line(" stdout  [::::::::::::] -- bytes -- -- --"),
-		line(" emit    [====              ]  detecting handoff"),
-		line(" panel   [ empty            ]"),
-	],
-	[
-		line(" stdout  [::::::::::::]"),
-		line(" emit    [============      ]  registry opening"),
-		line(" panel   [ empty            ]"),
-	],
-	[
-		line(" stdout  [::::::::::::]  draft.md"),
-		line(" emit    [================] metadata resolved"),
-		line(" panel   [....            ] file row forming"),
-	],
-	[
-		line(" stdout  [::::::::::::]  emit [====================]"),
-		line(" panel   [ file-list ghosted until first registered artifact ]"),
-		line(" cursor  [ steady ]"),
-	],
-	[
-		line(" stdout  [::::::::::::]  emit [....................]"),
-		line(" panel   [ empty, listening ]"),
-		line(" cursor  [ steady ]"),
-	],
-] satisfies readonly (readonly ArtifactEmptyStateLine[])[];
-
-export const ARTIFACT_EMPTY_STATE_VARIANT_COUNT = CODE_STREAM_VARIANTS.length;
-export const ARTIFACT_EMPTY_STATE_FRAME_COUNT = 6;
-export const ARTIFACT_EMPTY_STATE_FRAME_INTERVAL_MS = 880;
-
-const FINAL_FRAME_INDEX = ARTIFACT_EMPTY_STATE_FRAME_COUNT - 1;
-
-const addCursor = (line: ArtifactEmptyStateLine): ArtifactEmptyStateLine => [
-	...line,
-	cursor(" |"),
-];
-
-const buildFrameLines = (
-	variant: CodeStreamVariant,
-	frameIndex: number,
-): readonly ArtifactEmptyStateLine[] => {
-	const revealCount = Math.min(
-		variant.lines.length,
-		Math.ceil(
-			((frameIndex + 1) / ARTIFACT_EMPTY_STATE_FRAME_COUNT) *
-				variant.lines.length,
-		),
-	);
-	const visibleLines = variant.lines.slice(0, revealCount);
-	const animatedLines = visibleLines.map((codeLine, index) =>
-		index === visibleLines.length - 1 && frameIndex !== FINAL_FRAME_INDEX
-			? addCursor(codeLine)
-			: codeLine,
-	);
-
-	return [
-		line(" rp1://arcade/artifacts"),
-		line(` $ ${variant.command}`),
-		line(""),
-		line("  // waiting for your workflow to produce an artifact", "green"),
-		...animatedLines,
-		line(""),
-		...(ARTIFACT_EMPTY_STATE_FOOTERS[frameIndex] ?? []),
-	];
-};
-
-const ARTIFACT_EMPTY_STATE_VARIANT_FRAMES = CODE_STREAM_VARIANTS.map(
-	(variant) =>
-		Array.from({ length: ARTIFACT_EMPTY_STATE_FRAME_COUNT }, (_, frameIndex) =>
-			buildFrameLines(variant, frameIndex),
-		),
-);
-
-const randomVariantIndex = () =>
-	Math.floor(Math.random() * ARTIFACT_EMPTY_STATE_VARIANT_COUNT);
+.artifact-reconstruction-loader .neon-glow {
+	fill: var(--artifact-loader-neon);
+	text-shadow: var(--artifact-loader-shadow);
+}
+.artifact-reconstruction-loader .dim-glow {
+	fill: var(--artifact-loader-dim);
+	text-shadow: var(--artifact-loader-shadow-dim);
+}
+.artifact-reconstruction-loader .r9 { animation: artifact-loader-r9 10s infinite; }
+.artifact-reconstruction-loader .r8 { animation: artifact-loader-r8 10s infinite; }
+.artifact-reconstruction-loader .r7 { animation: artifact-loader-r7 10s infinite; }
+.artifact-reconstruction-loader .r6 { animation: artifact-loader-r6 10s infinite; }
+.artifact-reconstruction-loader .r5 { animation: artifact-loader-r5 10s infinite; }
+.artifact-reconstruction-loader .r4 { animation: artifact-loader-r4 10s infinite; }
+.artifact-reconstruction-loader .r3 { animation: artifact-loader-r3 10s infinite; }
+.artifact-reconstruction-loader .r2 { animation: artifact-loader-r2 10s infinite; }
+.artifact-reconstruction-loader .r1 { animation: artifact-loader-r1 10s infinite; }
+@keyframes artifact-loader-r9 { 0%, 20% { opacity: 0; } 21.5% { opacity: 1; fill: var(--artifact-loader-flash); text-shadow: var(--artifact-loader-shadow-flash); } 23%, 94% { opacity: 1; fill: var(--artifact-loader-neon); text-shadow: var(--artifact-loader-shadow); } 95.5% { opacity: 1; fill: var(--artifact-loader-flash); } 97%, 100% { opacity: 0; } }
+@keyframes artifact-loader-r8 { 0%, 22% { opacity: 0; } 23.5% { opacity: 1; fill: var(--artifact-loader-flash); text-shadow: var(--artifact-loader-shadow-flash); } 25%, 92% { opacity: 1; fill: var(--artifact-loader-neon); text-shadow: var(--artifact-loader-shadow); } 93.5% { opacity: 1; fill: var(--artifact-loader-flash); } 95%, 100% { opacity: 0; } }
+@keyframes artifact-loader-r7 { 0%, 24% { opacity: 0; } 25.5% { opacity: 1; fill: var(--artifact-loader-flash); text-shadow: var(--artifact-loader-shadow-flash); } 27%, 90% { opacity: 1; fill: var(--artifact-loader-neon); text-shadow: var(--artifact-loader-shadow); } 91.5% { opacity: 1; fill: var(--artifact-loader-flash); } 93%, 100% { opacity: 0; } }
+@keyframes artifact-loader-r6 { 0%, 26% { opacity: 0; } 27.5% { opacity: 1; fill: var(--artifact-loader-flash); text-shadow: var(--artifact-loader-shadow-flash); } 29%, 88% { opacity: 1; fill: var(--artifact-loader-neon); text-shadow: var(--artifact-loader-shadow); } 89.5% { opacity: 1; fill: var(--artifact-loader-flash); } 91%, 100% { opacity: 0; } }
+@keyframes artifact-loader-r5 { 0%, 28% { opacity: 0; } 29.5% { opacity: 1; fill: var(--artifact-loader-flash); text-shadow: var(--artifact-loader-shadow-flash); } 31%, 86% { opacity: 1; fill: var(--artifact-loader-neon); text-shadow: var(--artifact-loader-shadow); } 87.5% { opacity: 1; fill: var(--artifact-loader-flash); } 89%, 100% { opacity: 0; } }
+@keyframes artifact-loader-r4 { 0%, 30% { opacity: 0; } 31.5% { opacity: 1; fill: var(--artifact-loader-flash); text-shadow: var(--artifact-loader-shadow-flash); } 33%, 84% { opacity: 1; fill: var(--artifact-loader-neon); text-shadow: var(--artifact-loader-shadow); } 85.5% { opacity: 1; fill: var(--artifact-loader-flash); } 87%, 100% { opacity: 0; } }
+@keyframes artifact-loader-r3 { 0%, 32% { opacity: 0; } 33.5% { opacity: 1; fill: var(--artifact-loader-flash); text-shadow: var(--artifact-loader-shadow-flash); } 35%, 82% { opacity: 1; fill: var(--artifact-loader-neon); text-shadow: var(--artifact-loader-shadow); } 83.5% { opacity: 1; fill: var(--artifact-loader-flash); } 85%, 100% { opacity: 0; } }
+@keyframes artifact-loader-r2 { 0%, 34% { opacity: 0; } 35.5% { opacity: 1; fill: var(--artifact-loader-flash); text-shadow: var(--artifact-loader-shadow-flash); } 37%, 80% { opacity: 1; fill: var(--artifact-loader-neon); text-shadow: var(--artifact-loader-shadow); } 81.5% { opacity: 1; fill: var(--artifact-loader-flash); } 83%, 100% { opacity: 0; } }
+@keyframes artifact-loader-r1 { 0%, 36% { opacity: 0; } 37.5% { opacity: 1; fill: var(--artifact-loader-flash); text-shadow: var(--artifact-loader-shadow-flash); } 39%, 78% { opacity: 1; fill: var(--artifact-loader-neon); text-shadow: var(--artifact-loader-shadow); } 79.5% { opacity: 1; fill: var(--artifact-loader-flash); } 81%, 100% { opacity: 0; } }
+.artifact-reconstruction-loader .line-stagger-1 { animation: artifact-loader-title 10s infinite; }
+@keyframes artifact-loader-title { 0%, 5% { opacity: 0; } 6%, 95% { opacity: 1; } 100% { opacity: 0; } }
+.artifact-reconstruction-loader .cursor { animation: artifact-loader-blink 1s infinite; }
+@keyframes artifact-loader-blink { 0%, 49% { opacity: 1; } 50%, 100% { opacity: 0; } }
+.artifact-reconstruction-loader .grid-line { font-weight: 700; }
+.artifact-reconstruction-loader .gl1 { animation: artifact-loader-radar 2.5s infinite linear 0s; }
+.artifact-reconstruction-loader .gl2 { animation: artifact-loader-radar 2.5s infinite linear 0.4s; }
+.artifact-reconstruction-loader .gl3 { animation: artifact-loader-radar 2.5s infinite linear 0.8s; }
+.artifact-reconstruction-loader .gl4 { animation: artifact-loader-radar 2.5s infinite linear 1.2s; }
+.artifact-reconstruction-loader .gl5 { animation: artifact-loader-radar 2.5s infinite linear 1.6s; }
+.artifact-reconstruction-loader .gl6 { animation: artifact-loader-radar 2.5s infinite linear 2s; }
+@keyframes artifact-loader-radar { 0%, 100% { opacity: 0.2; fill: var(--artifact-loader-radar-low); text-shadow: none; } 50% { opacity: 1; fill: var(--artifact-loader-bright); text-shadow: var(--artifact-loader-shadow-bright); } }
+.artifact-reconstruction-loader .geo { font-size: 14px; font-weight: 700; opacity: 0.8; }
+.artifact-reconstruction-loader .float1 { animation: artifact-loader-hover1 8s ease-in-out infinite; transform-origin: 100px 330px; }
+.artifact-reconstruction-loader .float2 { animation: artifact-loader-hover2 6s ease-in-out infinite; transform-origin: 1100px 280px; }
+@keyframes artifact-loader-hover1 { 0%, 100% { transform: translateY(0) rotate(0deg); } 50% { transform: translateY(-25px) rotate(12deg); } }
+@keyframes artifact-loader-hover2 { 0%, 100% { transform: translateY(0) rotate(0deg); } 50% { transform: translateY(20px) rotate(-15deg); } }
+.artifact-reconstruction-loader .stars { animation: artifact-loader-twinkle 5s infinite; }
+@keyframes artifact-loader-twinkle { 0%, 100% { opacity: 0.2; } 50% { opacity: 0.7; fill: var(--artifact-loader-bright); text-shadow: var(--artifact-loader-shadow-bright); } }
+.artifact-reconstruction-loader[data-animation-state="static"] * {
+	animation: none !important;
+}
+.artifact-reconstruction-loader[data-animation-state="static"] .line-stagger-1,
+.artifact-reconstruction-loader[data-animation-state="static"] .stars,
+.artifact-reconstruction-loader[data-animation-state="static"] .grid-line,
+.artifact-reconstruction-loader[data-animation-state="static"] .geo,
+.artifact-reconstruction-loader[data-animation-state="static"] .reconstruction-row {
+	opacity: 1;
+	fill: var(--artifact-loader-neon);
+	text-shadow: var(--artifact-loader-shadow);
+}
+`;
 
 export function ArtifactEmptyState({ className }: ArtifactEmptyStateProps) {
 	const prefersReducedMotion = usePrefersReducedMotion();
-	const [variantIndex] = useState(randomVariantIndex);
-	const [frameIndex, setFrameIndex] = useState(() =>
-		prefersReducedMotion ? FINAL_FRAME_INDEX : 0,
-	);
-	const variantFrames =
-		ARTIFACT_EMPTY_STATE_VARIANT_FRAMES[variantIndex] ??
-		ARTIFACT_EMPTY_STATE_VARIANT_FRAMES[0];
-
-	useEffect(() => {
-		if (prefersReducedMotion) {
-			setFrameIndex(FINAL_FRAME_INDEX);
-			return;
-		}
-
-		setFrameIndex(0);
-
-		const intervalId = window.setInterval(() => {
-			setFrameIndex(
-				(current) => (current + 1) % ARTIFACT_EMPTY_STATE_FRAME_COUNT,
-			);
-		}, ARTIFACT_EMPTY_STATE_FRAME_INTERVAL_MS);
-
-		return () => {
-			window.clearInterval(intervalId);
-		};
-	}, [prefersReducedMotion]);
 
 	return (
 		<output
 			aria-live="polite"
-			aria-label="Waiting for artifacts"
+			aria-label="Creating artifacts"
 			className={cn(
-				"flex h-full min-h-[18rem] w-full items-center justify-center px-0 py-6",
+				"flex h-full min-h-[18rem] w-full items-center justify-center overflow-hidden",
 				className,
 			)}
 		>
-			<span className="sr-only">Waiting for artifacts</span>
-			<svg
-				aria-hidden="true"
-				data-testid="artifact-empty-state-visual"
-				data-animation-state={prefersReducedMotion ? "static" : "running"}
-				data-frame-index={frameIndex}
-				data-variant-index={variantIndex}
-				viewBox="0 0 680 360"
-				className="aspect-[17/9] w-[90%] min-w-[min(20rem,92%)] max-w-none select-none overflow-visible text-muted-foreground/65"
-			>
-				{variantFrames[frameIndex].map((line, index) => (
+			<span className="sr-only">Creating artifacts</span>
+			<div className="h-full w-full max-w-[1400px]">
+				<svg
+					aria-hidden="true"
+					data-testid="artifact-empty-state-visual"
+					data-animation-state={prefersReducedMotion ? "static" : "running"}
+					xmlns="http://www.w3.org/2000/svg"
+					viewBox="0 0 1200 800"
+					width="100%"
+					height="100%"
+					className="artifact-reconstruction-loader block h-full w-full select-none font-mono"
+				>
+					<style>{LOADER_CSS}</style>
+
+					<g className="stars dim-glow" fontSize="14" fontWeight="700">
+						{STAR_POINTS.map((point) => (
+							<text key={`${point.x}-${point.y}`} x={point.x} y={point.y}>
+								{point.text}
+							</text>
+						))}
+					</g>
+
+					<g className="grid neon-glow" textAnchor="middle">
+						{GRID_LINES.map((gridLine) => (
+							<text
+								key={gridLine.className}
+								x={gridLine.x}
+								y={gridLine.y}
+								fontSize={gridLine.size}
+								className={gridLine.className}
+								xmlSpace="preserve"
+							>
+								{gridLine.text}
+							</text>
+						))}
+					</g>
+
 					<text
-						key={`${index}-${line.map((item) => item.text).join("")}`}
-						x="2"
-						y={14 + index * 7}
-						className="font-mono text-[4.5px] leading-none"
+						x="80"
+						y="380"
+						className="geo float1 neon-glow"
 						xmlSpace="preserve"
 					>
-						{line.map((item, segmentIndex) => (
+						<tspan x="80" dy="0">
+							{"   *"}
+						</tspan>
+						<tspan x="80" dy="16">
+							{" /   \\"}
+						</tspan>
+						<tspan x="80" dy="16">
+							{"* *"}
+						</tspan>
+						<tspan x="80" dy="16">
+							{" \\   /"}
+						</tspan>
+						<tspan x="80" dy="16">
+							{"   *"}
+						</tspan>
+					</text>
+
+					<text
+						x="1100"
+						y="280"
+						className="geo float2 neon-glow"
+						xmlSpace="preserve"
+					>
+						<tspan x="1100" dy="0">
+							{"  /^\\"}
+						</tspan>
+						<tspan x="1100" dy="16">
+							{" / | \\"}
+						</tspan>
+						<tspan x="1100" dy="16">
+							{"<--+-->"}
+						</tspan>
+						<tspan x="1100" dy="16">
+							{" \\ | /"}
+						</tspan>
+						<tspan x="1100" dy="16">
+							{"  \\v/"}
+						</tspan>
+					</text>
+
+					<g className="neon-glow" fontSize="28" fontWeight="700">
+						<text x="50" y="80" className="line-stagger-1">
+							CREATING ARTIFACTS
+							<tspan className="cursor">_</tspan>
+						</text>
+					</g>
+
+					<text
+						className="neon-glow"
+						fontSize="42"
+						fontWeight="700"
+						xmlSpace="preserve"
+						textAnchor="middle"
+					>
+						{GAMEPAD_ROWS.map((row) => (
 							<tspan
-								key={`${segmentIndex}-${item.text}`}
-								data-segment-tone={item.tone}
-								style={{ fill: ARTIFACT_EMPTY_STATE_TONE_FILL[item.tone] }}
+								key={row.className}
+								x="600"
+								y={row.y}
+								className={row.className}
 							>
-								{item.text}
+								{row.text}
 							</tspan>
 						))}
 					</text>
-				))}
-			</svg>
+				</svg>
+			</div>
 		</output>
 	);
 }


### PR DESCRIPTION
## Summary
- replace the artifact empty-state code-stream loader with the new artifact reconstruction SVG animation
- make the loader transparent so it blends into the Arcade panel surface
- adapt the loader palette for light and dark themes while preserving reduced-motion support

## Verification
- bun test src/__tests__/components/v2/ArtifactEmptyState.test.tsx
- just check-web-ui
- just build-web-ui
- browser checked light and dark modes