### PR TITLE
fix(birds-eye): review fixes, mermaid validator hardening, animation resize

### DIFF
--- a/catalog/agents.yaml
+++ b/catalog/agents.yaml
@@ -42,7 +42,7 @@ agents:
   - name: rp1-base:project-documenter
     description: "Generates arc42/C4-aligned birds-eye-view documents with per-claim provenance and Reflexion appendix"
     plugin: base
-    last_checksum: f9ef93984a4d2fdab723afcac79398aa4a8098a0cdc31970f21a1f5d32157c52
+    last_checksum: e0822f5f22a28afea0f8ee3e31483eb3be9f1537f48677b14a9ab474f2e4da9e
   - name: rp1-base:prompt-pipeline-runner
     description: "Executes the six-stage prompt-writer pipeline and produces two mandatory output artifacts (ready-to-run prompt, confidence report)"
     plugin: base

--- a/cli/src/__tests__/agent-tools/mmd-validate/validator.test.ts
+++ b/cli/src/__tests__/agent-tools/mmd-validate/validator.test.ts
@@ -175,6 +175,21 @@ describe("validator", () => {
 			expect(result[0].context).toBe('  A["First\\nSecond"] --> B');
 		});
 
+		test("flags multiple escaped newlines on the same line", () => {
+			const block: DiagramBlock = {
+				index: 0,
+				content: 'flowchart TD\n  A["One\\nTwo\\nThree"] --> B',
+				startLine: 10,
+				endLine: 11,
+			};
+
+			const result = findEscapedNewlineErrors(block);
+
+			expect(result).toHaveLength(2);
+			expect(result[0].column).toBe(9);
+			expect(result[1].column).toBe(14);
+		});
+
 		test("allows Mermaid source without escaped newlines", () => {
 			const block: DiagramBlock = {
 				index: 0,

--- a/cli/src/__tests__/agent-tools/mmd-validate/validator.test.ts
+++ b/cli/src/__tests__/agent-tools/mmd-validate/validator.test.ts
@@ -6,7 +6,10 @@
 
 import { describe, expect, test } from "bun:test";
 import type { DiagramBlock } from "../../../agent-tools/mmd-validate/models.js";
-import { parseErrorLocation } from "../../../agent-tools/mmd-validate/validator.js";
+import {
+	findEscapedNewlineErrors,
+	parseErrorLocation,
+} from "../../../agent-tools/mmd-validate/validator.js";
 
 describe("validator", () => {
 	describe("parseErrorLocation", () => {
@@ -150,6 +153,37 @@ describe("validator", () => {
 			const result = parseErrorLocation(error, block);
 
 			expect(result.line).toBe(12);
+		});
+	});
+
+	describe("findEscapedNewlineErrors", () => {
+		test("flags literal escaped newlines in diagram source", () => {
+			const block: DiagramBlock = {
+				index: 2,
+				content: 'flowchart TD\n  A["First\\nSecond"] --> B',
+				startLine: 20,
+				endLine: 21,
+			};
+
+			const result = findEscapedNewlineErrors(block);
+
+			expect(result).toHaveLength(1);
+			expect(result[0].diagramIndex).toBe(2);
+			expect(result[0].line).toBe(21);
+			expect(result[0].column).toBe(11);
+			expect(result[0].message).toContain("Escaped newline");
+			expect(result[0].context).toBe('  A["First\\nSecond"] --> B');
+		});
+
+		test("allows Mermaid source without escaped newlines", () => {
+			const block: DiagramBlock = {
+				index: 0,
+				content: 'flowchart TD\n  A["First<br>Second"] --> B',
+				startLine: 1,
+				endLine: 2,
+			};
+
+			expect(findEscapedNewlineErrors(block)).toHaveLength(0);
 		});
 	});
 });

--- a/cli/src/__tests__/build/artifact-template-contracts.test.ts
+++ b/cli/src/__tests__/build/artifact-template-contracts.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+const projectRoot = join(import.meta.dir, "..", "..", "..", "..");
+const FRONTMATTER_REGEX = /^---\r?\n[\s\S]*?\r?\n---\r?\n/;
+
+const readProjectFile = async (relativePath: string): Promise<string> =>
+	readFile(join(projectRoot, relativePath), "utf-8");
+
+describe("artifact template contracts", () => {
+	test("birds-eye template stores snapshot metadata in generated frontmatter", async () => {
+		const template = await readProjectFile(
+			"plugins/base/skills/artifact-templates/templates/project-documenter/birds-eye-view.md",
+		);
+		const body = template.replace(FRONTMATTER_REGEX, "");
+
+		expect(body.startsWith("---\n")).toBe(true);
+		expect(body).toContain('snapshot_generated: "{YYYY-MM-DD}"');
+		expect(body).toContain('snapshot_git_sha: "{GIT_SHA}"');
+		expect(body).toContain("snapshot_coverage:");
+		expect(body).toContain("snapshot_regenerate_command:");
+		expect(body).not.toContain("> **Snapshot**");
+		expect(body).toContain("# {Project Name} — Bird's-Eye View");
+	});
+});

--- a/cli/src/agent-tools/mmd-validate/validator.ts
+++ b/cli/src/agent-tools/mmd-validate/validator.ts
@@ -75,18 +75,17 @@ export const findEscapedNewlineErrors = (
 	block: DiagramBlock,
 ): readonly DiagramError[] =>
 	block.content.split("\n").flatMap((line, offset): readonly DiagramError[] => {
-		const column = line.indexOf("\\n");
-		if (column === -1) return [];
-
-		return [
-			{
+		const errors: DiagramError[] = [];
+		for (const m of line.matchAll(/\\n/g)) {
+			errors.push({
 				diagramIndex: block.index,
 				message: ESCAPED_NEWLINE_MESSAGE,
 				line: block.startLine + offset,
-				column: column + 1,
+				column: m.index + 1,
 				context: line.slice(0, 80),
-			},
-		];
+			});
+		}
+		return errors;
 	});
 
 /**

--- a/cli/src/agent-tools/mmd-validate/validator.ts
+++ b/cli/src/agent-tools/mmd-validate/validator.ts
@@ -16,6 +16,9 @@ import type {
 	MmdValidateData,
 } from "./models.js";
 
+const ESCAPED_NEWLINE_MESSAGE =
+	'Escaped newline found in Mermaid source; use <br> or shorter labels instead of literal "\\n".';
+
 /**
  * Parse mermaid error for line/column information.
  * Attempts to extract location details from error message and hash.
@@ -64,6 +67,29 @@ export const parseErrorLocation = (
 };
 
 /**
+ * Mermaid accepts escaped newlines syntactically but renders them as visible
+ * "\\n" text. Treat this as a validation error before browser parsing so
+ * agents repair diagrams instead of shipping visually broken labels.
+ */
+export const findEscapedNewlineErrors = (
+	block: DiagramBlock,
+): readonly DiagramError[] =>
+	block.content.split("\n").flatMap((line, offset): readonly DiagramError[] => {
+		const column = line.indexOf("\\n");
+		if (column === -1) return [];
+
+		return [
+			{
+				diagramIndex: block.index,
+				message: ESCAPED_NEWLINE_MESSAGE,
+				line: block.startLine + offset,
+				column: column + 1,
+				context: line.slice(0, 80),
+			},
+		];
+	});
+
+/**
  * Create validation result from browser result.
  * Maps browser validation result to DiagramValidationResult.
  */
@@ -88,6 +114,22 @@ const toValidationResult = (
 	};
 };
 
+const buildValidationData = (
+	results: readonly DiagramValidationResult[],
+): MmdValidateData => {
+	const validCount = results.filter((r) => r.valid).length;
+	const invalidCount = results.filter((r) => !r.valid).length;
+
+	return {
+		diagrams: results,
+		summary: {
+			total: results.length,
+			valid: validCount,
+			invalid: invalidCount,
+		},
+	};
+};
+
 /**
  * Validate all diagram blocks in parallel.
  * Uses shared browser instance and returns MmdValidateData with results and summary.
@@ -104,13 +146,39 @@ export const validateDiagrams = (
 		});
 	}
 
+	const preValidationResults: Array<DiagramValidationResult | null> =
+		blocks.map((block) => {
+			const errors = findEscapedNewlineErrors(block);
+			return errors.length > 0
+				? ({
+						index: block.index,
+						valid: false,
+						startLine: block.startLine,
+						errors,
+					} satisfies DiagramValidationResult)
+				: null;
+		});
+	const browserBlocks = blocks.filter(
+		(_, index) => preValidationResults[index] === null,
+	);
+
+	if (browserBlocks.length === 0) {
+		return TE.right(
+			buildValidationData(
+				preValidationResults.filter(
+					(result): result is DiagramValidationResult => result !== null,
+				),
+			),
+		);
+	}
+
 	return pipe(
 		// Initialize browser once before parallel validation
 		initBrowser(),
 		TE.chain((page) =>
 			pipe(
 				// Create validation tasks for all blocks
-				blocks.map((block) =>
+				browserBlocks.map((block) =>
 					pipe(
 						validateInBrowser(page, block.content),
 						TE.map((result) => toValidationResult(result, block)),
@@ -121,18 +189,16 @@ export const validateDiagrams = (
 			),
 		),
 		// Map results to MmdValidateData
-		TE.map((results): MmdValidateData => {
-			const validCount = results.filter((r) => r.valid).length;
-			const invalidCount = results.filter((r) => !r.valid).length;
+		TE.map((browserResults): MmdValidateData => {
+			let browserIndex = 0;
+			const mergedResults = preValidationResults.map((result) => {
+				if (result) return result;
+				const browserResult = browserResults[browserIndex];
+				browserIndex += 1;
+				return browserResult;
+			});
 
-			return {
-				diagrams: results,
-				summary: {
-					total: results.length,
-					valid: validCount,
-					invalid: invalidCount,
-				},
-			};
+			return buildValidationData(mergedResults);
 		}),
 		// Clean up browser after validation
 		TE.chainFirst(() => closeBrowser()),

--- a/cli/web-ui/src/__tests__/components/v2/UnifiedContentRenderer.test.tsx
+++ b/cli/web-ui/src/__tests__/components/v2/UnifiedContentRenderer.test.tsx
@@ -9,10 +9,17 @@ mock.module("@/components/MilkdownEditor/MilkdownEditor", () => ({
 		HTMLDivElement,
 		{
 			content: string;
+			onContentChange?: (markdown: string) => void;
 		}
-	>(({ content }, ref) => (
+	>(({ content, onContentChange }, ref) => (
 		<div ref={ref} data-testid="milkdown-editor">
 			{content}
+			<button
+				type="button"
+				onClick={() => onContentChange?.(content.replace("Visible", "Edited"))}
+			>
+				Edit
+			</button>
 		</div>
 	)),
 }));
@@ -68,5 +75,40 @@ describe("UnifiedContentRenderer", () => {
 		);
 
 		expect(screen.getByText("Frontmatter")).toBeTruthy();
+	});
+
+	test("hides markdown html comments by default", async () => {
+		const { UnifiedContentRenderer } = await import(
+			`../../../components/v2/UnifiedContentRenderer.tsx?renderer-test=${++importVersion}`
+		);
+
+		render(
+			<UnifiedContentRenderer
+				content={`# Hello\n\n<!-- internal metadata -->\n\nVisible`}
+				path="docs/test.md"
+			/>,
+		);
+
+		const editor = screen.getByTestId("milkdown-editor");
+		expect(editor.textContent).not.toContain("internal metadata");
+		expect(editor.textContent).toContain("Visible");
+	});
+
+	test("shows markdown html comments with frontmatter visibility enabled", async () => {
+		const { UnifiedContentRenderer } = await import(
+			`../../../components/v2/UnifiedContentRenderer.tsx?renderer-test=${++importVersion}`
+		);
+
+		render(
+			<UnifiedContentRenderer
+				content={`# Hello\n\n<!-- internal metadata -->\n\nVisible`}
+				path="docs/test.md"
+				showFrontmatter
+			/>,
+		);
+
+		expect(screen.getByTestId("milkdown-editor").textContent).toContain(
+			"internal metadata",
+		);
 	});
 });

--- a/cli/web-ui/src/__tests__/lib/markdown-comments.test.ts
+++ b/cli/web-ui/src/__tests__/lib/markdown-comments.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "bun:test";
+import {
+	restoreMarkdownHtmlComments,
+	stripMarkdownHtmlComments,
+} from "../../lib/markdown-comments";
+
+describe("markdown html comments", () => {
+	test("strips comments from display body and restores raw content", () => {
+		const original = "# Title\n\n<!-- hidden metadata -->\n\nVisible\n";
+
+		const { body, comments } = stripMarkdownHtmlComments(original);
+
+		expect(body).toBe("# Title\n\n\n\nVisible\n");
+		expect(body).not.toContain("hidden metadata");
+		expect(comments).toHaveLength(1);
+		expect(restoreMarkdownHtmlComments(comments, body)).toBe(original);
+	});
+
+	test("restores hidden comments into edited display body", () => {
+		const original = "# Title\n\n<!-- hidden metadata -->\n\nVisible\n";
+		const { body, comments } = stripMarkdownHtmlComments(original);
+		const editedBody = body.replace("Visible", "Edited");
+
+		const restored = restoreMarkdownHtmlComments(comments, editedBody);
+
+		expect(restored).toContain("<!-- hidden metadata -->");
+		expect(restored).toContain("Edited");
+		expect(restored).not.toContain("Visible");
+	});
+
+	test("keeps comments inside fenced code blocks visible as code", () => {
+		const markdown = [
+			"# Title",
+			"",
+			"```html",
+			"<!-- code sample -->",
+			"```",
+			"",
+			"<!-- hidden metadata -->",
+		].join("\n");
+
+		const { body, comments } = stripMarkdownHtmlComments(markdown);
+
+		expect(body).toContain("<!-- code sample -->");
+		expect(body).not.toContain("hidden metadata");
+		expect(comments).toHaveLength(1);
+	});
+});

--- a/cli/web-ui/src/__tests__/lib/mermaid-utils.test.ts
+++ b/cli/web-ui/src/__tests__/lib/mermaid-utils.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "bun:test";
+import { normalizeMermaidEscapedNewlines } from "../../lib/mermaid-utils";
+
+describe("mermaid utils", () => {
+	test("normalizes escaped newlines for Mermaid display", () => {
+		const code = 'flowchart TD\n  A["First\\nSecond"] --> B';
+
+		expect(normalizeMermaidEscapedNewlines(code)).toBe(
+			'flowchart TD\n  A["First<br>Second"] --> B',
+		);
+	});
+
+	test("leaves normal Mermaid newlines intact", () => {
+		const code = "flowchart TD\n  A --> B";
+
+		expect(normalizeMermaidEscapedNewlines(code)).toBe(code);
+	});
+});

--- a/cli/web-ui/src/components/MarkdownViewer/MarkdownViewer.tsx
+++ b/cli/web-ui/src/components/MarkdownViewer/MarkdownViewer.tsx
@@ -22,6 +22,7 @@ import {
 	getEditableText,
 	getEditableTextNodes,
 } from "@/lib/editable-text-nodes";
+import { stripMarkdownHtmlComments } from "@/lib/markdown-comments";
 import { cn } from "@/lib/utils";
 import { useAnnotationContextSafe } from "@/providers/AnnotationProvider";
 import type { Annotation } from "@/types/annotations";
@@ -320,7 +321,15 @@ export function MarkdownViewer({
 		return parts.join("/");
 	}, [path]);
 
-	const headings = useMemo(() => extractHeadings(content), [content]);
+	const displayContent = useMemo(() => {
+		if (showFrontmatter) return content;
+		return stripMarkdownHtmlComments(content).body;
+	}, [content, showFrontmatter]);
+
+	const headings = useMemo(
+		() => extractHeadings(displayContent),
+		[displayContent],
+	);
 
 	useEffect(() => {
 		if (onHeadingsExtracted) {
@@ -439,7 +448,7 @@ export function MarkdownViewer({
 						},
 					}}
 				>
-					{content}
+					{displayContent}
 				</ReactMarkdown>
 			</article>
 

--- a/cli/web-ui/src/components/v2/ArtifactEmptyState.tsx
+++ b/cli/web-ui/src/components/v2/ArtifactEmptyState.tsx
@@ -203,7 +203,7 @@ export function ArtifactEmptyState({ className }: ArtifactEmptyStateProps) {
 			)}
 		>
 			<span className="sr-only">Creating artifacts</span>
-			<div className="h-full w-full max-w-[1400px]">
+			<div className="h-full w-full max-w-[700px] max-h-[400px]">
 				<svg
 					aria-hidden="true"
 					data-testid="artifact-empty-state-visual"

--- a/cli/web-ui/src/components/v2/UnifiedContentRenderer.tsx
+++ b/cli/web-ui/src/components/v2/UnifiedContentRenderer.tsx
@@ -95,6 +95,10 @@ function FrontmatterBlock({ raw }: { readonly raw: string }) {
 }
 
 import { restoreFrontmatter, stripFrontmatter } from "@/lib/frontmatter";
+import {
+	restoreMarkdownHtmlComments,
+	stripMarkdownHtmlComments,
+} from "@/lib/markdown-comments";
 
 function MarkdownEditorWithSave({
 	content,
@@ -187,10 +191,16 @@ function MarkdownEditorWithSave({
 		});
 	}, [content]);
 
-	const { body: editorContent, frontmatter } = useMemo(
+	const { body: bodyWithoutFrontmatter, frontmatter } = useMemo(
 		() => stripFrontmatter(resolvedContent),
 		[resolvedContent],
 	);
+	const { body: editorContent, comments: hiddenHtmlComments } = useMemo(() => {
+		if (showFrontmatter) {
+			return { body: bodyWithoutFrontmatter, comments: [] };
+		}
+		return stripMarkdownHtmlComments(bodyWithoutFrontmatter);
+	}, [bodyWithoutFrontmatter, showFrontmatter]);
 	const editorContainerRef = useRef<HTMLElement>(null);
 	const gutterRef = useRef<HTMLDivElement>(null);
 	const editorRef = useRef<MilkdownEditorHandle>(null);
@@ -201,7 +211,10 @@ function MarkdownEditorWithSave({
 		(markdown: string) => {
 			if (!canSave) return;
 
-			const fullContent = restoreFrontmatter(frontmatter, markdown);
+			const bodyWithComments = showFrontmatter
+				? markdown
+				: restoreMarkdownHtmlComments(hiddenHtmlComments, markdown);
+			const fullContent = restoreFrontmatter(frontmatter, bodyWithComments);
 			latestEditorContentRef.current = fullContent;
 
 			if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
@@ -249,7 +262,17 @@ function MarkdownEditorWithSave({
 				}, SAVE_INDICATOR_DURATION_MS);
 			}, SAVE_DEBOUNCE_MS);
 		},
-		[canSave, runId, projectId, filePath, path, frontmatter, setSaveStatus],
+		[
+			canSave,
+			runId,
+			projectId,
+			filePath,
+			path,
+			frontmatter,
+			showFrontmatter,
+			hiddenHtmlComments,
+			setSaveStatus,
+		],
 	);
 
 	useEffect(() => {

--- a/cli/web-ui/src/components/v2/UnifiedContentRenderer.tsx
+++ b/cli/web-ui/src/components/v2/UnifiedContentRenderer.tsx
@@ -96,6 +96,7 @@ function FrontmatterBlock({ raw }: { readonly raw: string }) {
 
 import { restoreFrontmatter, stripFrontmatter } from "@/lib/frontmatter";
 import {
+	type HiddenMarkdownHtmlComment,
 	restoreMarkdownHtmlComments,
 	stripMarkdownHtmlComments,
 } from "@/lib/markdown-comments";
@@ -195,11 +196,17 @@ function MarkdownEditorWithSave({
 		() => stripFrontmatter(resolvedContent),
 		[resolvedContent],
 	);
-	const { body: editorContent, comments: hiddenHtmlComments } = useMemo(() => {
+	const hiddenHtmlCommentsRef = useRef<readonly HiddenMarkdownHtmlComment[]>(
+		[],
+	);
+	const { body: editorContent } = useMemo(() => {
 		if (showFrontmatter) {
-			return { body: bodyWithoutFrontmatter, comments: [] };
+			hiddenHtmlCommentsRef.current = [];
+			return { body: bodyWithoutFrontmatter };
 		}
-		return stripMarkdownHtmlComments(bodyWithoutFrontmatter);
+		const result = stripMarkdownHtmlComments(bodyWithoutFrontmatter);
+		hiddenHtmlCommentsRef.current = result.comments;
+		return { body: result.body };
 	}, [bodyWithoutFrontmatter, showFrontmatter]);
 	const editorContainerRef = useRef<HTMLElement>(null);
 	const gutterRef = useRef<HTMLDivElement>(null);
@@ -213,7 +220,7 @@ function MarkdownEditorWithSave({
 
 			const bodyWithComments = showFrontmatter
 				? markdown
-				: restoreMarkdownHtmlComments(hiddenHtmlComments, markdown);
+				: restoreMarkdownHtmlComments(hiddenHtmlCommentsRef.current, markdown);
 			const fullContent = restoreFrontmatter(frontmatter, bodyWithComments);
 			latestEditorContentRef.current = fullContent;
 
@@ -270,7 +277,6 @@ function MarkdownEditorWithSave({
 			path,
 			frontmatter,
 			showFrontmatter,
-			hiddenHtmlComments,
 			setSaveStatus,
 		],
 	);

--- a/cli/web-ui/src/lib/markdown-comments.ts
+++ b/cli/web-ui/src/lib/markdown-comments.ts
@@ -1,0 +1,125 @@
+export interface HiddenMarkdownHtmlComment {
+	readonly text: string;
+	readonly offset: number;
+	readonly index: number;
+}
+
+const HTML_COMMENT_RE = /<!--[\s\S]*?-->/g;
+const FENCE_RE = /^ {0,3}(`{3,}|~{3,})/;
+
+export function stripMarkdownHtmlComments(markdown: string): {
+	readonly body: string;
+	readonly comments: readonly HiddenMarkdownHtmlComment[];
+} {
+	const fenceRanges = findFenceRanges(markdown);
+	const comments: HiddenMarkdownHtmlComment[] = [];
+	let body = "";
+	let cursor = 0;
+	let visibleOffset = 0;
+	let commentIndex = 0;
+	let fenceIndex = 0;
+
+	HTML_COMMENT_RE.lastIndex = 0;
+	let match: RegExpExecArray | null;
+	while ((match = HTML_COMMENT_RE.exec(markdown)) !== null) {
+		const start = match.index;
+		const end = start + match[0].length;
+
+		while (
+			fenceIndex < fenceRanges.length &&
+			fenceRanges[fenceIndex].end <= start
+		) {
+			fenceIndex += 1;
+		}
+
+		if (
+			fenceIndex < fenceRanges.length &&
+			rangesOverlap(start, end, fenceRanges[fenceIndex])
+		) {
+			continue;
+		}
+
+		const visibleSegment = markdown.slice(cursor, start);
+		body += visibleSegment;
+		visibleOffset += visibleSegment.length;
+		comments.push({
+			text: match[0],
+			offset: visibleOffset,
+			index: commentIndex,
+		});
+		commentIndex += 1;
+		cursor = end;
+	}
+
+	body += markdown.slice(cursor);
+	return { body, comments };
+}
+
+export function restoreMarkdownHtmlComments(
+	comments: readonly HiddenMarkdownHtmlComment[],
+	body: string,
+): string {
+	if (comments.length === 0) return body;
+
+	let restored = "";
+	let cursor = 0;
+	const orderedComments = [...comments].sort(
+		(a, b) => a.offset - b.offset || a.index - b.index,
+	);
+
+	for (const comment of orderedComments) {
+		const offset = Math.max(cursor, Math.min(comment.offset, body.length));
+		restored += body.slice(cursor, offset);
+		restored += comment.text;
+		cursor = offset;
+	}
+
+	return restored + body.slice(cursor);
+}
+
+function findFenceRanges(markdown: string): Array<{
+	readonly start: number;
+	readonly end: number;
+}> {
+	const ranges: Array<{ readonly start: number; readonly end: number }> = [];
+	let lineStart = 0;
+	let fence: {
+		readonly marker: "`" | "~";
+		readonly length: number;
+		readonly start: number;
+	} | null = null;
+
+	while (lineStart < markdown.length) {
+		const newlineIndex = markdown.indexOf("\n", lineStart);
+		const lineEnd = newlineIndex === -1 ? markdown.length : newlineIndex + 1;
+		const line = markdown.slice(lineStart, lineEnd);
+		const match = line.match(FENCE_RE);
+
+		if (match) {
+			const marker = match[1][0] as "`" | "~";
+			const length = match[1].length;
+			if (!fence) {
+				fence = { marker, length, start: lineStart };
+			} else if (fence.marker === marker && length >= fence.length) {
+				ranges.push({ start: fence.start, end: lineEnd });
+				fence = null;
+			}
+		}
+
+		lineStart = lineEnd;
+	}
+
+	if (fence) {
+		ranges.push({ start: fence.start, end: markdown.length });
+	}
+
+	return ranges;
+}
+
+function rangesOverlap(
+	start: number,
+	end: number,
+	range: { readonly start: number; readonly end: number },
+): boolean {
+	return start < range.end && end > range.start;
+}

--- a/cli/web-ui/src/lib/markdown-comments.ts
+++ b/cli/web-ui/src/lib/markdown-comments.ts
@@ -4,13 +4,13 @@ export interface HiddenMarkdownHtmlComment {
 	readonly index: number;
 }
 
-const HTML_COMMENT_RE = /<!--[\s\S]*?-->/g;
 const FENCE_RE = /^ {0,3}(`{3,}|~{3,})/;
 
 export function stripMarkdownHtmlComments(markdown: string): {
 	readonly body: string;
 	readonly comments: readonly HiddenMarkdownHtmlComment[];
 } {
+	const htmlCommentRe = /<!--[\s\S]*?-->/g;
 	const fenceRanges = findFenceRanges(markdown);
 	const comments: HiddenMarkdownHtmlComment[] = [];
 	let body = "";
@@ -19,9 +19,8 @@ export function stripMarkdownHtmlComments(markdown: string): {
 	let commentIndex = 0;
 	let fenceIndex = 0;
 
-	HTML_COMMENT_RE.lastIndex = 0;
 	let match: RegExpExecArray | null;
-	while ((match = HTML_COMMENT_RE.exec(markdown)) !== null) {
+	while ((match = htmlCommentRe.exec(markdown)) !== null) {
 		const start = match.index;
 		const end = start + match[0].length;
 

--- a/cli/web-ui/src/lib/mermaid-utils.ts
+++ b/cli/web-ui/src/lib/mermaid-utils.ts
@@ -21,6 +21,14 @@ export function initializeMermaid(isDark: boolean): void {
 	});
 }
 
+/**
+ * Mermaid renders escaped newlines as visible "\\n" text. Normalize them for
+ * display so older generated artifacts render with intended line breaks.
+ */
+export function normalizeMermaidEscapedNewlines(code: string): string {
+	return code.replace(/\\n/g, "<br>");
+}
+
 /** Render a Mermaid diagram and return the SVG string. */
 export async function renderMermaidSvg(
 	code: string,
@@ -28,7 +36,10 @@ export async function renderMermaidSvg(
 	isDark: boolean,
 ): Promise<string> {
 	initializeMermaid(isDark);
-	const { svg } = await mermaid.render(id, code);
+	const { svg } = await mermaid.render(
+		id,
+		normalizeMermaidEscapedNewlines(code),
+	);
 	return svg;
 }
 

--- a/plugins/base/agents/project-documenter.md
+++ b/plugins/base/agents/project-documenter.md
@@ -93,7 +93,7 @@ Every declarative sentence in sections §2–§14 MUST carry one of:
 | `[INFER — <rationale>, refutable by <evidence>]` | Claim is synthesized; state what would disprove it |
 | `[GAP — <what evidence would close it>]` | Expected claim but no source found |
 
-Section §0 SHOULD omit tags (metadata). Section §1 MAY omit tags (TL;DR summary). Sections §2–§14: MUST tag every sentence. Section §15 uses convergence/divergence/absence labels (Murphy & Notkin terminology) with `[KB]` and `[CODE]` citations.
+YAML frontmatter SHOULD omit tags. Section §1 MAY omit tags (TL;DR summary). Sections §2–§14: MUST tag every sentence. Section §15 uses convergence/divergence/absence labels (Murphy & Notkin terminology) with `[KB]` and `[CODE]` citations.
 
 ## CONDITIONAL_SECTIONS
 
@@ -144,11 +144,11 @@ Emit §15 when ≥1 divergence is found. List convergences briefly (1 line each)
 2. Read the template file at the listed **Template Path**.
 3. Use the template structure for output. Fill placeholders per the content guidance below.
 
-The template owns the 16-section structure, the Snapshot-header block at the top, diagram placement, and section ordering. This agent does not duplicate that contract — when they drift, the template wins.
+The template owns the 16-section structure, the snapshot YAML frontmatter, diagram placement, and section ordering. This agent does not duplicate that contract — when they drift, the template wins.
 
 ## Content Guidance
 
-- **Snapshot header** (top of file): populate `{YYYY-MM-DD}`, `{GIT_SHA}` (`git -C {CODE_ROOT} rev-parse --short HEAD`), KB files loaded (from §PROC step 3), KB last-updated date (from `{KB_ROOT}/meta.json` if present, else mtime), and the coverage tuple `{filled}/{total}/{conditional_emitted}/{gap_count}` computed from the classification in §PROC step 5.
+- **Snapshot frontmatter** (top of file): populate `snapshot_generated` from `{YYYY-MM-DD}`, `snapshot_git_sha` from `git -C {CODE_ROOT} rev-parse --short HEAD`, `snapshot_code_root`, `snapshot_kb_root`, `snapshot_kb_files` from §PROC step 3, and `snapshot_coverage` from the classification tuple `{filled}/{total}/{conditional_emitted}/{gap_count}` computed in §PROC step 5. Snapshot metadata belongs only in YAML frontmatter, not in a visible quote block.
 - **§1 TL;DR**: 5 bullets — what it is, who uses it, how to run it, where to look first, what's weird. Untagged.
 - **§2–§14**: every declarative sentence carries a `[KB|CODE|INFER|GAP]` tag per §PROVENANCE.
 - **§5 Tech stack**: name + purpose from `[CODE]` evidence; rationale from `[KB: charter.md|ADR|PRD]` or `[GAP — no decision note]`.
@@ -164,7 +164,7 @@ The template owns the 16-section structure, the Snapshot-header block at the top
 
 **Anti-loop**: Single-pass execution. No clarification, no iteration. Blocking issue → emit failure status, STOP. Mermaid validation loop is the sole exception (max 3 iterations).
 
-**Output discipline**: Output MUST conform to the 16-section structure defined by the loaded artifact template, with the Snapshot-header block at the top. Conditional sections (§7, §9, §15) are either emitted fully or omitted entirely — never stubs.
+**Output discipline**: Output MUST conform to the 16-section structure defined by the loaded artifact template, with snapshot metadata in YAML frontmatter at the top. Conditional sections (§7, §9, §15) are either emitted fully or omitted entirely — never stubs.
 
 **Truth constraints**: Generate ONLY from loaded KB + observed source + git metadata. Every claim in §2–§14 MUST carry a provenance tag per §PROVENANCE. Missing info → `[GAP]` tag with specific "what evidence would close it". Findings are conjectural — evidence suggests rather than asserts. Every significant claim MUST be refutable — state what would contradict it. Prefer hard-to-vary explanations where each detail is load-bearing. Do not self-immunize conclusions with unfalsifiable hedges. Preserve error-correction capacity: per-claim provenance tags let any reader challenge individual claims without dismissing the document.
 

--- a/plugins/base/skills/artifact-templates/templates/project-documenter/birds-eye-view.md
+++ b/plugins/base/skills/artifact-templates/templates/project-documenter/birds-eye-view.md
@@ -3,7 +3,7 @@ scope: workRoot
 path_pattern: "birds-eye/{YYYY-MM-DD}-{PROJECT_SLUG}.md"
 producer: project-documenter
 type: document
-description: "arc42/C4-aligned project overview artifact generated from KB + codebase by /project-birds-eye-view. 16 sections with per-claim provenance tags, snapshot metadata header, and conditional Reflexion appendix. Path uses date prefix and project slug with n+1 dedup — registration MUST use the producer's resolved OUTPUT_PATH, not this pattern, because dedup suffixes (-2, -3, …) are assigned at write time."
+description: "arc42/C4-aligned project overview artifact generated from KB + codebase by /project-birds-eye-view. 16 sections with per-claim provenance tags, snapshot metadata frontmatter, and conditional Reflexion appendix. Path uses date prefix and project slug with n+1 dedup — registration MUST use the producer's resolved OUTPUT_PATH, not this pattern, because dedup suffixes (-2, -3, …) are assigned at write time."
 strictness: flexible
 # No emit_hint: path_pattern is NOT safe to use directly for registration.
 # The `/project-birds-eye-view` dispatcher (or any caller) MUST register with the
@@ -11,11 +11,20 @@ strictness: flexible
 # n+1 dedup suffix that was actually assigned at write time. See
 # plugins/base/skills/project-birds-eye-view/SKILL.md for the canonical call.
 ---
-
-> **Snapshot** — generated {YYYY-MM-DD} from commit `{GIT_SHA}` in `{CODE_ROOT}`.
-> KB files loaded: {KB_FILES_WITH_VERSIONS}.
-> Coverage: {FILLED}/{TOTAL} sections, {CONDITIONAL_EMITTED} conditional emitted, {GAP_COUNT} GAPs.
-> **This is a regenerated snapshot. The source of truth is `{KB_ROOT}/`.** Regenerate via `/rp1-base:project-birds-eye-view` when KB changes materially.
+---
+snapshot_generated: "{YYYY-MM-DD}"
+snapshot_git_sha: "{GIT_SHA}"
+snapshot_code_root: "{CODE_ROOT}"
+snapshot_kb_root: "{KB_ROOT}"
+snapshot_kb_files: "{KB_FILES_WITH_VERSIONS}"
+snapshot_coverage:
+  filled: {FILLED}
+  total: {TOTAL}
+  conditional_emitted: {CONDITIONAL_EMITTED}
+  gaps: {GAP_COUNT}
+snapshot_source_of_truth: "{KB_ROOT}/"
+snapshot_regenerate_command: "/rp1-base:project-birds-eye-view"
+---
 
 # {Project Name} — Bird's-Eye View
 


### PR DESCRIPTION
## Summary
- **birds-eye-view**: move snapshot metadata to YAML frontmatter
- **mermaid validator**: reject escaped newline labels (`\n`) that break rendering, report all occurrences per line
- **markdown-comments**: move global regex into function scope to avoid shared mutable state
- **UnifiedContentRenderer**: use `useRef` for `hiddenHtmlComments` to prevent stale closures in save callback
- **artifact loading animation**: halve size (max-w 1400px → 700px)

## Test plan
- [x] `just test` passes
- [x] Mermaid validator rejects `\n` in labels (including multiple per line)
- [x] Birds-eye-view template uses frontmatter metadata
- [x] Web-UI type checks pass