### PR TITLE
fix(web-ui): make Activity project metadata inert

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
       - uses: extractions/setup-just@v2
 
       - name: Install dependencies
-        run: cd cli && bun install
+        run: cd cli && bun install --ignore-scripts
 
       - name: Verify catalogue is up to date
         run: just catalog-check

--- a/cli/web-ui/src/__tests__/pages/v2/HomePage.test.tsx
+++ b/cli/web-ui/src/__tests__/pages/v2/HomePage.test.tsx
@@ -372,7 +372,7 @@ describe("HomePage", () => {
 		).toBe("true");
 	});
 
-	test("treats project metadata clicks as run selection in the wide activity row", async () => {
+	test("opens the project from the dedicated project area in the wide activity row", async () => {
 		wideActivityLayout = true;
 
 		await renderHomePage();
@@ -381,12 +381,15 @@ describe("HomePage", () => {
 			expect(getPreviewText()).toBe("Preview run-1");
 		});
 
-		fireEvent.click(screen.getByText("Project Two"));
+		fireEvent.click(
+			screen.getByRole("button", { name: "Open project Project Two" }),
+		);
 
 		await waitFor(() => {
-			expect(getPreviewText()).toBe("Preview run-2");
+			expect(screen.getByTestId("location-probe").textContent).toBe(
+				"/projects/proj-2",
+			);
 		});
-		expect(screen.getByTestId("location-probe").textContent).toBe("/");
 	});
 
 	test("expands the selected run by focusing its existing workspace tab", async () => {

--- a/cli/web-ui/src/__tests__/pages/v2/HomePage.test.tsx
+++ b/cli/web-ui/src/__tests__/pages/v2/HomePage.test.tsx
@@ -372,6 +372,23 @@ describe("HomePage", () => {
 		).toBe("true");
 	});
 
+	test("treats project metadata clicks as run selection in the wide activity row", async () => {
+		wideActivityLayout = true;
+
+		await renderHomePage();
+
+		await waitFor(() => {
+			expect(getPreviewText()).toBe("Preview run-1");
+		});
+
+		fireEvent.click(screen.getByText("Project Two"));
+
+		await waitFor(() => {
+			expect(getPreviewText()).toBe("Preview run-2");
+		});
+		expect(screen.getByTestId("location-probe").textContent).toBe("/");
+	});
+
 	test("expands the selected run by focusing its existing workspace tab", async () => {
 		wideActivityLayout = true;
 		setStoredState({

--- a/cli/web-ui/src/components/v2/FilterBar.tsx
+++ b/cli/web-ui/src/components/v2/FilterBar.tsx
@@ -98,11 +98,11 @@ export function FilterBar({
 	];
 
 	return (
-		<div className={cn("flex flex-wrap items-center gap-1", className)}>
+		<div className={cn("flex w-full flex-col gap-2", className)}>
 			<div
 				role="tablist"
 				aria-label="Filter by status"
-				className="flex shrink-0 flex-wrap items-center gap-1"
+				className="-mx-0.5 flex max-w-full items-center gap-0.5 overflow-x-auto px-0.5 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
 			>
 				{STATUS_TABS.map((tab) => (
 					<button
@@ -112,7 +112,7 @@ export function FilterBar({
 						aria-selected={filters.status === tab.value}
 						onClick={() => handleStatusChange(tab.value)}
 						className={cn(
-							"px-2 py-1 rounded-md text-xs font-medium transition-colors duration-150",
+							"shrink-0 rounded-md px-1.5 py-1 text-[11px] font-medium leading-none transition-colors duration-150",
 							filters.status === tab.value
 								? "bg-surface text-fg"
 								: "text-fg-ghost hover:text-fg-muted hover:bg-surface/50",
@@ -123,41 +123,36 @@ export function FilterBar({
 				))}
 			</div>
 
-			<span
-				className="shrink-0 text-fg-ghost/40 select-none mx-1"
-				aria-hidden="true"
-			>
-				·
-			</span>
+			<div className="flex min-w-0 flex-wrap items-center gap-1.5">
+				<Select
+					size="sm"
+					value={filters.projectId ?? ""}
+					options={projectOptions}
+					onChange={(val) => handleProjectChange(val === "" ? null : val)}
+					placeholder="All Projects"
+					label="Filter by project"
+				/>
 
-			<Select
-				size="sm"
-				value={filters.projectId ?? ""}
-				options={projectOptions}
-				onChange={(val) => handleProjectChange(val === "" ? null : val)}
-				placeholder="All Projects"
-				label="Filter by project"
-			/>
+				<Select
+					size="sm"
+					value={filters.dateRange}
+					options={DATE_RANGES}
+					onChange={(val) => handleDateRangeChange(val)}
+					placeholder="All Time"
+					label="Filter by date range"
+				/>
 
-			<Select
-				size="sm"
-				value={filters.dateRange}
-				options={DATE_RANGES}
-				onChange={(val) => handleDateRangeChange(val)}
-				placeholder="All Time"
-				label="Filter by date range"
-			/>
-
-			{hasActiveFilters && (
-				<button
-					type="button"
-					onClick={handleClearFilters}
-					className="shrink-0 inline-flex items-center justify-center h-7 w-7 rounded-md text-fg-ghost transition-colors duration-150 hover:text-fg hover:bg-surface/50"
-					aria-label="Clear filters"
-				>
-					<X className="h-3.5 w-3.5" />
-				</button>
-			)}
+				{hasActiveFilters && (
+					<button
+						type="button"
+						onClick={handleClearFilters}
+						className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-fg-ghost transition-colors duration-150 hover:bg-surface/50 hover:text-fg"
+						aria-label="Clear filters"
+					>
+						<X className="h-3.5 w-3.5" />
+					</button>
+				)}
+			</div>
 		</div>
 	);
 }

--- a/cli/web-ui/src/pages/v2/HomePage.tsx
+++ b/cli/web-ui/src/pages/v2/HomePage.tsx
@@ -195,7 +195,7 @@ function FeedEntry({
 		>
 			<StatusDot status={run.status} />
 
-			<div className="flex min-w-0 flex-1 items-center gap-3 xl:flex-col xl:items-stretch xl:gap-1">
+			<div className="flex min-w-0 flex-1 flex-col items-stretch gap-1">
 				<div className="flex min-w-0 flex-1 items-center gap-3 xl:gap-2">
 					<span className="w-[5.5em] shrink-0 text-right type-secondary tabular-nums text-fg-ghost xl:w-auto xl:text-left">
 						{formatRelativeTime(latestEventAt)}
@@ -238,7 +238,7 @@ function FeedEntry({
 					<NotebookTabs className="h-3.5 w-3.5" strokeWidth={1.5} />
 				</button>
 
-				<span className="pointer-events-none ml-auto flex min-w-0 max-w-full shrink-0 items-center gap-1 pl-4 pr-7 type-secondary italic text-fg-ghost xl:ml-0 xl:pl-0 xl:pr-0">
+				<span className="pointer-events-none flex min-w-0 max-w-full shrink-0 items-center gap-1 type-secondary italic text-fg-ghost">
 					<NotebookTabs className="h-3 w-3 shrink-0" strokeWidth={1.5} />
 					<span className="truncate">{run.projectName}</span>
 				</span>

--- a/cli/web-ui/src/pages/v2/HomePage.tsx
+++ b/cli/web-ui/src/pages/v2/HomePage.tsx
@@ -238,8 +238,7 @@ function FeedEntry({
 					<NotebookTabs className="h-3.5 w-3.5" strokeWidth={1.5} />
 				</button>
 
-				<span className="pointer-events-none flex min-w-0 max-w-full shrink-0 items-center gap-1 type-secondary italic text-fg-ghost">
-					<NotebookTabs className="h-3 w-3 shrink-0" strokeWidth={1.5} />
+				<span className="pointer-events-none flex min-w-0 max-w-full shrink-0 justify-end type-secondary italic text-fg-ghost text-right">
 					<span className="truncate">{run.projectName}</span>
 				</span>
 

--- a/cli/web-ui/src/pages/v2/HomePage.tsx
+++ b/cli/web-ui/src/pages/v2/HomePage.tsx
@@ -185,7 +185,7 @@ function FeedEntry({
 			variants={reducedMotion ? feedItemVariantsReduced : feedItemVariants}
 			transition={reducedMotion ? { duration: 0 } : feedItemTransition}
 			className={cn(
-				"flex w-full items-center gap-3 px-3 py-2.5 text-left rounded-[var(--radius)]",
+				"group relative flex w-full items-center gap-3 py-2.5 pl-3 pr-10 text-left rounded-[var(--radius)]",
 				"transition-colors duration-150",
 				"hover:bg-surface",
 				"focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-border",
@@ -229,15 +229,19 @@ function FeedEntry({
 					onKeyDown={(e) => {
 						if (e.key === "Enter" || e.key === " ") {
 							e.stopPropagation();
-							onProjectClick(run.projectId);
 						}
 					}}
-					className="ml-auto flex min-w-0 max-w-full shrink-0 items-center gap-1 pl-4 type-secondary italic text-fg-ghost hover:text-fg-muted transition-colors duration-150 cursor-pointer bg-transparent border-none p-0 xl:ml-0 xl:pl-0"
+					className="absolute right-2 top-2 flex h-7 w-7 items-center justify-center rounded text-fg-ghost transition-colors duration-150 hover:bg-surface hover:text-fg-muted focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-border"
 					aria-label={`Open project ${run.projectName}`}
+					title={`Open project ${run.projectName}`}
 				>
+					<NotebookTabs className="h-3.5 w-3.5" strokeWidth={1.5} />
+				</button>
+
+				<span className="pointer-events-none ml-auto flex min-w-0 max-w-full shrink-0 items-center gap-1 pl-4 pr-7 type-secondary italic text-fg-ghost xl:ml-0 xl:pl-0 xl:pr-0">
 					<NotebookTabs className="h-3 w-3 shrink-0" strokeWidth={1.5} />
 					<span className="truncate">{run.projectName}</span>
-				</button>
+				</span>
 
 				<span className="w-5 shrink-0 xl:hidden" aria-hidden="true" />
 			</div>

--- a/cli/web-ui/src/pages/v2/HomePage.tsx
+++ b/cli/web-ui/src/pages/v2/HomePage.tsx
@@ -185,7 +185,7 @@ function FeedEntry({
 			variants={reducedMotion ? feedItemVariantsReduced : feedItemVariants}
 			transition={reducedMotion ? { duration: 0 } : feedItemTransition}
 			className={cn(
-				"group relative flex w-full items-center gap-3 py-2.5 pl-3 pr-10 text-left rounded-[var(--radius)]",
+				"group flex w-full items-center gap-2.5 px-3 py-2.5 text-left rounded-[var(--radius)]",
 				"transition-colors duration-150",
 				"hover:bg-surface",
 				"focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-border",
@@ -195,55 +195,48 @@ function FeedEntry({
 		>
 			<StatusDot status={run.status} />
 
-			<div className="flex min-w-0 flex-1 flex-col items-stretch gap-1">
-				<div className="flex min-w-0 flex-1 items-center gap-3 xl:gap-2">
-					<span className="w-[5.5em] shrink-0 text-right type-secondary tabular-nums text-fg-ghost xl:w-auto xl:text-left">
-						{formatRelativeTime(latestEventAt)}
-					</span>
-
-					<span className="inline-flex w-[14px] shrink-0 items-center justify-center">
-						<HarnessIcon harness={run.harness} size={14} />
-					</span>
-
-					<span className="shrink-0 type-body font-medium text-fg xl:min-w-0 xl:truncate">
-						{run.command}
-					</span>
-
-					<span className="truncate type-secondary text-fg-muted">
-						{resolveRunDisplayName(run) || run.command}
-					</span>
-
-					{statusLabel && (
-						<span className={cn("shrink-0 type-caption", statusToneClass)}>
-							{statusLabel}
-						</span>
-					)}
-				</div>
-
-				<button
-					type="button"
-					onClick={(e) => {
-						e.stopPropagation();
-						onProjectClick(run.projectId);
-					}}
-					onKeyDown={(e) => {
-						if (e.key === "Enter" || e.key === " ") {
-							e.stopPropagation();
-						}
-					}}
-					className="absolute right-2 top-2 flex h-7 w-7 items-center justify-center rounded text-fg-ghost transition-colors duration-150 hover:bg-surface hover:text-fg-muted focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-border"
-					aria-label={`Open project ${run.projectName}`}
-					title={`Open project ${run.projectName}`}
-				>
-					<NotebookTabs className="h-3.5 w-3.5" strokeWidth={1.5} />
-				</button>
-
-				<span className="pointer-events-none flex min-w-0 max-w-full shrink-0 justify-end type-secondary italic text-fg-ghost text-right">
-					<span className="truncate">{run.projectName}</span>
+			<div className="flex min-w-0 flex-1 items-center gap-3 xl:gap-2">
+				<span className="w-[5.5em] shrink-0 text-right type-secondary tabular-nums text-fg-ghost xl:w-auto xl:text-left">
+					{formatRelativeTime(latestEventAt)}
 				</span>
 
-				<span className="w-5 shrink-0 xl:hidden" aria-hidden="true" />
+				<span className="inline-flex w-[14px] shrink-0 items-center justify-center">
+					<HarnessIcon harness={run.harness} size={14} />
+				</span>
+
+				<span className="shrink-0 type-body font-medium text-fg xl:min-w-0 xl:truncate">
+					{run.command}
+				</span>
+
+				<span className="min-w-0 flex-1 truncate type-secondary text-fg-muted">
+					{resolveRunDisplayName(run) || run.command}
+				</span>
+
+				{statusLabel && (
+					<span className={cn("shrink-0 type-caption", statusToneClass)}>
+						{statusLabel}
+					</span>
+				)}
 			</div>
+
+			<button
+				type="button"
+				onClick={(e) => {
+					e.stopPropagation();
+					onProjectClick(run.projectId);
+				}}
+				onKeyDown={(e) => {
+					if (e.key === "Enter" || e.key === " ") {
+						e.stopPropagation();
+					}
+				}}
+				className="ml-auto flex h-7 min-w-[82px] max-w-[120px] shrink-0 items-center justify-end gap-1 rounded px-1.5 type-secondary italic text-fg-ghost transition-colors duration-150 hover:bg-surface hover:text-fg-muted focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-border"
+				aria-label={`Open project ${run.projectName}`}
+				title={`Open project ${run.projectName}`}
+			>
+				<span className="truncate">{run.projectName}</span>
+				<NotebookTabs className="h-3.5 w-3.5 shrink-0" strokeWidth={1.5} />
+			</button>
 		</motion.div>
 	);
 }
@@ -553,7 +546,7 @@ export function HomePage() {
 
 	return (
 		<div className="h-full min-h-0 overflow-y-auto px-4 py-6 md:px-6 xl:overflow-hidden xl:py-4">
-			<div className="mx-auto h-full min-h-0 max-w-[640px] xl:grid xl:max-w-none xl:grid-cols-[minmax(320px,420px)_minmax(0,1fr)] xl:gap-4">
+			<div className="mx-auto h-full min-h-0 max-w-[640px] xl:grid xl:max-w-none xl:grid-cols-[minmax(360px,460px)_minmax(0,1fr)] xl:gap-4">
 				<section
 					aria-label="Activity feed"
 					className="min-h-0 xl:flex xl:flex-col xl:overflow-hidden xl:border-r xl:border-border xl:pr-4"


### PR DESCRIPTION
## Summary
- keep Activity rows to a single-line layout in the split feed
- dedicate the right side of each row to a clickable project area with project name and icon
- widen the split Activity list column slightly so the one-row layout has enough room
- tighten the narrow Activity filter layout into a compact status strip plus secondary filter row

## Validation
- bun test src/__tests__/pages/v2/HomePage.test.tsx
- just check-web-ui
- Playwright split Activity row check
- Playwright project-area click check
- pre-push hooks