### PR TITLE
fix(web-ui): hide bootstrap-only activity runs

### DIFF
--- a/cli/src/__tests__/agent-tools/emit/database.test.ts
+++ b/cli/src/__tests__/agent-tools/emit/database.test.ts
@@ -3877,6 +3877,136 @@ describe("emit database", () => {
 			expect(result.records[0].lastEventAt).toBe("2026-03-04T00:00:00.000Z");
 		});
 
+		test("can exclude bootstrap-only runs without changing direct lookup", async () => {
+			const dbPath = join(tempDir, "list-runs-bootstrap-only.db");
+			const db = await expectTaskRight(getEmitDatabase(dbPath));
+
+			insertRun(db, {
+				id: "run-bootstrap-only",
+				flow: "phase-plan",
+				featureId: "phase-plan",
+				projectPath: "/p",
+				bootstrapContext: JSON.stringify({
+					run: { decision: "created_new_run" },
+				}),
+			});
+			insertRun(db, {
+				id: "run-normal-no-events",
+				flow: "build",
+				featureId: "feat",
+				projectPath: "/p",
+			});
+
+			const result = listRuns(db, { excludeBootstrapOnly: true });
+
+			expect(result.total).toBe(1);
+			expect(result.records.map((record) => record.id)).toEqual([
+				"run-normal-no-events",
+			]);
+			expect(getRunById(db, "run-bootstrap-only")?.bootstrapContext).toContain(
+				"created_new_run",
+			);
+			expect(listRuns(db).total).toBe(2);
+		});
+
+		test("keeps bootstrap-backed runs visible after they emit events", async () => {
+			const dbPath = join(tempDir, "list-runs-bootstrap-events.db");
+			const db = await expectTaskRight(getEmitDatabase(dbPath));
+
+			insertRun(db, {
+				id: "run-bootstrap-empty",
+				flow: "phase-plan",
+				featureId: "phase-plan",
+				projectPath: "/p",
+				bootstrapContext: JSON.stringify({
+					run: { decision: "created_new_run" },
+				}),
+			});
+			insertRun(db, {
+				id: "run-bootstrap-eventful",
+				flow: "phase-plan",
+				featureId: "phase-plan",
+				projectPath: "/p",
+				bootstrapContext: JSON.stringify({
+					run: { decision: "created_new_run" },
+				}),
+			});
+			insertEvent(db, {
+				runId: "run-bootstrap-eventful",
+				type: "status_change",
+				step: "planning",
+				data: JSON.stringify({ status: "running" }),
+				createdAt: "2026-03-05T00:00:00.000Z",
+			});
+
+			const result = listRuns(db, { excludeBootstrapOnly: true });
+
+			expect(result.total).toBe(1);
+			expect(result.records[0].id).toBe("run-bootstrap-eventful");
+			expect(result.records[0].lastEventAt).toBe("2026-03-05T00:00:00.000Z");
+		});
+
+		test("counts and paginates after excluding bootstrap-only runs", async () => {
+			const dbPath = join(tempDir, "list-runs-bootstrap-pagination.db");
+			const db = await expectTaskRight(getEmitDatabase(dbPath));
+
+			const insertRunAt = (
+				id: string,
+				createdAt: string,
+				bootstrapContext?: string,
+			) => {
+				insertRun(db, {
+					id,
+					flow: "build",
+					featureId: "feat",
+					projectPath: "/p",
+					...(bootstrapContext !== undefined ? { bootstrapContext } : {}),
+				});
+				db.prepare(
+					"UPDATE runs SET created_at = $createdAt WHERE id = $id",
+				).run({
+					$createdAt: createdAt,
+					$id: id,
+				});
+			};
+
+			const bootstrapContext = JSON.stringify({
+				run: { decision: "created_new_run" },
+			});
+			insertRunAt(
+				"run-hidden-newer",
+				"2026-03-05T00:00:00.000Z",
+				bootstrapContext,
+			);
+			insertRunAt("run-visible-first", "2026-03-04T00:00:00.000Z");
+			insertRunAt(
+				"run-hidden-middle",
+				"2026-03-03T00:00:00.000Z",
+				bootstrapContext,
+			);
+			insertRunAt("run-visible-second", "2026-03-02T00:00:00.000Z");
+
+			const page1 = listRuns(db, {
+				excludeBootstrapOnly: true,
+				limit: 1,
+				offset: 0,
+			});
+			const page2 = listRuns(db, {
+				excludeBootstrapOnly: true,
+				limit: 1,
+				offset: 1,
+			});
+
+			expect(page1.total).toBe(2);
+			expect(page1.records.map((record) => record.id)).toEqual([
+				"run-visible-first",
+			]);
+			expect(page2.total).toBe(2);
+			expect(page2.records.map((record) => record.id)).toEqual([
+				"run-visible-second",
+			]);
+		});
+
 		test("supports pagination with limit and offset", async () => {
 			const dbPath = join(tempDir, "list-runs-page.db");
 			const db = await expectTaskRight(getEmitDatabase(dbPath));

--- a/cli/src/agent-tools/emit/database.ts
+++ b/cli/src/agent-tools/emit/database.ts
@@ -2291,6 +2291,7 @@ export interface ListRunsOptions {
 	readonly projectPaths?: readonly string[];
 	readonly projectId?: string;
 	readonly status?: Status;
+	readonly excludeBootstrapOnly?: boolean;
 	readonly limit?: number;
 	readonly offset?: number;
 }
@@ -2345,6 +2346,14 @@ export const listRuns = (
 	if (opts.status != null) {
 		conditions.push("status = ?");
 		filterValues.push(opts.status);
+	}
+	if (opts.excludeBootstrapOnly === true) {
+		conditions.push(
+			`(runs.bootstrap_context IS NULL OR EXISTS (
+				SELECT 1 FROM events
+				WHERE events.run_id = runs.id
+			))`,
+		);
 	}
 
 	const whereClause =

--- a/cli/web-ui/src/__tests__/server/v2-api-feed.test.ts
+++ b/cli/web-ui/src/__tests__/server/v2-api-feed.test.ts
@@ -242,6 +242,63 @@ describe("handleV2FeedRequest", () => {
 		expect(body.items[0]?.run.status).toBe("failed");
 	});
 
+	test("hides bootstrap-only phase-plan runs while returning normal workflow runs", async () => {
+		const { db, projectId, projectRoot } = await setupProject(
+			tempDir,
+			"bootstrap-feed",
+		);
+
+		insertRun(db, {
+			id: "run-ghost-phase-plan",
+			flow: "phase-plan",
+			featureId: "phase-plan",
+			projectPath: projectRoot,
+			projectId,
+			name: "Ghost Phase Plan",
+			harness: "codex",
+			bootstrapContext: JSON.stringify({
+				run: { decision: "created_new_run" },
+			}),
+		});
+		db.prepare("UPDATE runs SET created_at = ? WHERE id = ?").run(
+			"2026-04-10T06:00:00.000Z",
+			"run-ghost-phase-plan",
+		);
+
+		insertRun(db, {
+			id: "run-normal-workflow",
+			flow: "build",
+			featureId: "hide-bootstrap-runs",
+			projectPath: projectRoot,
+			projectId,
+			name: "Normal Workflow",
+			harness: "codex",
+		});
+		insertEvent(db, {
+			runId: "run-normal-workflow",
+			type: "status_change",
+			step: "build",
+			data: JSON.stringify({ status: "running" }),
+			createdAt: "2026-04-10T05:00:00.000Z",
+		});
+		deriveRunStatus(db, "run-normal-workflow");
+
+		const response = await handleV2FeedRequest(
+			new Request(`http://localhost/api/v2/feed?project_id=${projectId}`),
+		);
+
+		expect(response.status).toBe(200);
+
+		const body = (await response.json()) as {
+			items: Array<{ id: string; run: { id: string } }>;
+			total: number;
+		};
+
+		expect(body.total).toBe(1);
+		expect(body.items.map((item) => item.id)).toEqual(["run-normal-workflow"]);
+		expect(body.items[0]?.run.id).toBe("run-normal-workflow");
+	});
+
 	test("broadcasts stale run inactivity when feed reads trigger reclassification", async () => {
 		const { db, projectId, projectRoot, registryProjectId } =
 			await setupProject(tempDir, "stale-feed");

--- a/cli/web-ui/src/__tests__/server/v2-api-runs.test.ts
+++ b/cli/web-ui/src/__tests__/server/v2-api-runs.test.ts
@@ -302,6 +302,60 @@ describe("V2 runs API", () => {
 		}
 	});
 
+	test("hides bootstrap-only phase-plan runs while returning normal workflow runs", async () => {
+		const { db, projectId, projectRoot } = await setupProject(
+			tempDir,
+			"bootstrap-list",
+		);
+
+		insertRun(db, {
+			id: "run-ghost-phase-plan",
+			flow: "phase-plan",
+			featureId: "phase-plan",
+			projectPath: projectRoot,
+			projectId,
+			name: "Ghost Phase Plan",
+			harness: "codex",
+			bootstrapContext: JSON.stringify({
+				run: { decision: "created_new_run" },
+			}),
+		});
+		db.prepare("UPDATE runs SET created_at = ? WHERE id = ?").run(
+			"2026-04-12T04:00:00.000Z",
+			"run-ghost-phase-plan",
+		);
+
+		insertRun(db, {
+			id: "run-normal-workflow",
+			flow: "build",
+			featureId: "hide-bootstrap-runs",
+			projectPath: projectRoot,
+			projectId,
+			name: "Normal Workflow",
+			harness: "codex",
+		});
+		insertEvent(db, {
+			runId: "run-normal-workflow",
+			type: "status_change",
+			step: "build",
+			data: JSON.stringify({ status: "running" }),
+			createdAt: "2026-04-12T03:00:00.000Z",
+		});
+		deriveRunStatus(db, "run-normal-workflow");
+
+		const response = await handleV2RunsListRequest(
+			new Request(`http://localhost/api/v2/runs?project_id=${projectId}`),
+		);
+		const body = (await response.json()) as {
+			runs: Array<{ id: string }>;
+			total: number;
+		};
+
+		expect(response.status).toBe(200);
+		expect(body.total).toBe(1);
+		expect(body.runs.map((run) => run.id)).toEqual(["run-normal-workflow"]);
+	});
+
 	test("returns the same lightweight run shape and project identity as the list view", async () => {
 		const { db, projectId, projectRoot, registryProjectId } =
 			await setupProject(tempDir, "summary");

--- a/cli/web-ui/src/server/routes/v2-api.ts
+++ b/cli/web-ui/src/server/routes/v2-api.ts
@@ -1298,6 +1298,7 @@ export async function handleV2RunsListRequest(
 			projectId: dbProjectIdFilter,
 			projectPath: dbProjectIdFilter ? undefined : projectPathFilter,
 			status: dbStatus,
+			excludeBootstrapOnly: true,
 			limit,
 			offset,
 		});
@@ -2399,6 +2400,7 @@ export async function handleV2FeedRequest(
 			status: dbStatus as
 				| import("../../../../shared/events.js").Status
 				| undefined,
+			excludeBootstrapOnly: true,
 			limit: 200,
 			offset: 0,
 		});


### PR DESCRIPTION
## Summary
- add an opt-in `listRuns` filter that excludes bootstrap-backed runs with no events
- apply the filter to Arcade `/api/v2/feed` and `/api/v2/runs`
- add regression coverage for hidden ghost phase-plan rows, visible eventful bootstrap rows, and filtered pagination/totals

## Tests
- `bun test cli/src/__tests__/agent-tools/emit/database.test.ts`
- `bun test cli/web-ui/src/__tests__/server/v2-api-feed.test.ts cli/web-ui/src/__tests__/server/v2-api-runs.test.ts`
- pre-commit: `biome format .`, `biome check .`
- pre-push: no-artifactory, eval-verify, catalog, typecheck-cli, typecheck-webui
