### PR TITLE
fix(pr-review): close terminal completion run

### DIFF
--- a/cli/src/__tests__/integration/tracked-workflow-lifecycle-prompts.test.ts
+++ b/cli/src/__tests__/integration/tracked-workflow-lifecycle-prompts.test.ts
@@ -206,6 +206,21 @@ describe("tracked workflow lifecycle prompts", () => {
 		expect(content).toContain("resume instruction");
 	});
 
+	test("closes pr-review on terminal posting completion", async () => {
+		const content = await readPrompt("plugins/dev/skills/pr-review/SKILL.md");
+		const terminalPostingLine = content
+			.split("\n")
+			.find(
+				(line) =>
+					line.includes("--workflow pr-review") &&
+					line.includes("--step posting") &&
+					line.includes('{"status": "completed"}'),
+			);
+
+		expect(terminalPostingLine).toBeDefined();
+		expect(terminalPostingLine).toContain("--close-run");
+	});
+
 	test("keeps tracked Claude workflow bundle attestations exact", async () => {
 		const manifest = JSON.parse(await readPrompt("evals/attestation.json")) as {
 			skills?: Record<

--- a/cli/src/__tests__/integration/tracked-workflow-lifecycle-prompts.test.ts
+++ b/cli/src/__tests__/integration/tracked-workflow-lifecycle-prompts.test.ts
@@ -16,10 +16,18 @@ const PLUGIN_PATHS: Record<string, string> = {
 	"rp1-utils": "utils",
 };
 const SHA256_REGEX = /^sha256:[0-9a-f]{64}$/;
+const COMPLETED_STATUS_REGEX = /\{"status":\s*"completed"/;
+const FENCED_BLOCK_REGEX = /```[^\n]*\n([\s\S]*?)```/g;
+// Literal terminal-step workflows with prompt-owned completion emits. Excludes
+// custom lifecycle flows and parameterized terminal steps such as `{STATE}`.
 const STANDARD_TERMINAL_WORKFLOW_CASES = [
 	{
 		path: "plugins/base/skills/deep-research/SKILL.md",
 		terminalStep: "report",
+	},
+	{
+		path: "plugins/base/skills/project-birds-eye-view/SKILL.md",
+		terminalStep: "validate_diagrams",
 	},
 	{
 		path: "plugins/dev/skills/address-pr-feedback/SKILL.md",
@@ -32,6 +40,10 @@ const STANDARD_TERMINAL_WORKFLOW_CASES = [
 	{
 		path: "plugins/dev/skills/build-fast/SKILL.md",
 		terminalStep: "review",
+	},
+	{
+		path: "plugins/dev/skills/code-investigate/SKILL.md",
+		terminalStep: "investigating",
 	},
 	{
 		path: "plugins/dev/skills/pr-review/SKILL.md",
@@ -102,6 +114,9 @@ const readPrompt = (relativePath: string): Promise<string> =>
 
 const escapeRegExp = (value: string): string =>
 	value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+const extractFencedBlocks = (content: string): string[] =>
+	[...content.matchAll(FENCED_BLOCK_REGEX)].map((match) => match[1] ?? "");
 
 const collectSkillFiles = async (dir: string): Promise<string[]> => {
 	const entries = await readdir(dir, { withFileTypes: true });
@@ -242,26 +257,32 @@ describe("tracked workflow lifecycle prompts", () => {
 				.split("\n")
 				.find(
 					(line) =>
-						line.includes("For terminal states") &&
-						line.includes('{"status": "completed"}'),
+						(line.includes("For terminal states") ||
+							line.includes("Terminal state") ||
+							line.includes("On completion")) &&
+						line.includes("--close-run"),
 				);
 
 			expect(terminalGuidanceLine, path).toBeDefined();
-			expect(terminalGuidanceLine, path).toContain("--close-run");
 
 			const stepPattern = new RegExp(
 				`--step\\s+${escapeRegExp(terminalStep)}\\b`,
-				"g",
 			);
-			const completionSnippets = [...content.matchAll(stepPattern)]
-				.map((match) =>
-					content.slice(match.index ?? 0, (match.index ?? 0) + 400),
-				)
-				.filter((snippet) => snippet.includes('{"status": "completed"'));
+			const terminalLines = content
+				.split("\n")
+				.filter(
+					(line) => stepPattern.test(line) && COMPLETED_STATUS_REGEX.test(line),
+				);
+			const terminalBlocks = extractFencedBlocks(content).filter(
+				(block) =>
+					stepPattern.test(block) && COMPLETED_STATUS_REGEX.test(block),
+			);
+			const terminalCommands =
+				terminalLines.length > 0 ? terminalLines : terminalBlocks;
 
-			expect(completionSnippets.length, path).toBeGreaterThan(0);
+			expect(terminalCommands.length, path).toBeGreaterThan(0);
 			expect(
-				completionSnippets.some((snippet) => snippet.includes("--close-run")),
+				terminalCommands.some((command) => command.includes("--close-run")),
 				path,
 			).toBe(true);
 		}

--- a/cli/src/__tests__/integration/tracked-workflow-lifecycle-prompts.test.ts
+++ b/cli/src/__tests__/integration/tracked-workflow-lifecycle-prompts.test.ts
@@ -16,6 +16,32 @@ const PLUGIN_PATHS: Record<string, string> = {
 	"rp1-utils": "utils",
 };
 const SHA256_REGEX = /^sha256:[0-9a-f]{64}$/;
+const STANDARD_TERMINAL_WORKFLOW_CASES = [
+	{
+		path: "plugins/base/skills/deep-research/SKILL.md",
+		terminalStep: "report",
+	},
+	{
+		path: "plugins/dev/skills/address-pr-feedback/SKILL.md",
+		terminalStep: "fixing",
+	},
+	{
+		path: "plugins/dev/skills/blueprint/SKILL.md",
+		terminalStep: "prd",
+	},
+	{
+		path: "plugins/dev/skills/build-fast/SKILL.md",
+		terminalStep: "review",
+	},
+	{
+		path: "plugins/dev/skills/pr-review/SKILL.md",
+		terminalStep: "posting",
+	},
+	{
+		path: "plugins/utils/skills/build-prompt/SKILL.md",
+		terminalStep: "pipeline_complete",
+	},
+] as const;
 
 interface HashResult {
 	readonly path: string;
@@ -73,6 +99,9 @@ const parseSkillRefs = (content: string): string[] => {
 
 const readPrompt = (relativePath: string): Promise<string> =>
 	readFile(join(REPO_ROOT, relativePath), "utf-8");
+
+const escapeRegExp = (value: string): string =>
+	value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 
 const collectSkillFiles = async (dir: string): Promise<string[]> => {
 	const entries = await readdir(dir, { withFileTypes: true });
@@ -206,19 +235,36 @@ describe("tracked workflow lifecycle prompts", () => {
 		expect(content).toContain("resume instruction");
 	});
 
-	test("closes pr-review on terminal posting completion", async () => {
-		const content = await readPrompt("plugins/dev/skills/pr-review/SKILL.md");
-		const terminalPostingLine = content
-			.split("\n")
-			.find(
-				(line) =>
-					line.includes("--workflow pr-review") &&
-					line.includes("--step posting") &&
-					line.includes('{"status": "completed"}'),
-			);
+	test("closes standard terminal workflow completions", async () => {
+		for (const { path, terminalStep } of STANDARD_TERMINAL_WORKFLOW_CASES) {
+			const content = await readPrompt(path);
+			const terminalGuidanceLine = content
+				.split("\n")
+				.find(
+					(line) =>
+						line.includes("For terminal states") &&
+						line.includes('{"status": "completed"}'),
+				);
 
-		expect(terminalPostingLine).toBeDefined();
-		expect(terminalPostingLine).toContain("--close-run");
+			expect(terminalGuidanceLine, path).toBeDefined();
+			expect(terminalGuidanceLine, path).toContain("--close-run");
+
+			const stepPattern = new RegExp(
+				`--step\\s+${escapeRegExp(terminalStep)}\\b`,
+				"g",
+			);
+			const completionSnippets = [...content.matchAll(stepPattern)]
+				.map((match) =>
+					content.slice(match.index ?? 0, (match.index ?? 0) + 400),
+				)
+				.filter((snippet) => snippet.includes('{"status": "completed"'));
+
+			expect(completionSnippets.length, path).toBeGreaterThan(0);
+			expect(
+				completionSnippets.some((snippet) => snippet.includes("--close-run")),
+				path,
+			).toBe(true);
+		}
 	});
 
 	test("keeps tracked Claude workflow bundle attestations exact", async () => {

--- a/plugins/base/skills/deep-research/SKILL.md
+++ b/plugins/base/skills/deep-research/SKILL.md
@@ -61,7 +61,7 @@ rp1 agent-tools emit \
 **State Progression Protocol**:
 1. Report each `--step` with `--data '{"status": "running"}'` when you enter that state
 2. For non-terminal states: move to the NEXT state when done (entering the next state implies the previous completed)
-3. For terminal states (those with `→ [*]` transitions): report with `--data '{"status": "completed"}'` when the step's work finishes
+3. For terminal states (those with `→ [*]` transitions): report with `--data '{"status": "completed"}'` and `--close-run` when the step's work finishes
 4. On error, transition to the appropriate failure state in the graph
 
 **Example sequence**:
@@ -71,7 +71,7 @@ rp1 agent-tools emit \
 --step explore --data '{"status": "running"}'       # plan ready, entering explore phase
 --step synthesize --data '{"status": "running"}'    # exploration done, entering synthesize phase
 --step report --data '{"status": "running"}'        # synthesis done, entering report phase
---step report --data '{"status": "completed"}'      # report work finished, workflow done
+--step report --data '{"status": "completed"}' --close-run      # report work finished, workflow done
 ```
 
 Use the pre-resolved `projectRoot`, `kbRoot`, and `workRoot` values from the generated Workflow Bootstrap section. Do not re-resolve directories manually, do not call `resolve-args`, and do not generate a UUID manually.

--- a/plugins/base/skills/project-birds-eye-view/SKILL.md
+++ b/plugins/base/skills/project-birds-eye-view/SKILL.md
@@ -61,7 +61,7 @@ rp1 agent-tools emit --harness $CURRENT_HOST \
 
 `RUN_NAME` is resolved once, up front, from `basename {projectRoot}` — it is stable before the sub-agent runs, so every emit (including the first) can carry it. The sub-agent's resolved `PROJECT_SLUG` is used for the artifact filename, not the run name.
 
-Terminal state `validate_diagrams` uses `--data '{"status": "completed"}'`.
+Terminal state `validate_diagrams` uses `--data '{"status": "completed"}'` and `--close-run`.
 
 ## Governance
 
@@ -98,7 +98,17 @@ rp1 agent-tools emit --harness $CURRENT_HOST \
   --data '{"path": "{OUTPUT_PATH}", "feature": "birds-eye", "storageRoot": "work_dir", "format": "markdown"}'
 ```
 
-6. Emit terminal `validate_diagrams` with `{"status":"completed"}`.
+6. Emit terminal `validate_diagrams` with `{"status":"completed"}` and `--close-run`:
+
+```bash
+rp1 agent-tools emit --harness $CURRENT_HOST \
+  --workflow birds-eye-view \
+  --type status_change \
+  --run-id {RUN_ID} \
+  --step validate_diagrams \
+  --close-run \
+  --data '{"status":"completed"}'
+```
 
 The agent loads the KB, generates a 16-section arc42/C4-aligned document with per-claim provenance, emits up to 6 Mermaid diagrams (validated via `rp1 agent-tools mmd-validate`), and writes to `{workRoot}/birds-eye/{YYYY-MM-DD}-{PROJECT_SLUG}.md` with n+1 dedup. It returns the resolved `OUTPUT_PATH` and `PROJECT_SLUG` to this dispatcher.
 

--- a/plugins/dev/skills/address-pr-feedback/SKILL.md
+++ b/plugins/dev/skills/address-pr-feedback/SKILL.md
@@ -69,13 +69,13 @@ stateDiagram-v2
 **State Progression Protocol**:
 1. Report each `--step` with `--data '{"status": "running"}'` when you enter that state
 2. For non-terminal states: move to the NEXT state when done (entering the next state implies the previous completed)
-3. For terminal states (those with `→ [*]` transitions): report with `--data '{"status": "completed"}'` when the step's work finishes
+3. For terminal states (those with `→ [*]` transitions): report with `--data '{"status": "completed"}'` and `--close-run` when the step's work finishes
 
 **Example sequence**:
 ```
 --workflow address-pr-feedback --step collecting --name "Feedback: PR #42" --data '{"status": "running"}'
 --workflow address-pr-feedback --step fixing --data '{"status": "running"}'
---workflow address-pr-feedback --step fixing --data '{"status": "completed"}'
+--workflow address-pr-feedback --step fixing --data '{"status": "completed"}' --close-run
 ```
 
 ## Phase 1: Collection

--- a/plugins/dev/skills/blueprint/SKILL.md
+++ b/plugins/dev/skills/blueprint/SKILL.md
@@ -64,7 +64,7 @@ rp1 agent-tools emit \
 **State Progression Protocol**:
 1. Report each `--step` with `--data '{"status": "running"}'` when you enter that state
 2. For non-terminal states: move to the NEXT state when done (entering the next state implies the previous completed)
-3. For terminal states (those with `→ [*]` transitions): report with `--data '{"status": "completed"}'` when the step's work finishes
+3. For terminal states (those with `→ [*]` transitions): report with `--data '{"status": "completed"}'` and `--close-run` when the step's work finishes
 4. On error, transition to the appropriate failure state in the graph
 
 **Example sequence** (with charter):
@@ -72,7 +72,7 @@ rp1 agent-tools emit \
 --workflow blueprint --step detect --name "Blueprint: mobile-app" --data '{"status": "running"}'   # first emit includes --name
 --workflow blueprint --step charter --data '{"status": "running"}'    # needs charter, entering charter phase
 --workflow blueprint --step prd --data '{"status": "running"}'        # charter done, entering prd phase
---workflow blueprint --step prd --data '{"status": "completed"}'      # prd done, workflow complete
+--workflow blueprint --step prd --data '{"status": "completed"}' --close-run      # prd done, workflow complete
 ```
 
 ## §CTX

--- a/plugins/dev/skills/build-fast/SKILL.md
+++ b/plugins/dev/skills/build-fast/SKILL.md
@@ -125,7 +125,7 @@ rp1 agent-tools emit \
 **State Progression Protocol**:
 1. Report each `--step` with `--data '{"status": "running"}'` when you enter that state
 2. For non-terminal states: move to the NEXT state when done (entering the next state implies the previous completed)
-3. For terminal states (those with `→ [*]` transitions): report with `--data '{"status": "completed"}'` when the step's work finishes
+3. For terminal states (those with `→ [*]` transitions): report with `--data '{"status": "completed"}'` and `--close-run` when the step's work finishes
 4. On error, transition to the appropriate failure state in the graph
 
 **Example sequence**:
@@ -133,7 +133,7 @@ rp1 agent-tools emit \
 --workflow build-fast --step plan --name "Feature: Add logout button" --data '{"status": "running"}'   # first emit includes --name
 --workflow build-fast --step build --data '{"status": "running"}'      # plan done, entering build phase
 --workflow build-fast --step review --data '{"status": "running"}'     # build done, entering review phase
---workflow build-fast --step review --data '{"status": "completed"}'   # review done, workflow complete
+--workflow build-fast --step review --data '{"status": "completed"}' --close-run   # review done, workflow complete
 ```
 
 ## §PHASE-1: Planning

--- a/plugins/dev/skills/code-investigate/SKILL.md
+++ b/plugins/dev/skills/code-investigate/SKILL.md
@@ -95,12 +95,13 @@ rp1 agent-tools emit \
   --data '{"path": "issues/{EFFECTIVE_ISSUE_ID}/investigation_report.md", "storageRoot": "work_dir", "format": "markdown"}'
 ```
 
-On completion, mark the step as completed:
+On completion, mark the step as completed with `--close-run`:
 ```bash
 rp1 agent-tools emit \
   --workflow code-investigate \
   --type status_change \
   --run-id {RUN_ID} \
   --step investigating \
+  --close-run \
   --data '{"status": "completed"}'
 ```

--- a/plugins/dev/skills/pr-review/SKILL.md
+++ b/plugins/dev/skills/pr-review/SKILL.md
@@ -94,7 +94,7 @@ rp1 agent-tools emit \
 **State Progression Protocol**:
 1. Report each `--step` with `--data '{"status": "running"}'` when you enter that state
 2. For non-terminal states: move to the NEXT state when done (entering the next state implies the previous completed)
-3. For terminal states (those with `→ [*]` transitions): report with `--data '{"status": "completed"}'` when the step's work finishes
+3. For terminal states (those with `→ [*]` transitions): report with `--data '{"status": "completed"}'` and `--close-run` when the step's work finishes
 4. On error, transition to the appropriate failure state in the graph
 
 **State mapping**:
@@ -105,7 +105,7 @@ rp1 agent-tools emit \
 ```
 --workflow pr-review --step reviewing --name "PR #42" --data '{"status": "running"}'   # first emit includes --name
 --workflow pr-review --step posting --data '{"status": "running"}'       # analysis done, entering posting phase
---workflow pr-review --step posting --data '{"status": "completed"}'     # posting done, workflow complete
+--workflow pr-review --step posting --data '{"status": "completed"}' --close-run     # posting done, workflow complete
 ```
 
 §ARCH

--- a/plugins/utils/skills/build-prompt/SKILL.md
+++ b/plugins/utils/skills/build-prompt/SKILL.md
@@ -123,7 +123,7 @@ rp1 agent-tools emit \
 **State Progression Protocol**:
 1. Report each `--step` with `--data '{"status": "running"}'` when you enter that state
 2. For non-terminal states: move to the NEXT state when done
-3. For terminal states (those with `-> [*]` transitions): report with `--data '{"status": "completed"}'`
+3. For terminal states (those with `-> [*]` transitions): report with `--data '{"status": "completed"}'` and `--close-run`
 
 ## §STEP-1: Pipeline Execution
 
@@ -203,6 +203,7 @@ rp1 agent-tools emit \
   --type status_change \
   --run-id {RUN_ID} \
   --step pipeline_complete \
+  --close-run \
   --data '{"status": "completed", "prompt_name": "{PROMPT_NAME}"}'
 ```
 


### PR DESCRIPTION
## Summary
- add `--close-run` to the `/pr-review` terminal `posting completed` emit instructions
- update the example lifecycle sequence to show explicit run closure
- add regression coverage so the pr-review terminal completion example keeps `--close-run`

## Root Cause
`/pr-review` could leave `reviewing` persisted as running while `posting` was completed. The emit runtime correctly keeps the run running whenever any effective step is still live, so terminal prompt instructions need to use the supported `--close-run` path.

## Validation
- `bun test src/__tests__/integration/tracked-workflow-lifecycle-prompts.test.ts`
- `bunx biome check src/__tests__/integration/tracked-workflow-lifecycle-prompts.test.ts`
- `bun run scripts/build-codex.ts`
- pre-push: no-artifactory, eval-verify, catalog, typecheck-cli, typecheck-webui