### PR TITLE
fix(web-ui): isolate Activity preview artifacts

### DIFF
--- a/cli/web-ui/src/__tests__/components/v2/ArtifactContentSurface.test.tsx
+++ b/cli/web-ui/src/__tests__/components/v2/ArtifactContentSurface.test.tsx
@@ -31,6 +31,31 @@ const secondArtifact: Artifact = {
 	step: "review",
 };
 
+function deferred<T>() {
+	let resolve!: (value: T) => void;
+	let reject!: (reason?: unknown) => void;
+	const promise = new Promise<T>((promiseResolve, promiseReject) => {
+		resolve = promiseResolve;
+		reject = promiseReject;
+	});
+	return { promise, resolve, reject };
+}
+
+function contentResponse(content: string): Response {
+	return {
+		ok: true,
+		json: async () => ({ content }),
+	} as Response;
+}
+
+function artifactNotFoundResponse(path: string): Response {
+	return {
+		ok: false,
+		statusText: "Not Found",
+		json: async () => ({ error: `Artifact not found: ${path}` }),
+	} as Response;
+}
+
 interface MockContentPanelProps {
 	readonly content?: string | null;
 	readonly error?: string | null;
@@ -228,5 +253,50 @@ describe("ArtifactContentSurface", () => {
 			expect(screen.getByLabelText("Open table of contents")).toBeTruthy();
 			expect(screen.getByLabelText("Toggle annotations")).toBeTruthy();
 		});
+	});
+
+	test("ignores stale artifact fetch errors after the selected artifact changes", async () => {
+		const firstFetch = deferred<Response>();
+		const secondFetch = deferred<Response>();
+		global.fetch = mock((input: RequestInfo | URL) => {
+			const url = String(input);
+			if (url.includes(encodeURIComponent(firstArtifact.path))) {
+				return firstFetch.promise;
+			}
+			if (url.includes(encodeURIComponent(secondArtifact.path))) {
+				return secondFetch.promise;
+			}
+			return Promise.resolve(artifactNotFoundResponse(".rp1/work/unknown.md"));
+		}) as unknown as typeof fetch;
+
+		const { ArtifactContentSurface } = await importSurface();
+
+		const view = render(
+			<ArtifactContentSurface {...surfaceProps(firstArtifact)} />,
+		);
+
+		await waitFor(() => {
+			expect(global.fetch).toHaveBeenCalledTimes(1);
+		});
+
+		view.rerender(<ArtifactContentSurface {...surfaceProps(secondArtifact)} />);
+
+		await waitFor(() => {
+			expect(global.fetch).toHaveBeenCalledTimes(2);
+		});
+		secondFetch.resolve(contentResponse("# Second artifact"));
+
+		await waitFor(() => {
+			const panel = screen.getByTestId("artifact-content-panel");
+			expect(panel.dataset.content).toBe("# Second artifact");
+			expect(panel.dataset.error).toBe("");
+		});
+
+		firstFetch.resolve(artifactNotFoundResponse(firstArtifact.path));
+		await new Promise((resolve) => setTimeout(resolve, 0));
+
+		const panel = screen.getByTestId("artifact-content-panel");
+		expect(panel.dataset.content).toBe("# Second artifact");
+		expect(panel.dataset.error).toBe("");
 	});
 });

--- a/cli/web-ui/src/__tests__/hooks/useRunDetail.test.ts
+++ b/cli/web-ui/src/__tests__/hooks/useRunDetail.test.ts
@@ -53,6 +53,23 @@ async function loadUseRunDetail() {
 	);
 }
 
+function deferred<T>() {
+	let resolve!: (value: T) => void;
+	let reject!: (reason?: unknown) => void;
+	const promise = new Promise<T>((promiseResolve, promiseReject) => {
+		resolve = promiseResolve;
+		reject = promiseReject;
+	});
+	return { promise, resolve, reject };
+}
+
+function okRunResponse(run: Run): Response {
+	return {
+		ok: true,
+		json: async () => ({ ...run }),
+	} as Response;
+}
+
 function emitEvent(msg: EventNotificationMessage) {
 	for (const listener of eventListeners) {
 		listener(msg);
@@ -296,6 +313,77 @@ describe("useRunDetail", () => {
 
 		expect(secondRender.result.current.run?.id).toBe("run-1");
 		expect(secondRender.result.current.isLoading).toBe(false);
+	});
+
+	test("does not expose stale run data after the requested run changes", async () => {
+		const staleRunOneFetch = deferred<Response>();
+		const runTwoFetch = deferred<Response>();
+		const runOne = { ...baseRun, id: "run-1", name: "Run One" };
+		const staleRunOne = { ...baseRun, id: "run-1", name: "Stale Run One" };
+		const runTwo = {
+			...baseRun,
+			id: "run-2",
+			projectId: "proj-2",
+			projectName: "Second Project",
+			name: "Run Two",
+		};
+		let runOneRequestCount = 0;
+
+		fetchMock = mock((url: string) => {
+			if (url === "/api/v2/runs/run-1") {
+				runOneRequestCount += 1;
+				if (runOneRequestCount === 1) {
+					return Promise.resolve(okRunResponse(runOne));
+				}
+				return staleRunOneFetch.promise;
+			}
+			if (url === "/api/v2/runs/run-2") {
+				return runTwoFetch.promise;
+			}
+			return Promise.resolve({
+				ok: false,
+				status: 404,
+				statusText: "Not Found",
+			});
+		});
+		globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+		const { useRunDetail } = await loadUseRunDetail();
+		const { result, rerender } = renderHook(
+			({ id }: { readonly id: string }) => useRunDetail(id),
+			{ initialProps: { id: "run-1" } },
+		);
+
+		await waitFor(() => {
+			expect(result.current.run?.id).toBe("run-1");
+		});
+
+		act(() => {
+			result.current.refetch();
+		});
+		await waitFor(() => {
+			expect(fetchMock).toHaveBeenCalledTimes(2);
+		});
+
+		rerender({ id: "run-2" });
+		expect(result.current.run).toBeNull();
+		expect(result.current.isLoading).toBe(true);
+
+		await waitFor(() => {
+			expect(fetchMock).toHaveBeenCalledWith("/api/v2/runs/run-2");
+		});
+		runTwoFetch.resolve(okRunResponse(runTwo));
+
+		await waitFor(() => {
+			expect(result.current.run?.id).toBe("run-2");
+			expect(result.current.run?.name).toBe("Run Two");
+		});
+
+		staleRunOneFetch.resolve(okRunResponse(staleRunOne));
+		await new Promise((resolve) => setTimeout(resolve, 0));
+
+		expect(result.current.run?.id).toBe("run-2");
+		expect(result.current.run?.name).toBe("Run Two");
 	});
 
 	test("reconciled artifact updates local state without refetching the run", async () => {

--- a/cli/web-ui/src/components/v2/ArtifactContentSurface.tsx
+++ b/cli/web-ui/src/components/v2/ArtifactContentSurface.tsx
@@ -64,18 +64,24 @@ function ArtifactContentSurfaceInner({
 	const [tocOpen, setTocOpen] = useState(false);
 	const [saveStatus, setSaveStatus] = useState<SaveStatus>("idle");
 	const scrollViewportRef = useRef<HTMLDivElement>(null);
+	const activeArtifactCacheKeyRef = useRef<string | null>(artifactCacheKey);
 	const { onFileChange } = useWebSocket();
+	activeArtifactCacheKeyRef.current = artifactCacheKey;
 
 	const fetchContent = useCallback(
 		async (preserveScroll: boolean) => {
-			if (!artifactPath || !runId) {
+			const requestArtifactPath = artifactPath;
+			const requestCacheKey = artifactCacheKey;
+			const requestRunId = runId;
+			const isActiveArtifactRequest = () =>
+				activeArtifactCacheKeyRef.current === requestCacheKey;
+
+			if (!requestArtifactPath || !requestRunId || !requestCacheKey) {
 				setContent(null);
 				return;
 			}
 
-			const cachedContent = artifactCacheKey
-				? (artifactContentCache.get(artifactCacheKey) ?? null)
-				: null;
+			const cachedContent = artifactContentCache.get(requestCacheKey) ?? null;
 
 			if (!preserveScroll && cachedContent === null) {
 				setContentLoading(true);
@@ -85,8 +91,9 @@ function ArtifactContentSurfaceInner({
 
 			try {
 				const response = await fetch(
-					`/api/v2/runs/${runId}/artifacts/${encodeURIComponent(artifactPath)}`,
+					`/api/v2/runs/${requestRunId}/artifacts/${encodeURIComponent(requestArtifactPath)}`,
 				);
+				if (!isActiveArtifactRequest()) return;
 				if (!response.ok) {
 					let errorMessage = `Failed to fetch artifact: ${response.statusText}`;
 					try {
@@ -100,26 +107,26 @@ function ArtifactContentSurfaceInner({
 					throw new Error(errorMessage);
 				}
 				const data = (await response.json()) as { content: string };
-				if (artifactCacheKey) {
-					artifactContentCache.set(artifactCacheKey, data.content);
-				}
+				if (!isActiveArtifactRequest()) return;
+				artifactContentCache.set(requestCacheKey, data.content);
 				setContent((current) =>
 					current === data.content ? current : data.content,
 				);
 			} catch (err) {
+				if (!isActiveArtifactRequest()) return;
 				const message = err instanceof Error ? err.message : String(err);
 				const isTerminalError =
 					message.startsWith("Artifact not found:") ||
 					message.startsWith("Run not found");
 				if (isTerminalError || cachedContent === null) {
-					if (isTerminalError && artifactCacheKey) {
-						artifactContentCache.delete(artifactCacheKey);
+					if (isTerminalError) {
+						artifactContentCache.delete(requestCacheKey);
 					}
 					setContentError(message);
 					setContent(null);
 				}
 			} finally {
-				if (!preserveScroll) {
+				if (isActiveArtifactRequest() && !preserveScroll) {
 					setContentLoading(false);
 				}
 			}

--- a/cli/web-ui/src/hooks/useRunDetail.ts
+++ b/cli/web-ui/src/hooks/useRunDetail.ts
@@ -55,6 +55,20 @@ function mergeLiveRunSummary(run: Run, summary: Run): Run {
 	};
 }
 
+function getCachedRun(runId: string | undefined): Run | null {
+	if (!runId) return null;
+
+	const cachedRun = runDetailCache.get(runId) ?? null;
+	if (cachedRun?.id === runId) return cachedRun;
+	if (cachedRun) runDetailCache.delete(runId);
+	return null;
+}
+
+function cacheRunForId(runId: string, run: Run): void {
+	if (run.id !== runId) return;
+	runDetailCache.set(runId, run);
+}
+
 function snapshotMayAffectRun(
 	currentRun: Run,
 	socketProjectId: string | null,
@@ -109,11 +123,9 @@ function updateReconciledArtifactPath(
 }
 
 export function useRunDetail(runId: string | undefined): UseRunDetailResult {
-	const [run, setRun] = useState<Run | null>(() =>
-		runId ? (runDetailCache.get(runId) ?? null) : null,
-	);
+	const [run, setRun] = useState<Run | null>(() => getCachedRun(runId));
 	const [isLoading, setIsLoading] = useState(() =>
-		runId ? !runDetailCache.has(runId) : false,
+		runId ? getCachedRun(runId) === null : false,
 	);
 	const [error, setError] = useState<Error | null>(null);
 	const {
@@ -123,43 +135,63 @@ export function useRunDetail(runId: string | undefined): UseRunDetailResult {
 		status: wsStatus,
 	} = useWebSocket();
 	const prevWsStatusRef = useRef<ConnectionStatus>(wsStatus);
+	const activeRunIdRef = useRef<string | null>(runId ?? null);
+	const fetchRequestIdRef = useRef(0);
 	const runRef = useRef<Run | null>(null);
+	activeRunIdRef.current = runId ?? null;
 	useLiveRunIndexBridge();
 	const liveSnapshot = useLiveRunIndexSnapshot();
 
 	const fetchRun = useCallback(async () => {
-		if (!runId) {
+		const requestedRunId = runId;
+		const requestId = ++fetchRequestIdRef.current;
+		const isActiveRequest = () =>
+			activeRunIdRef.current === requestedRunId &&
+			fetchRequestIdRef.current === requestId;
+
+		if (!requestedRunId) {
 			setRun(null);
+			runRef.current = null;
 			setIsLoading(false);
 			return;
 		}
 
 		try {
-			const response = await fetch(`/api/v2/runs/${runId}`);
+			const response = await fetch(`/api/v2/runs/${requestedRunId}`);
+			if (!isActiveRequest()) return;
 			if (!response.ok) {
 				if (response.status === 404) {
-					runDetailCache.delete(runId);
+					runDetailCache.delete(requestedRunId);
 					throw new Error("Run not found");
 				}
 				throw new Error(`Failed to fetch run: ${response.statusText}`);
 			}
 			const runData = (await response.json()) as Run;
+			if (!isActiveRequest()) return;
+			if (runData.id !== requestedRunId) {
+				throw new Error("Run response did not match requested run");
+			}
 			setRun(runData);
 			runRef.current = runData;
-			runDetailCache.set(runId, runData);
+			cacheRunForId(requestedRunId, runData);
 			liveRunIndex.upsertRun(runData);
 			setError(null);
 		} catch (err) {
+			if (!isActiveRequest()) return;
 			const nextError = err instanceof Error ? err : new Error(String(err));
+			const currentRun = runRef.current;
 			const shouldKeepStaleRun =
-				runRef.current !== null && nextError.message !== "Run not found";
+				currentRun?.id === requestedRunId &&
+				nextError.message !== "Run not found";
 			if (!shouldKeepStaleRun) {
 				setError(nextError);
 				setRun(null);
 				runRef.current = null;
 			}
 		} finally {
-			setIsLoading(false);
+			if (isActiveRequest()) {
+				setIsLoading(false);
+			}
 		}
 	}, [runId]);
 
@@ -172,7 +204,7 @@ export function useRunDetail(runId: string | undefined): UseRunDetailResult {
 			return;
 		}
 
-		const cachedRun = runDetailCache.get(runId) ?? null;
+		const cachedRun = getCachedRun(runId);
 		setRun(cachedRun);
 		runRef.current = cachedRun;
 		setError(null);
@@ -181,13 +213,13 @@ export function useRunDetail(runId: string | undefined): UseRunDetailResult {
 	}, [runId, fetchRun]);
 
 	useEffect(() => {
-		if (!runId || !run) return;
-		runDetailCache.set(runId, run);
+		if (!runId || !run || run.id !== runId) return;
+		cacheRunForId(runId, run);
 	}, [runId, run]);
 
 	useEffect(() => {
-		runRef.current = run;
-	}, [run]);
+		runRef.current = runId && run?.id === runId ? run : null;
+	}, [runId, run]);
 
 	const debouncedFetchRef = useRef<ReturnType<typeof setTimeout>>();
 
@@ -216,7 +248,7 @@ export function useRunDetail(runId: string | undefined): UseRunDetailResult {
 
 				if (step || stepStatus || nextStatus || rawStatusMessage) {
 					setRun((prev) => {
-						if (!prev) return null;
+						if (!prev || prev.id !== runId) return prev;
 
 						let updatedSteps = prev.steps;
 						if (step && stepStatus && !msg.unit) {
@@ -277,7 +309,7 @@ export function useRunDetail(runId: string | undefined): UseRunDetailResult {
 				if (data?.reconciled) {
 					shouldRefetch = false;
 					setRun((prev) => {
-						if (!prev) return null;
+						if (!prev || prev.id !== runId) return prev;
 						return {
 							...prev,
 							artifacts: updateReconciledArtifactPath(
@@ -299,7 +331,7 @@ export function useRunDetail(runId: string | undefined): UseRunDetailResult {
 					};
 
 					setRun((prev) => {
-						if (!prev) return null;
+						if (!prev || prev.id !== runId) return prev;
 						return {
 							...prev,
 							artifacts: mergeArtifactRegistration(prev.artifacts, newArtifact),
@@ -321,7 +353,7 @@ export function useRunDetail(runId: string | undefined): UseRunDetailResult {
 				};
 
 				setRun((prev) => {
-					if (!prev) return null;
+					if (!prev || prev.id !== runId) return prev;
 					return {
 						...prev,
 						steps: prev.steps.map((step) =>
@@ -349,7 +381,7 @@ export function useRunDetail(runId: string | undefined): UseRunDetailResult {
 				};
 
 				setRun((prev) => {
-					if (!prev) return null;
+					if (!prev || prev.id !== runId) return prev;
 					return {
 						...prev,
 						events: [...prev.events, btwEvent],
@@ -387,7 +419,7 @@ export function useRunDetail(runId: string | undefined): UseRunDetailResult {
 		}
 
 		setRun((prev) => {
-			if (!prev) {
+			if (!prev || prev.id !== runId) {
 				return prev;
 			}
 
@@ -448,10 +480,15 @@ export function useRunDetail(runId: string | undefined): UseRunDetailResult {
 		fetchRun();
 	}, [fetchRun]);
 
+	const visibleRun = runId && run?.id === runId ? run : null;
+	const visibleError = run && runId && run.id !== runId ? null : error;
+	const visibleIsLoading =
+		runId && !visibleRun && !visibleError ? true : isLoading;
+
 	return {
-		run,
-		isLoading,
-		error,
+		run: visibleRun,
+		isLoading: visibleIsLoading,
+		error: visibleError,
 		refetch,
 	};
 }

--- a/cli/web-ui/src/pages/v2/HomePage.tsx
+++ b/cli/web-ui/src/pages/v2/HomePage.tsx
@@ -306,7 +306,11 @@ function SelectedRunPane({
 			</header>
 			<div className="min-h-0 flex-1 overflow-hidden">
 				{selectedRunId ? (
-					<RunDetailSurface runId={selectedRunId} mode="activity-preview" />
+					<RunDetailSurface
+						key={selectedRunId}
+						runId={selectedRunId}
+						mode="activity-preview"
+					/>
 				) : (
 					<NoSelectedRunState />
 				)}


### PR DESCRIPTION
## Summary
- guard run-detail cache and fetch updates so a hook never exposes a run whose id does not match the requested run id
- remount the Activity preview per selected run and ignore stale artifact content fetch responses
- add regressions for run switching and stale artifact fetch errors

## Validation
- bun run lint
- bun test ./src/__tests__/hooks/useRunDetail.test.ts ./src/__tests__/components/v2/ArtifactContentSurface.test.tsx ./src/__tests__/pages/v2/HomePage.test.tsx
- just check-web-ui
- just build-web-ui
- just serve-web-ui + playwright-cli smoke: switch from the MCP build row to PR #361 and confirm the preview shows pr-361-review-002.md without an Artifact not found error