### PR TITLE
fix(native-app): derive launch test CLI version

### DIFF
--- a/native-app/src/__tests__/launch-state.test.ts
+++ b/native-app/src/__tests__/launch-state.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import cliPackage from "../../../cli/package.json";
 
 class MockDaemonExecutableResolutionError extends Error {
 	readonly checkedLocations: readonly unknown[];
@@ -164,7 +165,7 @@ describe("native launch state", () => {
 		expect(launchArcadeMock).toHaveBeenCalledWith({
 			projectPath: undefined,
 			rp1ExecutablePath: "/tmp/rp1",
-			cliVersion: "0.7.5-dev",
+			cliVersion: `${cliPackage.version}-dev`,
 			openProjectListWhenMissing: true,
 		});
 	});


### PR DESCRIPTION
## Summary
- derive the native launch-state test expected CLI dev version from `cli/package.json`
- avoids release-please version bumps making the test fail with stale hardcoded values

## Root cause
This was not flaky. The release branch bumped `cli/package.json` from `0.7.5` to `0.7.6`, but `native-app/src/__tests__/launch-state.test.ts` still expected `0.7.5-dev`.

## Validation
- `just check-native-app`
- `just test-native-app`
