### PR TITLE
fix(ui): activity feed and native Arcade polish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,7 +38,7 @@ cli/src/config/supported-tools.generated.ts
 bin/rp1
 
 # Native app build output
-native-app/build/
+native-app/
 
 # rp1:start:v0.7.1
 !.rp1/

--- a/.gitignore
+++ b/.gitignore
@@ -37,8 +37,9 @@ cli/src/config/supported-tools.generated.ts
 # local rp1 binary
 bin/rp1
 
-# Native app build output
-native-app/
+# Native app generated output
+native-app/build/
+native-app/artifacts/
 
 # rp1:start:v0.7.1
 !.rp1/

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -119,7 +119,7 @@ The recipe builds the local CLI, builds the Electrobun target, and copies the
 local `bin/rp1` into the app bundle. The generated app can then be opened later:
 
 ```bash
-open -n "native-app/build/dev-macos-arm64/RP1 Arcade-dev.app"
+open -n "native-app/build/stable-macos-arm64/rp1 Arcade.app"
 ```
 
 For direct project launch from the built app, use environment variables with the
@@ -128,7 +128,7 @@ values into the Bun worker.
 
 ```bash
 RP1_NATIVE_PROJECT_PATH="/path/to/rp1-project" \
-  "native-app/build/dev-macos-arm64/RP1 Arcade-dev.app/Contents/MacOS/launcher"
+  "native-app/build/stable-macos-arm64/rp1 Arcade.app/Contents/MacOS/launcher"
 ```
 
 Native launch inputs:

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -93,7 +93,7 @@ cd ..
 | `native-app-dev` | Build the local dev CLI and launch the macOS native Arcade shell on the registered projects route |
 | `native-app-dev PROJECT=/path/to/rp1-project` | Register and open a specific project directly in the native shell |
 | `native-app-dev RP1_EXECUTABLE=/absolute/path/to/rp1` | Launch with an explicit rp1 executable for daemon startup |
-| `build-native-app` | Build the macOS app bundle and bundle the local dev CLI without opening it |
+| `build-native-app` | Install the latest local CLI, build the macOS app bundle, and bundle the local dev CLI without opening it |
 
 Use `native-app-dev` without a project to verify registered project selection,
 and use the `PROJECT` form to verify optional direct project launch. Browser
@@ -115,11 +115,12 @@ To build the macOS app bundle without opening it:
 just build-native-app
 ```
 
-The recipe builds the local CLI, removes stale native app outputs, builds the
-Electrobun stable target, copies the local `bin/rp1` into the app bundle,
-unregisters stale `RP1 Arcade-dev.app` entries with the same bundle id, and
-refreshes the macOS app registration for the generated bundle. The generated app
-can then be opened later:
+The recipe runs the full local `just install` flow first so the installed CLI
+and Arcade daemon/cache use the latest build. It then removes stale native app
+outputs, builds the Electrobun stable target, copies the local `bin/rp1` into
+the app bundle, unregisters stale `RP1 Arcade-dev.app` entries with the same
+bundle id, and refreshes the macOS app registration for the generated bundle.
+The generated app can then be opened later:
 
 ```bash
 open -n "native-app/build/stable-macos-arm64/rp1 Arcade.app"

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -115,8 +115,11 @@ To build the macOS app bundle without opening it:
 just build-native-app
 ```
 
-The recipe builds the local CLI, builds the Electrobun target, and copies the
-local `bin/rp1` into the app bundle. The generated app can then be opened later:
+The recipe builds the local CLI, removes stale native app outputs, builds the
+Electrobun stable target, copies the local `bin/rp1` into the app bundle,
+unregisters stale `RP1 Arcade-dev.app` entries with the same bundle id, and
+refreshes the macOS app registration for the generated bundle. The generated app
+can then be opened later:
 
 ```bash
 open -n "native-app/build/stable-macos-arm64/rp1 Arcade.app"

--- a/Justfile
+++ b/Justfile
@@ -165,14 +165,43 @@ build-native-app: build-local-dev
     set -euo pipefail
     cd native-app
     bun install --frozen-lockfile
+    rm -rf \
+        "build/dev-macos-arm64/RP1 Arcade-dev.app" \
+        "build/stable-macos-arm64/rp1 Arcade.app" \
+        "artifacts/stable-macos-arm64-rp1Arcade.app.tar.zst" \
+        "artifacts/stable-macos-arm64-rp1Arcade.dmg" \
+        "artifacts/stable-macos-arm64-update.json"
     bun run build:macos
-    app_path="$(find build -maxdepth 2 -name 'rp1 Arcade.app' -print -quit)"
+    app_path="$(find build/stable-macos-arm64 -maxdepth 1 -name 'rp1 Arcade.app' -print -quit)"
     if [ -z "$app_path" ]; then
-        echo "Native app build finished, but no rp1 Arcade.app was found under native-app/build."
+        echo "Native app build finished, but no rp1 Arcade.app was found under native-app/build/stable-macos-arm64."
+        exit 1
+    fi
+    bundle_name="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleName' "${app_path}/Contents/Info.plist")"
+    bundle_id="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "${app_path}/Contents/Info.plist")"
+    if [ "$bundle_name" != "rp1 Arcade" ] || [ "$bundle_id" != "run.rp1.arcade" ]; then
+        echo "Native app bundle identity mismatch: CFBundleName=${bundle_name}, CFBundleIdentifier=${bundle_id}"
         exit 1
     fi
     cp ../bin/rp1 "${app_path}/Contents/MacOS/rp1"
     chmod +x "${app_path}/Contents/MacOS/rp1"
+    touch "$app_path"
+    lsregister="/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister"
+    if [ -x "$lsregister" ]; then
+        if command -v mdfind >/dev/null 2>&1; then
+            while IFS= read -r stale_app; do
+                if [ -z "$stale_app" ] || [ ! -f "${stale_app}/Contents/Info.plist" ]; then
+                    continue
+                fi
+                stale_bundle_id="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "${stale_app}/Contents/Info.plist" 2>/dev/null || true)"
+                if [ "$stale_bundle_id" = "run.rp1.arcade" ]; then
+                    "$lsregister" -u "$stale_app" >/dev/null 2>&1 || true
+                    echo "Unregistered stale native dev app: $stale_app"
+                fi
+            done < <(mdfind 'kMDItemFSName == "RP1 Arcade-dev.app"')
+        fi
+        "$lsregister" -f "$app_path" >/dev/null 2>&1 || true
+    fi
     echo "Built native app: native-app/${app_path}"
     echo "Bundled local rp1 executable: native-app/${app_path}/Contents/MacOS/rp1"
     echo "Run later with:"

--- a/Justfile
+++ b/Justfile
@@ -160,7 +160,7 @@ build-local-dev: build-web-ui clean-web-ui-cache
     cd cli && RP1_BUILD_INTERNAL=1 bun run scripts/build-opencode.ts && RP1_BUILD_INTERNAL=1 bun run scripts/build-codex.ts && RP1_BUILD_INTERNAL=1 bun run scripts/build-claude-code.ts && RP1_BUILD_INTERNAL=1 bun run scripts/build-copilot.ts && bun run generate:assets && bun build ./src/main.ts --compile --outfile ../bin/rp1 --define __RP1_DEV_BUILD__=true
 
 # Build the macOS native Arcade shell target without opening it
-build-native-app: build-local-dev
+build-native-app: install
     #!/usr/bin/env bash
     set -euo pipefail
     cd native-app

--- a/Justfile
+++ b/Justfile
@@ -164,6 +164,7 @@ build-native-app: build-local-dev
     #!/usr/bin/env bash
     set -euo pipefail
     cd native-app
+    bun install --frozen-lockfile
     bun run build:macos
     app_path="$(find build -maxdepth 2 -name 'RP1 Arcade-dev.app' -print -quit)"
     if [ -z "$app_path" ]; then

--- a/Justfile
+++ b/Justfile
@@ -166,9 +166,9 @@ build-native-app: build-local-dev
     cd native-app
     bun install --frozen-lockfile
     bun run build:macos
-    app_path="$(find build -maxdepth 2 -name 'RP1 Arcade-dev.app' -print -quit)"
+    app_path="$(find build -maxdepth 2 -name 'rp1 Arcade.app' -print -quit)"
     if [ -z "$app_path" ]; then
-        echo "Native app build finished, but no RP1 Arcade-dev.app was found under native-app/build."
+        echo "Native app build finished, but no rp1 Arcade.app was found under native-app/build."
         exit 1
     fi
     cp ../bin/rp1 "${app_path}/Contents/MacOS/rp1"

--- a/cli/src/__tests__/agent-tools/emit/database.test.ts
+++ b/cli/src/__tests__/agent-tools/emit/database.test.ts
@@ -2476,6 +2476,73 @@ describe("emit database", () => {
 	});
 
 	describe("inactive reclassification", () => {
+		test("skips stale bootstrap-only not_started runs with no events", async () => {
+			const dbPath = join(tempDir, "inactive-bootstrap-skip.db");
+			const db = await expectTaskRight(getEmitDatabase(dbPath));
+
+			insertRun(db, {
+				id: "run-bootstrap-only",
+				flow: "phase-plan",
+				featureId: "feat",
+				projectPath: "/p",
+				bootstrapContext: JSON.stringify({
+					run: { decision: "created_new_run" },
+				}),
+			});
+			db.prepare("UPDATE runs SET updated_at = ? WHERE id = ?").run(
+				"2026-04-10T00:00:00.000Z",
+				"run-bootstrap-only",
+			);
+
+			const reclassified = reclassifyInactiveRuns(
+				db,
+				new Date("2026-04-13T12:00:00.000Z"),
+			);
+
+			expect(reclassified).toEqual([]);
+			expect(getRunById(db, "run-bootstrap-only")?.status).toBe("not_started");
+			expect(getEventsForRun(db, "run-bootstrap-only")).toHaveLength(0);
+		});
+
+		test("reclassifies stale not_started runs after workflow events exist", async () => {
+			const dbPath = join(tempDir, "inactive-not-started-events.db");
+			const db = await expectTaskRight(getEmitDatabase(dbPath));
+
+			insertRun(db, {
+				id: "run-not-started-with-event",
+				flow: "build",
+				featureId: "feat",
+				projectPath: "/p",
+			});
+			insertEvent(db, {
+				runId: "run-not-started-with-event",
+				type: "status_change",
+				step: "build",
+				data: JSON.stringify({ status: "not_started" }),
+				createdAt: "2026-04-10T00:00:00.000Z",
+			});
+			deriveRunStatus(db, "run-not-started-with-event");
+			db.prepare("UPDATE runs SET updated_at = ? WHERE id = ?").run(
+				"2026-04-10T00:00:00.000Z",
+				"run-not-started-with-event",
+			);
+
+			const reclassified = reclassifyInactiveRuns(
+				db,
+				new Date("2026-04-13T12:00:00.000Z"),
+			);
+
+			expect(reclassified).toHaveLength(1);
+			expect(reclassified[0]).toMatchObject({
+				runId: "run-not-started-with-event",
+				previousStatus: "not_started",
+				runStatus: "inactive",
+			});
+			expect(getRunById(db, "run-not-started-with-event")?.status).toBe(
+				"inactive",
+			);
+		});
+
 		test("reclassifies stale running runs to inactive and lets new activity revive them", async () => {
 			const dbPath = join(tempDir, "inactive-reclassify.db");
 			const db = await expectTaskRight(getEmitDatabase(dbPath));

--- a/cli/src/__tests__/agent-tools/emit/database.test.ts
+++ b/cli/src/__tests__/agent-tools/emit/database.test.ts
@@ -42,6 +42,7 @@ import {
 	getRunWithLastEventById,
 	getSkippableSteps,
 	getStepStatuses,
+	INACTIVE_REAPER_STATUS_CHANGE,
 	insertEvent,
 	insertRun,
 	listRuns,
@@ -2504,6 +2505,39 @@ describe("emit database", () => {
 			expect(getEventsForRun(db, "run-bootstrap-only")).toHaveLength(0);
 		});
 
+		test("skips stale bootstrap-only runs with only inactivity reaper events", async () => {
+			const dbPath = join(tempDir, "inactive-bootstrap-reaper-skip.db");
+			const db = await expectTaskRight(getEmitDatabase(dbPath));
+
+			insertRun(db, {
+				id: "run-bootstrap-reaper-only",
+				flow: "phase-plan",
+				featureId: "feat",
+				projectPath: "/p",
+				bootstrapContext: JSON.stringify({
+					run: { decision: "created_new_run" },
+				}),
+			});
+			insertEvent(db, {
+				runId: "run-bootstrap-reaper-only",
+				type: "status_change",
+				data: JSON.stringify(INACTIVE_REAPER_STATUS_CHANGE),
+				createdAt: "2026-04-11T00:00:00.000Z",
+			});
+			db.prepare("UPDATE runs SET updated_at = ? WHERE id = ?").run(
+				"2026-04-10T00:00:00.000Z",
+				"run-bootstrap-reaper-only",
+			);
+
+			const reclassified = reclassifyInactiveRuns(
+				db,
+				new Date("2026-04-13T12:00:00.000Z"),
+			);
+
+			expect(reclassified).toEqual([]);
+			expect(getEventsForRun(db, "run-bootstrap-reaper-only")).toHaveLength(1);
+		});
+
 		test("reclassifies stale not_started runs after workflow events exist", async () => {
 			const dbPath = join(tempDir, "inactive-not-started-events.db");
 			const db = await expectTaskRight(getEmitDatabase(dbPath));
@@ -4011,6 +4045,56 @@ describe("emit database", () => {
 			expect(result.total).toBe(1);
 			expect(result.records[0].id).toBe("run-bootstrap-eventful");
 			expect(result.records[0].lastEventAt).toBe("2026-03-05T00:00:00.000Z");
+		});
+
+		test("excludes bootstrap-backed runs with only inactivity reaper events", async () => {
+			const dbPath = join(tempDir, "list-runs-bootstrap-reaper-only.db");
+			const db = await expectTaskRight(getEmitDatabase(dbPath));
+
+			const bootstrapContext = JSON.stringify({
+				run: { decision: "created_new_run" },
+			});
+			insertRun(db, {
+				id: "run-bootstrap-reaper-only",
+				flow: "analyse-security",
+				featureId: "ui-audit",
+				projectPath: "/p",
+				bootstrapContext,
+			});
+			insertEvent(db, {
+				runId: "run-bootstrap-reaper-only",
+				type: "status_change",
+				data: JSON.stringify(INACTIVE_REAPER_STATUS_CHANGE),
+				createdAt: "2026-03-05T00:00:00.000Z",
+			});
+			insertRun(db, {
+				id: "run-bootstrap-real-event",
+				flow: "analyse-security",
+				featureId: "cli",
+				projectPath: "/p",
+				bootstrapContext,
+			});
+			insertEvent(db, {
+				runId: "run-bootstrap-real-event",
+				type: "status_change",
+				step: "scan",
+				data: JSON.stringify({ status: "running" }),
+				createdAt: "2026-03-04T00:00:00.000Z",
+			});
+			insertEvent(db, {
+				runId: "run-bootstrap-real-event",
+				type: "status_change",
+				data: JSON.stringify(INACTIVE_REAPER_STATUS_CHANGE),
+				createdAt: "2026-03-06T00:00:00.000Z",
+			});
+
+			const result = listRuns(db, { excludeBootstrapOnly: true });
+
+			expect(result.total).toBe(1);
+			expect(result.records.map((record) => record.id)).toEqual([
+				"run-bootstrap-real-event",
+			]);
+			expect(result.records[0].lastEventAt).toBe("2026-03-06T00:00:00.000Z");
 		});
 
 		test("counts and paginates after excluding bootstrap-only runs", async () => {

--- a/cli/src/agent-tools/emit/database.ts
+++ b/cli/src/agent-tools/emit/database.ts
@@ -300,6 +300,20 @@ export const INACTIVE_REAPER_STATUS_CHANGE = {
 	source: "inactivity_reaper",
 } as const;
 
+const NON_REAPER_EVENT_EXISTS_SQL = `EXISTS (
+	SELECT 1 FROM events
+	WHERE events.run_id = runs.id
+	  AND (
+		  CASE
+			  WHEN events.type = 'status_change'
+			   AND events.data IS NOT NULL
+			   AND json_valid(events.data)
+			  THEN COALESCE(json_extract(events.data, '$.source'), '')
+			  ELSE ''
+		  END
+	  ) != 'inactivity_reaper'
+)`;
+
 /** Input for creating or retrieving a run */
 export interface RunInput {
 	readonly id: string;
@@ -2074,10 +2088,7 @@ export const reclassifyInactiveRuns = (
 			 FROM runs
 			 WHERE status IN ('running', 'not_started')
 			   AND updated_at <= $cutoff
-			   AND EXISTS (
-			       SELECT 1 FROM events
-			       WHERE events.run_id = runs.id
-			   )
+			   AND ${NON_REAPER_EVENT_EXISTS_SQL}
 			 ORDER BY updated_at ASC, id ASC`,
 		)
 		.all({ $cutoff: cutoffIso }) as {
@@ -2353,10 +2364,7 @@ export const listRuns = (
 	}
 	if (opts.excludeBootstrapOnly === true) {
 		conditions.push(
-			`(runs.bootstrap_context IS NULL OR EXISTS (
-				SELECT 1 FROM events
-				WHERE events.run_id = runs.id
-			))`,
+			`(runs.bootstrap_context IS NULL OR ${NON_REAPER_EVENT_EXISTS_SQL})`,
 		);
 	}
 

--- a/cli/src/agent-tools/emit/database.ts
+++ b/cli/src/agent-tools/emit/database.ts
@@ -2074,6 +2074,10 @@ export const reclassifyInactiveRuns = (
 			 FROM runs
 			 WHERE status IN ('running', 'not_started')
 			   AND updated_at <= $cutoff
+			   AND EXISTS (
+			       SELECT 1 FROM events
+			       WHERE events.run_id = runs.id
+			   )
 			 ORDER BY updated_at ASC, id ASC`,
 		)
 		.all({ $cutoff: cutoffIso }) as {

--- a/cli/web-ui/index.html
+++ b/cli/web-ui/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="Read-only markdown viewer for rp1 artifacts" />
     <meta name="theme-color" content="#0a0a0a" />
-    <title>rp1 arcade</title>
+    <title>rp1 Arcade</title>
     <script>
       (() => {
         const stored = localStorage.getItem('rp1-ui-theme');

--- a/cli/web-ui/src/__tests__/app/document-title.test.ts
+++ b/cli/web-ui/src/__tests__/app/document-title.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+describe("document title", () => {
+	test("omits the icon already supplied by the favicon", () => {
+		const html = readFileSync(
+			resolve(import.meta.dir, "../../../index.html"),
+			"utf8",
+		);
+
+		expect(html).toContain("<title>rp1 Arcade</title>");
+		expect(html).not.toContain("<title>🕹️ rp1 Arcade</title>");
+	});
+});

--- a/cli/web-ui/src/__tests__/components/MilkdownEditor/context-menu-selection-plugin.test.ts
+++ b/cli/web-ui/src/__tests__/components/MilkdownEditor/context-menu-selection-plugin.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, mock, test } from "bun:test";
+import type { Selection } from "@milkdown/kit/prose/state";
+import type { EditorView } from "@milkdown/kit/prose/view";
+import {
+	getContextMenuSelectionToPreserve,
+	isContextMenuPointerEvent,
+	isPositionInsideSelection,
+} from "../../../components/MilkdownEditor/context-menu-selection-plugin";
+
+function selection(from: number, to: number, empty = false): Selection {
+	return { empty, from, to } as Selection;
+}
+
+function pointerEvent({
+	button,
+	ctrlKey = false,
+}: {
+	readonly button: number;
+	readonly ctrlKey?: boolean;
+}): MouseEvent {
+	return {
+		button,
+		clientX: 24,
+		clientY: 48,
+		ctrlKey,
+	} as MouseEvent;
+}
+
+function editorView(
+	currentSelection: Selection,
+	position: number | null,
+): EditorView {
+	return {
+		state: {
+			selection: currentSelection,
+		},
+		posAtCoords: mock(() =>
+			position === null ? null : { pos: position, inside: -1 },
+		),
+	} as unknown as EditorView;
+}
+
+describe("context menu selection preservation", () => {
+	test("detects right click and macOS control click", () => {
+		expect(isContextMenuPointerEvent(pointerEvent({ button: 2 }))).toBe(true);
+		expect(
+			isContextMenuPointerEvent(pointerEvent({ button: 0, ctrlKey: true })),
+		).toBe(true);
+		expect(isContextMenuPointerEvent(pointerEvent({ button: 0 }))).toBe(false);
+	});
+
+	test("treats selection boundaries as inside the selected range", () => {
+		const currentSelection = selection(4, 16);
+
+		expect(isPositionInsideSelection(currentSelection, 4)).toBe(true);
+		expect(isPositionInsideSelection(currentSelection, 10)).toBe(true);
+		expect(isPositionInsideSelection(currentSelection, 16)).toBe(true);
+		expect(isPositionInsideSelection(currentSelection, 17)).toBe(false);
+	});
+
+	test("does not preserve collapsed selections", () => {
+		expect(isPositionInsideSelection(selection(8, 8, true), 8)).toBe(false);
+	});
+
+	test("returns the current selection for a context click inside it", () => {
+		const currentSelection = selection(4, 16);
+
+		expect(
+			getContextMenuSelectionToPreserve(
+				editorView(currentSelection, 10),
+				pointerEvent({ button: 2 }),
+			),
+		).toBe(currentSelection);
+	});
+
+	test("ignores context clicks outside the current selection", () => {
+		expect(
+			getContextMenuSelectionToPreserve(
+				editorView(selection(4, 16), 20),
+				pointerEvent({ button: 2 }),
+			),
+		).toBeNull();
+	});
+
+	test("ignores unresolved pointer positions", () => {
+		expect(
+			getContextMenuSelectionToPreserve(
+				editorView(selection(4, 16), null),
+				pointerEvent({ button: 2 }),
+			),
+		).toBeNull();
+	});
+});

--- a/cli/web-ui/src/__tests__/components/v2/CommandPalette.test.tsx
+++ b/cli/web-ui/src/__tests__/components/v2/CommandPalette.test.tsx
@@ -10,6 +10,7 @@ const toggleThemeMock = mock(() => {});
 const originalFetch = globalThis.fetch;
 const buildMetadataGlobals = globalThis as typeof globalThis & {
 	__RP1_WEB_UI_GIT_COMMIT__?: string;
+	__RP1_WEB_UI_VERSION__?: string;
 };
 
 mock.module("@/hooks/usePrefersReducedMotion", () => ({
@@ -139,6 +140,7 @@ describe("CommandPalette", () => {
 		document.body.innerHTML = "";
 		toggleThemeMock.mockClear();
 		delete buildMetadataGlobals.__RP1_WEB_UI_GIT_COMMIT__;
+		delete buildMetadataGlobals.__RP1_WEB_UI_VERSION__;
 	});
 
 	afterEach(() => {
@@ -146,6 +148,7 @@ describe("CommandPalette", () => {
 		globalThis.fetch = originalFetch;
 		mock.restore();
 		delete buildMetadataGlobals.__RP1_WEB_UI_GIT_COMMIT__;
+		delete buildMetadataGlobals.__RP1_WEB_UI_VERSION__;
 	});
 
 	test("renders contextual commands and executes them", async () => {
@@ -173,6 +176,7 @@ describe("CommandPalette", () => {
 	test("opens About panel with build metadata", async () => {
 		const onOpenChange = mock(() => {});
 		buildMetadataGlobals.__RP1_WEB_UI_GIT_COMMIT__ = "abc1234";
+		buildMetadataGlobals.__RP1_WEB_UI_VERSION__ = "0.7.6";
 		const fetchMock = mock(() =>
 			Promise.resolve(
 				new Response(
@@ -181,8 +185,8 @@ describe("CommandPalette", () => {
 						uptime: 3661,
 						port: 7710,
 						projectCount: 3,
-						isDev: false,
-						version: "0.7.6-dev",
+						isDev: true,
+						version: "0.1.0",
 					}),
 					{ headers: { "Content-Type": "application/json" } },
 				),
@@ -208,7 +212,12 @@ describe("CommandPalette", () => {
 		expect(
 			await screen.findByRole("heading", { name: "About rp1" }),
 		).toBeTruthy();
-		expect(await screen.findByText("0.7.6-dev+abc1234")).toBeTruthy();
+		expect(screen.getByText("rp1")).toBeTruthy();
+		expect(await screen.findByText("0.7.6+abc1234")).toBeTruthy();
+		expect(screen.queryByText(/0\.1\.0/)).toBeNull();
+		expect(screen.queryByText("Web UI")).toBeNull();
+		expect(screen.queryByText("Daemon")).toBeNull();
+		expect(screen.queryByText("Daemon dev")).toBeNull();
 		expect(screen.getByText("7710")).toBeTruthy();
 		expect(screen.getByText("3")).toBeTruthy();
 		expect(screen.getByText("1h 1m")).toBeTruthy();
@@ -220,6 +229,7 @@ describe("CommandPalette", () => {
 
 	test("keeps release About version unchanged when commit hash is available", async () => {
 		buildMetadataGlobals.__RP1_WEB_UI_GIT_COMMIT__ = "def5678";
+		buildMetadataGlobals.__RP1_WEB_UI_VERSION__ = "0.7.6";
 		globalThis.fetch = mock(() =>
 			Promise.resolve(
 				new Response(
@@ -251,6 +261,8 @@ describe("CommandPalette", () => {
 		fireEvent.click(screen.getByRole("button", { name: /^about$/i }));
 
 		expect(await screen.findByText("0.7.6")).toBeTruthy();
+		expect(screen.queryByText("Web UI")).toBeNull();
+		expect(screen.queryByText("Daemon")).toBeNull();
 		expect(screen.queryByText(/def5678/)).toBeNull();
 	});
 });

--- a/cli/web-ui/src/__tests__/components/v2/CommandPalette.test.tsx
+++ b/cli/web-ui/src/__tests__/components/v2/CommandPalette.test.tsx
@@ -7,6 +7,7 @@ import { ShortcutRegistryProvider } from "@/providers/ShortcutRegistryProvider";
 
 let importVersion = 0;
 const toggleThemeMock = mock(() => {});
+const originalFetch = globalThis.fetch;
 
 mock.module("@/hooks/usePrefersReducedMotion", () => ({
 	usePrefersReducedMotion: () => true,
@@ -138,6 +139,7 @@ describe("CommandPalette", () => {
 
 	afterEach(() => {
 		cleanup();
+		globalThis.fetch = originalFetch;
 		mock.restore();
 	});
 
@@ -161,5 +163,52 @@ describe("CommandPalette", () => {
 		fireEvent.click(item);
 
 		expect(action).toHaveBeenCalledTimes(1);
+	});
+
+	test("opens About panel with build metadata", async () => {
+		const onOpenChange = mock(() => {});
+		const fetchMock = mock(() =>
+			Promise.resolve(
+				new Response(
+					JSON.stringify({
+						status: "ok",
+						uptime: 3661,
+						port: 7710,
+						projectCount: 3,
+						isDev: false,
+						version: "0.7.6-dev",
+					}),
+					{ headers: { "Content-Type": "application/json" } },
+				),
+			),
+		);
+		globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+		const { CommandPalette } = await import(
+			`../../../components/v2/CommandPalette.tsx?command-palette-test=${++importVersion}`
+		);
+
+		render(
+			<MemoryRouter>
+				<ShortcutRegistryProvider>
+					<CommandPalette open onOpenChange={onOpenChange} />
+				</ShortcutRegistryProvider>
+			</MemoryRouter>,
+		);
+
+		fireEvent.click(screen.getByRole("button", { name: /^about$/i }));
+
+		expect(onOpenChange).not.toHaveBeenCalled();
+		expect(
+			await screen.findByRole("heading", { name: "About rp1" }),
+		).toBeTruthy();
+		expect(await screen.findByText("0.7.6-dev")).toBeTruthy();
+		expect(screen.getByText("7710")).toBeTruthy();
+		expect(screen.getByText("3")).toBeTruthy();
+		expect(screen.getByText("1h 1m")).toBeTruthy();
+		expect(fetchMock).toHaveBeenCalledWith(
+			"/api/v2/health",
+			expect.objectContaining({ signal: expect.any(AbortSignal) }),
+		);
 	});
 });

--- a/cli/web-ui/src/__tests__/components/v2/CommandPalette.test.tsx
+++ b/cli/web-ui/src/__tests__/components/v2/CommandPalette.test.tsx
@@ -8,6 +8,9 @@ import { ShortcutRegistryProvider } from "@/providers/ShortcutRegistryProvider";
 let importVersion = 0;
 const toggleThemeMock = mock(() => {});
 const originalFetch = globalThis.fetch;
+const buildMetadataGlobals = globalThis as typeof globalThis & {
+	__RP1_WEB_UI_GIT_COMMIT__?: string;
+};
 
 mock.module("@/hooks/usePrefersReducedMotion", () => ({
 	usePrefersReducedMotion: () => true,
@@ -135,12 +138,14 @@ describe("CommandPalette", () => {
 		mock.restore();
 		document.body.innerHTML = "";
 		toggleThemeMock.mockClear();
+		delete buildMetadataGlobals.__RP1_WEB_UI_GIT_COMMIT__;
 	});
 
 	afterEach(() => {
 		cleanup();
 		globalThis.fetch = originalFetch;
 		mock.restore();
+		delete buildMetadataGlobals.__RP1_WEB_UI_GIT_COMMIT__;
 	});
 
 	test("renders contextual commands and executes them", async () => {
@@ -167,6 +172,7 @@ describe("CommandPalette", () => {
 
 	test("opens About panel with build metadata", async () => {
 		const onOpenChange = mock(() => {});
+		buildMetadataGlobals.__RP1_WEB_UI_GIT_COMMIT__ = "abc1234";
 		const fetchMock = mock(() =>
 			Promise.resolve(
 				new Response(
@@ -202,7 +208,7 @@ describe("CommandPalette", () => {
 		expect(
 			await screen.findByRole("heading", { name: "About rp1" }),
 		).toBeTruthy();
-		expect(await screen.findByText("0.7.6-dev")).toBeTruthy();
+		expect(await screen.findByText("0.7.6-dev+abc1234")).toBeTruthy();
 		expect(screen.getByText("7710")).toBeTruthy();
 		expect(screen.getByText("3")).toBeTruthy();
 		expect(screen.getByText("1h 1m")).toBeTruthy();
@@ -210,5 +216,41 @@ describe("CommandPalette", () => {
 			"/api/v2/health",
 			expect.objectContaining({ signal: expect.any(AbortSignal) }),
 		);
+	});
+
+	test("keeps release About version unchanged when commit hash is available", async () => {
+		buildMetadataGlobals.__RP1_WEB_UI_GIT_COMMIT__ = "def5678";
+		globalThis.fetch = mock(() =>
+			Promise.resolve(
+				new Response(
+					JSON.stringify({
+						status: "ok",
+						uptime: 12,
+						port: 7710,
+						projectCount: 1,
+						isDev: false,
+						version: "0.7.6",
+					}),
+					{ headers: { "Content-Type": "application/json" } },
+				),
+			),
+		) as unknown as typeof fetch;
+
+		const { CommandPalette } = await import(
+			`../../../components/v2/CommandPalette.tsx?command-palette-test=${++importVersion}`
+		);
+
+		render(
+			<MemoryRouter>
+				<ShortcutRegistryProvider>
+					<CommandPalette open onOpenChange={() => {}} />
+				</ShortcutRegistryProvider>
+			</MemoryRouter>,
+		);
+
+		fireEvent.click(screen.getByRole("button", { name: /^about$/i }));
+
+		expect(await screen.findByText("0.7.6")).toBeTruthy();
+		expect(screen.queryByText(/def5678/)).toBeNull();
 	});
 });

--- a/cli/web-ui/src/__tests__/hooks/useFeed.test.ts
+++ b/cli/web-ui/src/__tests__/hooks/useFeed.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import { renderHook, waitFor } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import { useSyncExternalStore } from "react";
 import { liveRunIndex } from "@/lib/live-run-index";
 import type { Run } from "@/types/runs";
@@ -81,7 +81,7 @@ afterEach(() => {
 });
 
 describe("useFeed", () => {
-	test("patches known runs in place and inserts newly matching runs without refetching", async () => {
+	test("patches known runs in place and appends newly matching runs without refetching", async () => {
 		const { useFeed } = await loadUseFeed();
 		const { result } = renderHook(() => useFeed({ limit: 25, offset: 0 }));
 
@@ -94,29 +94,97 @@ describe("useFeed", () => {
 		expect(result.current.total).toBe(1);
 		expect(fetchMock).toHaveBeenCalledTimes(1);
 
-		liveRunIndex.upsertRuns([
-			buildRun({
-				id: "run-1",
-				status: "waiting",
-				currentStep: "review",
-				lastEventAt: "2026-04-10T00:06:00.000Z",
-			}),
-			buildRun({
-				id: "run-2",
-				name: "Fresh Run",
-				lastEventAt: "2026-04-10T00:07:00.000Z",
-			}),
-		]);
+		act(() => {
+			liveRunIndex.upsertRuns([
+				buildRun({
+					id: "run-1",
+					status: "waiting",
+					currentStep: "review",
+					lastEventAt: "2026-04-10T00:06:00.000Z",
+				}),
+				buildRun({
+					id: "run-2",
+					name: "Fresh Run",
+					lastEventAt: "2026-04-10T00:07:00.000Z",
+				}),
+			]);
+		});
 
 		await waitFor(() => {
 			expect(result.current.items).toHaveLength(2);
 		});
 
 		expect(result.current.items.map((item: { id: string }) => item.id)).toEqual(
-			["run-2", "run-1"],
+			["run-1", "run-2"],
+		);
+		expect(result.current.items[0]?.run.status).toBe("waiting");
+		expect(result.current.total).toBe(2);
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+	});
+
+	test("keeps existing feed order when live timestamps change", async () => {
+		fetchMock = mock(() =>
+			Promise.resolve({
+				ok: true,
+				json: () =>
+					Promise.resolve({
+						items: [
+							{
+								type: "run",
+								id: "run-1",
+								timestamp: "2026-04-10T00:10:00.000Z",
+								run: buildRun({
+									id: "run-1",
+									lastEventAt: "2026-04-10T00:10:00.000Z",
+								}),
+							},
+							{
+								type: "run",
+								id: "run-2",
+								timestamp: "2026-04-10T00:09:00.000Z",
+								run: buildRun({
+									id: "run-2",
+									lastEventAt: "2026-04-10T00:09:00.000Z",
+								}),
+							},
+						],
+						total: 2,
+					}),
+			}),
+		);
+		globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+		const { useFeed } = await loadUseFeed();
+		const { result } = renderHook(() => useFeed({ limit: 25, offset: 0 }));
+
+		await waitFor(() => {
+			expect(result.current.isLoading).toBe(false);
+		});
+
+		expect(result.current.items.map((item: { id: string }) => item.id)).toEqual(
+			["run-1", "run-2"],
+		);
+
+		act(() => {
+			liveRunIndex.upsertRun(
+				buildRun({
+					id: "run-2",
+					status: "waiting",
+					lastEventAt: "2026-04-10T00:11:00.000Z",
+				}),
+			);
+		});
+
+		await waitFor(() => {
+			expect(result.current.items[1]?.timestamp).toBe(
+				"2026-04-10T00:11:00.000Z",
+			);
+		});
+
+		expect(result.current.items.map((item: { id: string }) => item.id)).toEqual(
+			["run-1", "run-2"],
 		);
 		expect(result.current.items[1]?.run.status).toBe("waiting");
-		expect(result.current.total).toBe(2);
 		expect(fetchMock).toHaveBeenCalledTimes(1);
 	});
 });

--- a/cli/web-ui/src/__tests__/server/v2-api-feed.test.ts
+++ b/cli/web-ui/src/__tests__/server/v2-api-feed.test.ts
@@ -16,6 +16,7 @@ import {
 	deriveRunStatus,
 	getEmitDatabase,
 	getEventsForRun,
+	INACTIVE_REAPER_STATUS_CHANGE,
 	insertEvent,
 	insertRun,
 	resetInstance,
@@ -269,6 +270,12 @@ describe("handleV2FeedRequest", () => {
 			"2026-04-10T06:00:00.000Z",
 			"run-ghost-phase-plan",
 		);
+		insertEvent(db, {
+			runId: "run-ghost-phase-plan",
+			type: "status_change",
+			data: JSON.stringify(INACTIVE_REAPER_STATUS_CHANGE),
+			createdAt: "2026-04-11T06:00:00.000Z",
+		});
 
 		insertRun(db, {
 			id: "run-normal-workflow",
@@ -308,7 +315,7 @@ describe("handleV2FeedRequest", () => {
 		expect(body.items.map((item) => item.id)).toEqual(["run-normal-workflow"]);
 		expect(body.items[0]?.run.id).toBe("run-normal-workflow");
 		expect(websocketHub.broadcastEvent).not.toHaveBeenCalled();
-		expect(getEventsForRun(db, "run-ghost-phase-plan")).toHaveLength(0);
+		expect(getEventsForRun(db, "run-ghost-phase-plan")).toHaveLength(1);
 	});
 
 	test("broadcasts stale run inactivity when feed reads trigger reclassification", async () => {

--- a/cli/web-ui/src/__tests__/server/v2-api-feed.test.ts
+++ b/cli/web-ui/src/__tests__/server/v2-api-feed.test.ts
@@ -15,6 +15,7 @@ import {
 	closeDatabase,
 	deriveRunStatus,
 	getEmitDatabase,
+	getEventsForRun,
 	insertEvent,
 	insertRun,
 	resetInstance,
@@ -264,6 +265,10 @@ describe("handleV2FeedRequest", () => {
 			"2026-04-10T06:00:00.000Z",
 			"run-ghost-phase-plan",
 		);
+		db.prepare("UPDATE runs SET updated_at = ? WHERE id = ?").run(
+			"2026-04-10T06:00:00.000Z",
+			"run-ghost-phase-plan",
+		);
 
 		insertRun(db, {
 			id: "run-normal-workflow",
@@ -283,8 +288,13 @@ describe("handleV2FeedRequest", () => {
 		});
 		deriveRunStatus(db, "run-normal-workflow");
 
+		const websocketHub = {
+			broadcastEvent: mock(() => {}),
+		};
+
 		const response = await handleV2FeedRequest(
 			new Request(`http://localhost/api/v2/feed?project_id=${projectId}`),
+			{ websocketHub } as never,
 		);
 
 		expect(response.status).toBe(200);
@@ -297,6 +307,8 @@ describe("handleV2FeedRequest", () => {
 		expect(body.total).toBe(1);
 		expect(body.items.map((item) => item.id)).toEqual(["run-normal-workflow"]);
 		expect(body.items[0]?.run.id).toBe("run-normal-workflow");
+		expect(websocketHub.broadcastEvent).not.toHaveBeenCalled();
+		expect(getEventsForRun(db, "run-ghost-phase-plan")).toHaveLength(0);
 	});
 
 	test("broadcasts stale run inactivity when feed reads trigger reclassification", async () => {

--- a/cli/web-ui/src/__tests__/version.test.ts
+++ b/cli/web-ui/src/__tests__/version.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "bun:test";
+import cliPackage from "../../../package.json";
+import viteConfig from "../../vite.config";
+import { RP1_VERSION } from "../version";
+
+describe("web-ui version metadata", () => {
+	test("uses the CLI package version as the rp1 version source", () => {
+		expect(RP1_VERSION).toBe(cliPackage.version);
+	});
+
+	test("injects the rp1 version into About build metadata", () => {
+		const config = viteConfig as { define?: Record<string, unknown> };
+
+		expect(config.define?.__RP1_WEB_UI_VERSION__).toBe(
+			JSON.stringify(cliPackage.version),
+		);
+	});
+});

--- a/cli/web-ui/src/cli.ts
+++ b/cli/web-ui/src/cli.ts
@@ -3,8 +3,8 @@ import { resolve } from "node:path";
 import { isLeft } from "./lib/fp";
 import { createServer } from "./server";
 import { formatProjectError, validateProject } from "./server/project";
+import { RP1_VERSION } from "./version";
 
-const VERSION = "0.1.0";
 const DEFAULT_PORT = 7710;
 
 interface CliArgs {
@@ -76,7 +76,7 @@ Examples:
 }
 
 function printVersion(): void {
-	console.log(`rp1-ui version ${VERSION}`);
+	console.log(`rp1-ui version ${RP1_VERSION}`);
 }
 
 async function checkPortAvailable(port: number): Promise<boolean> {
@@ -166,7 +166,7 @@ async function main(): Promise<void> {
 		port: args.port,
 		projectPath: args.projectPath,
 		isDev,
-		version: VERSION,
+		version: RP1_VERSION,
 	});
 
 	const url = `http://127.0.0.1:${args.port}`;

--- a/cli/web-ui/src/cli.ts
+++ b/cli/web-ui/src/cli.ts
@@ -166,6 +166,7 @@ async function main(): Promise<void> {
 		port: args.port,
 		projectPath: args.projectPath,
 		isDev,
+		version: VERSION,
 	});
 
 	const url = `http://127.0.0.1:${args.port}`;

--- a/cli/web-ui/src/components/MilkdownEditor/MilkdownEditor.tsx
+++ b/cli/web-ui/src/components/MilkdownEditor/MilkdownEditor.tsx
@@ -30,6 +30,7 @@ import {
 	useState,
 } from "react";
 import { getHighlighter, normalizeLanguage } from "../../lib/shiki";
+import { createContextMenuSelectionPlugin } from "./context-menu-selection-plugin";
 import { createLinkClickPlugin } from "./link-click-plugin";
 import { createMermaidPlugin } from "./mermaid-plugin";
 
@@ -165,6 +166,7 @@ function MilkdownEditorInner({
 				.use(history)
 				.use(listener)
 				.use(createMermaidPlugin())
+				.use(createContextMenuSelectionPlugin())
 				.use(createLinkClickPlugin());
 
 			// Note: mermaid NodeView must come after commonmark (needs code_block schema)

--- a/cli/web-ui/src/components/MilkdownEditor/context-menu-selection-plugin.ts
+++ b/cli/web-ui/src/components/MilkdownEditor/context-menu-selection-plugin.ts
@@ -1,0 +1,118 @@
+import { Plugin, PluginKey, type Selection } from "@milkdown/kit/prose/state";
+import type { EditorView } from "@milkdown/kit/prose/view";
+import { $prose } from "@milkdown/kit/utils";
+
+const contextMenuSelectionPluginKey = new PluginKey(
+	"contextMenuSelectionPreservation",
+);
+const PRESERVE_SELECTION_MS = 1000;
+
+export function isContextMenuPointerEvent(event: MouseEvent): boolean {
+	return event.button === 2 || (event.button === 0 && event.ctrlKey);
+}
+
+export function isPositionInsideSelection(
+	selection: Selection,
+	position: number,
+): boolean {
+	return (
+		!selection.empty && position >= selection.from && position <= selection.to
+	);
+}
+
+export function getContextMenuSelectionToPreserve(
+	view: EditorView,
+	event: MouseEvent,
+): Selection | null {
+	if (!isContextMenuPointerEvent(event)) return null;
+
+	const selection = view.state.selection;
+	if (selection.empty) return null;
+
+	const position = view.posAtCoords({
+		left: event.clientX,
+		top: event.clientY,
+	});
+
+	if (!position || !isPositionInsideSelection(selection, position.pos)) {
+		return null;
+	}
+
+	return selection;
+}
+
+function restoreSelection(view: EditorView, selection: Selection): void {
+	if (selection.empty) return;
+	const docSize = view.state.doc.content.size;
+	if (selection.from < 0 || selection.to > docSize) return;
+	if (selection.eq(view.state.selection)) return;
+
+	view.dispatch(
+		view.state.tr
+			.setSelection(selection)
+			.setMeta("addToHistory", false)
+			.setMeta(contextMenuSelectionPluginKey, true),
+	);
+}
+
+export const createContextMenuSelectionPlugin = () =>
+	$prose(() => {
+		let preservedSelection: Selection | null = null;
+		let clearTimer: ReturnType<typeof setTimeout> | null = null;
+
+		const clearPreservedSelection = () => {
+			preservedSelection = null;
+			if (clearTimer) {
+				clearTimeout(clearTimer);
+				clearTimer = null;
+			}
+		};
+
+		const preserveSelection = (selection: Selection) => {
+			preservedSelection = selection;
+			if (clearTimer) clearTimeout(clearTimer);
+			clearTimer = setTimeout(() => {
+				preservedSelection = null;
+				clearTimer = null;
+			}, PRESERVE_SELECTION_MS);
+		};
+
+		const restorePreservedSelection = (view: EditorView): boolean => {
+			if (!preservedSelection) return false;
+			restoreSelection(view, preservedSelection);
+			return true;
+		};
+
+		return new Plugin({
+			key: contextMenuSelectionPluginKey,
+			props: {
+				handleDOMEvents: {
+					mousedown(view: EditorView, event: MouseEvent) {
+						const selection = getContextMenuSelectionToPreserve(view, event);
+						if (!selection) {
+							if (isContextMenuPointerEvent(event)) clearPreservedSelection();
+							return false;
+						}
+
+						preserveSelection(selection);
+						return true;
+					},
+					mouseup(view: EditorView, event: MouseEvent) {
+						if (!isContextMenuPointerEvent(event)) return false;
+						return restorePreservedSelection(view);
+					},
+					contextmenu(view: EditorView) {
+						const restored = restorePreservedSelection(view);
+						if (restored && clearTimer) {
+							clearTimeout(clearTimer);
+							clearTimer = setTimeout(() => {
+								preservedSelection = null;
+								clearTimer = null;
+							}, PRESERVE_SELECTION_MS);
+						}
+						return restored;
+					},
+				},
+			},
+		});
+	});

--- a/cli/web-ui/src/components/MilkdownEditor/context-menu-selection-plugin.ts
+++ b/cli/web-ui/src/components/MilkdownEditor/context-menu-selection-plugin.ts
@@ -7,6 +7,11 @@ const contextMenuSelectionPluginKey = new PluginKey(
 );
 const PRESERVE_SELECTION_MS = 1000;
 
+interface PreservedContextMenuSelection {
+	readonly editorSelection: Selection;
+	readonly browserRange: Range | null;
+}
+
 export function isContextMenuPointerEvent(event: MouseEvent): boolean {
 	return event.button === 2 || (event.button === 0 && event.ctrlKey);
 }
@@ -41,6 +46,25 @@ export function getContextMenuSelectionToPreserve(
 	return selection;
 }
 
+function cloneBrowserSelectionRange(): Range | null {
+	const selection = window.getSelection();
+	if (!selection || selection.isCollapsed || selection.rangeCount === 0) {
+		return null;
+	}
+
+	return selection.getRangeAt(0).cloneRange();
+}
+
+function restoreBrowserSelectionRange(range: Range | null): void {
+	if (!range) return;
+
+	const selection = window.getSelection();
+	if (!selection) return;
+
+	selection.removeAllRanges();
+	selection.addRange(range);
+}
+
 function restoreSelection(view: EditorView, selection: Selection): void {
 	if (selection.empty) return;
 	const docSize = view.state.doc.content.size;
@@ -57,7 +81,7 @@ function restoreSelection(view: EditorView, selection: Selection): void {
 
 export const createContextMenuSelectionPlugin = () =>
 	$prose(() => {
-		let preservedSelection: Selection | null = null;
+		let preservedSelection: PreservedContextMenuSelection | null = null;
 		let clearTimer: ReturnType<typeof setTimeout> | null = null;
 
 		const clearPreservedSelection = () => {
@@ -69,7 +93,10 @@ export const createContextMenuSelectionPlugin = () =>
 		};
 
 		const preserveSelection = (selection: Selection) => {
-			preservedSelection = selection;
+			preservedSelection = {
+				editorSelection: selection,
+				browserRange: cloneBrowserSelectionRange(),
+			};
 			if (clearTimer) clearTimeout(clearTimer);
 			clearTimer = setTimeout(() => {
 				preservedSelection = null;
@@ -79,7 +106,8 @@ export const createContextMenuSelectionPlugin = () =>
 
 		const restorePreservedSelection = (view: EditorView): boolean => {
 			if (!preservedSelection) return false;
-			restoreSelection(view, preservedSelection);
+			restoreSelection(view, preservedSelection.editorSelection);
+			restoreBrowserSelectionRange(preservedSelection.browserRange);
 			return true;
 		};
 
@@ -95,6 +123,8 @@ export const createContextMenuSelectionPlugin = () =>
 						}
 
 						preserveSelection(selection);
+						event.preventDefault();
+						restorePreservedSelection(view);
 						return true;
 					},
 					mouseup(view: EditorView, event: MouseEvent) {

--- a/cli/web-ui/src/components/v2/CommandPalette.tsx
+++ b/cli/web-ui/src/components/v2/CommandPalette.tsx
@@ -3,12 +3,14 @@ import { AnimatePresence, motion } from "framer-motion";
 import {
 	FileText,
 	Home,
+	Info,
 	List,
 	Moon,
 	NotebookTabs,
 	RefreshCw,
+	X,
 } from "lucide-react";
-import { useCallback } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import {
 	Command,
@@ -37,9 +39,35 @@ import {
 import { useShortcutRegistry } from "@/providers/ShortcutRegistryProvider";
 import { useTheme } from "@/providers/ThemeProvider";
 
+declare const __RP1_WEB_UI_BUILD_TIME__: string | undefined;
+declare const __RP1_WEB_UI_VERSION__: string | undefined;
+
 export interface CommandPaletteProps {
 	open: boolean;
 	onOpenChange: (open: boolean) => void;
+}
+
+type PaletteView = "commands" | "about";
+
+interface ClientBuildMetadata {
+	readonly buildTime: string;
+	readonly devBuild: boolean | undefined;
+	readonly mode: string;
+	readonly version: string;
+}
+
+interface HealthMetadata {
+	readonly status: "ok";
+	readonly uptime: number;
+	readonly port: number;
+	readonly projectCount: number;
+	readonly isDev?: boolean;
+	readonly version?: string;
+}
+
+interface MetadataRow {
+	readonly label: string;
+	readonly value: string;
 }
 
 const navigationIcons: Record<string, React.ReactNode> = {
@@ -64,6 +92,9 @@ const actionIcons: Record<string, React.ReactNode> = {
 	),
 	"act-refresh": (
 		<RefreshCw className="mr-2 h-4 w-4" strokeWidth={1.5} aria-hidden="true" />
+	),
+	"act-about": (
+		<Info className="mr-2 h-4 w-4" strokeWidth={1.5} aria-hidden="true" />
 	),
 };
 
@@ -96,11 +127,15 @@ function AnimatedCommandDialog({
 	onOpenChange,
 	children,
 	reducedMotion,
+	title = "Command Palette",
+	wrapCommand = true,
 }: {
 	open: boolean;
 	onOpenChange: (open: boolean) => void;
 	children: React.ReactNode;
 	reducedMotion: boolean;
+	title?: string;
+	wrapCommand?: boolean;
 }) {
 	return (
 		<DialogPrimitive.Root open={open} onOpenChange={onOpenChange}>
@@ -156,9 +191,13 @@ function AnimatedCommandDialog({
 									}
 								>
 									<DialogPrimitive.Title className="sr-only">
-										Command Palette
+										{title}
 									</DialogPrimitive.Title>
-									<Command className={CMDK_STYLES}>{children}</Command>
+									{wrapCommand ? (
+										<Command className={CMDK_STYLES}>{children}</Command>
+									) : (
+										children
+									)}
 								</motion.div>
 							</DialogPrimitive.Content>
 						</div>
@@ -169,12 +208,180 @@ function AnimatedCommandDialog({
 	);
 }
 
+function getClientBuildMetadata(): ClientBuildMetadata {
+	const viteEnv = (
+		import.meta as ImportMeta & {
+			readonly env?: {
+				readonly DEV?: boolean;
+				readonly MODE?: string;
+			};
+		}
+	).env;
+
+	return {
+		buildTime:
+			typeof __RP1_WEB_UI_BUILD_TIME__ === "string"
+				? __RP1_WEB_UI_BUILD_TIME__
+				: "Unknown",
+		devBuild: typeof viteEnv?.DEV === "boolean" ? viteEnv.DEV : undefined,
+		mode: typeof viteEnv?.MODE === "string" ? viteEnv.MODE : "Unknown",
+		version:
+			typeof __RP1_WEB_UI_VERSION__ === "string"
+				? __RP1_WEB_UI_VERSION__
+				: "Unknown",
+	};
+}
+
+function formatBoolean(value: boolean | undefined): string {
+	if (value === undefined) return "Unknown";
+	return value ? "Yes" : "No";
+}
+
+function formatUptime(seconds: number | undefined): string {
+	if (seconds === undefined) return "Unknown";
+	if (seconds < 60) return `${seconds}s`;
+
+	const minutes = Math.floor(seconds / 60);
+	if (minutes < 60) return `${minutes}m ${seconds % 60}s`;
+
+	const hours = Math.floor(minutes / 60);
+	return `${hours}h ${minutes % 60}m`;
+}
+
+function getDaemonDevBuild(health: HealthMetadata | null): boolean | undefined {
+	if (!health) return undefined;
+	if (health.version?.includes("-dev")) return true;
+	return typeof health.isDev === "boolean" ? health.isDev : undefined;
+}
+
+function AboutMetadataRow({ label, value }: MetadataRow) {
+	return (
+		<div className="grid grid-cols-[120px_minmax(0,1fr)] gap-3 border-t border-border/60 py-2 first:border-t-0">
+			<dt className="type-caption uppercase tracking-[0.08em] text-fg-ghost">
+				{label}
+			</dt>
+			<dd
+				className="min-w-0 truncate text-right font-mono text-[12px] text-fg"
+				title={value}
+			>
+				{value}
+			</dd>
+		</div>
+	);
+}
+
+function AboutPanel({ onClose }: { onClose: () => void }) {
+	const clientBuild = useMemo(getClientBuildMetadata, []);
+	const [health, setHealth] = useState<HealthMetadata | null>(null);
+	const [loading, setLoading] = useState(true);
+	const [error, setError] = useState<string | null>(null);
+
+	useEffect(() => {
+		const controller = new AbortController();
+
+		setLoading(true);
+		setError(null);
+
+		fetch("/api/v2/health", { signal: controller.signal })
+			.then(async (response) => {
+				if (!response.ok) {
+					throw new Error(`Health check failed (${response.status})`);
+				}
+				setHealth((await response.json()) as HealthMetadata);
+			})
+			.catch((fetchError: unknown) => {
+				if (controller.signal.aborted) return;
+				setError(fetchError instanceof Error ? fetchError.message : "Unknown");
+			})
+			.finally(() => {
+				if (!controller.signal.aborted) {
+					setLoading(false);
+				}
+			});
+
+		return () => controller.abort();
+	}, []);
+
+	const rows: MetadataRow[] = [
+		{ label: "Web UI", value: clientBuild.version },
+		{ label: "Build mode", value: clientBuild.mode },
+		{ label: "Dev build", value: formatBoolean(clientBuild.devBuild) },
+		{ label: "Build time", value: clientBuild.buildTime },
+		{
+			label: "Daemon",
+			value: loading ? "Loading..." : (health?.version ?? "Unknown"),
+		},
+		{ label: "Daemon dev", value: formatBoolean(getDaemonDevBuild(health)) },
+		{
+			label: "API port",
+			value:
+				loading || health?.port === undefined ? "Unknown" : String(health.port),
+		},
+		{
+			label: "Projects",
+			value:
+				loading || health?.projectCount === undefined
+					? "Unknown"
+					: String(health.projectCount),
+		},
+		{ label: "Uptime", value: formatUptime(health?.uptime) },
+	];
+
+	return (
+		<div>
+			<div className="flex items-start justify-between gap-4 border-b border-border px-4 py-3">
+				<div className="min-w-0">
+					<h2 className="type-body font-medium text-fg">About rp1</h2>
+					<p className="mt-1 type-secondary text-fg-muted">
+						Version and build metadata
+					</p>
+				</div>
+				<button
+					type="button"
+					onClick={onClose}
+					className="flex h-7 w-7 shrink-0 items-center justify-center rounded text-fg-ghost transition-colors duration-150 hover:bg-surface-void hover:text-fg focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-border"
+					aria-label="Close about dialog"
+				>
+					<X className="h-4 w-4" strokeWidth={1.5} aria-hidden="true" />
+				</button>
+			</div>
+			<dl className="px-4 py-3">
+				{rows.map((row) => (
+					<AboutMetadataRow key={row.label} {...row} />
+				))}
+			</dl>
+			{error && (
+				<p className="border-t border-border px-4 py-3 type-secondary text-failure">
+					{error}
+				</p>
+			)}
+		</div>
+	);
+}
+
 export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
 	const navigate = useNavigate();
 	const { toggleTheme } = useTheme();
 	const registry = useShortcutRegistry();
 	const reducedMotion = usePrefersReducedMotion();
 	const contextualCommands = registry.contextualShortcuts?.commands ?? [];
+	const [view, setView] = useState<PaletteView>("commands");
+
+	useEffect(() => {
+		if (!open) {
+			setView("commands");
+		}
+	}, [open]);
+
+	const handleOpenChange = useCallback(
+		(nextOpen: boolean) => {
+			if (!nextOpen) {
+				setView("commands");
+			}
+			onOpenChange(nextOpen);
+		},
+		[onOpenChange],
+	);
 
 	const executeCommand = useCallback(
 		(command: CommandType) => {
@@ -188,104 +395,122 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
 					case "refresh-data":
 						window.dispatchEvent(new CustomEvent("rp1:refresh"));
 						break;
+					case "show-about":
+						setView("about");
+						return;
 				}
 			}
-			onOpenChange(false);
+			handleOpenChange(false);
 		},
-		[navigate, toggleTheme, onOpenChange],
+		[navigate, toggleTheme, handleOpenChange],
 	);
 
 	const executeContextualCommand = useCallback(
 		(action: () => void) => {
 			action();
-			onOpenChange(false);
+			handleOpenChange(false);
 		},
-		[onOpenChange],
+		[handleOpenChange],
 	);
 
 	return (
 		<AnimatedCommandDialog
 			open={open}
-			onOpenChange={onOpenChange}
+			onOpenChange={handleOpenChange}
 			reducedMotion={reducedMotion}
+			title={view === "about" ? "About rp1" : "Command Palette"}
+			wrapCommand={view === "commands"}
 		>
-			<CommandInput placeholder="Type a command or search..." />
-			<CommandList>
-				<CommandEmpty>No results found.</CommandEmpty>
-				<motion.div
-					variants={
-						reducedMotion
-							? commandStaggerContainerReduced
-							: commandStaggerContainer
-					}
-					initial="initial"
-					animate="animate"
-				>
-					<CommandGroup heading="Navigation">
-						{navigationCommands.map((cmd) => (
-							<motion.div
-								key={cmd.id}
-								variants={reducedMotion ? staggerItemReduced : staggerItem}
-							>
-								<CommandItem
-									value={`${cmd.label} ${cmd.keywords.join(" ")}`}
-									onSelect={() => executeCommand(cmd)}
-								>
-									{navigationIcons[cmd.id]}
-									<span>{cmd.label}</span>
-									{cmd.shortcutLabel && (
-										<CommandShortcut>{cmd.shortcutLabel}</CommandShortcut>
-									)}
-								</CommandItem>
-							</motion.div>
-						))}
-					</CommandGroup>
-					<CommandGroup heading="Actions">
-						{actionCommands.map((cmd) => (
-							<motion.div
-								key={cmd.id}
-								variants={reducedMotion ? staggerItemReduced : staggerItem}
-							>
-								<CommandItem
-									value={`${cmd.label} ${cmd.keywords.join(" ")}`}
-									onSelect={() => executeCommand(cmd)}
-								>
-									{actionIcons[cmd.id]}
-									<span>{cmd.label}</span>
-									{cmd.shortcutLabel && (
-										<CommandShortcut>{cmd.shortcutLabel}</CommandShortcut>
-									)}
-								</CommandItem>
-							</motion.div>
-						))}
-					</CommandGroup>
-					{registry.contextualShortcuts && contextualCommands.length > 0 && (
-						<CommandGroup heading={registry.contextualShortcuts.viewLabel}>
-							{contextualCommands.map((cmd) => (
-								<motion.div
-									key={cmd.id}
-									variants={reducedMotion ? staggerItemReduced : staggerItem}
-								>
-									<CommandItem
-										value={`${cmd.label} ${cmd.description} ${(cmd.keywords ?? []).join(" ")}`}
-										onSelect={() => executeContextualCommand(cmd.action)}
+			{view === "about" ? (
+				<AboutPanel onClose={() => handleOpenChange(false)} />
+			) : (
+				<>
+					<CommandInput placeholder="Type a command or search..." />
+					<CommandList>
+						<CommandEmpty>No results found.</CommandEmpty>
+						<motion.div
+							variants={
+								reducedMotion
+									? commandStaggerContainerReduced
+									: commandStaggerContainer
+							}
+							initial="initial"
+							animate="animate"
+						>
+							<CommandGroup heading="Navigation">
+								{navigationCommands.map((cmd) => (
+									<motion.div
+										key={cmd.id}
+										variants={reducedMotion ? staggerItemReduced : staggerItem}
 									>
-										<List
-											className="mr-2 h-4 w-4"
-											strokeWidth={1.5}
-											aria-hidden="true"
-										/>
-										<span>{cmd.label}</span>
-										{cmd.shortcutHint && (
-											<CommandShortcut>{cmd.shortcutHint}</CommandShortcut>
-										)}
-									</CommandItem>
-								</motion.div>
-							))}
-						</CommandGroup>
-					)}
-				</motion.div>
-			</CommandList>
+										<CommandItem
+											value={`${cmd.label} ${cmd.keywords.join(" ")}`}
+											onSelect={() => executeCommand(cmd)}
+										>
+											{navigationIcons[cmd.id]}
+											<span>{cmd.label}</span>
+											{cmd.shortcutLabel && (
+												<CommandShortcut>{cmd.shortcutLabel}</CommandShortcut>
+											)}
+										</CommandItem>
+									</motion.div>
+								))}
+							</CommandGroup>
+							<CommandGroup heading="Actions">
+								{actionCommands.map((cmd) => (
+									<motion.div
+										key={cmd.id}
+										variants={reducedMotion ? staggerItemReduced : staggerItem}
+									>
+										<CommandItem
+											value={`${cmd.label} ${cmd.keywords.join(" ")}`}
+											onSelect={() => executeCommand(cmd)}
+										>
+											{actionIcons[cmd.id]}
+											<span>{cmd.label}</span>
+											{cmd.shortcutLabel && (
+												<CommandShortcut>{cmd.shortcutLabel}</CommandShortcut>
+											)}
+										</CommandItem>
+									</motion.div>
+								))}
+							</CommandGroup>
+							{registry.contextualShortcuts &&
+								contextualCommands.length > 0 && (
+									<CommandGroup
+										heading={registry.contextualShortcuts.viewLabel}
+									>
+										{contextualCommands.map((cmd) => (
+											<motion.div
+												key={cmd.id}
+												variants={
+													reducedMotion ? staggerItemReduced : staggerItem
+												}
+											>
+												<CommandItem
+													value={`${cmd.label} ${cmd.description} ${(cmd.keywords ?? []).join(" ")}`}
+													onSelect={() => executeContextualCommand(cmd.action)}
+												>
+													<List
+														className="mr-2 h-4 w-4"
+														strokeWidth={1.5}
+														aria-hidden="true"
+													/>
+													<span>{cmd.label}</span>
+													{cmd.shortcutHint && (
+														<CommandShortcut>
+															{cmd.shortcutHint}
+														</CommandShortcut>
+													)}
+												</CommandItem>
+											</motion.div>
+										))}
+									</CommandGroup>
+								)}
+						</motion.div>
+					</CommandList>
+				</>
+			)}
 		</AnimatedCommandDialog>
 	);
 }

--- a/cli/web-ui/src/components/v2/CommandPalette.tsx
+++ b/cli/web-ui/src/components/v2/CommandPalette.tsx
@@ -40,6 +40,7 @@ import { useShortcutRegistry } from "@/providers/ShortcutRegistryProvider";
 import { useTheme } from "@/providers/ThemeProvider";
 
 declare const __RP1_WEB_UI_BUILD_TIME__: string | undefined;
+declare const __RP1_WEB_UI_GIT_COMMIT__: string | undefined;
 declare const __RP1_WEB_UI_VERSION__: string | undefined;
 
 export interface CommandPaletteProps {
@@ -52,6 +53,7 @@ type PaletteView = "commands" | "about";
 interface ClientBuildMetadata {
 	readonly buildTime: string;
 	readonly devBuild: boolean | undefined;
+	readonly gitCommit: string;
 	readonly mode: string;
 	readonly version: string;
 }
@@ -224,12 +226,34 @@ function getClientBuildMetadata(): ClientBuildMetadata {
 				? __RP1_WEB_UI_BUILD_TIME__
 				: "Unknown",
 		devBuild: typeof viteEnv?.DEV === "boolean" ? viteEnv.DEV : undefined,
+		gitCommit:
+			typeof __RP1_WEB_UI_GIT_COMMIT__ === "string"
+				? __RP1_WEB_UI_GIT_COMMIT__
+				: "Unknown",
 		mode: typeof viteEnv?.MODE === "string" ? viteEnv.MODE : "Unknown",
 		version:
 			typeof __RP1_WEB_UI_VERSION__ === "string"
 				? __RP1_WEB_UI_VERSION__
 				: "Unknown",
 	};
+}
+
+function formatBuildVersion(
+	version: string,
+	devBuild: boolean | undefined,
+	gitCommit: string,
+): string {
+	if (
+		!devBuild ||
+		version === "Unknown" ||
+		!gitCommit ||
+		gitCommit === "Unknown"
+	) {
+		return version;
+	}
+
+	const separator = version.includes("+") ? "." : "+";
+	return `${version}${separator}${gitCommit}`;
 }
 
 function formatBoolean(value: boolean | undefined): string {
@@ -303,13 +327,26 @@ function AboutPanel({ onClose }: { onClose: () => void }) {
 	}, []);
 
 	const rows: MetadataRow[] = [
-		{ label: "Web UI", value: clientBuild.version },
+		{
+			label: "Web UI",
+			value: formatBuildVersion(
+				clientBuild.version,
+				clientBuild.devBuild,
+				clientBuild.gitCommit,
+			),
+		},
 		{ label: "Build mode", value: clientBuild.mode },
 		{ label: "Dev build", value: formatBoolean(clientBuild.devBuild) },
 		{ label: "Build time", value: clientBuild.buildTime },
 		{
 			label: "Daemon",
-			value: loading ? "Loading..." : (health?.version ?? "Unknown"),
+			value: loading
+				? "Loading..."
+				: formatBuildVersion(
+						health?.version ?? "Unknown",
+						getDaemonDevBuild(health),
+						clientBuild.gitCommit,
+					),
 		},
 		{ label: "Daemon dev", value: formatBoolean(getDaemonDevBuild(health)) },
 		{

--- a/cli/web-ui/src/components/v2/CommandPalette.tsx
+++ b/cli/web-ui/src/components/v2/CommandPalette.tsx
@@ -278,6 +278,13 @@ function getDaemonDevBuild(health: HealthMetadata | null): boolean | undefined {
 	return typeof health.isDev === "boolean" ? health.isDev : undefined;
 }
 
+function getRp1DevBuild(
+	clientBuild: ClientBuildMetadata,
+	health: HealthMetadata | null,
+): boolean | undefined {
+	return getDaemonDevBuild(health) ?? clientBuild.devBuild;
+}
+
 function AboutMetadataRow({ label, value }: MetadataRow) {
 	return (
 		<div className="grid grid-cols-[120px_minmax(0,1fr)] gap-3 border-t border-border/60 py-2 first:border-t-0">
@@ -299,6 +306,7 @@ function AboutPanel({ onClose }: { onClose: () => void }) {
 	const [health, setHealth] = useState<HealthMetadata | null>(null);
 	const [loading, setLoading] = useState(true);
 	const [error, setError] = useState<string | null>(null);
+	const rp1DevBuild = getRp1DevBuild(clientBuild, health);
 
 	useEffect(() => {
 		const controller = new AbortController();
@@ -328,27 +336,16 @@ function AboutPanel({ onClose }: { onClose: () => void }) {
 
 	const rows: MetadataRow[] = [
 		{
-			label: "Web UI",
+			label: "rp1",
 			value: formatBuildVersion(
 				clientBuild.version,
-				clientBuild.devBuild,
+				rp1DevBuild,
 				clientBuild.gitCommit,
 			),
 		},
 		{ label: "Build mode", value: clientBuild.mode },
-		{ label: "Dev build", value: formatBoolean(clientBuild.devBuild) },
+		{ label: "Dev build", value: formatBoolean(rp1DevBuild) },
 		{ label: "Build time", value: clientBuild.buildTime },
-		{
-			label: "Daemon",
-			value: loading
-				? "Loading..."
-				: formatBuildVersion(
-						health?.version ?? "Unknown",
-						getDaemonDevBuild(health),
-						clientBuild.gitCommit,
-					),
-		},
-		{ label: "Daemon dev", value: formatBoolean(getDaemonDevBuild(health)) },
 		{
 			label: "API port",
 			value:

--- a/cli/web-ui/src/components/v2/V2Sidebar.tsx
+++ b/cli/web-ui/src/components/v2/V2Sidebar.tsx
@@ -28,7 +28,12 @@ import { cn } from "@/lib/utils";
 import { Collapsible } from "./Collapsible";
 import { KeyboardShortcutHint } from "./KeyboardShortcutHint";
 
-const APP_VERSION = "0.1.0";
+declare const __RP1_WEB_UI_VERSION__: string | undefined;
+
+const APP_VERSION =
+	typeof __RP1_WEB_UI_VERSION__ === "string"
+		? __RP1_WEB_UI_VERSION__
+		: "Unknown";
 
 export interface V2SidebarProps {
 	collapsed: boolean;

--- a/cli/web-ui/src/daemon/ipc.ts
+++ b/cli/web-ui/src/daemon/ipc.ts
@@ -14,6 +14,7 @@ export interface HealthResponse {
 	readonly uptime: number;
 	readonly port: number;
 	readonly projectCount: number;
+	readonly isDev?: boolean;
 	readonly version?: string;
 }
 

--- a/cli/web-ui/src/hooks/useFeed.ts
+++ b/cli/web-ui/src/hooks/useFeed.ts
@@ -208,8 +208,7 @@ export function useFeed(options: UseFeedOptions = {}): UseFeedResult {
 		const nextLoadedItems = currentItems
 			.map((item) => liveRunIndex.getRun(item.run.id) ?? item.run)
 			.filter((run) => matchesFeedFilters(run, filterOptions))
-			.map(toFeedItem)
-			.sort(compareFeedItems);
+			.map(toFeedItem);
 		for (const item of nextLoadedItems) {
 			knownMatchingRunIds.add(item.id);
 		}
@@ -237,7 +236,7 @@ export function useFeed(options: UseFeedOptions = {}): UseFeedResult {
 				knownMatchingRunIds.add(run.id);
 			}
 			addedCount = additions.length;
-			nextItems = [...nextLoadedItems, ...additions].sort(compareFeedItems);
+			nextItems = [...nextLoadedItems, ...additions];
 			if (limit !== undefined) {
 				nextItems = nextItems.slice(0, limit);
 			}

--- a/cli/web-ui/src/lib/commands.ts
+++ b/cli/web-ui/src/lib/commands.ts
@@ -65,4 +65,11 @@ export const commands: readonly Command[] = [
 		action: "refresh-data",
 		keywords: ["reload", "refetch", "update"],
 	},
+	{
+		id: "act-about",
+		label: "About",
+		category: "Actions",
+		action: "show-about",
+		keywords: ["version", "build", "metadata", "dev"],
+	},
 ] as const;

--- a/cli/web-ui/src/server/http.ts
+++ b/cli/web-ui/src/server/http.ts
@@ -42,6 +42,7 @@ export function startServer(config: ServerConfig): AppServer {
 	const apiContext: ApiContext = {
 		port,
 		startTime,
+		isDev,
 		version,
 		websocketHub,
 		fileWatcherPool,

--- a/cli/web-ui/src/server/routes/content-utils.ts
+++ b/cli/web-ui/src/server/routes/content-utils.ts
@@ -26,6 +26,7 @@ export interface FileContent {
 export interface ApiContext {
 	readonly port: number;
 	readonly startTime: number;
+	readonly isDev?: boolean;
 	readonly version?: string;
 	readonly websocketHub?: WebSocketHub;
 	readonly fileWatcherPool?: FileWatcherPool;

--- a/cli/web-ui/src/server/routes/v2-api.ts
+++ b/cli/web-ui/src/server/routes/v2-api.ts
@@ -2050,6 +2050,7 @@ export async function handleV2HealthRequest(
 		uptime,
 		port: ctx.port,
 		projectCount,
+		isDev: ctx.isDev ?? false,
 		...(ctx.version && { version: ctx.version }),
 	});
 }

--- a/cli/web-ui/src/version.ts
+++ b/cli/web-ui/src/version.ts
@@ -1,0 +1,3 @@
+import cliPackage from "../../package.json";
+
+export const RP1_VERSION = cliPackage.version;

--- a/cli/web-ui/vite.config.ts
+++ b/cli/web-ui/vite.config.ts
@@ -2,7 +2,7 @@ import { execSync } from "node:child_process";
 import path from "node:path";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
-import pkg from "./package.json";
+import { RP1_VERSION } from "./src/version";
 
 const getGitCommit = (): string => {
 	try {
@@ -20,7 +20,7 @@ export default defineConfig({
 	define: {
 		__RP1_WEB_UI_BUILD_TIME__: JSON.stringify(new Date().toISOString()),
 		__RP1_WEB_UI_GIT_COMMIT__: JSON.stringify(getGitCommit()),
-		__RP1_WEB_UI_VERSION__: JSON.stringify(pkg.version),
+		__RP1_WEB_UI_VERSION__: JSON.stringify(RP1_VERSION),
 	},
 	resolve: {
 		alias: {

--- a/cli/web-ui/vite.config.ts
+++ b/cli/web-ui/vite.config.ts
@@ -1,9 +1,14 @@
 import path from "node:path";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
+import pkg from "./package.json";
 
 export default defineConfig({
 	plugins: [react()],
+	define: {
+		__RP1_WEB_UI_BUILD_TIME__: JSON.stringify(new Date().toISOString()),
+		__RP1_WEB_UI_VERSION__: JSON.stringify(pkg.version),
+	},
 	resolve: {
 		alias: {
 			"@": path.resolve(__dirname, "./src"),

--- a/cli/web-ui/vite.config.ts
+++ b/cli/web-ui/vite.config.ts
@@ -1,12 +1,25 @@
+import { execSync } from "node:child_process";
 import path from "node:path";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 import pkg from "./package.json";
 
+const getGitCommit = (): string => {
+	try {
+		return execSync("git rev-parse --short HEAD", {
+			encoding: "utf8",
+			stdio: ["ignore", "pipe", "ignore"],
+		}).trim();
+	} catch {
+		return "Unknown";
+	}
+};
+
 export default defineConfig({
 	plugins: [react()],
 	define: {
 		__RP1_WEB_UI_BUILD_TIME__: JSON.stringify(new Date().toISOString()),
+		__RP1_WEB_UI_GIT_COMMIT__: JSON.stringify(getGitCommit()),
 		__RP1_WEB_UI_VERSION__: JSON.stringify(pkg.version),
 	},
 	resolve: {

--- a/native-app/electrobun.config.ts
+++ b/native-app/electrobun.config.ts
@@ -14,6 +14,7 @@ export default {
 			entrypoint: "src/bun/index.ts",
 		},
 		copy: {
+			"../bin/rp1": "../../MacOS/rp1",
 			"src/views/launch/index.html": "views/launch/index.html",
 		},
 		mac: {

--- a/native-app/electrobun.config.ts
+++ b/native-app/electrobun.config.ts
@@ -2,7 +2,7 @@ import type { ElectrobunConfig } from "electrobun";
 
 export default {
 	app: {
-		name: "RP1 Arcade",
+		name: "rp1 Arcade",
 		identifier: "run.rp1.arcade",
 		version: "0.1.0",
 	},

--- a/native-app/package.json
+++ b/native-app/package.json
@@ -5,7 +5,7 @@
 	"type": "module",
 	"scripts": {
 		"dev": "electrobun dev --watch",
-		"build:macos": "electrobun build --env=dev",
+		"build:macos": "electrobun build --env=stable",
 		"check": "bun run typecheck && bun run test",
 		"test": "bun test",
 		"typecheck": "tsc --noEmit --strict --skipLibCheck --target ES2022 --module ESNext --moduleResolution bundler --types bun-types electrobun.config.ts src/bun/index.ts"

--- a/native-app/src/__tests__/launch-state.test.ts
+++ b/native-app/src/__tests__/launch-state.test.ts
@@ -13,9 +13,11 @@ class MockDaemonExecutableResolutionError extends Error {
 
 interface CapturedWindow {
 	readonly initialHtml?: string;
+	readonly executedScripts: string[];
 	readonly loadedHtml: string[];
 	readonly loadedUrls: string[];
 	readonly navigationRules: string[][];
+	readonly webviewHandlers: Record<string, Array<(event: unknown) => void>>;
 	title: string;
 }
 
@@ -24,9 +26,11 @@ const capturedApplicationMenus: unknown[] = [];
 
 class MockBrowserWindow {
 	readonly webview: {
+		readonly executeJavascript: (script: string) => void;
 		readonly setNavigationRules: (rules: string[]) => void;
 		readonly loadURL: (url: string) => void;
 		readonly loadHTML: (html: string) => void;
+		readonly on: (name: string, handler: (event: unknown) => void) => void;
 	};
 
 	readonly captured: CapturedWindow;
@@ -34,13 +38,18 @@ class MockBrowserWindow {
 	constructor(options: { readonly title: string; readonly html?: string }) {
 		this.captured = {
 			initialHtml: options.html,
+			executedScripts: [],
 			loadedHtml: [],
 			loadedUrls: [],
 			navigationRules: [],
+			webviewHandlers: {},
 			title: options.title,
 		};
 		capturedWindows.push(this.captured);
 		this.webview = {
+			executeJavascript: (script: string) => {
+				this.captured.executedScripts.push(script);
+			},
 			setNavigationRules: (rules: string[]) => {
 				this.captured.navigationRules.push(rules);
 			},
@@ -49,6 +58,11 @@ class MockBrowserWindow {
 			},
 			loadHTML: (html: string) => {
 				this.captured.loadedHtml.push(html);
+			},
+			on: (name: string, handler: (event: unknown) => void) => {
+				const handlers = this.captured.webviewHandlers[name] ?? [];
+				handlers.push(handler);
+				this.captured.webviewHandlers[name] = handlers;
 			},
 		};
 	}
@@ -196,6 +210,23 @@ describe("native launch state", () => {
 			cliVersion: `${cliPackage.version}-dev`,
 			openProjectListWhenMissing: true,
 		});
+	});
+
+	test("pins the visible title across webview navigations", async () => {
+		const window = await runNativeEntrypoint();
+		const domReadyHandlers = window.webviewHandlers["dom-ready"] ?? [];
+
+		expect(domReadyHandlers).toHaveLength(1);
+
+		window.title = "RP1 Arcade - Projects";
+		domReadyHandlers[0]?.({ detail: "http://127.0.0.1:7710/projects" });
+
+		expect(window.title).toBe("🕹️ rp1 Arcade");
+		expect(window.executedScripts.at(-1)).toContain(
+			"__RP1_NATIVE_TITLE_PINNED__",
+		);
+		expect(window.executedScripts.at(-1)).toContain("rp1 Arcade");
+		expect(window.executedScripts.at(-1)).not.toContain("🕹️ rp1 Arcade");
 	});
 
 	test("uses the app title for project launches", async () => {

--- a/native-app/src/__tests__/launch-state.test.ts
+++ b/native-app/src/__tests__/launch-state.test.ts
@@ -168,10 +168,10 @@ describe("native launch state", () => {
 		expect(setApplicationMenuMock).toHaveBeenCalledTimes(1);
 		expect(capturedApplicationMenus[0]).toEqual([
 			{
-				label: "RP1 Arcade",
+				label: "rp1 Arcade",
 				submenu: [
 					{
-						label: "Quit RP1 Arcade",
+						label: "Quit rp1 Arcade",
 						role: "quit",
 						accelerator: "Command+Q",
 					},
@@ -189,13 +189,32 @@ describe("native launch state", () => {
 		expect(initialState.message).toBe("Loading registered projects.");
 		expect(window.navigationRules[0]).toContain("http://127.0.0.1:*/*");
 		expect(window.loadedUrls).toEqual(["http://127.0.0.1:7710/projects"]);
-		expect(window.title).toBe("RP1 Arcade - Projects");
+		expect(window.title).toBe("🕹️ rp1 Arcade");
 		expect(launchArcadeMock).toHaveBeenCalledWith({
 			projectPath: undefined,
 			rp1ExecutablePath: "/tmp/rp1",
 			cliVersion: `${cliPackage.version}-dev`,
 			openProjectListWhenMissing: true,
 		});
+	});
+
+	test("uses the app title for project launches", async () => {
+		launchArcadeMock.mockImplementationOnce(async () => ({
+			kind: "project" as const,
+			projectId: "project-1",
+			projectName: "Example Project",
+			url: "http://127.0.0.1:7710/projects/project-1",
+			action: "started" as const,
+			wasRunning: false,
+			daemonPort: 7710,
+		}));
+
+		const window = await runNativeEntrypoint(["--project", "/tmp/project"]);
+
+		expect(window.loadedUrls).toEqual([
+			"http://127.0.0.1:7710/projects/project-1",
+		]);
+		expect(window.title).toBe("🕹️ rp1 Arcade");
 	});
 
 	test("renders option parsing failures before launching Arcade", async () => {

--- a/native-app/src/__tests__/launch-state.test.ts
+++ b/native-app/src/__tests__/launch-state.test.ts
@@ -191,6 +191,23 @@ describe("native launch state", () => {
 					},
 				],
 			},
+			{
+				label: "Edit",
+				submenu: [
+					{ role: "undo", accelerator: "Command+Z" },
+					{ role: "redo", accelerator: "Shift+Command+Z" },
+					{ type: "separator" },
+					{ role: "cut", accelerator: "Command+X" },
+					{ role: "copy", accelerator: "Command+C" },
+					{ role: "paste", accelerator: "Command+V" },
+					{
+						role: "pasteAndMatchStyle",
+						accelerator: "Shift+Command+V",
+					},
+					{ type: "separator" },
+					{ role: "selectAll", accelerator: "Command+A" },
+				],
+			},
 		]);
 	});
 

--- a/native-app/src/__tests__/launch-state.test.ts
+++ b/native-app/src/__tests__/launch-state.test.ts
@@ -20,6 +20,7 @@ interface CapturedWindow {
 }
 
 const capturedWindows: CapturedWindow[] = [];
+const capturedApplicationMenus: unknown[] = [];
 
 class MockBrowserWindow {
 	readonly webview: {
@@ -66,8 +67,14 @@ const launchArcadeMock = mock(async () => ({
 	wasRunning: false,
 	daemonPort: 7710,
 }));
+const setApplicationMenuMock = mock((menu: unknown) => {
+	capturedApplicationMenus.push(menu);
+});
 
 mock.module("electrobun/bun", () => ({
+	ApplicationMenu: {
+		setApplicationMenu: setApplicationMenuMock,
+	},
 	BrowserWindow: MockBrowserWindow,
 }));
 
@@ -135,8 +142,10 @@ const runNativeEntrypoint = async (
 describe("native launch state", () => {
 	beforeEach(() => {
 		capturedWindows.length = 0;
+		capturedApplicationMenus.length = 0;
 		resolveDaemonExecutablePathMock.mockClear();
 		launchArcadeMock.mockClear();
+		setApplicationMenuMock.mockClear();
 		resolveDaemonExecutablePathMock.mockImplementation(() => "/tmp/rp1");
 		launchArcadeMock.mockImplementation(async () => ({
 			kind: "project-list" as const,
@@ -150,6 +159,25 @@ describe("native launch state", () => {
 
 	afterEach(() => {
 		capturedWindows.length = 0;
+		capturedApplicationMenus.length = 0;
+	});
+
+	test("installs the standard macOS quit menu shortcut", async () => {
+		await runNativeEntrypoint();
+
+		expect(setApplicationMenuMock).toHaveBeenCalledTimes(1);
+		expect(capturedApplicationMenus[0]).toEqual([
+			{
+				label: "RP1 Arcade",
+				submenu: [
+					{
+						label: "Quit RP1 Arcade",
+						role: "quit",
+						accelerator: "Command+Q",
+					},
+				],
+			},
+		]);
 	});
 
 	test("loads the project-list route when no project path is supplied", async () => {

--- a/native-app/src/bun/index.ts
+++ b/native-app/src/bun/index.ts
@@ -1,6 +1,10 @@
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
-import { BrowserWindow } from "electrobun/bun";
+import {
+	ApplicationMenu,
+	BrowserWindow,
+	type ApplicationMenuItemConfig,
+} from "electrobun/bun";
 import cliPackage from "../../../cli/package.json";
 import { type CLIError, formatError } from "../../../cli/shared/errors.js";
 import { launchArcade } from "../../../cli/src/arcade/launch.js";
@@ -37,6 +41,18 @@ const ARCADE_NAVIGATION_RULES = [
 	"http://127.0.0.1:*/*",
 	"http://localhost:*/*",
 	"http://[::1]:*/*",
+];
+const APPLICATION_MENU: ApplicationMenuItemConfig[] = [
+	{
+		label: "RP1 Arcade",
+		submenu: [
+			{
+				label: "Quit RP1 Arcade",
+				role: "quit",
+				accelerator: "Command+Q",
+			},
+		],
+	},
 ];
 
 const parseFlagValue = (
@@ -295,6 +311,8 @@ const launchNativeShell = async (
 
 const launchOptions = parseLaunchOptions();
 const initialState = createInitialState(launchOptions);
+
+ApplicationMenu.setApplicationMenu(APPLICATION_MENU);
 
 const mainWindow = new BrowserWindow({
 	title: "RP1 Arcade",

--- a/native-app/src/bun/index.ts
+++ b/native-app/src/bun/index.ts
@@ -15,6 +15,17 @@ import {
 
 type LaunchStatus = "loading" | "failure";
 type NativeWindow = InstanceType<typeof BrowserWindow>;
+type NativeWebview = NativeWindow["webview"] & {
+	readonly executeJavascript?: (js: string) => void;
+	readonly on?: (
+		name:
+			| "did-commit-navigation"
+			| "did-navigate"
+			| "did-navigate-in-page"
+			| "dom-ready",
+		handler: (event: unknown) => void,
+	) => void;
+};
 
 interface LaunchOptions {
 	readonly projectPath?: string;
@@ -37,6 +48,7 @@ const LAUNCH_VIEW_TEMPLATE = readFileSync(
 const CLI_VERSION = `${cliPackage.version}-dev`;
 const APP_NAME = "rp1 Arcade";
 const WINDOW_TITLE = "🕹️ rp1 Arcade";
+const WEB_DOCUMENT_TITLE = APP_NAME;
 const OPENING_TITLE = `Opening ${APP_NAME}`;
 const ARCADE_NAVIGATION_RULES = [
 	"^*",
@@ -202,6 +214,48 @@ const loadLaunchView = (window: NativeWindow, state: LaunchViewState): void => {
 	webview.loadHTML(createLaunchViewHtml(state));
 };
 
+const pinDocumentTitleScript = (title: string): string => `
+(() => {
+	const title = ${JSON.stringify(title)};
+	const globalKey = "__RP1_NATIVE_TITLE_PINNED__";
+	if (window[globalKey] === title) {
+		document.title = title;
+		return;
+	}
+	window[globalKey] = title;
+	const applyTitle = () => {
+		if (document.title !== title) document.title = title;
+	};
+	applyTitle();
+	const titleElement =
+		document.querySelector("title") ||
+		document.head?.appendChild(document.createElement("title"));
+	if (titleElement) {
+		new MutationObserver(applyTitle).observe(titleElement, {
+			childList: true,
+			characterData: true,
+			subtree: true,
+		});
+	}
+})();
+`;
+
+const setVisibleWindowTitle = (window: NativeWindow): void => {
+	const webview = window.webview as NativeWebview;
+	webview.executeJavascript?.(pinDocumentTitleScript(WEB_DOCUMENT_TITLE));
+	window.setTitle(WINDOW_TITLE);
+};
+
+const pinVisibleWindowTitle = (window: NativeWindow): void => {
+	setVisibleWindowTitle(window);
+	const webview = window.webview as NativeWebview;
+	const restoreTitle = () => setVisibleWindowTitle(window);
+	webview.on?.("did-commit-navigation", restoreTitle);
+	webview.on?.("did-navigate", restoreTitle);
+	webview.on?.("did-navigate-in-page", restoreTitle);
+	webview.on?.("dom-ready", restoreTitle);
+};
+
 const isLoopbackArcadeUrl = (url: string): boolean => {
 	try {
 		const parsed = new URL(url);
@@ -304,7 +358,7 @@ const launchNativeShell = async (
 		throw new Error(`Arcade returned a non-loopback URL: ${result.url}`);
 	}
 
-	window.setTitle(WINDOW_TITLE);
+	setVisibleWindowTitle(window);
 	loadWindowUrl(window, result.url);
 };
 
@@ -323,6 +377,7 @@ const mainWindow = new BrowserWindow({
 	},
 });
 
+pinVisibleWindowTitle(mainWindow);
 setNavigationRules(mainWindow);
 loadLaunchView(mainWindow, initialState);
 

--- a/native-app/src/bun/index.ts
+++ b/native-app/src/bun/index.ts
@@ -35,6 +35,9 @@ const LAUNCH_VIEW_TEMPLATE = readFileSync(
 	"utf8",
 );
 const CLI_VERSION = `${cliPackage.version}-dev`;
+const APP_NAME = "rp1 Arcade";
+const WINDOW_TITLE = "🕹️ rp1 Arcade";
+const OPENING_TITLE = `Opening ${APP_NAME}`;
 const ARCADE_NAVIGATION_RULES = [
 	"^*",
 	"views://launch/*",
@@ -44,10 +47,10 @@ const ARCADE_NAVIGATION_RULES = [
 ];
 const APPLICATION_MENU: ApplicationMenuItemConfig[] = [
 	{
-		label: "RP1 Arcade",
+		label: APP_NAME,
 		submenu: [
 			{
-				label: "Quit RP1 Arcade",
+				label: `Quit ${APP_NAME}`,
 				role: "quit",
 				accelerator: "Command+Q",
 			},
@@ -164,7 +167,7 @@ const createInitialState = (options: LaunchOptions): LaunchViewState => {
 	if (!options.projectPath) {
 		return {
 			status: "loading",
-			title: "Opening RP1 Arcade",
+			title: OPENING_TITLE,
 			message: "Loading registered projects.",
 			detail: "No project path supplied; opening the Arcade projects view.",
 		};
@@ -172,7 +175,7 @@ const createInitialState = (options: LaunchOptions): LaunchViewState => {
 
 	return {
 		status: "loading",
-		title: "Opening RP1 Arcade",
+		title: OPENING_TITLE,
 		message: "Preparing the native shell.",
 		detail: options.projectPath,
 	};
@@ -301,11 +304,7 @@ const launchNativeShell = async (
 		throw new Error(`Arcade returned a non-loopback URL: ${result.url}`);
 	}
 
-	window.setTitle(
-		result.kind === "project"
-			? `RP1 Arcade - ${result.projectName}`
-			: "RP1 Arcade - Projects",
-	);
+	window.setTitle(WINDOW_TITLE);
 	loadWindowUrl(window, result.url);
 };
 
@@ -315,7 +314,7 @@ const initialState = createInitialState(launchOptions);
 ApplicationMenu.setApplicationMenu(APPLICATION_MENU);
 
 const mainWindow = new BrowserWindow({
-	title: "RP1 Arcade",
+	title: WINDOW_TITLE,
 	frame: {
 		width: 1280,
 		height: 860,

--- a/native-app/src/bun/index.ts
+++ b/native-app/src/bun/index.ts
@@ -68,6 +68,20 @@ const APPLICATION_MENU: ApplicationMenuItemConfig[] = [
 			},
 		],
 	},
+	{
+		label: "Edit",
+		submenu: [
+			{ role: "undo", accelerator: "Command+Z" },
+			{ role: "redo", accelerator: "Shift+Command+Z" },
+			{ type: "separator" },
+			{ role: "cut", accelerator: "Command+X" },
+			{ role: "copy", accelerator: "Command+C" },
+			{ role: "paste", accelerator: "Command+V" },
+			{ role: "pasteAndMatchStyle", accelerator: "Shift+Command+V" },
+			{ type: "separator" },
+			{ role: "selectAll", accelerator: "Command+A" },
+		],
+	},
 ];
 
 const parseFlagValue = (

--- a/native-app/src/views/launch/index.html
+++ b/native-app/src/views/launch/index.html
@@ -3,7 +3,7 @@
 	<head>
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
-		<title>RP1 Arcade</title>
+		<title>rp1 Arcade</title>
 		<style>
 			:root {
 				color-scheme: light dark;
@@ -131,7 +131,7 @@
 		<main>
 			<div class="status-row">
 				<div class="indicator" aria-hidden="true"></div>
-				<h1 id="title">Opening RP1 Arcade</h1>
+				<h1 id="title">Opening rp1 Arcade</h1>
 			</div>
 			<p id="message">Preparing the native shell.</p>
 			<p id="detail" class="detail" hidden></p>
@@ -148,7 +148,7 @@
 					? "failure"
 					: "loading";
 			const title =
-				injectedState.title || params.get("title") || "Opening RP1 Arcade";
+				injectedState.title || params.get("title") || "Opening rp1 Arcade";
 			const message =
 				injectedState.message ||
 				params.get("message") ||


### PR DESCRIPTION
## Summary
- Keep Activity feed order stable during live updates while preserving fresh-navigation sorting.
- Add About command with aligned rp1 version metadata and dev commit hashes.
- Fix native app build/runtime packaging, Command+Q quit behavior, app identity, bundle id, window title, stale macOS app registration cleanup, and web title icon duplication.

## Verification
- bun test src/__tests__/hooks/useFeed.test.ts
- just check-web-ui
- bun test src/__tests__/components/v2/CommandPalette.test.tsx
- bun test src/__tests__/version.test.ts src/__tests__/components/v2/CommandPalette.test.tsx
- just build-web-ui
- just build-native-app
- cd native-app && bun run check
- bun test cli/web-ui/src/__tests__/app/document-title.test.ts
- pre-push hooks: no-artifactory, eval-verify, catalog, typecheck-cli, typecheck-webui

## Notes
- Branch was force-pushed to origin/ui-fixes as requested.
- Local generated native-app/artifacts outputs remain untracked and are not part of this PR.