### PR TITLE
fix(socratic-duel): reject timeout close after peer registration

### DIFF
--- a/catalog/agents.yaml
+++ b/catalog/agents.yaml
@@ -66,7 +66,7 @@ agents:
   - name: rp1-base:socratic-duel-participant
     description: "Participates in a Socratic Duel run using pre-resolved launcher context and participant-owned artifact writes."
     plugin: base
-    last_checksum: b441437abf8b8c29f2cb78df021e76f95e5f5b7983f1b13b2941a151f25815a6
+    last_checksum: e04631ec0d9ad76bad6b7b1ac380c96963ea048cef085cd986b611a5dd3337ef
   - name: rp1-base:strategic-advisor
     description: "Analyzes systems holistically to provide strategic recommendations balancing cost, quality, performance, complexity, and business objectives with quantified trade-offs"
     plugin: base

--- a/cli/src/__tests__/agent-tools/command-cli.test.ts
+++ b/cli/src/__tests__/agent-tools/command-cli.test.ts
@@ -414,6 +414,22 @@ describe("agent-tools command adapter", () => {
 			1,
 		);
 		expect(errors.at(-1)).toContain("socratic-duel");
+
+		await expectExit(
+			[
+				"socratic-duel",
+				"release-lock",
+				"--duel-id",
+				"missing",
+				"--participant-id",
+				"p1",
+				"--close",
+				"--outcome",
+				"NOT_REAL",
+			],
+			1,
+		);
+		expect(errors.at(-1)).toContain("Invalid --outcome value");
 	});
 
 	test("socratic-duel command adapters run the join, status, claim, refresh, and release lifecycle", async () => {
@@ -527,5 +543,111 @@ describe("agent-tools command adapter", () => {
 		);
 		const released = lastOutput<{ data: { released: boolean } }>();
 		expect(released.data.released).toBe(true);
+	});
+
+	test("socratic-duel release-lock refuses TIMEOUT close after a late peer join", async () => {
+		tempDir = await mkdtemp(join(tmpdir(), "rp1-duel-timeout-command-"));
+		const targetPath = join(tempDir, "proposal.md");
+		const debateDir = join(tempDir, "debates");
+		await mkdir(debateDir, { recursive: true });
+		await writeFile(targetPath, "# Proposal\n\nInitial position.\n");
+
+		await expectExit(
+			[
+				"socratic-duel",
+				"join",
+				"--target",
+				targetPath,
+				"--topic",
+				"Timeout race",
+				"--debate-dir",
+				debateDir,
+				"--participant-name",
+				"codex",
+				"--harness",
+				"codex",
+				"--model-id",
+				"gpt-5",
+			],
+			0,
+		);
+		const joined = lastOutput<{
+			data: { duel_id: string; participant_id: string };
+		}>();
+
+		await expectExit(
+			[
+				"socratic-duel",
+				"claim-lock",
+				"--duel-id",
+				joined.data.duel_id,
+				"--participant-id",
+				joined.data.participant_id,
+				"--for-timeout",
+			],
+			0,
+		);
+		const timeoutClaim = lastOutput<{
+			data: {
+				lease_token: string;
+				participant_count: number;
+				next_step: string;
+			};
+		}>();
+		expect(timeoutClaim.data.participant_count).toBe(1);
+		expect(timeoutClaim.data.next_step).toBe("update_markdown");
+
+		await expectExit(
+			[
+				"socratic-duel",
+				"join",
+				"--target",
+				targetPath,
+				"--topic",
+				"Timeout race",
+				"--debate-dir",
+				debateDir,
+				"--participant-name",
+				"reviewer",
+				"--harness",
+				"codex",
+				"--model-id",
+				"gpt-5",
+			],
+			0,
+		);
+
+		await expectExit(
+			[
+				"socratic-duel",
+				"release-lock",
+				"--duel-id",
+				joined.data.duel_id,
+				"--participant-id",
+				joined.data.participant_id,
+				"--lease-token",
+				timeoutClaim.data.lease_token,
+				"--close",
+				"--outcome",
+				"TIMEOUT",
+			],
+			0,
+		);
+		const rejected = lastOutput<{
+			data: {
+				closed: boolean;
+				participant_count: number;
+				next_step: string;
+				outcome: string;
+				reason: string;
+				status: string;
+			};
+		}>();
+		expect(rejected.data.closed).toBe(false);
+		expect(rejected.data.participant_count).toBe(2);
+		expect(rejected.data.next_step).toBe("compose_turn");
+		expect(rejected.data.outcome).toBe("TIMEOUT");
+		expect(rejected.data.reason).toContain("second participant is present");
+		expect(rejected.data.status).toBe("ACTIVE");
 	});
 });

--- a/cli/src/__tests__/agent-tools/socratic-duel/coordinator.test.ts
+++ b/cli/src/__tests__/agent-tools/socratic-duel/coordinator.test.ts
@@ -325,6 +325,7 @@ describe("socratic-duel lock coordinator", () => {
 		);
 		expect(timeoutClaim.success).toBe(true);
 		expect(timeoutClaim.data.acquired).toBe(true);
+		expect(timeoutClaim.data.participant_count).toBe(1);
 		expect(typeof timeoutClaim.data.lease_token).toBe("string");
 		expect(timeoutClaim.data.owner_participant_id).toBe(first.participant_id);
 		expect(timeoutClaim.data.next_step).toBe("update_markdown");
@@ -336,13 +337,66 @@ describe("socratic-duel lock coordinator", () => {
 					participantId: first.participant_id,
 					leaseToken: timeoutClaim.data.lease_token ?? "",
 					close: true,
+					outcome: "TIMEOUT",
 				},
 				dbPath,
 			),
 		);
 		expect(closed.success).toBe(true);
 		expect(closed.data.closed).toBe(true);
+		expect(closed.data.participant_count).toBe(1);
+		expect(closed.data.outcome).toBe("TIMEOUT");
 		expect(closed.data.status).toBe("CLOSED");
+	});
+
+	test("refuses a TIMEOUT close when a peer joins after the timeout lease", async () => {
+		const first = await joinParticipant("participant-a");
+		const timeoutClaim = await expectTaskRight(
+			executeClaimLock(
+				{
+					duelId: first.duel_id,
+					participantId: first.participant_id,
+					forTimeout: true,
+				},
+				dbPath,
+			),
+		);
+		expect(timeoutClaim.data.acquired).toBe(true);
+		expect(timeoutClaim.data.participant_count).toBe(1);
+
+		await joinParticipant("participant-b");
+
+		const rejectedClose = await expectTaskRight(
+			executeReleaseLock(
+				{
+					duelId: first.duel_id,
+					participantId: first.participant_id,
+					leaseToken: timeoutClaim.data.lease_token ?? "",
+					close: true,
+					outcome: "TIMEOUT",
+				},
+				dbPath,
+			),
+		);
+
+		expect(rejectedClose.success).toBe(true);
+		expect(rejectedClose.data.participant_count).toBe(2);
+		expect(rejectedClose.data.released).toBe(false);
+		expect(rejectedClose.data.closed).toBe(false);
+		expect(rejectedClose.data.status).toBe("ACTIVE");
+		expect(rejectedClose.data.outcome).toBe("TIMEOUT");
+		expect(rejectedClose.data.owner_participant_id).toBe(first.participant_id);
+		expect(rejectedClose.data.reason).toContain(
+			"second participant is present",
+		);
+		expect(rejectedClose.data.next_step).toBe("compose_turn");
+
+		const status = await expectTaskRight(
+			executeStatus({ duelId: first.duel_id }, dbPath),
+		);
+		expect(status.data.participant_count).toBe(2);
+		expect(status.data.duel.status).toBe("ACTIVE");
+		expect(status.data.lock.owner_participant_id).toBe(first.participant_id);
 	});
 
 	test("rejects invalid targets and a third participant", async () => {

--- a/cli/src/__tests__/agent-tools/socratic-duel/skill-contract.test.ts
+++ b/cli/src/__tests__/agent-tools/socratic-duel/skill-contract.test.ts
@@ -87,6 +87,12 @@ describe("socratic-duel skill contract", () => {
 			"only a successful `claim-lock` or `refresh-lock` result can provide a usable token",
 		);
 		expect(content).toContain("--for-timeout");
+		expect(content).toContain("using non-zero sleeps between attempts");
+		expect(content).toContain(
+			"post-timeout-claim `status` shows `participant_count` is 2 or more",
+		);
+		expect(content).toContain("release-lock --close --outcome TIMEOUT");
+		expect(content).toContain('--close --outcome "{terminal_outcome}"');
 		expect(content).toContain("--unit conclusion:{terminal_outcome}");
 		expect(content).toContain("--close-run");
 
@@ -161,6 +167,12 @@ describe("socratic-duel skill contract", () => {
 		expect(participant).toContain(
 			"Close the run on terminal outcome with participant-owned `--close-run`.",
 		);
+		expect(participant).toContain("using non-zero sleeps between attempts");
+		expect(participant).toContain(
+			"post-timeout-claim `status` shows `participant_count` is 2 or more",
+		);
+		expect(participant).toContain("release-lock --close --outcome TIMEOUT");
+		expect(participant).toContain('--close --outcome "{terminal_outcome}"');
 		for (const step of [
 			"preparing",
 			"waiting_for_participant",

--- a/cli/src/agent-tools/command.ts
+++ b/cli/src/agent-tools/command.ts
@@ -47,6 +47,10 @@ import {
 	executeStatus as executeSocraticDuelStatus,
 } from "./socratic-duel/index.js";
 import {
+	type TerminalOutcome,
+	VALID_TERMINAL_OUTCOMES,
+} from "./socratic-duel/models.js";
+import {
 	executeCancel as executeTaskCancel,
 	executeComplete as executeTaskComplete,
 	executeCreate as executeTaskCreate,
@@ -1406,6 +1410,7 @@ Examples:
   rp1 agent-tools socratic-duel claim-lock --duel-id <id> --participant-id <id> --for-timeout
   rp1 agent-tools socratic-duel refresh-lock --duel-id <id> --participant-id <id> --lease-token <token>
   rp1 agent-tools socratic-duel release-lock --duel-id <id> --participant-id <id> --lease-token <token>
+  rp1 agent-tools socratic-duel release-lock --duel-id <id> --participant-id <id> --lease-token <token> --close --outcome TIMEOUT
 `,
 	);
 
@@ -1565,19 +1570,43 @@ socraticDuelCommand
 		"Close the lock context after releasing an owned lease",
 		false,
 	)
+	.option(
+		"--outcome <outcome>",
+		`Terminal outcome when used with --close: ${VALID_TERMINAL_OUTCOMES.join(", ")}`,
+	)
 	.action(
 		async (options: {
 			duelId: string;
 			participantId: string;
 			leaseToken?: string;
 			close: boolean;
+			outcome?: string;
 		}): Promise<void> => {
 			const toolName = "socratic-duel";
+			if (
+				options.outcome !== undefined &&
+				!VALID_TERMINAL_OUTCOMES.includes(options.outcome as TerminalOutcome)
+			) {
+				console.error(
+					createErrorResponse(
+						toolName,
+						formatError(
+							usageError(
+								`Invalid --outcome value: '${options.outcome}'. Must be one of: ${VALID_TERMINAL_OUTCOMES.join(", ")}`,
+							),
+							false,
+						),
+					),
+				);
+				process.exit(1);
+			}
+
 			const result = await executeSocraticDuelReleaseLock({
 				duelId: options.duelId,
 				participantId: options.participantId,
 				leaseToken: options.leaseToken,
 				close: options.close,
+				outcome: options.outcome as TerminalOutcome | undefined,
 			})();
 
 			if (E.isLeft(result)) {

--- a/cli/src/agent-tools/socratic-duel/database.ts
+++ b/cli/src/agent-tools/socratic-duel/database.ts
@@ -79,6 +79,7 @@ export interface ReleaseLockDecision extends DuelSnapshot {
 	readonly released: boolean;
 	readonly closed: boolean;
 	readonly reason: string | null;
+	readonly nextStep: "compose_turn" | "claim_lock" | "wait_turn" | "closed";
 }
 
 const nowIso = (): string => new Date().toISOString();
@@ -566,6 +567,7 @@ export const releaseLock = (
 					released: false,
 					closed: snapshot.duel.status === "CLOSED",
 					reason: "Duel lock context is closed",
+					nextStep: "closed",
 				};
 			}
 
@@ -589,6 +591,7 @@ export const releaseLock = (
 					closed: false,
 					reason:
 						"Closing a duel requires an active lock owned by this participant",
+					nextStep: "claim_lock",
 				};
 			}
 
@@ -598,6 +601,22 @@ export const releaseLock = (
 					released: false,
 					closed: false,
 					reason: "Participant does not own this active lock",
+					nextStep: "wait_turn",
+				};
+			}
+
+			if (
+				input.close &&
+				input.outcome === "TIMEOUT" &&
+				snapshot.participants.length >= 2
+			) {
+				return {
+					...snapshot,
+					released: false,
+					closed: false,
+					reason:
+						"TIMEOUT close rejected because a second participant is present; re-check status and continue debating",
+					nextStep: "compose_turn",
 				};
 			}
 
@@ -609,6 +628,7 @@ export const releaseLock = (
 					released: false,
 					closed: false,
 					reason: "No active lock to release",
+					nextStep: "claim_lock",
 				};
 			}
 
@@ -632,6 +652,7 @@ export const releaseLock = (
 				released: hasActiveOwner,
 				closed: snapshot.duel.status === "CLOSED",
 				reason: null,
+				nextStep: snapshot.duel.status === "CLOSED" ? "closed" : "wait_turn",
 			};
 		}),
 	);

--- a/cli/src/agent-tools/socratic-duel/index.ts
+++ b/cli/src/agent-tools/socratic-duel/index.ts
@@ -237,7 +237,9 @@ const claimNextStep = (
 		return "closed";
 	}
 	if (decision.acquired) {
-		return decision.forTimeout ? "update_markdown" : "compose_turn";
+		return decision.forTimeout && decision.participants.length < 2
+			? "update_markdown"
+			: "compose_turn";
 	}
 	return decision.participants.length < 2 ? "wait_peer" : "wait_turn";
 };
@@ -254,10 +256,7 @@ const refreshNextStep = (
 const releaseNextStep = (
 	decision: ReleaseLockDecision,
 ): ReleaseLockResult["next_step"] => {
-	if (decision.duel.status === "CLOSED") {
-		return "closed";
-	}
-	return decision.released ? "wait_turn" : "claim_lock";
+	return decision.nextStep;
 };
 
 const redactedDuel = (snapshot: DuelSnapshot): DuelSnapshot["duel"] => ({
@@ -364,6 +363,7 @@ export const executeClaimLock = (
 		return successResult(TOOL_NAME, {
 			duel_id: decision.duel.id,
 			participant_id: input.participantId,
+			participant_count: decision.participants.length,
 			acquired: decision.acquired,
 			lease_token: decision.acquired ? decision.duel.leaseToken : null,
 			lease_expires_at: decision.duel.leaseExpiresAt,
@@ -411,9 +411,11 @@ export const executeReleaseLock = (
 		return successResult(TOOL_NAME, {
 			duel_id: decision.duel.id,
 			participant_id: input.participantId,
+			participant_count: decision.participants.length,
 			released: decision.released,
 			closed: decision.closed,
 			status: decision.duel.status,
+			outcome: input.close ? (input.outcome ?? null) : null,
 			owner_participant_id: decision.duel.currentOwnerId,
 			reason: decision.reason,
 			next_step: releaseNextStep(decision),

--- a/cli/src/agent-tools/socratic-duel/models.ts
+++ b/cli/src/agent-tools/socratic-duel/models.ts
@@ -1,5 +1,15 @@
 export type DuelStatus = "ACTIVE" | "CLOSED";
 
+export const VALID_TERMINAL_OUTCOMES = [
+	"ACCEPTED_CONSENSUS",
+	"DISSENT",
+	"MAX_TURNS",
+	"TIMEOUT",
+	"INVALIDATED",
+] as const;
+
+export type TerminalOutcome = (typeof VALID_TERMINAL_OUTCOMES)[number];
+
 export const LEASE_DURATION_MS = 15 * 60 * 1000;
 export const RETRY_AFTER_SECONDS = 30;
 
@@ -55,6 +65,7 @@ export interface ReleaseLockInput {
 	readonly participantId: string;
 	readonly leaseToken?: string;
 	readonly close?: boolean;
+	readonly outcome?: TerminalOutcome;
 }
 
 export interface JoinResult {
@@ -94,6 +105,7 @@ export interface LockStatus {
 export interface ClaimLockResult {
 	readonly duel_id: string;
 	readonly participant_id: string;
+	readonly participant_count: number;
 	readonly acquired: boolean;
 	readonly lease_token: string | null;
 	readonly lease_expires_at: string | null;
@@ -122,12 +134,14 @@ export interface RefreshLockResult {
 export interface ReleaseLockResult {
 	readonly duel_id: string;
 	readonly participant_id: string;
+	readonly participant_count: number;
 	readonly released: boolean;
 	readonly closed: boolean;
 	readonly status: DuelStatus;
+	readonly outcome: TerminalOutcome | null;
 	readonly owner_participant_id: string | null;
 	readonly reason: string | null;
-	readonly next_step: "claim_lock" | "wait_turn" | "closed";
+	readonly next_step: "compose_turn" | "claim_lock" | "wait_turn" | "closed";
 }
 
 export interface ValidationIssue {

--- a/plugins/base/agents/socratic-duel-participant.md
+++ b/plugins/base/agents/socratic-duel-participant.md
@@ -248,10 +248,12 @@ rp1 agent-tools emit --harness $CURRENT_HOST \
 
 2. **waiting_for_participant**
    - Emit `participant_waiting`.
-   - Poll `rp1 agent-tools socratic-duel status --duel-id "{duel_id}"` only within bounded wait guidance.
+   - Poll `rp1 agent-tools socratic-duel status --duel-id "{duel_id}"` only within bounded wait guidance, using non-zero sleeps between attempts.
    - If a peer appears, transition to `debating`.
    - If waiting expires, run `claim-lock --for-timeout`.
-   - If timeout claim succeeds, transition to `closing`, write `TIMEOUT` conclusion while leased, then `release-lock --close`.
+   - If timeout claim succeeds, capture `lease_token`, `lease_expires_at`, and `participant_count`, then immediately re-run `rp1 agent-tools socratic-duel status --duel-id "{duel_id}"`.
+   - If the post-timeout-claim `status` shows `participant_count` is 2 or more, do not write a `TIMEOUT` conclusion; transition to `debating` while holding the lease and continue the duel using the existing `lease_token`.
+   - Only if the post-timeout-claim `status` still shows `participant_count` fewer than 2, transition to `closing`, write `TIMEOUT` conclusion while leased, then `release-lock --close --outcome TIMEOUT`.
    - If peer owns an unexpired lease, keep bounded waiting; do not emit terminal completion.
 
 3. **debating**
@@ -277,7 +279,8 @@ rp1 agent-tools emit --harness $CURRENT_HOST \
    - Enter only while holding active `lease_token`.
    - Write terminal conclusion to `{debate_path}` while leased. For `TIMEOUT`, append no turn.
    - Conclusion includes exact outcome, closed timestamp, candidate convergence, reason, summary, source reference, and topic.
-   - Run `rp1 agent-tools socratic-duel release-lock --duel-id "{duel_id}" --participant-id "{participant_id}" --lease-token "{lease_token}" --close`.
+   - Run `rp1 agent-tools socratic-duel release-lock --duel-id "{duel_id}" --participant-id "{participant_id}" --lease-token "{lease_token}" --close --outcome "{terminal_outcome}"`.
+   - If close returns `closed:false`, do not emit terminal completion; re-run `status`, follow the returned `next_step`, and continue bounded coordination.
    - Emit `lock_released` with `closed:true`.
    - Emit `artifact_updated` with `--unit conclusion:{terminal_outcome}`.
    - If outcome is `INVALIDATED`, transition to `invalidated`; otherwise transition to `completed`.
@@ -370,6 +373,7 @@ Return JSON only:
 - Do not ask the backend for candidate convergence, terminal content, turn numbers, prior-artifact hashes, or template text.
 - Do not exceed 3 turn pairs or 6 total turns.
 - Do not continue after terminal outcome.
+- Do not write or close `TIMEOUT` after a timeout claim until a post-claim `status` re-check still shows fewer than 2 participants.
 - Do not release another participant's active lock.
 - Do not append debate content to the source document.
 - Do not append outside the debate artifact.

--- a/plugins/base/skills/socratic-duel/SKILL.md
+++ b/plugins/base/skills/socratic-duel/SKILL.md
@@ -245,11 +245,13 @@ rp1 agent-tools emit --harness $CURRENT_HOST \
 
 2. **waiting_for_participant**
    - Emit `participant_waiting` with `--unit participant:{participant_id}` and bounded wait guidance.
-   - Poll `rp1 agent-tools socratic-duel status --duel-id "{duel_id}"` only within bounded wait guidance.
+   - Poll `rp1 agent-tools socratic-duel status --duel-id "{duel_id}"` only within bounded wait guidance, using non-zero sleeps between attempts.
    - If a peer appears, transition to `debating`.
    - If timeout expires, do not edit the debate artifact from `status` alone. First run `rp1 agent-tools socratic-duel claim-lock --duel-id "{duel_id}" --participant-id "{participant_id}" --for-timeout`.
    - `--for-timeout` may acquire a lease after bounded waiting even if the second participant never joined, but it still refuses when a peer owns an unexpired lock.
-   - If the timeout claim succeeds, capture `lease_token`, transition to `closing`, create or append the debate artifact conclusion with `TIMEOUT` while holding that lease, then run `release-lock --close`.
+   - If the timeout claim succeeds, capture `lease_token`, `lease_expires_at`, and `participant_count`, then immediately re-run `rp1 agent-tools socratic-duel status --duel-id "{duel_id}"`.
+   - If the post-timeout-claim `status` shows `participant_count` is 2 or more, do not write a `TIMEOUT` conclusion; transition to `debating` while holding the lease and continue the duel using the existing `lease_token`.
+   - Only if the post-timeout-claim `status` still shows `participant_count` fewer than 2, transition to `closing`, create or append the debate artifact conclusion with `TIMEOUT` while holding that lease, then run `release-lock --close --outcome TIMEOUT`.
    - If the timeout claim does not acquire a lock because a peer owns an unexpired lease, emit `participant_waiting` with the returned wait guidance and continue bounded waiting; do not emit terminal completion.
    - If waiting, explain the bounded wait briefly; do not ask open-ended questions.
 
@@ -278,7 +280,8 @@ rp1 agent-tools emit --harness $CURRENT_HOST \
    - Enter `closing` only while holding the active `lease_token` for terminal artifact writes.
    - Write the terminal conclusion to `{debate_path}` while holding the lease. For `TIMEOUT`, append no turn and update only the conclusion metadata/body.
    - Terminal conclusion must include the exact outcome, closed timestamp, candidate convergence, reason, summary, source reference, and topic.
-   - Run `rp1 agent-tools socratic-duel release-lock --duel-id "{duel_id}" --participant-id "{participant_id}" --lease-token "{lease_token}" --close`.
+   - Run `rp1 agent-tools socratic-duel release-lock --duel-id "{duel_id}" --participant-id "{participant_id}" --lease-token "{lease_token}" --close --outcome "{terminal_outcome}"`.
+   - If close returns `closed:false`, do not emit terminal completion; re-run `status`, follow the returned `next_step`, and continue bounded coordination.
    - Emit `lock_released` with `closed:true`.
    - Emit `artifact_updated` with `--unit conclusion:{terminal_outcome}`.
    - If the terminal outcome is `INVALIDATED`, transition to `invalidated`; otherwise transition to `completed`.
@@ -355,6 +358,7 @@ Support:
 - Do not ask the backend for candidate convergence, terminal content, turn numbers, prior-artifact hashes, or template text.
 - Do not exceed 3 turn pairs or 6 total turns.
 - Do not continue after terminal outcome.
+- Do not write or close `TIMEOUT` after a timeout claim until a post-claim `status` re-check still shows fewer than 2 participants.
 - Do not release another participant's active lock.
 - Do not append debate content to the source document.
 - Do not append outside the debate artifact.


### PR DESCRIPTION
## Summary
- add explicit Socratic Duel close outcome plumbing through models, backend responses, and `release-lock --outcome`
- reject `TIMEOUT` lock release when a late peer has registered, returning recoverable next-step context
- tighten Socratic Duel timeout re-check instructions and cover the race in backend, CLI, and prompt-contract tests
- regenerate the agent catalog checksum for the updated participant prompt

## Tests
- `biome format .`
- `biome check .`
- `tsc --noEmit`
- targeted Socratic Duel and command tests: 34/34
- `just catalog-generate`
- pre-push: eval-verify, catalog, no-artifactory, typecheck-cli, typecheck-webui

## Note
- pre-push reported a stale attestation warning for `rp1-dev:build@claude-code`, but the hook completed and allowed the push.