### PR TITLE
feat(agent-tools): add comment cleanup manifests

### DIFF
--- a/catalog/agents.yaml
+++ b/catalog/agents.yaml
@@ -202,7 +202,7 @@ agents:
   - name: rp1-dev:task-builder
     description: "Implements assigned task(s) w/ full context, writes summaries to the resolved task file. Uses extended thinking (or ultrathink)."
     plugin: dev
-    last_checksum: ec6172172d8b8a95accb2601633be9a3b4e23d582af714f535fa2f4936d51109
+    last_checksum: 06b80f5d3932570835feaf1a3b03102dffd6774a07b34672f5e417072aa44f27
   - name: rp1-dev:task-reviewer
     description: "Verifies builder's work for discipline, accuracy, completeness, and commit quality. Returns SUCCESS or FAILURE with actionable feedback. Uses extended thinking for careful verification."
     plugin: dev

--- a/cli/src/__tests__/agent-tools/change-manifest/command.test.ts
+++ b/cli/src/__tests__/agent-tools/change-manifest/command.test.ts
@@ -1,0 +1,453 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+import type {
+	GenerateChangeManifestResult,
+	SnapshotResult,
+} from "../../../agent-tools/change-manifest/index.js";
+import type { ToolResult } from "../../../agent-tools/models.js";
+import {
+	captureMainRepoState,
+	cleanupTempDir,
+	createInitialCommit,
+	createTempDir,
+	initTestRepo,
+	spawnGit,
+	verifyNoMainRepoContamination,
+	writeFixture,
+} from "../../helpers/index.js";
+
+const mainPath = path.join(import.meta.dir, "..", "..", "..", "main.ts");
+
+const readJson = async <T>(filePath: string): Promise<T> =>
+	JSON.parse(await Bun.file(filePath).text()) as T;
+
+const parseCliOutput = <T>(output: string): ToolResult<T> =>
+	JSON.parse(output) as ToolResult<T>;
+
+const createRepo = async (
+	name: string,
+): Promise<{ root: string; cleanup: () => Promise<void> }> => {
+	const tempDir = await createTempDir(name);
+	const repoRoot = path.join(tempDir, "repo");
+	await mkdir(repoRoot, { recursive: true });
+	await initTestRepo(repoRoot);
+	await createInitialCommit(repoRoot);
+	return {
+		root: repoRoot,
+		cleanup: () => cleanupTempDir(tempDir),
+	};
+};
+
+const runCli = async (
+	args: readonly string[],
+	cwd: string,
+): Promise<{
+	readonly exitCode: number;
+	readonly stdout: string;
+	readonly stderr: string;
+}> => {
+	const proc = Bun.spawn([process.execPath, mainPath, "agent-tools", ...args], {
+		cwd,
+		stdout: "pipe",
+		stderr: "pipe",
+		env: {
+			...process.env,
+			RP1_DB: path.join(cwd, ".rp1", "test-rp1.db"),
+		},
+	});
+	const [exitCode, stdout, stderr] = await Promise.all([
+		proc.exited,
+		new Response(proc.stdout).text(),
+		new Response(proc.stderr).text(),
+	]);
+	return { exitCode, stdout, stderr };
+};
+
+const git = async (repoRoot: string, args: string[]): Promise<string> => {
+	const proc = spawnGit(args, { cwd: repoRoot });
+	const [exitCode, stdout, stderr] = await Promise.all([
+		proc.exited,
+		new Response(proc.stdout as ReadableStream).text(),
+		new Response(proc.stderr as ReadableStream).text(),
+	]);
+	if (exitCode !== 0) {
+		throw new Error(`git ${args.join(" ")} failed: ${stderr}`);
+	}
+	return stdout.trim();
+};
+
+describe("change-manifest command", () => {
+	let mainRepoSnapshot: Awaited<ReturnType<typeof captureMainRepoState>>;
+	const cleanups: Array<() => Promise<void>> = [];
+
+	beforeAll(async () => {
+		mainRepoSnapshot = await captureMainRepoState();
+	});
+
+	afterAll(async () => {
+		for (const cleanup of cleanups.reverse()) {
+			await cleanup();
+		}
+		await verifyNoMainRepoContamination(mainRepoSnapshot);
+	});
+
+	test("snapshots and generates a build manifest through the agent-tool CLI", async () => {
+		const repo = await createRepo("change-manifest-command-build");
+		cleanups.push(repo.cleanup);
+
+		const baselinePath = path.join(repo.root, ".rp1", "baseline.json");
+		const snapshot = await runCli(
+			[
+				"change-manifest",
+				"snapshot",
+				"--code-root",
+				repo.root,
+				"--out",
+				baselinePath,
+			],
+			repo.root,
+		);
+		const snapshotOutput = parseCliOutput<SnapshotResult>(snapshot.stdout);
+
+		expect(snapshot.exitCode).toBe(0);
+		expect(snapshot.stderr).toBe("");
+		expect(snapshotOutput.success).toBe(true);
+		expect(snapshotOutput.tool).toBe("change-manifest");
+		expect(snapshotOutput.data.snapshotPath).toBe(baselinePath);
+		expect(snapshotOutput.data.dirtyPaths).toEqual([]);
+
+		await writeFixture(repo.root, "src/owned.ts", "const owned = true;\n");
+
+		const manifestPath = path.join(repo.root, ".rp1", "manifest.json");
+		const statusPath = path.join(repo.root, ".rp1", "status.json");
+		const generate = await runCli(
+			[
+				"change-manifest",
+				"generate",
+				"--code-root",
+				repo.root,
+				"--out",
+				manifestPath,
+				"--status-out",
+				statusPath,
+				"--source",
+				"build",
+				"--baseline",
+				baselinePath,
+			],
+			repo.root,
+		);
+		const generateOutput = parseCliOutput<GenerateChangeManifestResult>(
+			generate.stdout,
+		);
+		const manifest = await readJson<{
+			files: Array<{
+				path: string;
+				ownedHunks: unknown[];
+				allowedOperations: string[];
+			}>;
+		}>(manifestPath);
+		const status = await readJson<{ status: string; manifestPath: string }>(
+			statusPath,
+		);
+
+		expect(generate.exitCode).toBe(0);
+		expect(generate.stderr).toBe("");
+		expect(generateOutput.success).toBe(true);
+		expect(generateOutput.tool).toBe("change-manifest");
+		expect(generateOutput.data).toMatchObject({
+			status: "created",
+			manifestPath,
+			statusPath,
+			files: 1,
+			ownedLineCount: 1,
+			skipReason: null,
+		});
+		expect(manifest.files).toEqual([
+			{
+				path: "src/owned.ts",
+				ownedHunks: [{ startLine: 1, endLine: 1 }],
+				allowedOperations: ["remove_comments"],
+			},
+		]);
+		expect(status).toMatchObject({ status: "created", manifestPath });
+	});
+
+	test("returns a skipped envelope and writes status for outside-root scope", async () => {
+		const repo = await createRepo("change-manifest-command-scope");
+		cleanups.push(repo.cleanup);
+		const outside = await writeFixture(
+			path.dirname(repo.root),
+			"outside.ts",
+			"const outside = true;\n",
+		);
+		const manifestPath = path.join(repo.root, ".rp1", "manifest.json");
+		const statusPath = path.join(repo.root, ".rp1", "status.json");
+
+		const result = await runCli(
+			[
+				"change-manifest",
+				"generate",
+				"--code-root",
+				repo.root,
+				"--out",
+				manifestPath,
+				"--status-out",
+				statusPath,
+				"--source",
+				"code-clean-comments",
+				"--scope",
+				outside,
+			],
+			repo.root,
+		);
+		const output = parseCliOutput<GenerateChangeManifestResult>(result.stdout);
+		const status = await readJson<{ status: string; skipReason: string }>(
+			statusPath,
+		);
+
+		expect(result.exitCode).toBe(0);
+		expect(output.success).toBe(true);
+		expect(output.data).toMatchObject({
+			status: "skipped",
+			manifestPath: null,
+			statusPath,
+			files: 0,
+			ownedLineCount: 0,
+			skipReason: "scope_outside_code_root",
+		});
+		expect(status).toMatchObject({
+			status: "skipped",
+			skipReason: "scope_outside_code_root",
+		});
+		expect(await Bun.file(manifestPath).exists()).toBe(false);
+	});
+
+	test("generates code-clean-comments manifests for supported scope forms", async () => {
+		const repo = await createRepo("change-manifest-command-scope-forms");
+		cleanups.push(repo.cleanup);
+
+		await writeFixture(
+			repo.root,
+			"src/from-manifest.ts",
+			"const first = 1;\nconst second = 2;\n",
+		);
+		const existingManifestPath = await writeFixture(
+			repo.root,
+			".rp1/existing-manifest.json",
+			JSON.stringify({
+				version: 1,
+				source: "code-clean-comments",
+				codeRoot: repo.root,
+				files: [
+					{
+						path: "src/from-manifest.ts",
+						ownedHunks: [{ startLine: 2, endLine: 2 }],
+						allowedOperations: ["remove_comments"],
+					},
+				],
+			}),
+		);
+		await writeFixture(
+			repo.root,
+			"src/file-scope.ts",
+			"const one = 1;\nconst two = 2;\n",
+		);
+		await writeFixture(
+			repo.root,
+			"packages/pkg/dir-scope.ts",
+			"const dir = true;\n",
+		);
+		await writeFixture(repo.root, "packages/pkg/ignore.md", "# Unsupported\n");
+
+		await writeFixture(repo.root, "src/git-scope.ts", "const before = 1;\n");
+		await git(repo.root, ["add", "src/git-scope.ts"]);
+		await git(repo.root, ["commit", "-m", "Add git scope source"]);
+		const baseRef = await git(repo.root, ["rev-parse", "HEAD"]);
+		await writeFixture(
+			repo.root,
+			"src/git-scope.ts",
+			"const before = 1;\nconst after = 2;\n",
+		);
+		await git(repo.root, ["add", "src/git-scope.ts"]);
+		await git(repo.root, ["commit", "-m", "Update git scope source"]);
+
+		const generateScope = async (
+			name: string,
+			scope: string,
+		): Promise<{
+			readonly output: ToolResult<GenerateChangeManifestResult>;
+			readonly manifest: {
+				readonly files: ReadonlyArray<{
+					readonly path: string;
+					readonly ownedHunks: ReadonlyArray<{
+						readonly startLine: number;
+						readonly endLine: number;
+					}>;
+					readonly allowedOperations: readonly string[];
+				}>;
+			};
+		}> => {
+			const manifestPath = path.join(repo.root, ".rp1", `${name}.json`);
+			const statusPath = path.join(repo.root, ".rp1", `${name}-status.json`);
+			const result = await runCli(
+				[
+					"change-manifest",
+					"generate",
+					"--code-root",
+					repo.root,
+					"--out",
+					manifestPath,
+					"--status-out",
+					statusPath,
+					"--source",
+					"code-clean-comments",
+					"--scope",
+					scope,
+				],
+				repo.root,
+			);
+			const output = parseCliOutput<GenerateChangeManifestResult>(
+				result.stdout,
+			);
+
+			expect(result.exitCode).toBe(0);
+			expect(result.stderr).toBe("");
+			expect(output.success).toBe(true);
+			expect(output.data).toMatchObject({
+				status: "created",
+				manifestPath,
+				statusPath,
+				skipReason: null,
+			});
+
+			return {
+				output,
+				manifest: await readJson<{
+					files: Array<{
+						path: string;
+						ownedHunks: Array<{ startLine: number; endLine: number }>;
+						allowedOperations: string[];
+					}>;
+				}>(manifestPath),
+			};
+		};
+
+		const existingManifest = await generateScope(
+			"existing-manifest-scope",
+			existingManifestPath,
+		);
+		expect(existingManifest.output.data?.files).toBe(1);
+		expect(existingManifest.manifest.files).toEqual([
+			{
+				path: "src/from-manifest.ts",
+				ownedHunks: [{ startLine: 2, endLine: 2 }],
+				allowedOperations: ["remove_comments"],
+			},
+		]);
+
+		const fileScope = await generateScope(
+			"file-scope",
+			path.join(repo.root, "src/file-scope.ts"),
+		);
+		expect(fileScope.manifest.files).toEqual([
+			{
+				path: "src/file-scope.ts",
+				ownedHunks: [{ startLine: 1, endLine: 2 }],
+				allowedOperations: ["remove_comments"],
+			},
+		]);
+
+		const directoryScope = await generateScope(
+			"directory-scope",
+			"packages/pkg",
+		);
+		expect(directoryScope.manifest.files).toEqual([
+			{
+				path: "packages/pkg/dir-scope.ts",
+				ownedHunks: [{ startLine: 1, endLine: 1 }],
+				allowedOperations: ["remove_comments"],
+			},
+		]);
+
+		const gitRefScope = await generateScope("git-ref-scope", baseRef);
+		expect(gitRefScope.manifest.files).toEqual([
+			{
+				path: "src/git-scope.ts",
+				ownedHunks: [{ startLine: 2, endLine: 2 }],
+				allowedOperations: ["remove_comments"],
+			},
+		]);
+
+		const gitRangeScope = await generateScope(
+			"git-range-scope",
+			`${baseRef}..HEAD`,
+		);
+		expect(gitRangeScope.manifest.files).toEqual([
+			{
+				path: "src/git-scope.ts",
+				ownedHunks: [{ startLine: 2, endLine: 2 }],
+				allowedOperations: ["remove_comments"],
+			},
+		]);
+	});
+
+	test("rejects invalid source and ambiguous mode selection", async () => {
+		const repo = await createRepo("change-manifest-command-invalid");
+		cleanups.push(repo.cleanup);
+		const baselinePath = path.join(repo.root, ".rp1", "baseline.json");
+
+		const invalidSource = await runCli(
+			[
+				"change-manifest",
+				"generate",
+				"--code-root",
+				repo.root,
+				"--out",
+				path.join(repo.root, ".rp1", "manifest.json"),
+				"--status-out",
+				path.join(repo.root, ".rp1", "status.json"),
+				"--source",
+				"unknown",
+				"--baseline",
+				baselinePath,
+			],
+			repo.root,
+		);
+		const invalidSourceOutput = parseCliOutput<null>(invalidSource.stdout);
+
+		expect(invalidSource.exitCode).toBe(1);
+		expect(invalidSourceOutput.success).toBe(false);
+		expect(invalidSourceOutput.errors?.[0]?.message).toContain(
+			"--source must be one of",
+		);
+
+		const ambiguousMode = await runCli(
+			[
+				"change-manifest",
+				"generate",
+				"--code-root",
+				repo.root,
+				"--out",
+				path.join(repo.root, ".rp1", "manifest.json"),
+				"--status-out",
+				path.join(repo.root, ".rp1", "status.json"),
+				"--source",
+				"build",
+				"--baseline",
+				baselinePath,
+				"--scope",
+				"src",
+			],
+			repo.root,
+		);
+		const ambiguousModeOutput = parseCliOutput<null>(ambiguousMode.stdout);
+
+		expect(ambiguousMode.exitCode).toBe(1);
+		expect(ambiguousModeOutput.success).toBe(false);
+		expect(ambiguousModeOutput.errors?.[0]?.message).toContain(
+			"Use exactly one of --baseline or --scope",
+		);
+	});
+});

--- a/cli/src/__tests__/agent-tools/change-manifest/generator.test.ts
+++ b/cli/src/__tests__/agent-tools/change-manifest/generator.test.ts
@@ -1,0 +1,451 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+import {
+	createBaselineSnapshot,
+	generateChangeManifest,
+} from "../../../agent-tools/change-manifest/index.js";
+import {
+	captureMainRepoState,
+	cleanupTempDir,
+	createInitialCommit,
+	createTempDir,
+	expectRight,
+	initTestRepo,
+	spawnGit,
+	verifyNoMainRepoContamination,
+	writeFixture,
+} from "../../helpers/index.js";
+
+const fixedNow = (): Date => new Date("2026-04-28T00:00:00.000Z");
+
+const readJson = async <T>(filePath: string): Promise<T> =>
+	JSON.parse(await Bun.file(filePath).text()) as T;
+
+const createRepo = async (
+	name: string,
+): Promise<{ root: string; cleanup: () => Promise<void> }> => {
+	const tempDir = await createTempDir(name);
+	const repoRoot = path.join(tempDir, "repo");
+	await mkdir(repoRoot, { recursive: true });
+	await initTestRepo(repoRoot);
+	await createInitialCommit(repoRoot);
+	return {
+		root: repoRoot,
+		cleanup: () => cleanupTempDir(tempDir),
+	};
+};
+
+const git = async (repoRoot: string, args: string[]): Promise<void> => {
+	const proc = spawnGit(args, { cwd: repoRoot });
+	const exitCode = await proc.exited;
+	if (exitCode !== 0) {
+		const stderr = await new Response(proc.stderr as ReadableStream).text();
+		throw new Error(`git ${args.join(" ")} failed: ${stderr}`);
+	}
+};
+
+describe("change-manifest generator", () => {
+	let mainRepoSnapshot: Awaited<ReturnType<typeof captureMainRepoState>>;
+	const cleanups: Array<() => Promise<void>> = [];
+
+	beforeAll(async () => {
+		mainRepoSnapshot = await captureMainRepoState();
+	});
+
+	afterAll(async () => {
+		for (const cleanup of cleanups.reverse()) {
+			await cleanup();
+		}
+		await verifyNoMainRepoContamination(mainRepoSnapshot);
+	});
+
+	test("captures baseline HEAD and dirty paths", async () => {
+		const repo = await createRepo("change-manifest-snapshot");
+		cleanups.push(repo.cleanup);
+		await writeFixture(repo.root, "src/dirty.ts", "const before = 1;\n");
+		await git(repo.root, ["add", "src/dirty.ts"]);
+		await git(repo.root, ["commit", "-m", "Add tracked file"]);
+		await writeFixture(repo.root, "src/dirty.ts", "const after = 2;\n");
+
+		const snapshotPath = path.join(repo.root, ".rp1", "baseline.json");
+		const result = await createBaselineSnapshot({
+			codeRoot: repo.root,
+			out: snapshotPath,
+			now: fixedNow,
+		})();
+		const output = expectRight(result);
+		const snapshot = await readJson<{
+			dirtyPaths: string[];
+			generatedAt: string;
+		}>(snapshotPath);
+
+		expect(output.snapshotPath).toBe(snapshotPath);
+		expect(output.dirtyPaths).toEqual(["src/dirty.ts"]);
+		expect(snapshot.dirtyPaths).toEqual(["src/dirty.ts"]);
+		expect(snapshot.generatedAt).toBe("2026-04-28T00:00:00.000Z");
+	});
+
+	test("combines committed, staged, unstaged, and untracked source hunks", async () => {
+		const repo = await createRepo("change-manifest-build");
+		cleanups.push(repo.cleanup);
+		await writeFixture(repo.root, "src/tracked.ts", "const before = 1;\n");
+		await git(repo.root, ["add", "src/tracked.ts"]);
+		await git(repo.root, ["commit", "-m", "Add tracked source"]);
+
+		const baselinePath = path.join(repo.root, ".rp1", "baseline.json");
+		await expectRight(
+			await createBaselineSnapshot({
+				codeRoot: repo.root,
+				out: baselinePath,
+				now: fixedNow,
+			})(),
+		);
+
+		await writeFixture(
+			repo.root,
+			"src/committed.ts",
+			"const a = 1;\nconst b = 2;\n",
+		);
+		await git(repo.root, ["add", "src/committed.ts"]);
+		await git(repo.root, ["commit", "-m", "Add committed source"]);
+
+		await writeFixture(
+			repo.root,
+			"src/staged.ts",
+			"const c = 3;\nconst d = 4;\n",
+		);
+		await git(repo.root, ["add", "src/staged.ts"]);
+
+		await writeFixture(
+			repo.root,
+			"src/tracked.ts",
+			"const before = 1;\nconst after = 2;\n",
+		);
+		await writeFixture(
+			repo.root,
+			"scripts/untracked.py",
+			"print('a')\nprint('b')\n",
+		);
+		await writeFixture(repo.root, "notes.md", "# Unsupported\n");
+		await writeFixture(
+			repo.root,
+			"catalog/agents.yaml",
+			"agents:\n  - name: generated\n",
+		);
+		await writeFixture(
+			repo.root,
+			"cli/src/init/templates/generated.ts",
+			"export const generated = true;\n",
+		);
+
+		const manifestPath = path.join(
+			repo.root,
+			".rp1",
+			"change-manifest-001.json",
+		);
+		const statusPath = path.join(
+			repo.root,
+			".rp1",
+			"change-manifest-status.json",
+		);
+		const result = await generateChangeManifest({
+			codeRoot: repo.root,
+			out: manifestPath,
+			statusOut: statusPath,
+			source: "build",
+			baseline: baselinePath,
+			now: fixedNow,
+		})();
+		const output = expectRight(result);
+		const manifest = await readJson<{
+			files: Array<{
+				path: string;
+				ownedHunks: Array<{ startLine: number; endLine: number }>;
+				allowedOperations: string[];
+			}>;
+		}>(manifestPath);
+
+		expect(output.status).toBe("created");
+		expect(output.files).toBe(4);
+		expect(output.ownedLineCount).toBe(7);
+		expect(manifest.files.map((file) => file.path)).toEqual([
+			"scripts/untracked.py",
+			"src/committed.ts",
+			"src/staged.ts",
+			"src/tracked.ts",
+		]);
+		expect(
+			manifest.files.find((file) => file.path === "src/tracked.ts")?.ownedHunks,
+		).toEqual([{ startLine: 2, endLine: 2 }]);
+	});
+
+	test("skips when baseline dirty paths overlap generated candidates", async () => {
+		const repo = await createRepo("change-manifest-dirty-overlap");
+		cleanups.push(repo.cleanup);
+		await writeFixture(repo.root, "src/dirty.ts", "const before = 1;\n");
+		await git(repo.root, ["add", "src/dirty.ts"]);
+		await git(repo.root, ["commit", "-m", "Add dirty source"]);
+		await writeFixture(repo.root, "src/dirty.ts", "const dirty = 1;\n");
+
+		const baselinePath = path.join(repo.root, ".rp1", "baseline.json");
+		await expectRight(
+			await createBaselineSnapshot({
+				codeRoot: repo.root,
+				out: baselinePath,
+				now: fixedNow,
+			})(),
+		);
+		await writeFixture(
+			repo.root,
+			"src/dirty.ts",
+			"const dirty = 1;\nconst build = 2;\n",
+		);
+
+		const manifestPath = path.join(
+			repo.root,
+			".rp1",
+			"change-manifest-001.json",
+		);
+		const statusPath = path.join(
+			repo.root,
+			".rp1",
+			"change-manifest-status.json",
+		);
+		const result = await generateChangeManifest({
+			codeRoot: repo.root,
+			out: manifestPath,
+			statusOut: statusPath,
+			source: "build",
+			baseline: baselinePath,
+			now: fixedNow,
+		})();
+		const output = expectRight(result);
+		const status = await readJson<{
+			skipReason: string;
+			overlappedDirtyPaths: string[];
+		}>(statusPath);
+
+		expect(output.status).toBe("skipped");
+		expect(output.skipReason).toBe("pre_existing_dirty_paths_overlap");
+		expect(status.overlappedDirtyPaths).toEqual(["src/dirty.ts"]);
+		expect(await Bun.file(manifestPath).exists()).toBe(false);
+	});
+
+	test("skips when a baseline untracked directory contains generated candidates", async () => {
+		const repo = await createRepo("change-manifest-untracked-dir-overlap");
+		cleanups.push(repo.cleanup);
+		await writeFixture(
+			repo.root,
+			"src/preexisting.ts",
+			"const preexisting = 1;\n",
+		);
+
+		const baselinePath = path.join(repo.root, ".rp1", "baseline.json");
+		const snapshot = expectRight(
+			await createBaselineSnapshot({
+				codeRoot: repo.root,
+				out: baselinePath,
+				now: fixedNow,
+			})(),
+		);
+
+		const manifestPath = path.join(
+			repo.root,
+			".rp1",
+			"change-manifest-001.json",
+		);
+		const statusPath = path.join(
+			repo.root,
+			".rp1",
+			"change-manifest-status.json",
+		);
+		const result = await generateChangeManifest({
+			codeRoot: repo.root,
+			out: manifestPath,
+			statusOut: statusPath,
+			source: "build",
+			baseline: baselinePath,
+			now: fixedNow,
+		})();
+		const output = expectRight(result);
+		const status = await readJson<{
+			skipReason: string;
+			dirtyPaths: string[];
+			overlappedDirtyPaths: string[];
+		}>(statusPath);
+
+		expect(snapshot.dirtyPaths).toEqual(["src/"]);
+		expect(output.status).toBe("skipped");
+		expect(output.skipReason).toBe("pre_existing_dirty_paths_overlap");
+		expect(status.dirtyPaths).toEqual(["src/"]);
+		expect(status.overlappedDirtyPaths).toEqual(["src/"]);
+		expect(await Bun.file(manifestPath).exists()).toBe(false);
+	});
+
+	test("writes skipped status for empty and invalid baselines", async () => {
+		const repo = await createRepo("change-manifest-baseline-skip");
+		cleanups.push(repo.cleanup);
+		const manifestPath = path.join(repo.root, ".rp1", "manifest.json");
+		const statusPath = path.join(repo.root, ".rp1", "status.json");
+
+		const missing = expectRight(
+			await generateChangeManifest({
+				codeRoot: repo.root,
+				out: manifestPath,
+				statusOut: statusPath,
+				source: "build",
+				baseline: path.join(repo.root, ".rp1", "missing.json"),
+				now: fixedNow,
+			})(),
+		);
+		expect(missing.skipReason).toBe("missing_baseline");
+
+		const malformedPath = await writeFixture(
+			repo.root,
+			".rp1/malformed.json",
+			"{",
+		);
+		const malformed = expectRight(
+			await generateChangeManifest({
+				codeRoot: repo.root,
+				out: manifestPath,
+				statusOut: statusPath,
+				source: "build",
+				baseline: malformedPath,
+				now: fixedNow,
+			})(),
+		);
+		expect(malformed.skipReason).toBe("invalid_baseline");
+
+		const wrongRootPath = await writeFixture(
+			repo.root,
+			".rp1/wrong-root.json",
+			JSON.stringify({
+				version: 1,
+				codeRoot: path.dirname(repo.root),
+				head: "1234567",
+				dirtyPaths: [],
+				generatedAt: "2026-04-28T00:00:00.000Z",
+			}),
+		);
+		const wrongRoot = expectRight(
+			await generateChangeManifest({
+				codeRoot: repo.root,
+				out: manifestPath,
+				statusOut: statusPath,
+				source: "build",
+				baseline: wrongRootPath,
+				now: fixedNow,
+			})(),
+		);
+		expect(wrongRoot.skipReason).toBe("baseline_code_root_mismatch");
+	});
+
+	test("skips when no supported source hunks exist", async () => {
+		const repo = await createRepo("change-manifest-empty");
+		cleanups.push(repo.cleanup);
+		const baselinePath = path.join(repo.root, ".rp1", "baseline.json");
+		await expectRight(
+			await createBaselineSnapshot({
+				codeRoot: repo.root,
+				out: baselinePath,
+				now: fixedNow,
+			})(),
+		);
+
+		const result = expectRight(
+			await generateChangeManifest({
+				codeRoot: repo.root,
+				out: path.join(repo.root, ".rp1", "manifest.json"),
+				statusOut: path.join(repo.root, ".rp1", "status.json"),
+				source: "build",
+				baseline: baselinePath,
+				now: fixedNow,
+			})(),
+		);
+
+		expect(result.status).toBe("skipped");
+		expect(result.skipReason).toBe("no_supported_source_hunks");
+	});
+
+	test("scope mode includes supported files when scope is the code root", async () => {
+		const repo = await createRepo("change-manifest-root-scope");
+		cleanups.push(repo.cleanup);
+		await writeFixture(repo.root, "src/owned.ts", "const a = 1;\n");
+		await writeFixture(repo.root, "scripts/owned.py", "print('a')\n");
+		await writeFixture(
+			repo.root,
+			"node_modules/pkg/ignored.ts",
+			"ignored();\n",
+		);
+		await writeFixture(
+			repo.root,
+			"catalog/agents.yaml",
+			"agents:\n  - name: generated\n",
+		);
+		await writeFixture(
+			repo.root,
+			"cli/src/init/templates/generated.ts",
+			"export const generated = true;\n",
+		);
+		await writeFixture(repo.root, "README.md", "# Unsupported\n");
+
+		const manifestPath = path.join(repo.root, ".rp1", "manifest.json");
+		const result = expectRight(
+			await generateChangeManifest({
+				codeRoot: repo.root,
+				out: manifestPath,
+				statusOut: path.join(repo.root, ".rp1", "status.json"),
+				source: "code-clean-comments",
+				scope: ".",
+				now: fixedNow,
+			})(),
+		);
+		const manifest = await readJson<{
+			files: Array<{
+				path: string;
+				ownedHunks: Array<{ startLine: number; endLine: number }>;
+				allowedOperations: string[];
+			}>;
+		}>(manifestPath);
+
+		expect(result.status).toBe("created");
+		expect(manifest.files).toEqual([
+			{
+				path: "scripts/owned.py",
+				ownedHunks: [{ startLine: 1, endLine: 1 }],
+				allowedOperations: ["remove_comments"],
+			},
+			{
+				path: "src/owned.ts",
+				ownedHunks: [{ startLine: 1, endLine: 1 }],
+				allowedOperations: ["remove_comments"],
+			},
+		]);
+	});
+
+	test("scope mode fails closed for outside-root files", async () => {
+		const repo = await createRepo("change-manifest-outside-scope");
+		cleanups.push(repo.cleanup);
+		const outside = await writeFixture(
+			path.dirname(repo.root),
+			"outside.ts",
+			"const x = 1;\n",
+		);
+
+		const result = expectRight(
+			await generateChangeManifest({
+				codeRoot: repo.root,
+				out: path.join(repo.root, ".rp1", "manifest.json"),
+				statusOut: path.join(repo.root, ".rp1", "status.json"),
+				source: "code-clean-comments",
+				scope: outside,
+				now: fixedNow,
+			})(),
+		);
+
+		expect(result.status).toBe("skipped");
+		expect(result.skipReason).toBe("scope_outside_code_root");
+	});
+});

--- a/cli/src/__tests__/build/comment-cleanup-manifest-contracts.test.ts
+++ b/cli/src/__tests__/build/comment-cleanup-manifest-contracts.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, test } from "bun:test";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+const projectRoot = join(import.meta.dir, "..", "..", "..", "..");
+
+const readProjectFile = async (relativePath: string): Promise<string> =>
+	readFile(join(projectRoot, relativePath), "utf-8");
+
+describe("comment cleanup manifest prompt contracts", () => {
+	test("build snapshots and gates comment-cleaner on a generated non-empty manifest", async () => {
+		const buildSkill = await readProjectFile(
+			"plugins/dev/skills/build/SKILL.md",
+		);
+
+		expect(buildSkill).toContain("change-manifest snapshot");
+		expect(buildSkill).toContain("change-manifest-baseline.json");
+		expect(buildSkill).toContain("change-manifest generate");
+		expect(buildSkill).toContain("--source build");
+		expect(buildSkill).toContain("change-manifest-001.json");
+		expect(buildSkill).toContain("change-manifest-status.json");
+		expect(buildSkill).toContain('data.status == "created"');
+		expect(buildSkill).toContain("data.files > 0");
+		expect(buildSkill).toContain("data.ownedLineCount > 0");
+		expect(buildSkill).toContain(
+			"Do not dispatch `comment-cleaner` later unless",
+		);
+		expect(buildSkill).toContain("Include `comment-cleaner` only when");
+		expect(buildSkill).toContain('"files_checked": 0');
+		expect(buildSkill).toContain('"manifest_status_path"');
+		expect(buildSkill).toContain('"skip_reason"');
+		expect(buildSkill).toContain(
+			"Do not dispatch comment-cleaner with branch, unstaged, commit-range, base-branch, mode, or commit parameters",
+		);
+	});
+
+	test("build-fast snapshots and gates comment-cleaner on a generated non-empty manifest", async () => {
+		const buildFastSkill = await readProjectFile(
+			"plugins/dev/skills/build-fast/SKILL.md",
+		);
+
+		expect(buildFastSkill).toContain("change-manifest snapshot");
+		expect(buildFastSkill).toContain("{RUN_ID}-change-manifest-baseline.json");
+		expect(buildFastSkill).toContain("change-manifest generate");
+		expect(buildFastSkill).toContain("--source build-fast");
+		expect(buildFastSkill).toContain("{RUN_ID}-change-manifest-001.json");
+		expect(buildFastSkill).toContain("{RUN_ID}-change-manifest-status.json");
+		expect(buildFastSkill).toContain('data.status == "created"');
+		expect(buildFastSkill).toContain("data.files > 0");
+		expect(buildFastSkill).toContain("data.ownedLineCount > 0");
+		expect(buildFastSkill).toContain(
+			"CHANGE_MANIFEST={cleanup_manifest_result.data.manifestPath}, CODE_ROOT={codeRoot}",
+		);
+		expect(buildFastSkill).toContain('"files_checked": 0');
+		expect(buildFastSkill).toContain('"manifest_status_path"');
+		expect(buildFastSkill).toContain('"skip_reason"');
+		expect(buildFastSkill).toContain("**Comment Cleanup**");
+		expect(buildFastSkill).toContain("**Cleanup Manifest**");
+		expect(buildFastSkill).toContain("**Cleanup Status**");
+		expect(buildFastSkill).toContain("**Cleanup Skip Reason**");
+		expect(buildFastSkill).toContain(
+			"Do not dispatch comment-cleaner with branch, unstaged, commit-range, base-branch, mode, or commit parameters",
+		);
+	});
+
+	test("code-clean-comments delegates scope resolution to change-manifest", async () => {
+		const cleanupSkill = await readProjectFile(
+			"plugins/dev/skills/code-clean-comments/SKILL.md",
+		);
+
+		expect(cleanupSkill).toContain("change-manifest generate");
+		expect(cleanupSkill).toContain("--source code-clean-comments");
+		expect(cleanupSkill).toContain('--scope "{SCOPE}"');
+		expect(cleanupSkill).toContain(
+			"The generator is responsible for existing manifest JSON, file, directory, git ref, and git range scopes.",
+		);
+		expect(cleanupSkill).toContain(
+			"Do not inspect files, walk directories, parse git diffs, validate existing manifest JSON, or write manifest JSON yourself.",
+		);
+		expect(cleanupSkill).toContain('data.status != "created"');
+		expect(cleanupSkill).toContain("data.files == 0");
+		expect(cleanupSkill).toContain("data.ownedLineCount == 0");
+		expect(cleanupSkill).toContain(
+			"CHANGE_MANIFEST={cleanup_manifest_result.data.manifestPath}, CODE_ROOT={resolved_code_root}",
+		);
+		expect(cleanupSkill).not.toContain(
+			"create one manifest file entry with a full-file owned hunk",
+		);
+		expect(cleanupSkill).not.toContain("git diff -U0 --no-color {SCOPE}");
+		expect(cleanupSkill).not.toContain("Write durable JSON");
+	});
+
+	test("task-builder keeps cleanup ownership outside its responsibility", async () => {
+		const taskBuilder = await readProjectFile(
+			"plugins/dev/agents/task-builder.md",
+		);
+
+		expect(taskBuilder).toContain("## Implementation Commandments");
+		expect(taskBuilder).toContain(
+			"Write for humans first: optimize for maintainers reading, reviewing, debugging, and modifying code under time pressure.",
+		);
+		expect(taskBuilder).toContain(
+			"Complexity is the enemy; prefer deep modules with simple interfaces and real behavior behind them.",
+		);
+		expect(taskBuilder).toContain(
+			"Model the data and domain well; make illegal states unrepresentable or fail closed at boundaries.",
+		);
+		expect(taskBuilder).toContain("High cohesion, low coupling.");
+		expect(taskBuilder).toContain(
+			"YAGNI: code is cost, not asset; avoid speculative hooks, layers, parameters, and features.",
+		);
+		expect(taskBuilder).toContain(
+			"Prefer duplication to the wrong abstraction.",
+		);
+		expect(taskBuilder).toContain(
+			"Make the change easy, then make the easy change.",
+		);
+		expect(taskBuilder).toContain("Listen to test pain as design feedback.");
+		expect(taskBuilder).toContain(
+			"Test behavior through public seams, not implementation internals.",
+		);
+		expect(taskBuilder).toContain("Measure before optimizing; cut surgically.");
+		expect(taskBuilder).toContain(
+			"Task builders MUST NOT calculate, merge, create, or hand off comment cleanup manifests or cleanup-owned hunks.",
+		);
+		expect(taskBuilder).toContain("rp1 agent-tools change-manifest");
+	});
+});

--- a/cli/src/__tests__/commands/fake-command.test.ts
+++ b/cli/src/__tests__/commands/fake-command.test.ts
@@ -71,37 +71,47 @@ describe("fake workflow command", () => {
 		expect(errors.at(-1)).toContain("Invalid speed");
 	});
 
-	test("runs a fast fake workflow with artifact and subflow events in an isolated project", async () => {
-		tempDir = await mkdtemp(join(tmpdir(), "rp1-fake-command-"));
-		const rp1Dir = join(tempDir, ".rp1");
-		await mkdir(join(rp1Dir, "work"), { recursive: true });
-		await writeFile(join(rp1Dir, "project_id"), crypto.randomUUID());
-		process.env.RP1_DB = join(tempDir, "events.db");
-		process.chdir(tempDir);
+	test(
+		"runs a fast fake workflow with artifact and subflow events in an isolated project",
+		async () => {
+			tempDir = await mkdtemp(join(tmpdir(), "rp1-fake-command-"));
+			const rp1Dir = join(tempDir, ".rp1");
+			await mkdir(join(rp1Dir, "work"), { recursive: true });
+			await writeFile(join(rp1Dir, "project_id"), crypto.randomUUID());
+			process.env.RP1_DB = join(tempDir, "events.db");
+			process.chdir(tempDir);
 
-		fakeCommand.exitOverride();
-		await fakeCommand.parseAsync([
-			"node",
-			"fake",
-			"/build 'coverage repair'",
-			"--speed",
-			"fast",
-			"--feature",
-			"coverage-repair",
-			"--pause-at",
-			"build",
-			"--with-btw",
-			"--with-artifacts",
-			"--with-subflows",
-		]);
+			fakeCommand.exitOverride();
+			await fakeCommand.parseAsync([
+				"node",
+				"fake",
+				"/build 'coverage repair'",
+				"--speed",
+				"fast",
+				"--feature",
+				"coverage-repair",
+				"--pause-at",
+				"build",
+				"--with-btw",
+				"--with-artifacts",
+				"--with-subflows",
+			]);
 
-		const output = logs.join("\n");
-		expect(output).toContain('Simulating workflow "build"');
-		expect(output).toContain("Simulation paused");
-		await expect(
-			stat(
-				join(rp1Dir, "work", "features", "coverage-repair", "requirements.md"),
-			),
-		).resolves.toBeDefined();
-	});
+			const output = logs.join("\n");
+			expect(output).toContain('Simulating workflow "build"');
+			expect(output).toContain("Simulation paused");
+			await expect(
+				stat(
+					join(
+						rp1Dir,
+						"work",
+						"features",
+						"coverage-repair",
+						"requirements.md",
+					),
+				),
+			).resolves.toBeDefined();
+		},
+		{ timeout: 10000 },
+	);
 });

--- a/cli/src/agent-tools/change-manifest/generator.ts
+++ b/cli/src/agent-tools/change-manifest/generator.ts
@@ -1,0 +1,736 @@
+import { existsSync } from "node:fs";
+import {
+	mkdir,
+	readdir,
+	readFile,
+	rm,
+	stat,
+	writeFile,
+} from "node:fs/promises";
+import path from "node:path";
+import { pipe } from "fp-ts/lib/function.js";
+import * as TE from "fp-ts/lib/TaskEither.js";
+import type { CLIError } from "../../../shared/errors.js";
+import { runtimeError } from "../../../shared/errors.js";
+import { isSupportedSourcePath } from "../comment-extract/patterns.js";
+import { execGitCommand, execGitCommandMayFail } from "../git.js";
+import {
+	type BaselineSnapshot,
+	CHANGE_MANIFEST_VERSION,
+	type ChangeManifest,
+	type ChangeManifestFile,
+	type ChangeManifestHunk,
+	type GenerateChangeManifestOptions,
+	type GenerateChangeManifestResult,
+	type ManifestSkipReason,
+	type ManifestStatus,
+	type SnapshotOptions,
+	type SnapshotResult,
+} from "./models.js";
+
+type HunkMap = Map<string, ChangeManifestHunk[]>;
+
+const isoNow = (now: (() => Date) | undefined): string =>
+	(now ? now() : new Date()).toISOString();
+
+const toJson = (value: unknown): string =>
+	`${JSON.stringify(value, null, 2)}\n`;
+
+const writeJson = async (filePath: string, value: unknown): Promise<void> => {
+	await mkdir(path.dirname(filePath), { recursive: true });
+	await writeFile(filePath, toJson(value), "utf-8");
+};
+
+const removeIfExists = async (filePath: string): Promise<void> => {
+	await rm(filePath, { force: true });
+};
+
+const normalizePath = (filePath: string): string =>
+	filePath.replace(/\\/g, "/").split(path.sep).join("/").replace(/^\.\//, "");
+
+const cliErrorMessage = (error: CLIError): string => {
+	if ("message" in error) {
+		return error.message;
+	}
+	if ("resource" in error) {
+		return `${error.resource} not found`;
+	}
+	return error._tag;
+};
+
+const resolveInsideCodeRoot = (
+	codeRoot: string,
+	filePath: string,
+): string | null => {
+	const resolved = path.isAbsolute(filePath)
+		? path.resolve(filePath)
+		: path.resolve(codeRoot, filePath);
+	const relative = path.relative(codeRoot, resolved);
+	if (relative.startsWith("..") || path.isAbsolute(relative)) {
+		return null;
+	}
+	return resolved;
+};
+
+const relativeToCodeRoot = (
+	codeRoot: string,
+	filePath: string,
+): string | null => {
+	const resolved = resolveInsideCodeRoot(codeRoot, filePath);
+	if (!resolved) {
+		return null;
+	}
+	return normalizePath(path.relative(codeRoot, resolved));
+};
+
+const addHunk = (
+	hunksByPath: HunkMap,
+	relativePath: string,
+	hunk: ChangeManifestHunk,
+): void => {
+	if (hunk.startLine < 1 || hunk.endLine < hunk.startLine) {
+		return;
+	}
+	const hunks = hunksByPath.get(relativePath) ?? [];
+	hunks.push(hunk);
+	hunksByPath.set(relativePath, hunks);
+};
+
+const mergeHunks = (
+	hunks: readonly ChangeManifestHunk[],
+): readonly ChangeManifestHunk[] => {
+	const sorted = [...hunks].sort(
+		(a, b) => a.startLine - b.startLine || a.endLine - b.endLine,
+	);
+	const merged: ChangeManifestHunk[] = [];
+	for (const hunk of sorted) {
+		const previous = merged.at(-1);
+		if (!previous || hunk.startLine > previous.endLine + 1) {
+			merged.push({ ...hunk });
+			continue;
+		}
+		merged[merged.length - 1] = {
+			startLine: previous.startLine,
+			endLine: Math.max(previous.endLine, hunk.endLine),
+		};
+	}
+	return merged;
+};
+
+const ownedLineCount = (files: readonly ChangeManifestFile[]): number =>
+	files.reduce(
+		(total, file) =>
+			total +
+			file.ownedHunks.reduce(
+				(fileTotal, hunk) => fileTotal + hunk.endLine - hunk.startLine + 1,
+				0,
+			),
+		0,
+	);
+
+const buildManifestFiles = (hunksByPath: HunkMap): ChangeManifestFile[] =>
+	Array.from(hunksByPath.entries())
+		.map(([filePath, hunks]) => ({
+			path: filePath,
+			ownedHunks: mergeHunks(hunks),
+			allowedOperations: ["remove_comments"] as const,
+		}))
+		.filter((file) => file.ownedHunks.length > 0)
+		.sort((a, b) => a.path.localeCompare(b.path));
+
+const recordSkip = async (
+	options: GenerateChangeManifestOptions,
+	codeRoot: string,
+	reason: ManifestSkipReason,
+	details: {
+		readonly dirtyPaths?: readonly string[];
+		readonly overlappedDirtyPaths?: readonly string[];
+	} = {},
+): Promise<GenerateChangeManifestResult> => {
+	const statusPath = path.resolve(options.statusOut);
+	const status: ManifestStatus = {
+		version: CHANGE_MANIFEST_VERSION,
+		status: "skipped",
+		source: options.source,
+		codeRoot,
+		generatedAt: isoNow(options.now),
+		manifestPath: null,
+		files: 0,
+		ownedLineCount: 0,
+		skipReason: reason,
+		...details,
+	};
+	await removeIfExists(path.resolve(options.out));
+	await writeJson(statusPath, status);
+	return {
+		status: "skipped",
+		manifestPath: null,
+		statusPath,
+		files: 0,
+		ownedLineCount: 0,
+		skipReason: reason,
+	};
+};
+
+const recordCreated = async (
+	options: GenerateChangeManifestOptions,
+	codeRoot: string,
+	files: readonly ChangeManifestFile[],
+	dirtyPaths: readonly string[] = [],
+): Promise<GenerateChangeManifestResult> => {
+	const manifestPath = path.resolve(options.out);
+	const statusPath = path.resolve(options.statusOut);
+	const lineCount = ownedLineCount(files);
+	const generatedAt = isoNow(options.now);
+	const manifest: ChangeManifest = {
+		version: CHANGE_MANIFEST_VERSION,
+		source: options.source,
+		codeRoot,
+		generatedAt,
+		files,
+	};
+	const status: ManifestStatus = {
+		version: CHANGE_MANIFEST_VERSION,
+		status: "created",
+		source: options.source,
+		codeRoot,
+		generatedAt,
+		manifestPath,
+		files: files.length,
+		ownedLineCount: lineCount,
+		skipReason: null,
+		dirtyPaths,
+	};
+	await writeJson(manifestPath, manifest);
+	await writeJson(statusPath, status);
+	return {
+		status: "created",
+		manifestPath,
+		statusPath,
+		files: files.length,
+		ownedLineCount: lineCount,
+		skipReason: null,
+	};
+};
+
+const parseDirtyPaths = (statusOutput: string): readonly string[] => {
+	const paths = new Set<string>();
+	for (const line of statusOutput.split("\n")) {
+		if (!line.trim()) {
+			continue;
+		}
+		const match = line.match(/^(?:[ MADRCU?!]{1,2})\s+(.+)$/);
+		const rawPath = (match?.[1] ?? line).trim();
+		if (!rawPath) {
+			continue;
+		}
+		const renameParts = rawPath.split(" -> ");
+		for (const part of renameParts) {
+			paths.add(normalizePath(part));
+		}
+	}
+	return Array.from(paths).sort();
+};
+
+const dirtyPathOverlapsCandidate = (
+	dirtyPath: string,
+	candidatePath: string,
+): boolean => {
+	const dirty = normalizePath(dirtyPath).replace(/\/+$/, "");
+	const candidate = normalizePath(candidatePath);
+	return (
+		dirty !== "" && (candidate === dirty || candidate.startsWith(`${dirty}/`))
+	);
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+	typeof value === "object" && value !== null && !Array.isArray(value);
+
+const isPositiveInteger = (value: unknown): value is number =>
+	Number.isInteger(value) && Number(value) > 0;
+
+const isValidHead = (value: string): boolean => /^[0-9a-f]{7,40}$/i.test(value);
+
+const parseBaselineSnapshot = (
+	content: string,
+	expectedCodeRoot: string,
+): BaselineSnapshot | ManifestSkipReason => {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(content);
+	} catch {
+		return "invalid_baseline";
+	}
+	if (
+		!isRecord(parsed) ||
+		parsed.version !== CHANGE_MANIFEST_VERSION ||
+		typeof parsed.codeRoot !== "string" ||
+		typeof parsed.head !== "string" ||
+		typeof parsed.generatedAt !== "string" ||
+		!Array.isArray(parsed.dirtyPaths) ||
+		!parsed.dirtyPaths.every((item) => typeof item === "string") ||
+		!isValidHead(parsed.head)
+	) {
+		return "invalid_baseline";
+	}
+	if (path.resolve(parsed.codeRoot) !== expectedCodeRoot) {
+		return "baseline_code_root_mismatch";
+	}
+	return {
+		version: CHANGE_MANIFEST_VERSION,
+		codeRoot: expectedCodeRoot,
+		head: parsed.head,
+		dirtyPaths: parsed.dirtyPaths.map(normalizePath).sort(),
+		generatedAt: parsed.generatedAt,
+	};
+};
+
+const loadBaselineSnapshot = async (
+	baselinePath: string | undefined,
+	codeRoot: string,
+): Promise<BaselineSnapshot | ManifestSkipReason> => {
+	if (!baselinePath) {
+		return "missing_baseline";
+	}
+	const resolved = path.resolve(baselinePath);
+	if (!existsSync(resolved)) {
+		return "missing_baseline";
+	}
+	const content = await readFile(resolved, "utf-8");
+	const baseline = parseBaselineSnapshot(content, codeRoot);
+	if (typeof baseline === "string") {
+		return baseline;
+	}
+	const headExists = await execGitCommandMayFail(
+		["cat-file", "-e", `${baseline.head}^{commit}`],
+		codeRoot,
+	)();
+	if (headExists._tag === "Left" || !headExists.right.success) {
+		return "invalid_baseline";
+	}
+	return baseline;
+};
+
+export const parseUnifiedDiffHunks = (
+	diff: string,
+	codeRoot: string,
+): HunkMap => {
+	const hunksByPath: HunkMap = new Map();
+	let currentPath: string | null = null;
+
+	for (const line of diff.split("\n")) {
+		if (line.startsWith("+++ /dev/null")) {
+			currentPath = null;
+			continue;
+		}
+		if (line.startsWith("+++ b/")) {
+			const relativePath = relativeToCodeRoot(codeRoot, line.slice(6));
+			currentPath =
+				relativePath && isSupportedSourcePath(relativePath)
+					? relativePath
+					: null;
+			continue;
+		}
+		if (!line.startsWith("@@") || !currentPath) {
+			continue;
+		}
+		const match = line.match(/@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@/);
+		if (!match) {
+			continue;
+		}
+		const startLine = Number.parseInt(match[1], 10);
+		const count = match[2] ? Number.parseInt(match[2], 10) : 1;
+		if (count > 0) {
+			addHunk(hunksByPath, currentPath, {
+				startLine,
+				endLine: startLine + count - 1,
+			});
+		}
+	}
+
+	return hunksByPath;
+};
+
+const mergeHunkMaps = (target: HunkMap, source: HunkMap): void => {
+	for (const [filePath, hunks] of source) {
+		for (const hunk of hunks) {
+			addHunk(target, filePath, hunk);
+		}
+	}
+};
+
+const lineCount = (content: string): number => {
+	if (content.length === 0) {
+		return 0;
+	}
+	const lines = content.split(/\r?\n/);
+	return content.endsWith("\n") || content.endsWith("\r\n")
+		? lines.length - 1
+		: lines.length;
+};
+
+const addFullFileHunk = async (
+	hunksByPath: HunkMap,
+	codeRoot: string,
+	filePath: string,
+): Promise<"added" | "outside" | "skipped"> => {
+	const relativePath = relativeToCodeRoot(codeRoot, filePath);
+	if (!relativePath) {
+		return "outside";
+	}
+	if (!isSupportedSourcePath(relativePath)) {
+		return "skipped";
+	}
+	const resolved = path.resolve(codeRoot, relativePath);
+	const content = await readFile(resolved, "utf-8");
+	const count = lineCount(content);
+	if (count < 1) {
+		return "skipped";
+	}
+	addHunk(hunksByPath, relativePath, { startLine: 1, endLine: count });
+	return "added";
+};
+
+const addDirectoryHunks = async (
+	hunksByPath: HunkMap,
+	codeRoot: string,
+	dirPath: string,
+): Promise<"added" | "outside" | "skipped"> => {
+	const resolved = resolveInsideCodeRoot(codeRoot, dirPath);
+	if (!resolved) {
+		return "outside";
+	}
+	let added = false;
+	const entries = await readdir(resolved, { withFileTypes: true });
+	for (const entry of entries) {
+		const child = path.join(resolved, entry.name);
+		const relativePath = path.relative(codeRoot, child);
+		if (entry.isDirectory()) {
+			if (isSupportedSourcePath(path.join(relativePath, "placeholder.ts"))) {
+				const result = await addDirectoryHunks(hunksByPath, codeRoot, child);
+				added ||= result === "added";
+			}
+			continue;
+		}
+		if (!entry.isFile()) {
+			continue;
+		}
+		const result = await addFullFileHunk(hunksByPath, codeRoot, child);
+		if (result === "outside") {
+			return "outside";
+		}
+		added ||= result === "added";
+	}
+	return added ? "added" : "skipped";
+};
+
+const parseExistingManifestHunks = async (
+	hunksByPath: HunkMap,
+	codeRoot: string,
+	manifestPath: string,
+): Promise<"added" | "outside" | "invalid" | "skipped"> => {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(await readFile(manifestPath, "utf-8"));
+	} catch {
+		return "invalid";
+	}
+	if (
+		!isRecord(parsed) ||
+		parsed.version !== CHANGE_MANIFEST_VERSION ||
+		!Array.isArray(parsed.files)
+	) {
+		return "invalid";
+	}
+	const manifestCodeRoot =
+		typeof parsed.codeRoot === "string"
+			? path.resolve(parsed.codeRoot)
+			: codeRoot;
+	let added = false;
+	for (const file of parsed.files) {
+		if (!isRecord(file) || typeof file.path !== "string" || !file.path) {
+			return "invalid";
+		}
+		if (
+			file.allowedOperations !== undefined &&
+			!Array.isArray(file.allowedOperations)
+		) {
+			return "invalid";
+		}
+		if (
+			Array.isArray(file.allowedOperations) &&
+			!file.allowedOperations.includes("remove_comments") &&
+			!file.allowedOperations.includes("comment_cleanup")
+		) {
+			return "invalid";
+		}
+		const resolvedFile = resolveInsideCodeRoot(manifestCodeRoot, file.path);
+		if (!resolvedFile) {
+			return "outside";
+		}
+		const relativePath = relativeToCodeRoot(codeRoot, resolvedFile);
+		if (!relativePath) {
+			return "outside";
+		}
+		if (!isSupportedSourcePath(relativePath)) {
+			continue;
+		}
+		const lines = new Set<number>();
+		if (file.ownedLines !== undefined) {
+			if (
+				!Array.isArray(file.ownedLines) ||
+				!file.ownedLines.every(isPositiveInteger)
+			) {
+				return "invalid";
+			}
+			for (const line of file.ownedLines) {
+				lines.add(line);
+			}
+		}
+		if (file.ownedHunks !== undefined) {
+			if (!Array.isArray(file.ownedHunks)) {
+				return "invalid";
+			}
+			for (const hunk of file.ownedHunks) {
+				if (
+					!isRecord(hunk) ||
+					!isPositiveInteger(hunk.startLine) ||
+					!isPositiveInteger(hunk.endLine) ||
+					hunk.endLine < hunk.startLine
+				) {
+					return "invalid";
+				}
+				addHunk(hunksByPath, relativePath, {
+					startLine: hunk.startLine,
+					endLine: hunk.endLine,
+				});
+				added = true;
+			}
+		}
+		for (const line of lines) {
+			addHunk(hunksByPath, relativePath, { startLine: line, endLine: line });
+			added = true;
+		}
+		if (!lines.size && file.ownedHunks === undefined) {
+			return "invalid";
+		}
+	}
+	return added ? "added" : "skipped";
+};
+
+const collectUntrackedHunks = async (codeRoot: string): Promise<HunkMap> => {
+	const result = await execGitCommandMayFail(
+		["ls-files", "--others", "--exclude-standard", "-z"],
+		codeRoot,
+	)();
+	if (result._tag === "Left" || !result.right.stdout) {
+		return new Map();
+	}
+	const hunksByPath: HunkMap = new Map();
+	for (const filePath of result.right.stdout.split("\0").filter(Boolean)) {
+		await addFullFileHunk(hunksByPath, codeRoot, filePath);
+	}
+	return hunksByPath;
+};
+
+const collectBuildHunks = async (
+	codeRoot: string,
+	baseline: BaselineSnapshot,
+): Promise<HunkMap> => {
+	const hunksByPath: HunkMap = new Map();
+	for (const args of [
+		["diff", "-U0", "--no-color", `${baseline.head}..HEAD`],
+		["diff", "--cached", "-U0", "--no-color"],
+		["diff", "-U0", "--no-color"],
+	] as const) {
+		const result = await execGitCommandMayFail(args, codeRoot)();
+		if (result._tag === "Right" && result.right.stdout) {
+			mergeHunkMaps(
+				hunksByPath,
+				parseUnifiedDiffHunks(result.right.stdout, codeRoot),
+			);
+		}
+	}
+	mergeHunkMaps(hunksByPath, await collectUntrackedHunks(codeRoot));
+	return hunksByPath;
+};
+
+const collectScopeHunks = async (
+	codeRoot: string,
+	scope: string | undefined,
+): Promise<HunkMap | ManifestSkipReason> => {
+	if (!scope || !scope.trim()) {
+		return "invalid_scope";
+	}
+	const hunksByPath: HunkMap = new Map();
+	const resolvedScope = path.isAbsolute(scope)
+		? path.resolve(scope)
+		: path.resolve(codeRoot, scope);
+
+	if (existsSync(resolvedScope)) {
+		const scopeStat = await stat(resolvedScope);
+		if (
+			scopeStat.isFile() &&
+			path.extname(resolvedScope).toLowerCase() === ".json"
+		) {
+			const result = await parseExistingManifestHunks(
+				hunksByPath,
+				codeRoot,
+				resolvedScope,
+			);
+			if (result === "invalid") {
+				return "invalid_scope";
+			}
+			if (result === "outside") {
+				return "scope_outside_code_root";
+			}
+			return hunksByPath;
+		}
+		if (scopeStat.isFile()) {
+			const result = await addFullFileHunk(
+				hunksByPath,
+				codeRoot,
+				resolvedScope,
+			);
+			return result === "outside" ? "scope_outside_code_root" : hunksByPath;
+		}
+		if (scopeStat.isDirectory()) {
+			const result = await addDirectoryHunks(
+				hunksByPath,
+				codeRoot,
+				resolvedScope,
+			);
+			return result === "outside" ? "scope_outside_code_root" : hunksByPath;
+		}
+		return "unsupported_scope";
+	}
+
+	const args = scope.includes("..")
+		? ["diff", "-U0", "--no-color", scope]
+		: ["diff", "-U0", "--no-color", `${scope}...HEAD`];
+	const result = await execGitCommandMayFail(args, codeRoot)();
+	if (result._tag === "Left" || !result.right.success) {
+		return "unsupported_scope";
+	}
+	mergeHunkMaps(
+		hunksByPath,
+		parseUnifiedDiffHunks(result.right.stdout, codeRoot),
+	);
+	return hunksByPath;
+};
+
+export const createBaselineSnapshot = (
+	options: SnapshotOptions,
+): TE.TaskEither<CLIError, SnapshotResult> =>
+	pipe(
+		TE.tryCatch(
+			async () => {
+				const codeRoot = path.resolve(options.codeRoot);
+				const head = await execGitCommand(["rev-parse", "HEAD"], codeRoot)();
+				if (head._tag === "Left") {
+					throw new Error(cliErrorMessage(head.left));
+				}
+				const status = await execGitCommand(
+					["status", "--porcelain", "--untracked-files=normal"],
+					codeRoot,
+				)();
+				if (status._tag === "Left") {
+					throw new Error(cliErrorMessage(status.left));
+				}
+				const snapshot: BaselineSnapshot = {
+					version: CHANGE_MANIFEST_VERSION,
+					codeRoot,
+					head: head.right,
+					dirtyPaths: parseDirtyPaths(status.right),
+					generatedAt: isoNow(options.now),
+				};
+				const snapshotPath = path.resolve(options.out);
+				await writeJson(snapshotPath, snapshot);
+				return {
+					snapshotPath,
+					codeRoot,
+					head: snapshot.head,
+					dirtyPaths: snapshot.dirtyPaths,
+				};
+			},
+			(error) =>
+				runtimeError(
+					`Failed to create change manifest baseline: ${
+						error instanceof Error ? error.message : String(error)
+					}`,
+				),
+		),
+	);
+
+export const generateChangeManifest = (
+	options: GenerateChangeManifestOptions,
+): TE.TaskEither<CLIError, GenerateChangeManifestResult> =>
+	pipe(
+		TE.tryCatch(
+			async () => {
+				const codeRoot = path.resolve(options.codeRoot);
+				const hunksByPath =
+					options.baseline !== undefined
+						? await (async () => {
+								const baseline = await loadBaselineSnapshot(
+									options.baseline,
+									codeRoot,
+								);
+								if (typeof baseline === "string") {
+									return baseline;
+								}
+								return collectBuildHunks(codeRoot, baseline).then((hunks) => ({
+									hunks,
+									baseline,
+								}));
+							})()
+						: await collectScopeHunks(codeRoot, options.scope);
+
+				if (typeof hunksByPath === "string") {
+					return recordSkip(options, codeRoot, hunksByPath);
+				}
+
+				const baseline =
+					"hunks" in hunksByPath ? hunksByPath.baseline : undefined;
+				const hunkMap =
+					"hunks" in hunksByPath ? hunksByPath.hunks : hunksByPath;
+				const files = buildManifestFiles(hunkMap);
+
+				if (baseline) {
+					const overlappedDirtyPaths = baseline.dirtyPaths.filter((dirtyPath) =>
+						files.some((file) =>
+							dirtyPathOverlapsCandidate(dirtyPath, file.path),
+						),
+					);
+					if (overlappedDirtyPaths.length > 0) {
+						return recordSkip(
+							options,
+							codeRoot,
+							"pre_existing_dirty_paths_overlap",
+							{
+								dirtyPaths: baseline.dirtyPaths,
+								overlappedDirtyPaths,
+							},
+						);
+					}
+					if (files.length === 0) {
+						return recordSkip(options, codeRoot, "no_supported_source_hunks", {
+							dirtyPaths: baseline.dirtyPaths,
+						});
+					}
+					return recordCreated(options, codeRoot, files, baseline.dirtyPaths);
+				}
+
+				if (files.length === 0) {
+					return recordSkip(options, codeRoot, "no_supported_source_hunks");
+				}
+				return recordCreated(options, codeRoot, files);
+			},
+			(error) =>
+				runtimeError(
+					`Failed to generate change manifest: ${
+						error instanceof Error ? error.message : String(error)
+					}`,
+				),
+		),
+	);

--- a/cli/src/agent-tools/change-manifest/index.ts
+++ b/cli/src/agent-tools/change-manifest/index.ts
@@ -1,0 +1,292 @@
+import { stat } from "node:fs/promises";
+import path from "node:path";
+import * as E from "fp-ts/lib/Either.js";
+import type * as TE from "fp-ts/lib/TaskEither.js";
+import type { CLIError } from "../../../shared/errors.js";
+import { parseError } from "../../../shared/errors.js";
+import { registerTool, type ToolOptions } from "../index.js";
+import type { ToolResult } from "../models.js";
+import { errorResult, successResult } from "../output.js";
+import {
+	createBaselineSnapshot,
+	generateChangeManifest,
+	parseUnifiedDiffHunks,
+} from "./generator.js";
+import {
+	CHANGE_MANIFEST_SOURCES,
+	type ChangeManifestSource,
+	type GenerateChangeManifestOptions,
+	type GenerateChangeManifestResult,
+	type SnapshotOptions,
+	type SnapshotResult,
+} from "./models.js";
+
+const TOOL_NAME = "change-manifest";
+
+type ChangeManifestToolData =
+	| SnapshotResult
+	| GenerateChangeManifestResult
+	| null;
+
+type ChangeManifestToolResult = ToolResult<ChangeManifestToolData>;
+
+interface SnapshotCommandInput {
+	readonly codeRoot?: unknown;
+	readonly out?: unknown;
+}
+
+interface GenerateCommandInput {
+	readonly codeRoot?: unknown;
+	readonly out?: unknown;
+	readonly statusOut?: unknown;
+	readonly source?: unknown;
+	readonly baseline?: unknown;
+	readonly scope?: unknown;
+}
+
+interface RegistryCommandInput
+	extends SnapshotCommandInput,
+		GenerateCommandInput {
+	readonly command?: unknown;
+	readonly action?: unknown;
+}
+
+const validationError = (message: string): ChangeManifestToolResult =>
+	errorResult(TOOL_NAME, null, [{ message }]);
+
+const isNonEmptyString = (value: unknown): value is string =>
+	typeof value === "string" && value.trim().length > 0;
+
+const requiredString = (
+	value: unknown,
+	flag: string,
+): E.Either<ChangeManifestToolResult, string> => {
+	if (!isNonEmptyString(value)) {
+		return E.left(validationError(`${flag} is required`));
+	}
+	return E.right(value.trim());
+};
+
+const normalizeCodeRoot = async (
+	value: unknown,
+): Promise<E.Either<ChangeManifestToolResult, string>> => {
+	const parsed = requiredString(value, "--code-root");
+	if (E.isLeft(parsed)) {
+		return parsed;
+	}
+
+	const codeRoot = path.resolve(parsed.right);
+	try {
+		const codeRootStat = await stat(codeRoot);
+		if (!codeRootStat.isDirectory()) {
+			return E.left(
+				validationError(`--code-root must be a directory: ${codeRoot}`),
+			);
+		}
+		return E.right(codeRoot);
+	} catch {
+		return E.left(validationError(`--code-root does not exist: ${codeRoot}`));
+	}
+};
+
+const normalizeOutputPath = (
+	value: unknown,
+	flag: string,
+): E.Either<ChangeManifestToolResult, string> => {
+	const parsed = requiredString(value, flag);
+	if (E.isLeft(parsed)) {
+		return parsed;
+	}
+	return E.right(path.resolve(parsed.right));
+};
+
+const isChangeManifestSource = (value: string): value is ChangeManifestSource =>
+	(CHANGE_MANIFEST_SOURCES as readonly string[]).includes(value);
+
+const normalizeSource = (
+	value: unknown,
+): E.Either<ChangeManifestToolResult, ChangeManifestSource> => {
+	const parsed = requiredString(value, "--source");
+	if (E.isLeft(parsed)) {
+		return parsed;
+	}
+	if (!isChangeManifestSource(parsed.right)) {
+		return E.left(
+			validationError(
+				`--source must be one of: ${CHANGE_MANIFEST_SOURCES.join(", ")}`,
+			),
+		);
+	}
+	return E.right(parsed.right);
+};
+
+const optionalString = (value: unknown): string | undefined =>
+	isNonEmptyString(value) ? value.trim() : undefined;
+
+const normalizeSnapshotInput = async (
+	input: SnapshotCommandInput,
+): Promise<E.Either<ChangeManifestToolResult, SnapshotOptions>> => {
+	const codeRoot = await normalizeCodeRoot(input.codeRoot);
+	if (E.isLeft(codeRoot)) {
+		return codeRoot;
+	}
+	const out = normalizeOutputPath(input.out, "--out");
+	if (E.isLeft(out)) {
+		return out;
+	}
+	return E.right({ codeRoot: codeRoot.right, out: out.right });
+};
+
+const normalizeGenerateInput = async (
+	input: GenerateCommandInput,
+): Promise<
+	E.Either<ChangeManifestToolResult, GenerateChangeManifestOptions>
+> => {
+	const codeRoot = await normalizeCodeRoot(input.codeRoot);
+	if (E.isLeft(codeRoot)) {
+		return codeRoot;
+	}
+	const out = normalizeOutputPath(input.out, "--out");
+	if (E.isLeft(out)) {
+		return out;
+	}
+	const statusOut = normalizeOutputPath(input.statusOut, "--status-out");
+	if (E.isLeft(statusOut)) {
+		return statusOut;
+	}
+	const source = normalizeSource(input.source);
+	if (E.isLeft(source)) {
+		return source;
+	}
+
+	const baseline = optionalString(input.baseline);
+	const scope = optionalString(input.scope);
+	if ((baseline === undefined) === (scope === undefined)) {
+		return E.left(validationError("Use exactly one of --baseline or --scope"));
+	}
+	if (source.right === "code-clean-comments" && scope === undefined) {
+		return E.left(
+			validationError("--scope is required for source code-clean-comments"),
+		);
+	}
+	if (source.right !== "code-clean-comments" && baseline === undefined) {
+		return E.left(
+			validationError(`--baseline is required for source ${source.right}`),
+		);
+	}
+
+	return E.right({
+		codeRoot: codeRoot.right,
+		out: out.right,
+		statusOut: statusOut.right,
+		source: source.right,
+		...(baseline ? { baseline: path.resolve(baseline) } : {}),
+		...(scope ? { scope } : {}),
+	});
+};
+
+export const executeChangeManifestSnapshot =
+	(
+		input: SnapshotCommandInput,
+	): TE.TaskEither<CLIError, ChangeManifestToolResult> =>
+	async () => {
+		const normalized = await normalizeSnapshotInput(input);
+		if (E.isLeft(normalized)) {
+			return E.right(normalized.left);
+		}
+
+		const result = await createBaselineSnapshot(normalized.right)();
+		if (E.isLeft(result)) {
+			return result;
+		}
+
+		return E.right(successResult(TOOL_NAME, result.right));
+	};
+
+export const executeGenerateChangeManifest =
+	(
+		input: GenerateCommandInput,
+	): TE.TaskEither<CLIError, ChangeManifestToolResult> =>
+	async () => {
+		const normalized = await normalizeGenerateInput(input);
+		if (E.isLeft(normalized)) {
+			return E.right(normalized.left);
+		}
+
+		const result = await generateChangeManifest(normalized.right)();
+		if (E.isLeft(result)) {
+			return result;
+		}
+
+		return E.right(successResult(TOOL_NAME, result.right));
+	};
+
+const parseInput = (
+	input: string,
+): E.Either<CLIError, RegistryCommandInput> => {
+	let parsed: unknown;
+	try {
+		parsed = input.trim() ? JSON.parse(input) : {};
+	} catch {
+		return E.left(parseError("stdin", "Invalid JSON input"));
+	}
+
+	if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+		return E.left(parseError("stdin", "Input must be a JSON object"));
+	}
+
+	return E.right(parsed as RegistryCommandInput);
+};
+
+const execute =
+	(
+		input: string,
+		_options: ToolOptions,
+	): TE.TaskEither<CLIError, ChangeManifestToolResult> =>
+	async () => {
+		const parsed = parseInput(input);
+		if (E.isLeft(parsed)) {
+			return parsed;
+		}
+
+		const command =
+			optionalString(parsed.right.command) ??
+			optionalString(parsed.right.action);
+		if (command === "snapshot") {
+			return executeChangeManifestSnapshot(parsed.right)();
+		}
+		if (command === "generate") {
+			return executeGenerateChangeManifest(parsed.right)();
+		}
+
+		return E.right(
+			validationError("command must be one of: snapshot, generate"),
+		);
+	};
+
+registerTool({
+	name: TOOL_NAME,
+	description: "Create cleanup change manifests from repository evidence",
+	execute,
+});
+
+export {
+	CHANGE_MANIFEST_SOURCES,
+	createBaselineSnapshot,
+	generateChangeManifest,
+	parseUnifiedDiffHunks,
+	TOOL_NAME,
+};
+export type {
+	BaselineSnapshot,
+	ChangeManifest,
+	ChangeManifestFile,
+	ChangeManifestHunk,
+	ChangeManifestSource,
+	GenerateChangeManifestOptions,
+	GenerateChangeManifestResult,
+	ManifestSkipReason,
+	ManifestStatus,
+	SnapshotOptions,
+	SnapshotResult,
+} from "./models.js";

--- a/cli/src/agent-tools/change-manifest/models.ts
+++ b/cli/src/agent-tools/change-manifest/models.ts
@@ -1,0 +1,94 @@
+export const CHANGE_MANIFEST_VERSION = 1;
+
+export const CHANGE_MANIFEST_SOURCES = [
+	"build",
+	"build-fast",
+	"code-clean-comments",
+] as const;
+
+export type ChangeManifestSource = (typeof CHANGE_MANIFEST_SOURCES)[number];
+
+export type ManifestStatusValue = "created" | "skipped";
+
+export type ManifestSkipReason =
+	| "baseline_code_root_mismatch"
+	| "invalid_baseline"
+	| "invalid_scope"
+	| "missing_baseline"
+	| "no_supported_source_hunks"
+	| "pre_existing_dirty_paths_overlap"
+	| "scope_outside_code_root"
+	| "unsupported_scope";
+
+export interface ChangeManifestHunk {
+	readonly startLine: number;
+	readonly endLine: number;
+}
+
+export interface ChangeManifestFile {
+	readonly path: string;
+	readonly ownedHunks: readonly ChangeManifestHunk[];
+	readonly allowedOperations: readonly ["remove_comments"];
+}
+
+export interface ChangeManifest {
+	readonly version: typeof CHANGE_MANIFEST_VERSION;
+	readonly source: ChangeManifestSource;
+	readonly codeRoot: string;
+	readonly generatedAt: string;
+	readonly files: readonly ChangeManifestFile[];
+}
+
+export interface BaselineSnapshot {
+	readonly version: typeof CHANGE_MANIFEST_VERSION;
+	readonly codeRoot: string;
+	readonly head: string;
+	readonly dirtyPaths: readonly string[];
+	readonly generatedAt: string;
+}
+
+export interface ManifestStatus {
+	readonly version: typeof CHANGE_MANIFEST_VERSION;
+	readonly status: ManifestStatusValue;
+	readonly source: ChangeManifestSource;
+	readonly codeRoot: string;
+	readonly generatedAt: string;
+	readonly manifestPath: string | null;
+	readonly files: number;
+	readonly ownedLineCount: number;
+	readonly skipReason: ManifestSkipReason | null;
+	readonly dirtyPaths?: readonly string[];
+	readonly overlappedDirtyPaths?: readonly string[];
+}
+
+export interface SnapshotOptions {
+	readonly codeRoot: string;
+	readonly out: string;
+	readonly now?: () => Date;
+}
+
+export interface SnapshotResult {
+	readonly snapshotPath: string;
+	readonly codeRoot: string;
+	readonly head: string;
+	readonly dirtyPaths: readonly string[];
+}
+
+export interface GenerateChangeManifestOptions {
+	readonly codeRoot: string;
+	readonly out: string;
+	readonly statusOut: string;
+	readonly source: ChangeManifestSource;
+	readonly baseline?: string;
+	readonly scope?: string;
+	readonly now?: () => Date;
+}
+
+export interface GenerateChangeManifestResult {
+	readonly status: ManifestStatusValue;
+	readonly manifestPath: string | null;
+	readonly statusPath: string;
+	readonly files: number;
+	readonly ownedLineCount: number;
+	readonly skipReason: ManifestSkipReason | null;
+}

--- a/cli/src/agent-tools/command.ts
+++ b/cli/src/agent-tools/command.ts
@@ -7,6 +7,11 @@ import { Command } from "commander";
 import * as E from "fp-ts/lib/Either.js";
 import { formatError, usageError } from "../../shared/errors.js";
 import { VALID_EVENT_TYPES } from "../../shared/events.js";
+import {
+	CHANGE_MANIFEST_SOURCES,
+	executeChangeManifestSnapshot,
+	executeGenerateChangeManifest,
+} from "./change-manifest/index.js";
 import { executeExtract } from "./comment-extract/index.js";
 import {
 	closeDatabase as closeEmitDatabase,
@@ -123,6 +128,7 @@ Available Tools:
   resolve-args      Resolve structured arguments from schema, settings, and user input
   rp1-root-dir      Resolve project, KB, and work directories with worktree detection
   workflow-bootstrap Resolve canonical tracked-workflow bootstrap context and run selection
+  change-manifest  Create cleanup manifests from repository change evidence
   comment-extract   Extract comments from git-changed files
   emit              Record events for the rp1 workflow event system
   feedback          Read, resolve, reply to, and accept feedback from the Arcade
@@ -136,6 +142,8 @@ Examples:
   cat diagram.mmd | rp1 agent-tools mmd-validate
   echo "graph TD; A-->B" | rp1 agent-tools mmd-validate
   rp1 agent-tools rp1-root-dir
+  rp1 agent-tools change-manifest snapshot --code-root . --out .rp1/work/features/example/change-manifest-baseline.json
+  rp1 agent-tools change-manifest generate --code-root . --out .rp1/work/features/example/change-manifest-001.json --status-out .rp1/work/features/example/change-manifest-status.json --source build --baseline .rp1/work/features/example/change-manifest-baseline.json
   rp1 agent-tools comment-extract branch main
   rp1 agent-tools comment-extract unstaged main
   echo '{"owner":"org","repo":"repo","pr_number":123}' | rp1 agent-tools github-pr fetch-comments
@@ -650,6 +658,138 @@ Examples:
 				}),
 				{ inputSource: "stdin" },
 			)();
+
+			if (E.isLeft(result)) {
+				console.error(
+					createErrorResponse(toolName, formatError(result.left, false)),
+				);
+				process.exit(1);
+			}
+
+			console.log(formatOutput(result.right));
+			process.exit(result.right.success ? 0 : 1);
+		},
+	);
+
+/**
+ * change-manifest subcommand.
+ * Creates durable cleanup manifests from repository evidence.
+ */
+const changeManifestCommand = agentToolsCommand
+	.command("change-manifest")
+	.description("Create cleanup manifests from repository change evidence")
+	.addHelpText(
+		"after",
+		`
+Subcommands:
+  snapshot    Record the starting repository state for build-owned cleanup
+  generate    Create or skip a cleanup manifest from a baseline or user scope
+
+Examples:
+  rp1 agent-tools change-manifest snapshot --code-root . --out .rp1/work/features/example/change-manifest-baseline.json
+  rp1 agent-tools change-manifest generate --code-root . --out .rp1/work/features/example/change-manifest-001.json --status-out .rp1/work/features/example/change-manifest-status.json --source build --baseline .rp1/work/features/example/change-manifest-baseline.json
+`,
+	);
+
+changeManifestCommand
+	.command("snapshot")
+	.description("Record baseline HEAD and dirty paths")
+	.requiredOption("--code-root <path>", "Repository source root")
+	.requiredOption("--out <path>", "Baseline snapshot JSON path")
+	.addHelpText(
+		"after",
+		`
+Description:
+  Records the current HEAD and dirty paths for later manifest generation.
+
+Output:
+  JSON ToolResult with snapshotPath, codeRoot, head, and dirtyPaths.
+
+Example:
+  rp1 agent-tools change-manifest snapshot \\
+    --code-root . \\
+    --out .rp1/work/features/example/change-manifest-baseline.json
+`,
+	)
+	.action(async (options: { codeRoot: string; out: string }): Promise<void> => {
+		const toolName = "change-manifest";
+		const result = await executeChangeManifestSnapshot({
+			codeRoot: options.codeRoot,
+			out: options.out,
+		})();
+
+		if (E.isLeft(result)) {
+			console.error(
+				createErrorResponse(toolName, formatError(result.left, false)),
+			);
+			process.exit(1);
+		}
+
+		console.log(formatOutput(result.right));
+		process.exit(result.right.success ? 0 : 1);
+	});
+
+changeManifestCommand
+	.command("generate")
+	.description("Create or skip a cleanup manifest")
+	.requiredOption("--code-root <path>", "Repository source root")
+	.requiredOption("--out <path>", "Change manifest JSON path")
+	.requiredOption("--status-out <path>", "Manifest status JSON path")
+	.requiredOption(
+		"--source <source>",
+		`Manifest source (${CHANGE_MANIFEST_SOURCES.join(", ")})`,
+	)
+	.option("--baseline <path>", "Baseline snapshot path for build-owned changes")
+	.option("--scope <scope>", "User cleanup scope for code-clean-comments")
+	.addHelpText(
+		"after",
+		`
+Description:
+  Generates a manifest from either a build baseline or a code-clean-comments
+  user scope. Skipped outcomes still write --status-out with the reason.
+
+Options:
+  --baseline <path>   Required for source build or build-fast
+  --scope <scope>     Required for source code-clean-comments
+
+Output:
+  JSON ToolResult with status, manifestPath, statusPath, files,
+  ownedLineCount, and skipReason.
+
+Examples:
+  rp1 agent-tools change-manifest generate \\
+    --code-root . \\
+    --out .rp1/work/features/example/change-manifest-001.json \\
+    --status-out .rp1/work/features/example/change-manifest-status.json \\
+    --source build \\
+    --baseline .rp1/work/features/example/change-manifest-baseline.json
+
+  rp1 agent-tools change-manifest generate \\
+    --code-root . \\
+    --out .rp1/work/comment-cleanup/change-manifest-001.json \\
+    --status-out .rp1/work/comment-cleanup/change-manifest-status.json \\
+    --source code-clean-comments \\
+    --scope src/
+`,
+	)
+	.action(
+		async (options: {
+			codeRoot: string;
+			out: string;
+			statusOut: string;
+			source: string;
+			baseline?: string;
+			scope?: string;
+		}): Promise<void> => {
+			const toolName = "change-manifest";
+			const result = await executeGenerateChangeManifest({
+				codeRoot: options.codeRoot,
+				out: options.out,
+				statusOut: options.statusOut,
+				source: options.source,
+				baseline: options.baseline,
+				scope: options.scope,
+			})();
 
 			if (E.isLeft(result)) {
 				console.error(

--- a/cli/src/agent-tools/comment-extract/patterns.ts
+++ b/cli/src/agent-tools/comment-extract/patterns.ts
@@ -1,7 +1,4 @@
-/**
- * Comment pattern definitions for various programming languages.
- * Maps file extensions to single-line and multi-line comment patterns.
- */
+import path from "node:path";
 
 /**
  * Comment pattern configuration for a file type.
@@ -69,10 +66,47 @@ export const PATTERNS: Readonly<Record<string, CommentPatterns>> = {
 	".php": { single: [/\/\//, /#/], multi: [[/\/\*/, /\*\//]] },
 };
 
+export const SUPPORTED_SOURCE_EXTENSIONS: readonly string[] =
+	Object.keys(PATTERNS);
+
+export const EXCLUDED_SOURCE_DIRECTORIES: readonly string[] = [
+	".git",
+	".next",
+	".rp1",
+	"build",
+	"coverage",
+	"dist",
+	"node_modules",
+	"vendor",
+];
+
+export const PROTECTED_GENERATED_SOURCE_PATHS: readonly string[] = [
+	"catalog/agents.yaml",
+	"cli/src/init/templates/generated.ts",
+];
+
+const normalizeRelativePath = (filePath: string): string =>
+	filePath.replace(/\\/g, "/").split(path.sep).join("/").replace(/^\.\//, "");
+
 /**
  * Check if a file extension is supported.
  */
 export const isSupportedExtension = (ext: string): boolean => ext in PATTERNS;
+
+export const isProtectedGeneratedPath = (filePath: string): boolean =>
+	PROTECTED_GENERATED_SOURCE_PATHS.includes(normalizeRelativePath(filePath));
+
+export const isExcludedSourcePath = (filePath: string): boolean => {
+	const segments = normalizeRelativePath(filePath).split("/");
+	return segments.some((segment) =>
+		EXCLUDED_SOURCE_DIRECTORIES.includes(segment),
+	);
+};
+
+export const isSupportedSourcePath = (filePath: string): boolean =>
+	isSupportedExtension(path.extname(filePath).toLowerCase()) &&
+	!isExcludedSourcePath(filePath) &&
+	!isProtectedGeneratedPath(filePath);
 
 /**
  * Get patterns for a file extension.

--- a/docs/reference/dev/build-fast.md
+++ b/docs/reference/dev/build-fast.md
@@ -36,6 +36,11 @@ Every invocation starts a fresh tracked run. Implementation changes happen in
 your current checkout, while workflow artifacts are stored under the canonical
 project work root. Use `--git-*` flags to enable commits or pushing.
 
+`build-fast` also snapshots the repository before implementation and resolves
+automatic comment cleanup through a generated change manifest after
+implementation and optional review. Cleanup runs only when that manifest is
+created and non-empty.
+
 This command uses the [skill-agent pattern](../../concepts/command-agent-pattern.md)
 with scope gating and AFK mode support.
 
@@ -235,8 +240,8 @@ planning, build, and review/finalization:
 |------|---------------|
 | Bootstrap | Resolves canonical `projectRoot`, `kbRoot`, and `workRoot`, then creates a new `build-fast` run. Unlike `/build`, `build-fast` never resumes an earlier run. |
 | Plan | Loads KB context, assesses scope, creates a quick-build artifact for Small/Medium requests, and optionally pauses for plan confirmation. Large single-feature requests stop here with a redirect to `/build`; initiative-sized requests stop here with a redirect to `/phase-plan`. |
-| Build | Delegates the planned work to `task-builder` using the quick-build artifact as the source of truth. |
-| Review / Finalize | Optionally runs `task-reviewer`, retries once on failure, optionally pushes, and optionally pauses for a post-implementation checkpoint before final output. |
+| Build | Snapshots the cleanup baseline, then delegates the planned work to `task-builder` using the quick-build artifact as the source of truth. |
+| Review / Finalize | Optionally runs `task-reviewer`, retries once on failure, generates the cleanup manifest, runs manifest-gated cleanup when safe, optionally pushes, and optionally pauses for a post-implementation checkpoint before final output. |
 
 ## KB Loading
 
@@ -279,6 +284,34 @@ This file is the workflow's source of truth and includes:
 - Task checklist for `task-builder`
 - Implementation summary
 - Verification notes (when review is enabled)
+
+### Comment Cleanup Output
+
+For Small and Medium requests, `build-fast` writes cleanup artifacts next to the
+quick-build artifact:
+
+- `{RUN_ID}-change-manifest-baseline.json` - repository state before
+  `task-builder` runs
+- `{RUN_ID}-change-manifest-001.json` - cleanup-owned files and line ranges,
+  when generated
+- `{RUN_ID}-change-manifest-status.json` - created/skipped status, file counts,
+  owned-line counts, dirty-path metadata, and skip reason
+
+The final output includes:
+
+| Field | Meaning |
+|-------|---------|
+| `Comment Cleanup` | Cleaner status, or `WARN` when cleanup was skipped before dispatch |
+| `Cleanup Manifest` | Generated manifest path, or `None` when skipped |
+| `Cleanup Status` | Status artifact path for created and skipped outcomes |
+| `Cleanup Skip Reason` | `None` when cleanup ran, otherwise the fail-closed reason |
+
+Common skip reasons include `no_supported_source_hunks`,
+`pre_existing_dirty_paths_overlap`, `missing_baseline`,
+`invalid_baseline`, `baseline_code_root_mismatch`,
+`scope_outside_code_root`, `invalid_scope`, and `unsupported_scope`.
+`build-fast` never asks `comment-cleaner` to infer scope from branch names,
+commit ranges, dirty labels, or task-builder-authored hunks.
 
 ### Large and Initiative Redirects
 

--- a/docs/reference/dev/build.md
+++ b/docs/reference/dev/build.md
@@ -42,6 +42,7 @@ new tracker or milestone artifacts.
 - **Safe defaults**: No git operations unless explicitly requested via flags
 - **Opt-in git operations**: Use `--git-*` flags for commit, push, PR
 - **Builder-reviewer architecture**: Quality-gated implementation with feedback loops
+- **Manifest-gated cleanup**: Automatic comment cleanup runs only from a generated change manifest
 
 ## Parameters
 
@@ -81,6 +82,37 @@ The command orchestrates these steps:
 | 4.1 User Review | Manual verification checkpoint | User decision |
 | 5. Follow-up | Add more work if needed | Loops to Build |
 | 6. Archive | Store completed feature | Archived artifacts |
+
+### Manifest-Gated Comment Cleanup
+
+During the build step, `/build` snapshots the repository state before the
+first `task-builder` unit runs. After builders, reviewers, doc tasks, and any
+checkpoint-added tasks finish, it generates the cleanup handoff before verify.
+
+The feature work directory can contain:
+
+- `change-manifest-baseline.json` - build-start `CODE_ROOT`, `HEAD`, and dirty
+  paths
+- `change-manifest-001.json` - cleanup-owned files and line ranges, when
+  supported changes are safe to classify
+- `change-manifest-status.json` - created/skipped status, file counts,
+  owned-line counts, dirty-path metadata, and skip reason
+
+Verify dispatches `comment-cleaner` only when the generated manifest is
+`created` and non-empty. The cleaner receives only `CHANGE_MANIFEST` and
+`CODE_ROOT`; `/build` does not pass branch names, commit ranges, dirty-state
+labels, or task-builder-authored hunks as cleanup scope.
+
+If manifest generation skips, verify records a warning result with
+`files_checked: 0`, the status artifact path, and the skip reason. Common skip
+reasons include `no_supported_source_hunks`,
+`pre_existing_dirty_paths_overlap`, `missing_baseline`,
+`invalid_baseline`, `baseline_code_root_mismatch`,
+`scope_outside_code_root`, `invalid_scope`, and `unsupported_scope`.
+
+Task builders do not calculate, merge, create, or hand off comment cleanup
+manifests. Review the generated manifest and status artifacts to audit why a
+file or line range was eligible for automatic cleanup.
 
 ### Oversized Scope Redirect
 
@@ -315,6 +347,9 @@ worktree, rp1 still uses the owning repository's canonical work root.
 - `tasks.md` - Implementation tasks
 - `verification-report.md` - Verification results
 - `field-notes.md` - Implementation notes (if any)
+- `change-manifest-baseline.json` - build-start cleanup baseline
+- `change-manifest-001.json` - generated cleanup boundary, when created
+- `change-manifest-status.json` - cleanup manifest status and skip reason
 
 ## Related Commands
 

--- a/docs/reference/dev/code-clean-comments.md
+++ b/docs/reference/dev/code-clean-comments.md
@@ -27,15 +27,44 @@ Removes unnecessary comments from a scoped set of code changes while preserving 
 
 **Scope Options:**
 
-- `<file>` - A single file under `code-root`
-- `<directory>` - Supported code files under a directory
-- `<git-ref>` - Changes from the ref to `HEAD`
-- `<commit-range>` - Any valid git commit range (e.g., `HEAD~5..HEAD`, `abc123..def456`)
-- `<change-manifest.json>` - Existing manifest to validate and reuse
+- `<file>` - Generate a full-file manifest for one supported source file under
+  `code-root`
+- `<directory>` - Generate a manifest for supported source files under a
+  directory, excluding generated and dependency paths
+- `<git-ref>` - Generate a manifest from changes between the ref and `HEAD`
+- `<commit-range>` - Generate a manifest from any valid git commit range
+  (for example, `HEAD~5..HEAD` or `abc123..def456`)
+- `<change-manifest.json>` - Validate and reuse an existing manifest as the
+  cleanup boundary
 
 ## Description
 
-The `code-clean-comments` command first resolves the requested scope into a durable `change-manifest-*.json` artifact, then invokes the comment-cleaner agent with only `CHANGE_MANIFEST` and `CODE_ROOT`. The cleaner itself does not accept branch-wide or unstaged cleanup parameters directly.
+The `code-clean-comments` command first resolves the requested scope into a
+durable `change-manifest-*.json` artifact with
+`rp1 agent-tools change-manifest generate --source code-clean-comments`. It
+then invokes the comment-cleaner agent only when the manifest is created and
+non-empty.
+
+The cleaner receives only `CHANGE_MANIFEST` and `CODE_ROOT`. It does not accept
+branch-wide, unstaged, dirty-state, or commit-range cleanup parameters
+directly; those inputs must be converted into a manifest before cleanup can
+edit files.
+
+### Generated Artifacts
+
+Artifacts are written under the canonical work root:
+
+- `.rp1/work/comment-clean-comments/change-manifest-001.json` - cleanup-owned
+  files and line ranges, when generated
+- `.rp1/work/comment-clean-comments/change-manifest-status-001.json` -
+  created/skipped status, file counts, owned-line counts, and skip reason
+
+The number increments when either artifact already exists.
+
+If generation skips, no cleaner is dispatched. Common skip reasons include
+`no_supported_source_hunks`, `scope_outside_code_root`, `invalid_scope`, and
+`unsupported_scope`. Invalid, missing, empty, or outside-root manifests fail
+closed rather than widening cleanup authority.
 
 ## What's Preserved
 
@@ -97,6 +126,7 @@ Files scanned: 45
 Comments removed: 23
 Comments preserved: 67
 Manifest: .rp1/work/comment-clean-comments/change-manifest-001.json
+Manifest status: .rp1/work/comment-clean-comments/change-manifest-status-001.json
 
 Changes:
 - src/utils/helpers.ts: Removed 5 obvious comments
@@ -104,6 +134,17 @@ Changes:
 - src/models/user.ts: Removed 2 redundant docstrings
 
 Note: Run code-check to verify no issues introduced
+```
+
+**Skipped output includes:**
+
+```
+Comment Cleanup Skipped
+
+Scope: .
+Manifest: None
+Status: .rp1/work/comment-clean-comments/change-manifest-status-001.json
+Skip reason: no_supported_source_hunks
 ```
 
 ## Related Commands

--- a/evals/attestation.json
+++ b/evals/attestation.json
@@ -3,37 +3,37 @@
   "skills": {
     "rp1-dev:build@claude-code": {
       "platform": "claude-code",
-      "prompt_hash": "sha256:82c8a163f8c8b7e13593714e0ec0914abcab30878f771a77ab2f949991286c7e",
-      "deps_hash": "sha256:5044e6a03ebf54c9c40e480cdae1469a6bc4f1b4adb3f39a031bd727b1bcd465",
+      "prompt_hash": "sha256:b20f1c3e818542d18a696a8a2a3169f0638eb945658909bb2a4a231f7555b147",
+      "deps_hash": "sha256:4d7663a65e9649f8670d0ada86a520cf6ddf1e5f3b111cbcf2a14e7a6634020d",
       "version": "3.0.0",
       "last_eval": {
         "passed": true,
         "timestamp": "2026-04-26T09:06:33.843Z",
-        "git_commit": "1b4765f0",
+        "git_commit": "4dbbac41",
         "result_file": "output/rp1-dev-build.json"
       }
     },
     "rp1-dev:build-fast@claude-code": {
       "platform": "claude-code",
-      "prompt_hash": "sha256:8ac16f84d13604cdd316f5910aec96cba8c98624d322beb58ff23427364c7614",
-      "deps_hash": "sha256:d0f505d698df715f6c9aeddea710c83c4d93f6094e5c39c4556d5c333312ed9a",
+      "prompt_hash": "sha256:1f7931228884c8a56b7c35a282232bf46b7bdeb5b4aae777523b2330822b2eba",
+      "deps_hash": "sha256:6ae94dcb1a896d17a9c87812007ce735dfda9472476c8779159c287477607eeb",
       "version": "3.0.0",
       "last_eval": {
         "passed": true,
         "timestamp": "2026-04-26T08:40:58.447Z",
-        "git_commit": "219e0487",
+        "git_commit": "4dbbac41",
         "result_file": "output/rp1-dev-build-fast.json"
       }
     },
     "rp1-dev:speedrun@claude-code": {
       "platform": "claude-code",
-      "prompt_hash": "sha256:bd01b6c7cbad5cd815134e9bcd2c83697790b0903191f6734b92c7decda01911",
-      "deps_hash": "sha256:f58c23b6c2a089cbec2d22efa5b133508ca0749ba6e732d24bff257f66e32772",
+      "prompt_hash": "sha256:92e3e3639261d1f567c0defc43cd8e34340b88c404e1f67b3ec43f48936961ab",
+      "deps_hash": "sha256:829b5149c42a522bdba01a672002e07b9d2ae1b083bdf94b212942f5baa76160",
       "version": "1.1.0",
       "last_eval": {
         "passed": true,
         "timestamp": "2026-04-26T07:22:06.417Z",
-        "git_commit": "a7441f7e",
+        "git_commit": "4dbbac41",
         "result_file": "output/rp1-dev-speedrun.json"
       }
     }
@@ -77,13 +77,13 @@
     "cli/dist/claude-code/dev/agents/comment-cleaner.md": "sha256:800dae18626e99a3bb049d49c70c63866dd2e43b3d1e68c70f3a59b62b4a4465",
     "cli/dist/claude-code/dev/agents/build-verify-aggregator.md": "sha256:1795be632e3e27765c48c3a7a2ec0cdd8bb973250c56ab6021276614101b86bc",
     "cli/dist/claude-code/dev/agents/feature-archiver.md": "sha256:f42c24e35090a6d8b2d44bef8d71064ec736bda289f8e263e9e61430448d9b4d",
-    "dist/claude-code/dev/skills/build-fast/SKILL.md": "sha256:8ac16f84d13604cdd316f5910aec96cba8c98624d322beb58ff23427364c7614",
+    "dist/claude-code/dev/skills/build-fast/SKILL.md": "sha256:1f7931228884c8a56b7c35a282232bf46b7bdeb5b4aae777523b2330822b2eba",
     "dist/claude-code/dev/agents/build-fast-planner.md": "sha256:63db9545cd45d985f7f3333aa7c11bacf0f10e9930b0ac8bfb51de1b52e0e115",
-    "dist/claude-code/dev/agents/task-builder.md": "sha256:1a1e232075937bed29e3f07008ad4fe73006a4817240fde156ad663c5f1fa656",
+    "dist/claude-code/dev/agents/task-builder.md": "sha256:fc1ac8ed7c69a1234a51402fca3a1bc0f26cbd621f921581358e8f9ac2ca9d75",
     "dist/claude-code/dev/agents/task-reviewer.md": "sha256:88e23dc5e3a0123f191ee456a0b8328f64612f4f308db35b7118281c31e77be6",
-    "dist/claude-code/dev/skills/speedrun/SKILL.md": "sha256:bd01b6c7cbad5cd815134e9bcd2c83697790b0903191f6734b92c7decda01911",
+    "dist/claude-code/dev/skills/speedrun/SKILL.md": "sha256:92e3e3639261d1f567c0defc43cd8e34340b88c404e1f67b3ec43f48936961ab",
     "dist/claude-code/dev/agents/speedrun-builder.md": "sha256:56c1e35239bf39f964a5dd9d32a78a91b6083475dfb0d042861c8523e0da2d87",
-    "dist/claude-code/dev/skills/build/SKILL.md": "sha256:82c8a163f8c8b7e13593714e0ec0914abcab30878f771a77ab2f949991286c7e",
+    "dist/claude-code/dev/skills/build/SKILL.md": "sha256:b20f1c3e818542d18a696a8a2a3169f0638eb945658909bb2a4a231f7555b147",
     "dist/claude-code/dev/agents/build-artifact-detector.md": "sha256:a03ad12988346655af60da11117cb05b2179d7eb3f21d25ad5be5455444b0a4f",
     "dist/claude-code/dev/agents/feature-requirement-gatherer.md": "sha256:a284b096990dc4c625b5ce3e946c29dd975bac2956699bd573fcbad942eb79f9",
     "dist/claude-code/dev/agents/feature-architect.md": "sha256:7b4bd6b2e0e584fa4636b261c19b00a9adffac86f021f1d9df60a24af940516a",

--- a/plugins/base/skills/code-comments/SKILL.md
+++ b/plugins/base/skills/code-comments/SKILL.md
@@ -41,6 +41,10 @@ Activate this skill when:
 
 ### Extract Comments from a Change Manifest
 
+Use a generated or validated change manifest as the cleanup boundary. This
+skill extracts comments inside that boundary; it does not decide which files or
+lines are cleanup-owned.
+
 ```bash
 # Required for comment-cleaner
 rp1 agent-tools comment-extract manifest manifest --change-manifest .rp1/work/features/example/change-manifest-001.json --code-root .
@@ -56,7 +60,6 @@ Manifest shape:
   "files": [
     {
       "path": "src/auth.ts",
-      "ownedLines": [12, 13],
       "ownedHunks": [{ "startLine": 20, "endLine": 28 }],
       "allowedOperations": ["remove_comments"]
     }
@@ -64,9 +67,17 @@ Manifest shape:
 }
 ```
 
-### Extract Comments from Git Scope
+Generated manifests can come from `/build`, `/build-fast`, or
+`/code-clean-comments`. Build workflows generate manifests from their recorded
+baseline; standalone cleanup uses `rp1 agent-tools change-manifest generate`
+with `--source code-clean-comments --scope ...` to convert file, directory,
+git ref, git range, or existing-manifest input into the same manifest shape.
 
-Git scopes remain available for audit/reporting use. Do not use them as a comment-cleaner cleanup boundary.
+### Audit-Only Git Scopes
+
+Git scopes remain available for audit/reporting use. Do not use them as a
+comment-cleaner cleanup boundary. For cleanup, first generate a change manifest
+and then extract with `--change-manifest`.
 
 ```bash
 rp1 agent-tools comment-extract branch main
@@ -107,7 +118,7 @@ rp1 agent-tools comment-extract "abc123..def456" main --line-scoped
 |-------|-------------|
 | `success` | Whether extraction completed successfully |
 | `tool` | Tool name (`comment-extract`) |
-| `data.scope` | The scope used (`manifest`, `branch`, `unstaged`, or commit range) |
+| `data.scope` | The extraction scope used (`manifest`, `branch`, `unstaged`, or commit range); only `manifest` is valid for cleanup |
 | `data.base` | Base branch for comparison, or `manifest` for manifest extraction |
 | `data.filesScanned` | Number of files processed |
 | `data.linesAdded` | Total lines added in diff, or manifest-owned line count |
@@ -154,6 +165,10 @@ This skill is used by the `comment-cleaner` agent to:
 1. Get a manifest-owned list of comments
 2. Avoid reading entire files for comment detection
 3. Process comments efficiently with context and line/hunk boundaries
+
+The `comment-cleaner` agent should call this skill through the manifest path it
+was given. It should not pass branch names, commit ranges, dirty-state labels,
+or task-builder-authored hunks as cleanup authority.
 
 ## Limitations
 

--- a/plugins/dev/agents/task-builder.md
+++ b/plugins/dev/agents/task-builder.md
@@ -64,6 +64,23 @@ Expert dev implementing tasks from feature task list. Load context (KB, PRD, des
 
 **Core**: Implement ONLY assigned tasks. DO NOT modify code outside scope.
 
+## Implementation Commandments
+
+Treat these as implementation constraints for every task:
+
+- Write for humans first: optimize for maintainers reading, reviewing, debugging, and modifying code under time pressure.
+- Complexity is the enemy; prefer deep modules with simple interfaces and real behavior behind them.
+- Model the data and domain well; make illegal states unrepresentable or fail closed at boundaries.
+- High cohesion, low coupling.
+- YAGNI: code is cost, not asset; avoid speculative hooks, layers, parameters, and features.
+- Prefer duplication to the wrong abstraction.
+- Make the change easy, then make the easy change.
+- Listen to test pain as design feedback.
+- Test behavior through public seams, not implementation internals.
+- Measure before optimizing; cut surgically.
+
+**Negative responsibility**: Task builders MUST NOT calculate, merge, create, or hand off comment cleanup manifests or cleanup-owned hunks. Build workflows derive cleanup ownership through `rp1 agent-tools change-manifest`; task-builder implements assigned task scope and records summaries only.
+
 <feature_id>
 {{FEATURE_ID from prompt}}
 </feature_id>

--- a/plugins/dev/skills/build-fast/SKILL.md
+++ b/plugins/dev/skills/build-fast/SKILL.md
@@ -67,6 +67,7 @@ metadata:
     - "rp1-dev:build-fast-planner"
     - "rp1-dev:task-builder"
     - "rp1-dev:task-reviewer"
+    - "rp1-dev:comment-cleaner"
 ---
 
 # Build Fast Command
@@ -218,7 +219,19 @@ Output "Build fast cancelled. Artifact preserved at {artifact_path}" and STOP.
 
 **CRITICAL**: You are an orchestrator. You MUST delegate implementation to `task-builder` by spawning an agent. Do NOT write, edit, or create source code files yourself. Do NOT implement the plan directly. Your only job is to spawn agents and parse their responses.
 
-### §2.1 Task Execution
+### §2.1 Cleanup Manifest Baseline
+
+Before task-builder runs, snapshot the repository state that bounds build-owned cleanup:
+
+```bash
+rp1 agent-tools change-manifest snapshot \
+  --code-root "{codeRoot}" \
+  --out "{workRoot}/quick-builds/{RUN_ID}-change-manifest-baseline.json"
+```
+
+Parse the `ToolResult` envelope. If the command fails or returns malformed output, continue execution but record `cleanup_manifest_result` as skipped with `skipReason: "baseline_snapshot_failed"`, `files: 0`, `ownedLineCount: 0`, and `statusPath: "{workRoot}/quick-builds/{RUN_ID}-change-manifest-status.json"`. Do not dispatch `comment-cleaner` later unless a generated manifest result explicitly returns `status: "created"` and non-empty ownership.
+
+### §2.2 Task Execution
 
 **You MUST spawn task-builder here.** Do not implement the tasks yourself.
 
@@ -279,9 +292,51 @@ RUN_ID={RUN_ID}
 
 ## §PHASE-4: Finalization
 
-**Phase handoff rule**: After §PHASE-3 completes successfully, do not register artifacts, do not emit final output, and do not stop. First evaluate §4.2. When `AFK=false` AND `CONFIRM_PLAN=true`, the very next workflow actions after review completion must be the post-implementation checkpoint actions from §4.2.
+**Phase handoff rule**: After §PHASE-3 completes successfully, do not register artifacts, do not emit final output, and do not stop. First generate the cleanup manifest and run manifest-gated cleanup, then evaluate §4.4. When `AFK=false` AND `CONFIRM_PLAN=true`, the post-implementation checkpoint in §4.4 must run before §OUTPUT.
 
-### §4.1 Push (Conditional)
+### §4.1 Cleanup Manifest Generation
+
+After implementation and optional review finish, generate the durable cleanup handoff:
+
+```bash
+rp1 agent-tools change-manifest generate \
+  --code-root "{codeRoot}" \
+  --out "{workRoot}/quick-builds/{RUN_ID}-change-manifest-001.json" \
+  --status-out "{workRoot}/quick-builds/{RUN_ID}-change-manifest-status.json" \
+  --source build-fast \
+  --baseline "{workRoot}/quick-builds/{RUN_ID}-change-manifest-baseline.json"
+```
+
+Parse the `ToolResult` envelope into `cleanup_manifest_result`.
+
+- If `data.status == "created"` and `data.files > 0` and `data.ownedLineCount > 0`, dispatch `comment-cleaner` with `data.manifestPath` and `{codeRoot}`.
+- If `data.status == "skipped"`, keep `data.statusPath` and `data.skipReason` for final output. Do not ask `comment-cleaner` to infer scope.
+- If the tool fails or returns malformed output, set `cleanup_manifest_result` to a skipped warning with `skipReason: "change_manifest_generate_failed"`, `files: 0`, `ownedLineCount: 0`, and `statusPath: "{workRoot}/quick-builds/{RUN_ID}-change-manifest-status.json"`.
+
+### §4.2 Comment Cleanup
+
+If `cleanup_manifest_result` is created and non-empty:
+
+{% dispatch_agent "rp1-dev:comment-cleaner" %}
+CHANGE_MANIFEST={cleanup_manifest_result.data.manifestPath}, CODE_ROOT={codeRoot}
+{% enddispatch_agent %}
+
+Otherwise set the `comment_cleaner` result yourself:
+
+```json
+{
+  "status": "WARN",
+  "files_checked": 0,
+  "manifest_path": null,
+  "manifest_status_path": "{cleanup_manifest_result.data.statusPath}",
+  "skip_reason": "{cleanup_manifest_result.data.skipReason}",
+  "message": "Automatic comment cleanup skipped because no non-empty generated manifest was available."
+}
+```
+
+Do not dispatch comment-cleaner with branch, unstaged, commit-range, base-branch, mode, or commit parameters; the generated manifest is the only safe cleanup boundary.
+
+### §4.3 Push (Conditional)
 
 **Skip if**: `GIT_PUSH=false`
 
@@ -289,7 +344,7 @@ RUN_ID={RUN_ID}
 git push -u origin {branch}
 ```
 
-### §4.2 Post-Implementation Checkpoint
+### §4.4 Post-Implementation Checkpoint
 
 **SKIP ENTIRELY if**: `AFK=true` OR `CONFIRM_PLAN=false`
 
@@ -300,7 +355,7 @@ When skipped: Do NOT prompt the user. Proceed directly to §OUTPUT.
 2. Call `ask_user` and wait for the answer
 
 The `waiting_for_user` emit does not replace the `ask_user` call. Continuing to §OUTPUT without both is an invalid workflow transition.
-The next action after §PHASE-3 success must be this checkpoint when interactive confirm mode is active.
+The next action after manifest-gated cleanup must be this checkpoint when interactive confirm mode is active.
 Do not emit `artifact_registered` for the build step before this checkpoint completes.
 
 Emit waiting status so the Arcade dashboard reflects the gate pause:
@@ -360,6 +415,10 @@ rp1 agent-tools emit \
 
 **Quality**: {format/lint/test status from builder}
 **Review**: {PASSED | SKIPPED | FAILED+RETRIED} (based on REVIEW flag)
+**Comment Cleanup**: {comment_cleaner.status}
+**Cleanup Manifest**: {cleanup_manifest_result.data.manifestPath or "None"}
+**Cleanup Status**: {cleanup_manifest_result.data.statusPath}
+**Cleanup Skip Reason**: {cleanup_manifest_result.data.skipReason or "None"}
 ```
 
 ## §ORCHESTRATOR-RULES

--- a/plugins/dev/skills/build/SKILL.md
+++ b/plugins/dev/skills/build/SKILL.md
@@ -369,7 +369,19 @@ TASKS: {implementation_tasks JSON}, MAX_SIMPLE_BATCH: 3, COMPLEX_ISOLATED: true
 
 Extract `task_units` array.
 
-### §4.2 Builder-Reviewer Loop
+### §4.2 Cleanup Manifest Baseline
+
+Before the first task-builder unit, snapshot the build-start repository state:
+
+```bash
+rp1 agent-tools change-manifest snapshot \
+  --code-root "{codeRoot}" \
+  --out "{workRoot}/features/{FEATURE_ID}/change-manifest-baseline.json"
+```
+
+Parse the `ToolResult` envelope. If the command fails or returns malformed output, continue the build but record `cleanup_manifest_result` as skipped with `skipReason: "baseline_snapshot_failed"`, `files: 0`, `ownedLineCount: 0`, and `statusPath: "{workRoot}/features/{FEATURE_ID}/change-manifest-status.json"`. Do not dispatch `comment-cleaner` later unless a generated manifest result explicitly returns `status: "created"` and non-empty ownership.
+
+### §4.3 Builder-Reviewer Loop
 
 For each task unit, run builder then reviewer:
 
@@ -396,7 +408,7 @@ FEATURE_ID={FEATURE_ID}, KB_ROOT={kbRoot}, WORK_ROOT={workRoot}, CODE_ROOT={code
 
 Else: escalate (AFK: mark blocked; Interactive: prompt user).
 
-### §4.3 Post-Build
+### §4.4 Post-Build
 
 Doc tasks (TD*): build doc_scan_results.json, spawn scribe.
 
@@ -415,7 +427,26 @@ rp1 agent-tools emit \
 On Add Task: spawn builder+reviewer for ad-hoc TX-{timestamp} task, loop back.
 On Review feedback from Arcade: load `arcade-collab` skill, process all feedback for RUN_ID, then return to this checkpoint with original options.
 
-### §4.4 Close Build Step
+### §4.5 Cleanup Manifest Generation
+
+After builders, reviewers, doc tasks, and any checkpoint-added tasks finish, generate the durable cleanup handoff before verification:
+
+```bash
+rp1 agent-tools change-manifest generate \
+  --code-root "{codeRoot}" \
+  --out "{workRoot}/features/{FEATURE_ID}/change-manifest-001.json" \
+  --status-out "{workRoot}/features/{FEATURE_ID}/change-manifest-status.json" \
+  --source build \
+  --baseline "{workRoot}/features/{FEATURE_ID}/change-manifest-baseline.json"
+```
+
+Parse the `ToolResult` envelope into `cleanup_manifest_result`.
+
+- If `data.status == "created"` and `data.files > 0` and `data.ownedLineCount > 0`, verification may dispatch `comment-cleaner` with `data.manifestPath` and `{codeRoot}`.
+- If `data.status == "skipped"`, keep `data.statusPath` and `data.skipReason` for the verify aggregator. Do not ask `comment-cleaner` to infer scope.
+- If the tool fails or returns malformed output, set `cleanup_manifest_result` to a skipped warning with `skipReason: "change_manifest_generate_failed"`, `files: 0`, `ownedLineCount: 0`, and `statusPath: "{workRoot}/features/{FEATURE_ID}/change-manifest-status.json"`.
+
+### §4.6 Close Build Step
 
 **Before transitioning to verify**, emit `build → completed` (required even if sub-tasks had retried/escalated failures):
 
@@ -430,9 +461,9 @@ rp1 agent-tools emit \
 
 ## §STEP-5: Verify
 
-**Skip if**: start_step > 5. **Invoke ALL THREE in SINGLE response:**
+**Skip if**: start_step > 5.
 
-Use the durable cleaner hand-off manifest at `{workRoot}/features/{FEATURE_ID}/change-manifest-001.json`, or the highest numbered `change-manifest-*.json` path already produced by the build task handoff for this feature. Do not dispatch comment-cleaner with branch, unstaged, commit-range, base-branch, mode, or commit parameters; it must fail closed if the manifest is missing or invalid.
+Invoke `code-checker` and `feature-verifier`. Include `comment-cleaner` only when `cleanup_manifest_result.data.status == "created"`, `cleanup_manifest_result.data.files > 0`, `cleanup_manifest_result.data.ownedLineCount > 0`, and `cleanup_manifest_result.data.manifestPath` is present. Do not dispatch comment-cleaner with branch, unstaged, commit-range, base-branch, mode, or commit parameters; the generated manifest is the only safe cleanup boundary.
 
 {% dispatch_agent "rp1-dev:code-checker" %}
 FEATURE_ID={FEATURE_ID}, KB_ROOT={kbRoot}, WORK_ROOT={workRoot}, CODE_ROOT={codeRoot}
@@ -442,11 +473,26 @@ FEATURE_ID={FEATURE_ID}, KB_ROOT={kbRoot}, WORK_ROOT={workRoot}, CODE_ROOT={code
 FEATURE_ID={FEATURE_ID}, KB_ROOT={kbRoot}, WORK_ROOT={workRoot}, CODE_ROOT={codeRoot}, WORKFLOW=build, RUN_ID={RUN_ID}
 {% enddispatch_agent %}
 
+If `cleanup_manifest_result` is created and non-empty:
+
 {% dispatch_agent "rp1-dev:comment-cleaner" %}
-CHANGE_MANIFEST={workRoot}/features/{FEATURE_ID}/change-manifest-001.json, CODE_ROOT={codeRoot}
+CHANGE_MANIFEST={cleanup_manifest_result.data.manifestPath}, CODE_ROOT={codeRoot}
 {% enddispatch_agent %}
 
-Then aggregate:
+Otherwise set the `comment_cleaner` phase result yourself:
+
+```json
+{
+  "status": "WARN",
+  "files_checked": 0,
+  "manifest_path": null,
+  "manifest_status_path": "{cleanup_manifest_result.data.statusPath}",
+  "skip_reason": "{cleanup_manifest_result.data.skipReason}",
+  "message": "Automatic comment cleanup skipped because no non-empty generated manifest was available."
+}
+```
+
+Then aggregate with the real cleaner response or the synthetic warning result:
 
 {% dispatch_agent "rp1-dev:build-verify-aggregator" %}
 PHASE_RESULTS: { code_checker: {...}, feature_verifier: {...}, comment_cleaner: {...} }

--- a/plugins/dev/skills/code-clean-comments/SKILL.md
+++ b/plugins/dev/skills/code-clean-comments/SKILL.md
@@ -44,56 +44,42 @@ Create the manifest directory if needed:
 mkdir -p "{workRoot}/comment-clean-comments"
 ```
 
-Choose the next numbered manifest path:
+Choose the next numbered manifest/status path pair:
 
 ```text
 {workRoot}/comment-clean-comments/change-manifest-001.json
+{workRoot}/comment-clean-comments/change-manifest-status-001.json
 ```
 
-Increment the number if that file already exists.
+Increment the number if either file already exists. Set `resolved_change_manifest_path` and `resolved_change_manifest_status_path` to the selected pair.
 
-## 2. Resolve `SCOPE`
+## 2. Generate Manifest
 
-Supported scopes:
+Delegate all scope resolution to the typed generator:
 
-- Existing change-manifest JSON: validate it and use or copy it as the durable manifest.
-- File path under `CODE_ROOT`: create one manifest file entry with a full-file owned hunk.
-- Directory path under `CODE_ROOT`: create manifest entries for supported code files under that directory, excluding generated/dependency directories such as `.git`, `node_modules`, `dist`, `build`, `.next`, `coverage`, `.rp1`, and `vendor`.
-- Git range containing `..`: derive owned hunks from `git diff -U0 --no-color {SCOPE}`.
-- Git ref without `..`: derive owned hunks from `git diff -U0 --no-color {SCOPE}...HEAD`.
-
-If `SCOPE` cannot be resolved, or it resolves to zero owned files/hunks, fail closed and do not dispatch comment-cleaner.
-
-## 3. Manifest Schema
-
-Write durable JSON:
-
-```json
-{
-  "version": 1,
-  "source": "code-clean-comments",
-  "codeRoot": "{resolved_code_root}",
-  "scope": "{SCOPE}",
-  "files": [
-    {
-      "path": "relative/path/from/CODE_ROOT.ts",
-      "ownedHunks": [{ "startLine": 1, "endLine": 10 }],
-      "allowedOperations": ["remove_comments"]
-    }
-  ]
-}
+```bash
+rp1 agent-tools change-manifest generate \
+  --code-root "{resolved_code_root}" \
+  --out "{resolved_change_manifest_path}" \
+  --status-out "{resolved_change_manifest_status_path}" \
+  --source code-clean-comments \
+  --scope "{SCOPE}"
 ```
 
-Use relative file paths from `CODE_ROOT`. Hunks are inclusive line bounds in the current file. For full-file scopes, use one hunk from line 1 to the current line count. For git scopes, include only added/modified new-file hunk lines from the diff.
+Parse the `ToolResult` envelope into `cleanup_manifest_result`. The generator is responsible for existing manifest JSON, file, directory, git ref, and git range scopes. Do not inspect files, walk directories, parse git diffs, validate existing manifest JSON, or write manifest JSON yourself.
 
-## 4. Dispatch Cleaner
+If `cleanup_manifest_result.data.status != "created"`, `cleanup_manifest_result.data.files == 0`, `cleanup_manifest_result.data.ownedLineCount == 0`, or `cleanup_manifest_result.data.manifestPath` is missing, fail closed and do not dispatch `comment-cleaner`. Report the status path and skip reason instead.
 
-After writing and validating the manifest, invoke:
+If the tool fails or returns malformed output, fail closed and do not dispatch `comment-cleaner`. Report `change_manifest_generate_failed` with the intended status path.
+
+## 3. Dispatch Cleaner
+
+Only when the generated manifest is created and non-empty, invoke:
 
 {% dispatch_agent "rp1-dev:comment-cleaner" %}
-CHANGE_MANIFEST={resolved_change_manifest_path}, CODE_ROOT={resolved_code_root}
+CHANGE_MANIFEST={cleanup_manifest_result.data.manifestPath}, CODE_ROOT={resolved_code_root}
 {% enddispatch_agent %}
 
-## 5. Output
+## 4. Output
 
-Report the scope, manifest path, files covered, and comment-cleaner result. Do not stage or commit changes.
+Report the scope, cleanup status, manifest path when created, status path, files covered, skip reason when skipped, and comment-cleaner result when it ran. Do not stage or commit changes.


### PR DESCRIPTION
## Summary
- Add a `change-manifest` agent-tool with snapshot/generate commands for durable comment-cleanup ownership.
- Integrate manifest-gated cleanup into `/build`, `/build-fast`, and `/code-clean-comments`.
- Update task-builder responsibilities, comment extraction support, reference docs, and catalog checksum.
- Add generator, command, and prompt-contract tests.

## Verification
- Focused builder/reviewer checks passed during the rp1 build workflow.
- Feature verifier passed 25/25 acceptance criteria.
- `git push` pre-push checks passed for catalog, no-artifactory, CLI typecheck, and web UI typecheck.

## Known Draft Follow-Ups
- `eval-verify` reports stale attestations for `rp1-dev:build@claude-code` and `rp1-dev:build-fast@claude-code`.
- Full code checker reported existing broader issues: eval formatting, native-app missing `bun-types`, and one CLI attestation/hash contract failure.
- Comment-cleaner verification failed closed in the resumed workflow because this run started before the new build-baseline snapshot existed, producing `pre_existing_dirty_paths_overlap`.
