### PR TITLE
fix: arcade native/web runtime reliability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,4 @@ native-app/artifacts/
 .osgrep
 # rp1 directory
 !.rp1/project_id
+cli/coverage/

--- a/.rp1/context/interaction-model.md
+++ b/.rp1/context/interaction-model.md
@@ -75,7 +75,8 @@
 | Skill invocation syntax | Claude Code uses short slash commands; OpenCode uses rp1-prefixed names |
 | Execution vs observability | Host tools do the work; Agent Tools carry protocol; Arcade shows passive status |
 | Responsive layout | Desktop: icon-rail sidebar + resizable panels. Mobile: bottom tab bar + drawers |
-| Workflow freshness source | Arcade: emitted workflow events hydrate `LiveRunIndex`, run detail, and attention/project surfaces via project-scoped `lastEventId` cursors. Host tools: inline gates still come from the emitting workflow |
+| Workflow freshness source | Arcade: emitted workflow events hydrate `LiveRunIndex`, run detail, and attention/project surfaces via scope-aware global/project `lastEventId` cursors. Host tools: inline gates still come from the emitting workflow |
+| Browser/native runtime contract | Browser launch defaults to `hostMode=browser`; native launch appends `hostMode=native` and `cacheBust` while loading the same loopback Arcade SPA. Both host modes validate the no-store `/api/v2/runtime` contract before route-level WebSocket consumers mount |
 | Notification delivery | Arcade: real-time toasts with dedup + dismissible sidebar driven by the same emit stream. Host tools: inline gates |
 | Recovery semantics | Arcade reconnects with its saved cursor, replays missed events when possible, and falls back to bounded snapshot reconciliation or persisted REST recovery only when needed |
 | Run invocation context | Hidden by default, toggled via contextual command; shows workflow, run policy, worktree state |

--- a/.rp1/context/patterns.md
+++ b/.rp1/context/patterns.md
@@ -66,13 +66,16 @@
 ## UI Patterns
 
 - **Contextual commands**: Views register `CommandDefinition[]` via `useContextualShortcuts` hook, surfaced in command palette alongside navigation/action commands
-- **SessionStorage persistence**: `showFrontmatter`/`showMetadata` use `useState` + `sessionStorage` for per-tab, per-view toggle persistence; WebSocket cursors follow the same pattern with `rp1:last-event-id:{projectId}`
+- **SessionStorage persistence**: `showFrontmatter`/`showMetadata` use `useState` + `sessionStorage` for per-tab, per-view toggle persistence; WebSocket cursors follow the same pattern with `rp1:last-event-id:global` and `rp1:last-event-id:{projectId}`
 - **Notification lifecycle**: Toasts auto-dismiss 6s with dedup guard; sidebar groups by attention level; "Read all" bulk dismiss
 - **Attention-level styling**: `itemClassForLevel` maps attention levels to differentiated background colors for visual triage
-- **LiveRunIndex projection**: Feed, runs, attention, project summaries, and run detail seed from REST, then project emitted workflow activity through a shared `LiveRunIndex` keyed by `runId` to patch only affected surfaces
+- **Runtime contract boundary**: `RuntimeProvider` loads the no-store `/api/v2/runtime` contract before WebSocket consumers mount, validates browser/native host mode, exposes reconnect policy, and performs one cache-busted reload before controlled runtime-load failure
+- **LiveRunIndex projection**: Feed, runs, attention, project summaries, and run detail seed from REST, then scope-aware emitted workflow activity flows through a shared `LiveRunIndex` keyed by `runId` to patch only affected surfaces
+- **Scope-aware Activity replay**: Global Activity stores `rp1:last-event-id:global`, project Activity stores `rp1:last-event-id:{projectId}`, and global live events advance both the global cursor and the event project's cursor when project identity is available
 - **Server-side Activity search projection**: Search feed requests refresh compact `activity_search_runs` rows, match normalized tokens against Activity-visible fields before pagination, then apply runtime visibility and reuse `runRecordToListRun` so search and browse keep the same feed item contract
-- **Snapshot reconciliation**: `state:snapshot` replaces the project's active-run subset and triggers bounded refetch only for currently visible collections whose membership may have changed
+- **Snapshot reconciliation**: Project `state:snapshot` replaces the project's active-run subset; global snapshots upsert/hydrate without pruning unrelated project runs. Both paths trigger bounded refetch only for currently visible collections whose membership may have changed
 - **Targeted hydration**: Unknown run events hydrate a single run summary before reducers apply queued updates, avoiding collection-wide invalidation for routine workflow activity
+- **Policy-driven Activity recovery**: `useReconnectRecovery`, `useFeed`, and `useRuns` read reconnect timing and `activityRecoveryLimit` from the runtime contract, reconcile in the background after reconnect, and merge replay/REST overlap through stable run identity
 
 ## Observability
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -102,6 +102,15 @@ Arcade remains the fallback path; after a native launch, run `./bin/rp1 arcade`
 from the same project directory to verify the browser flow still opens the
 project.
 
+The native shell still loads the shared loopback Arcade web app. Before Arcade
+routes mount, the SPA fetches `/api/v2/runtime` with `no-store` semantics and
+expects the same contract in browser and native mode: base URL, host mode,
+version, build ID, cache-bust value, and reconnect policy. Browser launches
+default to `hostMode=browser`; native launches append `hostMode=native` and a
+`native-*` `cacheBust` query value while preserving existing URL parameters.
+When runtime fields change, validate both host modes so browser fallback and
+native launch do not drift.
+
 For repeated launch checks where rebuilding would interfere with daemon reuse,
 build once with `just build-local-dev`, then run Electrobun directly:
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -46,6 +46,7 @@ All development commands use [Just](https://github.com/casey/just). Run `just` t
 | `test-unit` | Run unit tests only (~60 files, fast) |
 | `test-integration` | Run integration tests |
 | `test-all` | Run all CLI tests |
+| `test-web-ui-smoke` | Run Chromium smoke coverage for Arcade runtime loading and reconnect reliability |
 
 ### Code Quality
 
@@ -160,6 +161,19 @@ Manual verification on macOS:
 | Optional direct project launch | Run `just native-app-dev PROJECT=/path/to/rp1-project` | The project registers through Arcade if needed and the returned project URL loads |
 | Failure state | Use an invalid `PROJECT` path or non-executable `RP1_EXECUTABLE` | The launch view shows a clear failure instead of stale project content |
 | Browser fallback | From the same project directory, run `./bin/rp1 arcade` after native launch | Browser Arcade still opens the same project experience |
+
+Runtime reliability validation:
+
+| Check | Command or setup | Expected result |
+|-------|------------------|-----------------|
+| Chromium runtime smoke | `just test-web-ui-smoke` | The real Bun Arcade server loads the runtime contract in Chromium, returns structured missing-asset failures, replays a missed global Activity event, and keeps live event delivery working after reconnect |
+| Native/WebKit release validation | Run `just build-local-dev`, then `just native-app-dev PROJECT=/path/to/rp1-project`; repeat the cold launch, warm launch, failure state, and browser fallback checks above | Native Arcade loads the shared loopback web app with native runtime metadata and cache-bust query values, Activity recovers after reconnect or host pause, and browser Arcade remains equivalent |
+
+WebKit/native-like automation is intentionally manual for now. The current
+repository has stable Chromium automation through the CLI Puppeteer dependency,
+but no approved WebKit browser dependency, browser cache setup, or CI wiring.
+Do not claim WebKit/native-like automated coverage until those pieces are added
+as an explicit dependency and CI change.
 
 This phase proves a macOS shell bootstrap only. It does not include signing,
 notarization, auto-update, production packaging, tray or menu controls, native

--- a/Justfile
+++ b/Justfile
@@ -364,6 +364,10 @@ test-cli:
 test-native-app:
     cd native-app && bun run test
 
+# Run Chromium smoke coverage for Arcade runtime reliability
+test-web-ui-smoke:
+    cd cli && bun run test:smoke:web-ui
+
 # Run evals unit tests
 test-evals:
     cd evals && bun run test

--- a/cli/package.json
+++ b/cli/package.json
@@ -53,6 +53,7 @@
 		"test": "bun test",
 		"test:unit": "find src/__tests__ -name '*.test.ts' ! -path '*integration*' -print0 | xargs -0 bun test",
 		"test:integration": "find src/__tests__ -name '*.test.ts' -path '*integration*' -print0 | xargs -0 bun test",
+		"test:smoke:web-ui": "bun run scripts/runtime-reliability-smoke.ts",
 		"test:coverage": "bun run scripts/test-coverage.ts",
 		"test:watch": "bun test --watch",
 		"prepublishOnly": "bun run build:all"

--- a/cli/scripts/runtime-reliability-smoke.ts
+++ b/cli/scripts/runtime-reliability-smoke.ts
@@ -1,0 +1,356 @@
+#!/usr/bin/env bun
+
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import puppeteer, { type Browser } from "puppeteer";
+import { startServer } from "../web-ui/src/server/http";
+import { WebSocketHub } from "../web-ui/src/server/websocket";
+import {
+	ARCADE_RUNTIME_MANIFEST_FILENAME,
+	type ArcadeRuntimeManifest,
+	DEFAULT_ARCADE_RECONNECT_POLICY,
+} from "../web-ui/src/types/runtime";
+
+const SMOKE_POLICY = {
+	...DEFAULT_ARCADE_RECONNECT_POLICY,
+	heartbeatIntervalMs: 100,
+	heartbeatMissThreshold: 5,
+};
+
+interface SmokeState {
+	readonly done: boolean;
+	readonly error: string | null;
+	readonly result: SmokeResult | null;
+}
+
+interface SmokeResult {
+	readonly runtime: {
+		readonly hostMode?: string;
+		readonly buildId?: string;
+		readonly reconnectPolicy?: {
+			readonly activityRecoveryLimit?: number;
+		};
+	};
+	readonly missingStatus: number;
+	readonly missingHeader: string | null;
+	readonly replay: {
+		readonly type?: string;
+		readonly scope?: string;
+		readonly event?: {
+			readonly id?: number;
+			readonly projectId?: string;
+			readonly featureId?: string;
+		};
+	};
+	readonly live: {
+		readonly type?: string;
+		readonly eventId?: number;
+		readonly projectId?: string;
+	};
+	readonly rootText: string | null;
+}
+
+function assert(condition: unknown, message: string): asserts condition {
+	if (!condition) {
+		throw new Error(message);
+	}
+}
+
+async function findAvailablePort(): Promise<number> {
+	for (let attempt = 0; attempt < 20; attempt += 1) {
+		const port = 24000 + Math.floor(Math.random() * 20000);
+		try {
+			const probe = Bun.serve({
+				port,
+				hostname: "127.0.0.1",
+				fetch() {
+					return new Response("ok");
+				},
+			});
+			probe.stop();
+			return port;
+		} catch {}
+	}
+
+	throw new Error("Could not find an available port for smoke coverage");
+}
+
+async function writeSmokeAssets(webUIDir: string): Promise<void> {
+	const clientDir = join(webUIDir, "client");
+	await mkdir(join(clientDir, "assets"), { recursive: true });
+	await Bun.write(join(clientDir, "index.html"), smokeHarnessHtml());
+
+	const manifest: ArcadeRuntimeManifest = {
+		version: "0.7.6-smoke",
+		gitCommit: "smoke",
+		buildTime: "2026-05-04T00:00:00.000Z",
+		buildId: "smoke-build",
+	};
+	await Bun.write(
+		join(clientDir, ARCADE_RUNTIME_MANIFEST_FILENAME),
+		`${JSON.stringify(manifest)}\n`,
+	);
+}
+
+function smokeHarnessHtml(): string {
+	return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>rp1 Arcade smoke</title>
+</head>
+<body>
+  <div id="root">Arcade runtime smoke ready</div>
+  <script>
+    (() => {
+      const state = { done: false, error: null, result: null };
+      window.__rp1Smoke = state;
+      window.__rp1SmokeLiveReady = false;
+
+      const fail = (error) => {
+        state.done = true;
+        state.error = error instanceof Error ? error.message : String(error);
+      };
+
+      const socketUrl = (lastEventId) => {
+        const url = new URL("/ws", location.href);
+        url.protocol = url.protocol === "https:" ? "wss:" : "ws:";
+        url.searchParams.set("scope", "global");
+        url.searchParams.set("lastEventId", String(lastEventId));
+        return url.toString();
+      };
+
+      const ackHeartbeat = (socket, message) => {
+        if (message.type !== "heartbeat" || !message.heartbeatId) return;
+        socket.send(JSON.stringify({
+          type: "heartbeat:ack",
+          heartbeatId: message.heartbeatId,
+          receivedAt: new Date().toISOString()
+        }));
+      };
+
+      const waitForReplay = () => new Promise((resolve, reject) => {
+        const socket = new WebSocket(socketUrl(5));
+        const timeout = setTimeout(() => {
+          socket.close();
+          reject(new Error("Timed out waiting for global replay"));
+        }, 4000);
+
+        socket.onmessage = (event) => {
+          const message = JSON.parse(event.data);
+          ackHeartbeat(socket, message);
+          if (message.type === "event:replay") {
+            clearTimeout(timeout);
+            socket.close();
+            resolve(message);
+          }
+        };
+        socket.onerror = () => {
+          clearTimeout(timeout);
+          reject(new Error("Global replay socket failed"));
+        };
+      });
+
+      const waitForLiveEvent = (lastEventId) => new Promise((resolve, reject) => {
+        const socket = new WebSocket(socketUrl(lastEventId));
+        const timeout = setTimeout(() => {
+          socket.close();
+          reject(new Error("Timed out waiting for live reconnect event"));
+        }, 4000);
+
+        socket.onopen = () => {
+          window.__rp1SmokeLiveReady = true;
+        };
+        socket.onmessage = (event) => {
+          const message = JSON.parse(event.data);
+          ackHeartbeat(socket, message);
+          if (message.type === "event:notification") {
+            clearTimeout(timeout);
+            socket.close();
+            resolve(message);
+          }
+        };
+        socket.onerror = () => {
+          clearTimeout(timeout);
+          reject(new Error("Live reconnect socket failed"));
+        };
+      });
+
+      const run = async () => {
+        try {
+          const runtime = await fetch("/api/v2/runtime?hostMode=browser", {
+            cache: "no-store"
+          }).then((response) => response.json());
+          const missing = await fetch("/assets/missing-entry.js", {
+            headers: { Accept: "*/*" }
+          });
+          const replay = await waitForReplay();
+          const live = await waitForLiveEvent(replay.event.id);
+
+          state.result = {
+            runtime,
+            missingStatus: missing.status,
+            missingHeader: missing.headers.get("X-RP1-Asset-Missing"),
+            replay,
+            live,
+            rootText: document.getElementById("root")?.textContent ?? null
+          };
+          state.done = true;
+        } catch (error) {
+          fail(error);
+        }
+      };
+
+      run();
+    })();
+  </script>
+</body>
+</html>`;
+}
+
+async function launchBrowser(): Promise<Browser> {
+	return puppeteer.launch({
+		headless: true,
+		args: ["--no-sandbox", "--disable-setuid-sandbox"],
+	});
+}
+
+async function main(): Promise<void> {
+	const tempDir = await mkdtemp(join(tmpdir(), "rp1-runtime-smoke-"));
+	const projectDir = join(tempDir, "project");
+	const webUIDir = join(tempDir, "web-ui");
+	const port = await findAvailablePort();
+	const websocketHub = new WebSocketHub(SMOKE_POLICY);
+	let browser: Browser | null = null;
+
+	websocketHub.setReplayProvider({
+		getEventsSince: (afterId) =>
+			afterId < 6
+				? [
+						{
+							id: 6,
+							runId: "run-smoke",
+							type: "status_change",
+							step: "task-builder:building",
+							unit: "T8",
+							data: JSON.stringify({ status: "running" }),
+							createdAt: "2026-05-04T00:00:00.000Z",
+						},
+					]
+				: [],
+		getRunContext: (runId) =>
+			runId === "run-smoke"
+				? {
+						projectId: "proj-smoke",
+						featureId: "fix-all-ui",
+						runStatus: "running",
+					}
+				: null,
+		getRunStatus: () => "running",
+		getActiveRunsSnapshot: () => [],
+		getMaxEventId: () => 6,
+	});
+
+	await mkdir(join(projectDir, ".rp1"), { recursive: true });
+	await writeSmokeAssets(webUIDir);
+
+	const server = startServer({
+		port,
+		projectPath: projectDir,
+		websocketHub,
+		isDev: false,
+		webUIDir,
+		version: "0.7.6-smoke",
+	});
+
+	try {
+		browser = await launchBrowser();
+		const page = await browser.newPage();
+		await page.goto(`http://127.0.0.1:${port}`, {
+			waitUntil: "domcontentloaded",
+		});
+
+		await page.waitForFunction(
+			"window.__rp1SmokeLiveReady === true || window.__rp1Smoke?.done === true",
+			{ timeout: 5000 },
+		);
+
+		const readyState = (await page.evaluate("window.__rp1Smoke")) as SmokeState;
+		assert(
+			readyState.done !== true || readyState.error === null,
+			`Chromium smoke failed before live event broadcast: ${readyState.error}`,
+		);
+
+		websocketHub.broadcastEvent(
+			"proj-smoke",
+			7,
+			"status_change",
+			"run-smoke",
+			"fix-all-ui",
+			"completed",
+			"task-builder:completed",
+			"T8",
+			{ status: "completed" },
+			"2026-05-04T00:00:01.000Z",
+		);
+
+		await page.waitForFunction("window.__rp1Smoke?.done === true", {
+			timeout: 5000,
+		});
+
+		const smokeState = (await page.evaluate("window.__rp1Smoke")) as SmokeState;
+		assert(!smokeState.error, `Chromium smoke failed: ${smokeState.error}`);
+		assert(smokeState.result, "Chromium smoke finished without a result");
+
+		const { result } = smokeState;
+		assert(
+			result.rootText === "Arcade runtime smoke ready",
+			"HTML shell failed",
+		);
+		assert(
+			result.runtime.hostMode === "browser",
+			"Runtime contract did not resolve browser host mode",
+		);
+		assert(
+			result.runtime.buildId === "smoke-build",
+			"Runtime contract did not load the smoke build manifest",
+		);
+		assert(
+			typeof result.runtime.reconnectPolicy?.activityRecoveryLimit === "number",
+			"Runtime contract did not expose reconnect policy",
+		);
+		assert(
+			result.missingStatus === 404 && result.missingHeader === "true",
+			"Missing JavaScript asset was not reported as a structured asset miss",
+		);
+		assert(
+			result.replay.type === "event:replay" &&
+				result.replay.scope === "global" &&
+				result.replay.event?.id === 6 &&
+				result.replay.event.projectId === "proj-smoke" &&
+				result.replay.event.featureId === "fix-all-ui",
+			"Global reconnect did not replay the missed project event",
+		);
+		assert(
+			result.live.type === "event:notification" &&
+				result.live.eventId === 7 &&
+				result.live.projectId === "proj-smoke",
+			"Live event delivery did not continue after reconnect replay",
+		);
+
+		console.log(
+			`Chromium ${await browser.version()} smoke passed: runtime loading, structured asset miss, global replay, and live reconnect delivery verified.`,
+		);
+	} finally {
+		await browser?.close();
+		server.stop();
+		websocketHub.stop();
+		await rm(tempDir, { recursive: true, force: true });
+	}
+}
+
+main().catch((error) => {
+	console.error(error instanceof Error ? error.message : String(error));
+	process.exit(1);
+});

--- a/cli/src/__tests__/arcade/launch.test.ts
+++ b/cli/src/__tests__/arcade/launch.test.ts
@@ -78,6 +78,17 @@ describe("Arcade launch bridge", () => {
 		});
 	});
 
+	test("rejects existing directories that are not rp1 project roots", async () => {
+		const resolved = resolveArcadeProjectRoot(tempDir);
+
+		expect(resolved).toMatchObject({
+			_tag: "Left",
+			left: {
+				_tag: "NotFoundError",
+			},
+		});
+	});
+
 	test("launches a valid project through daemon startup and project registration", async () => {
 		const projectRoot = await createProjectRoot();
 
@@ -231,6 +242,18 @@ describe("Arcade launch bridge", () => {
 		expect(registerProjectWithDaemonMock).not.toHaveBeenCalled();
 	});
 
+	test("rejects project-list responses without a projects array", async () => {
+		globalThis.fetch = mock(async () =>
+			Response.json({}),
+		) as unknown as typeof fetch;
+
+		await expect(
+			launchArcadeProjectList({
+				port: 6811,
+			}),
+		).rejects.toThrow("Project list response did not include projects");
+	});
+
 	test("surfaces project-list API failures without falling back to project registration", async () => {
 		const fetchMock = mock(async () =>
 			Response.json({ error: "Project API unavailable" }, { status: 503 }),
@@ -291,5 +314,17 @@ describe("Arcade launch bridge", () => {
 				port: 6811,
 			}),
 		).rejects.toThrow("Project API unavailable");
+	});
+
+	test("uses HTTP status when project-list API failures are not JSON", async () => {
+		globalThis.fetch = mock(
+			async () => new Response("not-json", { status: 502 }),
+		) as unknown as typeof fetch;
+
+		await expect(
+			launchArcadeProjectList({
+				port: 6811,
+			}),
+		).rejects.toThrow("HTTP 502");
 	});
 });

--- a/cli/src/__tests__/commands/arcade-runtime-branch.test.ts
+++ b/cli/src/__tests__/commands/arcade-runtime-branch.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Command } from "commander";
+
+class ProcessExit extends Error {
+	readonly code: number;
+
+	constructor(code: number | string | null | undefined) {
+		super(`process.exit(${code ?? 0})`);
+		this.code = Number(code ?? 0);
+	}
+}
+
+const originalExit = process.exit;
+const originalError = console.error;
+
+async function importArcadeCommand() {
+	return await import(
+		`../../commands/arcade.ts?runtime-branch=${Date.now()}-${Math.random()}`
+	);
+}
+
+describe("arcade command runtime branches", () => {
+	afterEach(() => {
+		process.exit = originalExit;
+		console.error = originalError;
+		mock.restore();
+		mock.module("../../../shared/runtime.js", () => ({
+			detectRuntime: () => ({ runtime: "bun" as const, version: Bun.version }),
+			isBun: () => true,
+		}));
+	});
+
+	test("prints Bun runtime guidance before daemon work in Node-like runtimes", async () => {
+		const errors: string[] = [];
+		process.exit = ((code?: number | string | null) => {
+			throw new ProcessExit(code);
+		}) as typeof process.exit;
+		console.error = (...args: unknown[]) => {
+			errors.push(args.map(String).join(" "));
+		};
+
+		mock.module("../../../shared/runtime.js", () => ({
+			isBun: () => false,
+		}));
+
+		const { createArcadeCommand } = await importArcadeCommand();
+		const command = createArcadeCommand({
+			getStatus: async () => ({ running: false }),
+		});
+		command.exitOverride();
+
+		await expect(
+			command.parseAsync(["node", "arcade", "--status"]),
+		).rejects.toMatchObject({ code: 1 });
+
+		expect(errors.join("\n")).toContain(
+			"Error: The 'arcade' command requires Bun runtime.",
+		);
+		expect(errors.join("\n")).toContain("bun rp1 arcade");
+	});
+
+	test("uses node child_process spawning when browser opening runs outside Bun", async () => {
+		const tempDir = await mkdtemp(join(tmpdir(), "rp1-arcade-runtime-"));
+		const infos: string[] = [];
+		const debugs: string[] = [];
+		const warnings: string[] = [];
+		const spawned: Array<{ command: string; args: string[] }> = [];
+		let runtimeChecks = 0;
+
+		try {
+			await mkdir(join(tempDir, ".rp1", "context"), { recursive: true });
+			await writeFile(join(tempDir, ".rp1", "project_id"), "project-1\n");
+
+			mock.module("../../../shared/runtime.js", () => ({
+				isBun: () => {
+					runtimeChecks += 1;
+					return runtimeChecks === 1;
+				},
+			}));
+			mock.module("node:child_process", () => ({
+				spawn: (command: string, args: string[]) => {
+					spawned.push({ command, args });
+					return { unref: () => undefined };
+				},
+			}));
+
+			const { createArcadeCommand } = await importArcadeCommand();
+			const command = createArcadeCommand({
+				launchArcadeForProject: async ({ port }: { port?: number }) => {
+					const daemonPort = port ?? 7710;
+					return {
+						kind: "project" as const,
+						projectId: "project-1",
+						projectName: "Fixture Project",
+						url: `http://127.0.0.1:${daemonPort}/projects/project-1`,
+						action: "reused" as const,
+						reason: "missing_pid" as const,
+						wasRunning: true,
+						daemonPort,
+					};
+				},
+			});
+			const parent = new Command("rp1");
+			parent.version("0.7.5");
+			Object.assign(parent, {
+				_logger: {
+					debug: (message: string) => debugs.push(message),
+					info: (message: string) => infos.push(message),
+					warn: (message: string) => warnings.push(message),
+					error: () => undefined,
+				},
+			});
+			parent.addCommand(command);
+			parent.exitOverride();
+
+			await parent.parseAsync([
+				"node",
+				"rp1",
+				"arcade",
+				tempDir,
+				"--port",
+				"8131",
+			]);
+
+			const url = "http://127.0.0.1:8131/projects/project-1";
+			const expectedSpawn =
+				process.platform === "darwin"
+					? { command: "open", args: [url] }
+					: process.platform === "win32"
+						? { command: "cmd", args: ["/c", "start", "", url] }
+						: { command: "xdg-open", args: [url] };
+
+			expect(spawned).toEqual([expectedSpawn]);
+			expect(infos).toContain(`Opened ${url}`);
+			expect(debugs.join("\n")).toContain("Opening browser");
+			expect(warnings).toEqual([]);
+		} finally {
+			await rm(tempDir, { recursive: true, force: true });
+		}
+	});
+});

--- a/cli/src/__tests__/commands/arcade.test.ts
+++ b/cli/src/__tests__/commands/arcade.test.ts
@@ -3,6 +3,7 @@ import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Command } from "commander";
+import { runtimeError } from "../../../shared/errors.js";
 import {
 	arcadeCommand,
 	createArcadeCommand,
@@ -67,6 +68,8 @@ describe("arcade command action coverage", () => {
 	const originalExit = process.exit;
 	const originalLog = console.log;
 	const originalError = console.error;
+	const originalBunSpawn = Bun.spawn;
+	const originalPlatform = process.platform;
 	let tempDir: string;
 	let logs: string[];
 	let errors: string[];
@@ -108,6 +111,11 @@ describe("arcade command action coverage", () => {
 		process.exit = originalExit;
 		console.log = originalLog;
 		console.error = originalError;
+		Bun.spawn = originalBunSpawn;
+		Object.defineProperty(process, "platform", {
+			value: originalPlatform,
+			configurable: true,
+		});
 		await rm(tempDir, { recursive: true, force: true });
 	});
 
@@ -174,6 +182,20 @@ describe("arcade command action coverage", () => {
 		return parent.parseAsync(["node", "rp1", "arcade", ...args]);
 	};
 
+	const browserCommandFor = (url: string): string[] =>
+		process.platform === "darwin"
+			? ["open", url]
+			: process.platform === "win32"
+				? ["cmd", "/c", "start", "", url]
+				: ["xdg-open", url];
+
+	const setPlatform = (platform: NodeJS.Platform): void => {
+		Object.defineProperty(process, "platform", {
+			value: platform,
+			configurable: true,
+		});
+	};
+
 	test("runs project, hook, daemon-only, restart, stop, and status branches", async () => {
 		const projectRoot = await createProject();
 
@@ -219,6 +241,64 @@ describe("arcade command action coverage", () => {
 		expect(errors).toEqual([]);
 	});
 
+	test("opens the browser by default through the platform launcher", async () => {
+		const projectRoot = await createProject();
+		const launched: Array<{
+			command: string[];
+			stdout?: unknown;
+			stderr?: unknown;
+		}> = [];
+		Bun.spawn = ((
+			command: string[],
+			options?: { stdout?: unknown; stderr?: unknown },
+		) => {
+			launched.push({
+				command,
+				stdout: options?.stdout,
+				stderr: options?.stderr,
+			});
+			return { exited: Promise.resolve(0) };
+		}) as unknown as typeof Bun.spawn;
+
+		await runArcade([projectRoot, "--port", "8127"]);
+
+		const url = "http://127.0.0.1:8127/projects/project-1";
+		expect(launched).toEqual([
+			{ command: browserCommandFor(url), stdout: "ignore", stderr: "ignore" },
+		]);
+		expect(infos).toContain(`Opened ${url}`);
+	});
+
+	test("opens the browser through the Windows launcher branch", async () => {
+		setPlatform("win32");
+		const projectRoot = await createProject();
+		const launched: string[][] = [];
+		Bun.spawn = ((command: string[]) => {
+			launched.push(command);
+			return { exited: Promise.resolve(0) };
+		}) as unknown as typeof Bun.spawn;
+
+		await runArcade([projectRoot, "--port", "8130"]);
+
+		expect(launched).toEqual([
+			["cmd", "/c", "start", "", "http://127.0.0.1:8130/projects/project-1"],
+		]);
+	});
+
+	test("warns when the platform browser launcher fails", async () => {
+		const projectRoot = await createProject();
+		Bun.spawn = (() => {
+			throw new Error("launcher missing");
+		}) as unknown as typeof Bun.spawn;
+
+		await runArcade([projectRoot, "--port", "8128"]);
+
+		expect(logs).toContain(
+			"WARN Could not open browser automatically. Please open http://127.0.0.1:8128/projects/project-1",
+		);
+		expect(infos).toContain("Opened http://127.0.0.1:8128/projects/project-1");
+	});
+
 	test("maps daemon port conflicts to CLI exit code", async () => {
 		const projectRoot = await createProject();
 		const conflict = new Error("port busy") as Error & { port: number };
@@ -255,6 +335,53 @@ describe("arcade command action coverage", () => {
 			]),
 		).rejects.toMatchObject({ code: 3 });
 		expect(errors.join("\n")).toContain("Port 8126 is already in use");
+	});
+
+	test("preserves CLI errors raised by daemon startup", async () => {
+		const projectRoot = await createProject();
+		const command = createArcadeCommand({
+			launchArcadeForProject: async () => {
+				throw runtimeError("daemon unavailable");
+			},
+		});
+		const parent = new Command("rp1");
+		parent.version("0.7.5");
+		Object.assign(parent, {
+			_logger: {
+				debug: () => {},
+				info: () => {},
+				warn: () => {},
+				error: () => {},
+			},
+		});
+		parent.addCommand(command);
+		parent.exitOverride();
+
+		await expect(
+			parent.parseAsync([
+				"node",
+				"rp1",
+				"arcade",
+				projectRoot,
+				"--port",
+				"8129",
+				"--no-open",
+			]),
+		).rejects.toMatchObject({ code: 1 });
+		expect(errors.join("\n")).toContain("daemon unavailable");
+	});
+
+	test("exits before daemon work when the parent logger is missing", async () => {
+		const command = createArcadeCommand({
+			getStatus: async () => ({ running: false }),
+		});
+		command.exitOverride();
+
+		await expect(
+			command.parseAsync(["node", "arcade", "--status"]),
+		).rejects.toMatchObject({ code: 1 });
+		expect(errors).toContain("Logger not initialized");
+		expect(daemonCalls).toEqual([]);
 	});
 });
 

--- a/cli/src/__tests__/daemon/runtime-helpers.test.ts
+++ b/cli/src/__tests__/daemon/runtime-helpers.test.ts
@@ -1,0 +1,396 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { readFile, stat, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { cleanupTempDir, createTempDir } from "../helpers/index.js";
+
+const originalFetch = globalThis.fetch;
+const originalPlatform = process.platform;
+const originalAppData = process.env.APPDATA;
+const originalXdgConfigHome = process.env.XDG_CONFIG_HOME;
+
+let tempDir: string;
+
+function setPlatform(platform: NodeJS.Platform): void {
+	Object.defineProperty(process, "platform", {
+		value: platform,
+		configurable: true,
+	});
+}
+
+async function loadConfigDirModule() {
+	return await import(
+		`../../../web-ui/src/daemon/config-dir.ts?runtime-helpers=${Date.now()}-${Math.random()}`
+	);
+}
+
+async function loadIpcModule() {
+	return await import(
+		`../../../web-ui/src/daemon/ipc.ts?runtime-helpers=${Date.now()}-${Math.random()}`
+	);
+}
+
+async function loadDiagnosticsModule() {
+	return await import(
+		`../../../web-ui/src/daemon/diagnostics.ts?runtime-helpers=${Date.now()}-${Math.random()}`
+	);
+}
+
+function mockConfigDir(configDir: string): void {
+	const module = {
+		getConfigDir: () => configDir,
+	};
+	mock.module("../../../web-ui/src/daemon/config-dir", () => module);
+	mock.module("../../../web-ui/src/daemon/config-dir.js", () => module);
+}
+
+describe("daemon runtime helpers", () => {
+	beforeEach(async () => {
+		tempDir = await createTempDir("daemon-runtime-helpers");
+	});
+
+	afterEach(async () => {
+		globalThis.fetch = originalFetch;
+		Object.defineProperty(process, "platform", {
+			value: originalPlatform,
+			configurable: true,
+		});
+		if (originalAppData === undefined) {
+			delete process.env.APPDATA;
+		} else {
+			process.env.APPDATA = originalAppData;
+		}
+		if (originalXdgConfigHome === undefined) {
+			delete process.env.XDG_CONFIG_HOME;
+		} else {
+			process.env.XDG_CONFIG_HOME = originalXdgConfigHome;
+		}
+		await cleanupTempDir(tempDir);
+	});
+
+	describe("daemon config paths", () => {
+		test("uses platform config directories for Arcade daemon state", async () => {
+			const { getConfigDir } = await loadConfigDirModule();
+
+			setPlatform("darwin");
+			expect(getConfigDir()).toBe(
+				join(homedir(), "Library", "Application Support", "rp1"),
+			);
+
+			setPlatform("win32");
+			process.env.APPDATA = join(tempDir, "AppData", "Roaming");
+			expect(getConfigDir()).toBe(join(process.env.APPDATA, "rp1"));
+
+			delete process.env.APPDATA;
+			expect(getConfigDir()).toBe(join(homedir(), "AppData", "Roaming", "rp1"));
+
+			setPlatform("linux");
+			process.env.XDG_CONFIG_HOME = join(tempDir, "xdg");
+			expect(getConfigDir()).toBe(join(process.env.XDG_CONFIG_HOME, "rp1"));
+
+			delete process.env.XDG_CONFIG_HOME;
+			expect(getConfigDir()).toBe(join(homedir(), ".config", "rp1"));
+		});
+
+		test("derives daemon sidecar paths from the active config directory", async () => {
+			const {
+				getDaemonStatePath,
+				getLifecycleLockPath,
+				getPidFilePath,
+				getRestartMarkerPath,
+			} = await loadConfigDirModule();
+
+			setPlatform("linux");
+			process.env.XDG_CONFIG_HOME = join(tempDir, "xdg");
+
+			const configDir = join(tempDir, "xdg", "rp1");
+
+			expect(getPidFilePath()).toBe(join(configDir, "daemon.pid"));
+			expect(getLifecycleLockPath()).toBe(
+				join(configDir, "daemon.lifecycle.lock"),
+			);
+			expect(getRestartMarkerPath()).toBe(
+				join(configDir, "restart-arcade-after-install"),
+			);
+			expect(getDaemonStatePath()).toBe(
+				join(homedir(), ".rp1", "daemon-state.json"),
+			);
+		});
+
+		test("creates the config directory with daemon-only permissions", async () => {
+			const { ensureConfigDir } = await loadConfigDirModule();
+
+			setPlatform("linux");
+			process.env.XDG_CONFIG_HOME = join(tempDir, "xdg");
+
+			const configDir = join(tempDir, "xdg", "rp1");
+			expect(await ensureConfigDir()).toBe(configDir);
+			const configStat = await stat(configDir);
+			expect(configStat.isDirectory()).toBe(true);
+		});
+	});
+
+	describe("daemon diagnostics", () => {
+		test("writes structured daemon events and errors to the config log", async () => {
+			const configDir = join(tempDir, "config");
+			mockConfigDir(configDir);
+			try {
+				const { logDaemonError, logDaemonEvent } =
+					await loadDiagnosticsModule();
+
+				logDaemonEvent("daemon-started", { port: 7710 });
+				logDaemonError("daemon-crashed", new TypeError("boom"));
+				logDaemonError("daemon-signal", "SIGTERM");
+
+				const entries = (await readFile(join(configDir, "daemon.log"), "utf-8"))
+					.trim()
+					.split("\n")
+					.map((line) => JSON.parse(line) as Record<string, unknown>);
+
+				expect(entries[0]).toMatchObject({
+					event: "daemon-started",
+					pid: process.pid,
+					port: 7710,
+				});
+				expect(entries[1]).toMatchObject({
+					event: "daemon-crashed",
+					name: "TypeError",
+					message: "boom",
+				});
+				expect(entries[2]).toMatchObject({
+					event: "daemon-signal",
+					name: "string",
+					message: "SIGTERM",
+					stack: "",
+				});
+			} finally {
+				mock.restore();
+			}
+		});
+
+		test("ignores diagnostics write failures", async () => {
+			const configDir = join(tempDir, "blocked", "config");
+			await writeFile(join(tempDir, "blocked"), "not a directory");
+			mockConfigDir(configDir);
+
+			try {
+				const { logDaemonEvent } = await loadDiagnosticsModule();
+
+				expect(() => logDaemonEvent("daemon-started")).not.toThrow();
+			} finally {
+				mock.restore();
+			}
+		});
+	});
+
+	describe("daemon IPC", () => {
+		test("checks health and reports daemon status from the v2 health route", async () => {
+			const { checkHealth, createConnection, getDaemonStatus } =
+				await loadIpcModule();
+			const requests: Array<{ url: string; init?: RequestInit }> = [];
+			globalThis.fetch = mock(
+				async (input: RequestInfo | URL, init?: RequestInit) => {
+					requests.push({ url: String(input), init });
+					return Response.json({
+						status: "ok",
+						uptime: 42,
+						port: 7710,
+						projectCount: 3,
+						isDev: true,
+						version: "0.7.6-test",
+					});
+				},
+			) as unknown as typeof fetch;
+
+			const conn = createConnection(7710);
+			const health = await checkHealth(conn);
+			const status = await getDaemonStatus(conn);
+
+			expect(conn).toEqual({
+				port: 7710,
+				baseUrl: "http://127.0.0.1:7710",
+			});
+			expect(health).toMatchObject({
+				status: "ok",
+				uptime: 42,
+				port: 7710,
+				projectCount: 3,
+			});
+			expect(status).toEqual({
+				running: true,
+				port: 7710,
+				uptime: 42,
+				projectCount: 3,
+			});
+			expect(requests.map((request) => request.url)).toEqual([
+				"http://127.0.0.1:7710/api/v2/health",
+				"http://127.0.0.1:7710/api/v2/health",
+			]);
+			expect(requests[0].init?.method).toBe("GET");
+		});
+
+		test("returns disconnected status when health checks fail", async () => {
+			const { checkHealth, createConnection, getDaemonStatus } =
+				await loadIpcModule();
+			globalThis.fetch = mock(
+				async () => new Response("nope", { status: 503 }),
+			) as unknown as typeof fetch;
+
+			expect(await checkHealth(createConnection(7711))).toBeNull();
+			expect(await getDaemonStatus(createConnection(7711))).toEqual({
+				running: false,
+			});
+
+			globalThis.fetch = mock(async () => {
+				throw new Error("connection refused");
+			}) as unknown as typeof fetch;
+
+			expect(await checkHealth(createConnection(7712))).toBeNull();
+		});
+
+		test("registers projects and propagates daemon error responses", async () => {
+			const { createConnection, registerProjectWithDaemon } =
+				await loadIpcModule();
+			const requests: Array<{ url: string; body: string | undefined }> = [];
+			globalThis.fetch = mock(
+				async (input: RequestInfo | URL, init?: RequestInit) => {
+					requests.push({
+						url: String(input),
+						body: typeof init?.body === "string" ? init.body : undefined,
+					});
+					return Response.json({
+						project: {
+							id: "project-1",
+							path: "/repo",
+							name: "repo",
+							registeredAt: "2026-05-04T00:00:00.000Z",
+							lastAccessedAt: "2026-05-04T00:00:00.000Z",
+						},
+						url: "http://127.0.0.1:7710/projects/project-1",
+					});
+				},
+			) as unknown as typeof fetch;
+
+			const registered = await registerProjectWithDaemon(
+				createConnection(7710),
+				"/repo",
+			);
+
+			expect(registered.url).toBe("http://127.0.0.1:7710/projects/project-1");
+			expect(requests[0]).toEqual({
+				url: "http://127.0.0.1:7710/api/v2/projects",
+				body: JSON.stringify({ path: "/repo" }),
+			});
+
+			globalThis.fetch = mock(async () =>
+				Response.json({ error: "Project path is required" }, { status: 400 }),
+			) as unknown as typeof fetch;
+
+			await expect(
+				registerProjectWithDaemon(createConnection(7710), ""),
+			).rejects.toThrow("Project path is required");
+		});
+
+		test("posts event and notification envelopes to daemon notify routes", async () => {
+			const { createConnection, notifyEvent, notifyNotification } =
+				await loadIpcModule();
+			const requests: Array<{ url: string; body: unknown }> = [];
+			globalThis.fetch = mock(
+				async (input: RequestInfo | URL, init?: RequestInit) => {
+					requests.push({
+						url: String(input),
+						body: JSON.parse(String(init?.body)),
+					});
+					return Response.json({ ok: true });
+				},
+			) as unknown as typeof fetch;
+
+			const eventPayload = {
+				eventType: "status_change",
+				eventId: 7,
+				runId: "run-1",
+				projectPath: "/repo",
+				projectId: "project-1",
+				rp1ProjectRoot: "/repo",
+				featureId: "fix-all-ui",
+				runStatus: "completed" as const,
+				step: "task-builder:completed",
+				unit: "T8",
+				data: { status: "completed" },
+				createdAt: "2026-05-04T00:00:00.000Z",
+			};
+			const notification = {
+				id: 9,
+				message: "Runtime recovered",
+				sourceType: "workflow",
+				sourceId: "run-1",
+				route: "/runs/run-1",
+				projectId: "project-1",
+				createdAt: "2026-05-04T00:00:01.000Z",
+			};
+
+			expect(await notifyEvent(createConnection(7710), eventPayload)).toBe(
+				true,
+			);
+			expect(
+				await notifyNotification(createConnection(7710), notification),
+			).toBe(true);
+
+			expect(requests).toEqual([
+				{
+					url: "http://127.0.0.1:7710/api/v2/status/notify",
+					body: {
+						type: "event",
+						...eventPayload,
+					},
+				},
+				{
+					url: "http://127.0.0.1:7710/api/v2/notifications/notify",
+					body: {
+						type: "notification",
+						notification,
+					},
+				},
+			]);
+		});
+
+		test("returns false for failed shutdown and notify attempts", async () => {
+			const { createConnection, notifyEvent, notifyNotification, stopDaemon } =
+				await loadIpcModule();
+			globalThis.fetch = mock(
+				async () => new Response("nope", { status: 500 }),
+			) as unknown as typeof fetch;
+
+			expect(await stopDaemon(createConnection(7710))).toBe(false);
+			expect(
+				await notifyEvent(createConnection(7710), {
+					eventType: "status_change",
+					eventId: 1,
+					runId: "run-1",
+					projectPath: "/repo",
+					featureId: "fix-all-ui",
+					step: null,
+					data: null,
+					createdAt: "2026-05-04T00:00:00.000Z",
+				}),
+			).toBe(false);
+
+			globalThis.fetch = mock(async () => {
+				throw new Error("daemon offline");
+			}) as unknown as typeof fetch;
+
+			expect(await stopDaemon(createConnection(7710))).toBe(false);
+			expect(
+				await notifyNotification(createConnection(7710), {
+					id: 1,
+					message: "offline",
+					sourceType: "workflow",
+					sourceId: null,
+					route: null,
+					projectId: null,
+					createdAt: "2026-05-04T00:00:00.000Z",
+				}),
+			).toBe(false);
+		});
+	});
+});

--- a/cli/web-ui/src/__tests__/hooks/useFeed.test.ts
+++ b/cli/web-ui/src/__tests__/hooks/useFeed.test.ts
@@ -1,12 +1,14 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import { act, renderHook, waitFor } from "@testing-library/react";
-import { useSyncExternalStore } from "react";
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import { useEffect, useSyncExternalStore } from "react";
 import type { FeedItem } from "@/hooks/useFeed";
 import { liveRunIndex } from "@/lib/live-run-index";
 import type { Run } from "@/types/runs";
 
 let fetchMock: ReturnType<typeof mock>;
 let useFeedImportVersion = 0;
+let reconnectRecoveryCallbacks: Array<() => void | Promise<void>> = [];
+let activityRecoveryLimit = 10;
 
 function buildRun(overrides: Partial<Run> = {}): Run {
 	return {
@@ -67,6 +69,17 @@ function buildFeedItem(run: Run): FeedItem {
 	};
 }
 
+function feedItemIds(items: readonly FeedItem[]): string[] {
+	return items.map((item) => item.id);
+}
+
+function findFeedItem(
+	items: readonly FeedItem[],
+	id: string,
+): FeedItem | undefined {
+	return items.find((item) => item.id === id);
+}
+
 function buildFeedResponse(
 	runs: readonly Run[],
 	total = runs.length,
@@ -90,7 +103,16 @@ function createAbortError(): Error {
 
 async function loadUseFeed() {
 	mock.module("../../hooks/useReconnectRecovery.ts", () => ({
-		useReconnectRecovery: () => {},
+		useReconnectRecovery: (recover: () => void | Promise<void>) => {
+			useEffect(() => {
+				reconnectRecoveryCallbacks.push(recover);
+				return () => {
+					reconnectRecoveryCallbacks = reconnectRecoveryCallbacks.filter(
+						(callback) => callback !== recover,
+					);
+				};
+			}, [recover]);
+		},
 	}));
 	mock.module("../../hooks/useLiveRunIndex.ts", () => ({
 		useLiveRunIndexBridge: () => {},
@@ -101,6 +123,13 @@ async function loadUseFeed() {
 				liveRunIndex.getSnapshot,
 			),
 	}));
+	mock.module("@/providers/RuntimeProvider", () => ({
+		useRuntimeContract: () => ({
+			reconnectPolicy: {
+				activityRecoveryLimit,
+			},
+		}),
+	}));
 
 	return import(
 		`../../hooks/useFeed.ts?use-feed-test=${++useFeedImportVersion}`
@@ -110,6 +139,8 @@ async function loadUseFeed() {
 beforeEach(() => {
 	mock.restore();
 	liveRunIndex.clear();
+	reconnectRecoveryCallbacks = [];
+	activityRecoveryLimit = 10;
 
 	fetchMock = mock(() => Promise.resolve(buildFeedResponse([buildRun()])));
 
@@ -117,6 +148,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+	cleanup();
 	liveRunIndex.clear();
 	mock.restore();
 });
@@ -510,5 +542,160 @@ describe("useFeed", () => {
 		expect(result.current.items).toHaveLength(0);
 		expect(result.current.total).toBe(0);
 		expect(result.current.error).toBeNull();
+	});
+
+	test("reconciles after reconnect with a bounded background request and deduplicates replay overlap", async () => {
+		const initialRun = buildRun({
+			id: "run-1",
+			lastEventAt: "2026-04-10T00:05:00.000Z",
+		});
+		const replayRun = buildRun({
+			id: "run-2",
+			name: "Replay Run",
+			lastEventAt: "2026-04-10T00:07:00.000Z",
+		});
+		const recoveredReplayRun = buildRun({
+			id: "run-2",
+			name: "Replay Run",
+			status: "waiting",
+			lastEventAt: "2026-04-10T00:08:00.000Z",
+		});
+		const liveAfterRecoveryRun = buildRun({
+			id: "run-3",
+			name: "Post Recovery Live Run",
+			lastEventAt: "2026-04-10T00:09:00.000Z",
+		});
+		const recoveryResponse = createDeferred<MockFeedResponse>();
+		let requestCount = 0;
+
+		fetchMock = mock(() => {
+			requestCount += 1;
+			if (requestCount === 1) {
+				return Promise.resolve(buildFeedResponse([initialRun], 1));
+			}
+
+			return recoveryResponse.promise;
+		});
+		globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+		const { useFeed } = await loadUseFeed();
+		const { result } = renderHook(() => useFeed({ limit: 25, offset: 0 }));
+
+		await waitFor(() => {
+			expect(result.current.isLoading).toBe(false);
+		});
+		expect(reconnectRecoveryCallbacks).toHaveLength(1);
+
+		act(() => {
+			liveRunIndex.upsertRun(replayRun);
+		});
+
+		await waitFor(() => {
+			expect(feedItemIds(result.current.items)).toContain("run-2");
+		});
+
+		let recoveryPromise: void | Promise<void>;
+		act(() => {
+			recoveryPromise = reconnectRecoveryCallbacks[0]?.();
+		});
+
+		expect(result.current.isLoading).toBe(false);
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+		const recoveryUrl = new URL(
+			fetchMock.mock.calls[1]?.[0] as string,
+			"http://localhost",
+		);
+		expect(recoveryUrl.searchParams.get("limit")).toBe("35");
+
+		await act(async () => {
+			recoveryResponse.resolve(
+				buildFeedResponse([initialRun, recoveredReplayRun], 2),
+			);
+			await recoveryPromise;
+			await recoveryResponse.promise;
+			await Promise.resolve();
+		});
+
+		await waitFor(() => {
+			expect(feedItemIds(result.current.items)).toEqual(
+				expect.arrayContaining(["run-1", "run-2"]),
+			);
+		});
+		expect(new Set(feedItemIds(result.current.items)).size).toBe(
+			result.current.items.length,
+		);
+		expect(findFeedItem(result.current.items, "run-2")?.run.status).toBe(
+			"waiting",
+		);
+
+		act(() => {
+			liveRunIndex.upsertRun(liveAfterRecoveryRun);
+		});
+
+		await waitFor(() => {
+			expect(feedItemIds(result.current.items)).toContain("run-3");
+		});
+	});
+
+	test("preserves feed rows on recoverable reconciliation failure and retries later", async () => {
+		const initialRun = buildRun({
+			id: "run-1",
+			lastEventAt: "2026-04-10T00:05:00.000Z",
+		});
+		const recoveredRun = buildRun({
+			id: "run-2",
+			lastEventAt: "2026-04-10T00:06:00.000Z",
+		});
+		let requestCount = 0;
+
+		fetchMock = mock(() => {
+			requestCount += 1;
+			if (requestCount === 1) {
+				return Promise.resolve(buildFeedResponse([initialRun], 1));
+			}
+			if (requestCount === 2) {
+				return Promise.resolve({
+					ok: false,
+					statusText: "Service Unavailable",
+					json: () => Promise.resolve({ items: [], total: 0 }),
+				});
+			}
+
+			return Promise.resolve(buildFeedResponse([initialRun, recoveredRun], 2));
+		});
+		globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+		const { useFeed } = await loadUseFeed();
+		const { result } = renderHook(() => useFeed({ limit: 25, offset: 0 }));
+
+		await waitFor(() => {
+			expect(result.current.isLoading).toBe(false);
+		});
+
+		await act(async () => {
+			await reconnectRecoveryCallbacks[0]?.();
+			await Promise.resolve();
+		});
+
+		await waitFor(() => {
+			expect(result.current.error?.message).toBe(
+				"Failed to fetch feed: Service Unavailable",
+			);
+		});
+		expect(result.current.isLoading).toBe(false);
+		expect(feedItemIds(result.current.items)).toEqual(["run-1"]);
+
+		await act(async () => {
+			await reconnectRecoveryCallbacks[0]?.();
+			await Promise.resolve();
+		});
+
+		await waitFor(() => {
+			expect(result.current.error).toBeNull();
+			expect(feedItemIds(result.current.items)).toEqual(
+				expect.arrayContaining(["run-1", "run-2"]),
+			);
+		});
+		expect(fetchMock).toHaveBeenCalledTimes(3);
 	});
 });

--- a/cli/web-ui/src/__tests__/hooks/useReconnectRecovery.test.ts
+++ b/cli/web-ui/src/__tests__/hooks/useReconnectRecovery.test.ts
@@ -7,6 +7,7 @@ type ConnectionStatus = "connecting" | "connected" | "disconnected";
 let reconnectListeners: ReconnectCallback[] = [];
 let socketStatus: ConnectionStatus = "connected";
 let intervalCallback: (() => void) | null = null;
+let intervalDelay: number | undefined;
 let intervalId = 0;
 let clearedIntervalIds: ReturnType<typeof setInterval>[] = [];
 let useReconnectRecoveryImportVersion = 0;
@@ -27,6 +28,13 @@ async function loadUseReconnectRecovery() {
 			},
 		}),
 	}));
+	mock.module("@/providers/RuntimeProvider", () => ({
+		useRuntimeContract: () => ({
+			reconnectPolicy: {
+				disconnectedRecoveryIntervalMs: 1234,
+			},
+		}),
+	}));
 
 	return import(
 		`../../hooks/useReconnectRecovery.ts?use-reconnect-recovery-test=${++useReconnectRecoveryImportVersion}`
@@ -38,10 +46,12 @@ beforeEach(() => {
 	reconnectListeners = [];
 	socketStatus = "connected";
 	intervalCallback = null;
+	intervalDelay = undefined;
 	intervalId = 0;
 	clearedIntervalIds = [];
-	globalThis.setInterval = ((callback: TimerHandler) => {
+	globalThis.setInterval = ((callback: TimerHandler, delay?: number) => {
 		intervalCallback = callback as () => void;
+		intervalDelay = delay;
 		intervalId += 1;
 		return intervalId as unknown as ReturnType<typeof setInterval>;
 	}) as unknown as typeof setInterval;
@@ -56,6 +66,7 @@ afterEach(() => {
 	reconnectListeners = [];
 	socketStatus = "connected";
 	intervalCallback = null;
+	intervalDelay = undefined;
 	clearedIntervalIds = [];
 	globalThis.setInterval = originalSetInterval;
 	globalThis.clearInterval = originalClearInterval;
@@ -77,6 +88,7 @@ describe("useReconnectRecovery", () => {
 		rerender();
 
 		expect(intervalCallback).not.toBeNull();
+		expect(intervalDelay).toBe(1234);
 
 		act(() => {
 			intervalCallback?.();

--- a/cli/web-ui/src/__tests__/hooks/useRuns.test.ts
+++ b/cli/web-ui/src/__tests__/hooks/useRuns.test.ts
@@ -1,11 +1,13 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import { renderHook, waitFor } from "@testing-library/react";
-import { useSyncExternalStore } from "react";
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import { useEffect, useSyncExternalStore } from "react";
 import { liveRunIndex } from "@/lib/live-run-index";
 import type { Run } from "@/types/runs";
 
 let fetchMock: ReturnType<typeof mock>;
 let useRunsImportVersion = 0;
+let reconnectRecoveryCallbacks: Array<() => void | Promise<void>> = [];
+let activityRecoveryLimit = 10;
 
 function buildRun(overrides: Partial<Run> = {}): Run {
 	return {
@@ -31,9 +33,35 @@ function buildRun(overrides: Partial<Run> = {}): Run {
 	};
 }
 
+interface Deferred<T> {
+	readonly promise: Promise<T>;
+	readonly resolve: (value: T) => void;
+	readonly reject: (reason?: unknown) => void;
+}
+
+function createDeferred<T>(): Deferred<T> {
+	let resolve: (value: T) => void = () => {};
+	let reject: (reason?: unknown) => void = () => {};
+	const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+		resolve = resolvePromise;
+		reject = rejectPromise;
+	});
+
+	return { promise, resolve, reject };
+}
+
 async function loadUseRuns() {
 	mock.module("../../hooks/useReconnectRecovery.ts", () => ({
-		useReconnectRecovery: () => {},
+		useReconnectRecovery: (recover: () => void | Promise<void>) => {
+			useEffect(() => {
+				reconnectRecoveryCallbacks.push(recover);
+				return () => {
+					reconnectRecoveryCallbacks = reconnectRecoveryCallbacks.filter(
+						(callback) => callback !== recover,
+					);
+				};
+			}, [recover]);
+		},
 	}));
 	mock.module("../../hooks/useLiveRunIndex.ts", () => ({
 		useLiveRunIndexSnapshot: () =>
@@ -42,6 +70,13 @@ async function loadUseRuns() {
 				liveRunIndex.getSnapshot,
 				liveRunIndex.getSnapshot,
 			),
+	}));
+	mock.module("@/providers/RuntimeProvider", () => ({
+		useRuntimeContract: () => ({
+			reconnectPolicy: {
+				activityRecoveryLimit,
+			},
+		}),
 	}));
 
 	return import(
@@ -52,6 +87,8 @@ async function loadUseRuns() {
 beforeEach(() => {
 	mock.restore();
 	liveRunIndex.clear();
+	reconnectRecoveryCallbacks = [];
+	activityRecoveryLimit = 10;
 
 	fetchMock = mock(() =>
 		Promise.resolve({
@@ -68,6 +105,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+	cleanup();
 	liveRunIndex.clear();
 	mock.restore();
 });
@@ -106,5 +144,84 @@ describe("useRuns", () => {
 
 		expect(result.current.total).toBe(1);
 		expect(fetchMock).toHaveBeenCalledTimes(1);
+	});
+
+	test("reconciles after reconnect with a bounded background request", async () => {
+		const initialRun = buildRun({
+			id: "run-1",
+			lastEventAt: "2026-04-10T00:05:00.000Z",
+		});
+		const recoveredRun = buildRun({
+			id: "run-2",
+			lastEventAt: "2026-04-10T00:06:00.000Z",
+		});
+		const recoveryResponse = createDeferred<{
+			readonly ok: boolean;
+			readonly json: () => Promise<{
+				readonly runs: Run[];
+				readonly total: number;
+			}>;
+		}>();
+		let requestCount = 0;
+
+		fetchMock = mock(() => {
+			requestCount += 1;
+			if (requestCount === 1) {
+				return Promise.resolve({
+					ok: true,
+					json: () =>
+						Promise.resolve({
+							runs: [initialRun],
+							total: 1,
+						}),
+				});
+			}
+
+			return recoveryResponse.promise;
+		});
+		globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+		const { useRuns } = await loadUseRuns();
+		const { result } = renderHook(() =>
+			useRuns({ status: "running", limit: 25, offset: 0 }),
+		);
+
+		await waitFor(() => {
+			expect(result.current.isLoading).toBe(false);
+		});
+
+		let recoveryPromise: void | Promise<void>;
+		act(() => {
+			recoveryPromise = reconnectRecoveryCallbacks[0]?.();
+		});
+
+		expect(result.current.isLoading).toBe(false);
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+		const recoveryUrl = new URL(
+			fetchMock.mock.calls[1]?.[0] as string,
+			"http://localhost",
+		);
+		expect(recoveryUrl.searchParams.get("limit")).toBe("35");
+
+		await act(async () => {
+			recoveryResponse.resolve({
+				ok: true,
+				json: () =>
+					Promise.resolve({
+						runs: [initialRun, recoveredRun],
+						total: 2,
+					}),
+			});
+			await recoveryPromise;
+			await recoveryResponse.promise;
+			await Promise.resolve();
+		});
+
+		await waitFor(() => {
+			expect(result.current.runs.map((run: Run) => run.id)).toEqual(
+				expect.arrayContaining(["run-1", "run-2"]),
+			);
+		});
+		expect(result.current.error).toBeNull();
 	});
 });

--- a/cli/web-ui/src/__tests__/lib/live-run-index.test.ts
+++ b/cli/web-ui/src/__tests__/lib/live-run-index.test.ts
@@ -54,6 +54,8 @@ function buildSnapshot(
 ): StateSnapshotMessage {
 	return {
 		type: "state:snapshot",
+		scope: overrides.scope ?? "project",
+		projectId: overrides.projectId ?? "proj-1",
 		lastEventId: overrides.lastEventId ?? 41,
 		runs: overrides.runs ?? [],
 	};
@@ -355,5 +357,79 @@ describe("LiveRunIndex", () => {
 		expect(new Set(index.getProjectRunIds("proj-1"))).toEqual(
 			new Set(["run-keep", "run-terminal"]),
 		);
+	});
+
+	test("applies global snapshots without pruning unrelated project runs", () => {
+		let fetchCount = 0;
+		const index = createLiveRunIndex({
+			fetchRunSummary: (runId) => {
+				fetchCount += 1;
+				return Promise.resolve(
+					buildRun({
+						id: runId,
+						projectId: "proj-2",
+						projectName: "Project Two",
+					}),
+				);
+			},
+		});
+
+		index.upsertRuns([
+			buildRun({
+				id: "run-keep",
+				status: "running",
+				currentStep: "build",
+				lastEventAt: "2026-04-14T00:03:00.000Z",
+			}),
+			buildRun({
+				id: "run-other-project",
+				projectId: "proj-2",
+				projectName: "Project Two",
+				status: "running",
+				currentStep: "build",
+				lastEventAt: "2026-04-14T00:04:00.000Z",
+			}),
+		]);
+
+		index.applyGlobalSnapshot(
+			buildSnapshot({
+				scope: "global",
+				projectId: null,
+				lastEventId: 50,
+				runs: [
+					{
+						id: "run-keep",
+						projectId: "proj-1",
+						flow: "build",
+						featureId: "emit-daemon",
+						projectPath: "/tmp/project",
+						status: "waiting",
+						steps: [{ step: "review", status: "waiting" }],
+						artifacts: [],
+					},
+					{
+						id: "run-new",
+						projectId: "proj-2",
+						flow: "build",
+						featureId: "emit-daemon",
+						projectPath: "/tmp/other-project",
+						status: "running",
+						steps: [{ step: "build", status: "running" }],
+						artifacts: [],
+					},
+				],
+			}),
+		);
+
+		expect(index.getRun("run-keep")).toMatchObject({
+			status: "waiting",
+			currentStep: "review",
+		});
+		expect(index.getRun("run-other-project")).toMatchObject({
+			status: "running",
+			currentStep: "build",
+		});
+		expect(index.getProjectRunIds("proj-2")).toContain("run-other-project");
+		expect(fetchCount).toBe(1);
 	});
 });

--- a/cli/web-ui/src/__tests__/providers/RuntimeProvider.test.tsx
+++ b/cli/web-ui/src/__tests__/providers/RuntimeProvider.test.tsx
@@ -39,12 +39,14 @@ describe("RuntimeProvider", () => {
 
 	beforeEach(() => {
 		window.location.href = "http://localhost/";
+		window.sessionStorage.clear();
 	});
 
 	afterEach(() => {
 		cleanup();
 		globalThis.fetch = originalFetch;
 		window.location.href = "http://localhost/";
+		window.sessionStorage.clear();
 	});
 
 	test("builds the runtime endpoint from host launch metadata", () => {
@@ -121,5 +123,81 @@ describe("RuntimeProvider", () => {
 				"runtime unavailable",
 			);
 		});
+	});
+
+	test("accepts the development runtime fallback without a reload loop", async () => {
+		const devRuntime: ArcadeRuntimeContract = {
+			...TEST_RUNTIME,
+			buildId: `dev-${TEST_RUNTIME.version}`,
+			cacheBust: `dev-${TEST_RUNTIME.version}`,
+		};
+		const loadRuntime = mock(async () => devRuntime);
+		const reloadRuntime = mock((_contract: ArcadeRuntimeContract) => {});
+
+		render(
+			<RuntimeProvider
+				loadRuntime={loadRuntime}
+				clientBuildMetadata={{
+					buildId: "vite-dev-build",
+					version: TEST_RUNTIME.version,
+				}}
+				reloadRuntime={reloadRuntime}
+			>
+				<RuntimeProbe />
+			</RuntimeProvider>,
+		);
+
+		await waitFor(() => {
+			expect(screen.getByTestId("host-mode").textContent).toBe("native");
+		});
+		expect(reloadRuntime).not.toHaveBeenCalled();
+	});
+
+	test("attempts one cache-busted reload before failing a persistent runtime build mismatch", async () => {
+		const updatedRuntime: ArcadeRuntimeContract = {
+			...TEST_RUNTIME,
+			buildId: "build-2",
+			cacheBust: "build-2",
+		};
+		const loadRuntime = mock(async () => updatedRuntime);
+		const reloadRuntime = mock((_contract: ArcadeRuntimeContract) => {});
+		const clientBuildMetadata = {
+			buildId: "build-1",
+			version: TEST_RUNTIME.version,
+		};
+
+		render(
+			<RuntimeProvider
+				loadRuntime={loadRuntime}
+				clientBuildMetadata={clientBuildMetadata}
+				reloadRuntime={reloadRuntime}
+			>
+				<RuntimeProbe />
+			</RuntimeProvider>,
+		);
+
+		await waitFor(() => {
+			expect(reloadRuntime).toHaveBeenCalledWith(updatedRuntime);
+		});
+		expect(screen.queryByTestId("host-mode")).toBeNull();
+
+		cleanup();
+
+		render(
+			<RuntimeProvider
+				loadRuntime={loadRuntime}
+				clientBuildMetadata={clientBuildMetadata}
+				reloadRuntime={reloadRuntime}
+			>
+				<RuntimeProbe />
+			</RuntimeProvider>,
+		);
+
+		await waitFor(() => {
+			expect(screen.getByRole("alert").textContent).toContain(
+				"cache-busted reload did not resolve",
+			);
+		});
+		expect(reloadRuntime).toHaveBeenCalledTimes(1);
 	});
 });

--- a/cli/web-ui/src/__tests__/providers/RuntimeProvider.test.tsx
+++ b/cli/web-ui/src/__tests__/providers/RuntimeProvider.test.tsx
@@ -1,0 +1,125 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import {
+	buildRuntimeEndpoint,
+	RuntimeProvider,
+	useRuntimeContract,
+} from "@/providers/RuntimeProvider";
+import {
+	ARCADE_RUNTIME_SCHEMA_VERSION,
+	type ArcadeRuntimeContract,
+	DEFAULT_ARCADE_RECONNECT_POLICY,
+} from "@/types/runtime";
+
+const TEST_RUNTIME: ArcadeRuntimeContract = {
+	schemaVersion: ARCADE_RUNTIME_SCHEMA_VERSION,
+	baseUrl: "http://127.0.0.1:7710",
+	hostMode: "native",
+	version: "0.7.6",
+	buildId: "build-1",
+	cacheBust: "cache-1",
+	reconnectPolicy: DEFAULT_ARCADE_RECONNECT_POLICY,
+};
+
+function RuntimeProbe() {
+	const runtime = useRuntimeContract();
+
+	return (
+		<div>
+			<span data-testid="host-mode">{runtime.hostMode}</span>
+			<span data-testid="initial-delay">
+				{runtime.reconnectPolicy.initialDelayMs}
+			</span>
+		</div>
+	);
+}
+
+describe("RuntimeProvider", () => {
+	const originalFetch = globalThis.fetch;
+
+	beforeEach(() => {
+		window.location.href = "http://localhost/";
+	});
+
+	afterEach(() => {
+		cleanup();
+		globalThis.fetch = originalFetch;
+		window.location.href = "http://localhost/";
+	});
+
+	test("builds the runtime endpoint from host launch metadata", () => {
+		expect(
+			buildRuntimeEndpoint(
+				"?host-mode=native&cache-bust=native-load&projectId=ignored",
+			),
+		).toBe("/api/v2/runtime?hostMode=native&cacheBust=native-load");
+	});
+
+	test("fetches the runtime contract without cache and exposes it to children", async () => {
+		window.location.href =
+			"http://localhost/?hostMode=native&cacheBust=cache-1";
+		const fetchMock = mock(async () => {
+			return new Response(JSON.stringify(TEST_RUNTIME), {
+				headers: { "Content-Type": "application/json" },
+			});
+		});
+		globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+		render(
+			<RuntimeProvider>
+				<RuntimeProbe />
+			</RuntimeProvider>,
+		);
+
+		await waitFor(() => {
+			expect(screen.getByTestId("host-mode").textContent).toBe("native");
+		});
+
+		expect(screen.getByTestId("initial-delay").textContent).toBe("2000");
+		expect(fetchMock).toHaveBeenCalledWith(
+			"/api/v2/runtime?hostMode=native&cacheBust=cache-1",
+			{ cache: "no-store" },
+		);
+	});
+
+	test("renders a controlled failure for unsupported host modes", async () => {
+		const fetchMock = mock(async () => {
+			return new Response(
+				JSON.stringify({ ...TEST_RUNTIME, hostMode: "mobile" }),
+				{ headers: { "Content-Type": "application/json" } },
+			);
+		});
+		globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+		render(
+			<RuntimeProvider>
+				<RuntimeProbe />
+			</RuntimeProvider>,
+		);
+
+		await waitFor(() => {
+			expect(screen.getByRole("alert").textContent).toContain(
+				"Unsupported Arcade host mode: mobile",
+			);
+		});
+	});
+
+	test("renders a controlled failure when the runtime request fails", async () => {
+		const fetchMock = mock(async () => {
+			throw new Error("runtime unavailable");
+		});
+		globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+		render(
+			<RuntimeProvider>
+				<RuntimeProbe />
+			</RuntimeProvider>,
+		);
+
+		await waitFor(() => {
+			expect(screen.getByRole("alert").textContent).toContain(
+				"runtime unavailable",
+			);
+		});
+	});
+});

--- a/cli/web-ui/src/__tests__/providers/WebSocketProvider.test.tsx
+++ b/cli/web-ui/src/__tests__/providers/WebSocketProvider.test.tsx
@@ -78,6 +78,16 @@ function wrapper({ children }: { children: ReactNode }) {
 	);
 }
 
+function wrapperWithRuntime(runtime: ArcadeRuntimeContract) {
+	return function TestWrapper({ children }: { children: ReactNode }) {
+		return (
+			<RuntimeProvider runtime={runtime}>
+				<WebSocketProvider>{children}</WebSocketProvider>
+			</RuntimeProvider>
+		);
+	};
+}
+
 function getLatestProjectSocket(projectId: string): MockWebSocket | undefined {
 	return [...MockWebSocket.instances]
 		.reverse()
@@ -326,5 +336,61 @@ describe("WebSocketProvider", () => {
 		expect(
 			sessionStorage.getItem(`${LAST_EVENT_ID_STORAGE_PREFIX}proj-2`),
 		).toBe("62");
+	});
+
+	test("acknowledges heartbeat messages immediately", async () => {
+		renderHook(() => useWebSocket(), { wrapper });
+
+		await waitFor(() => {
+			expect(getLatestGlobalSocket()).toBeDefined();
+		});
+
+		const globalSocket = getLatestGlobalSocket();
+		expect(globalSocket).toBeDefined();
+
+		act(() => {
+			globalSocket!.open();
+			globalSocket!.receive({
+				type: "heartbeat",
+				heartbeatId: "heartbeat-1",
+				timestamp: "2026-04-14T00:00:00.000Z",
+			});
+		});
+
+		expect(JSON.parse(globalSocket!.sentMessages[0])).toMatchObject({
+			type: "heartbeat:ack",
+			heartbeatId: "heartbeat-1",
+			receivedAt: expect.any(String),
+		});
+	});
+
+	test("starts reconnect recovery after a server-side heartbeat closure", async () => {
+		const fastReconnectRuntime: ArcadeRuntimeContract = {
+			...TEST_RUNTIME,
+			reconnectPolicy: {
+				...TEST_RUNTIME.reconnectPolicy,
+				initialDelayMs: 5,
+				maxDelayMs: 5,
+			},
+		};
+		const fastWrapper = wrapperWithRuntime(fastReconnectRuntime);
+
+		renderHook(() => useWebSocket(), { wrapper: fastWrapper });
+
+		await waitFor(() => {
+			expect(getLatestGlobalSocket()).toBeDefined();
+		});
+
+		const globalSocket = getLatestGlobalSocket();
+		expect(globalSocket).toBeDefined();
+
+		act(() => {
+			globalSocket!.open();
+			globalSocket!.close();
+		});
+
+		await waitFor(() => {
+			expect(MockWebSocket.instances.length).toBeGreaterThanOrEqual(2);
+		});
 	});
 });

--- a/cli/web-ui/src/__tests__/providers/WebSocketProvider.test.tsx
+++ b/cli/web-ui/src/__tests__/providers/WebSocketProvider.test.tsx
@@ -87,6 +87,14 @@ function getLatestProjectSocket(projectId: string): MockWebSocket | undefined {
 		);
 }
 
+function getLatestGlobalSocket(): MockWebSocket | undefined {
+	return [...MockWebSocket.instances]
+		.reverse()
+		.find(
+			(socket) => new URL(socket.url).searchParams.get("scope") === "global",
+		);
+}
+
 describe("WebSocketProvider", () => {
 	const originalWebSocket = globalThis.WebSocket;
 
@@ -118,9 +126,29 @@ describe("WebSocketProvider", () => {
 
 		const projectSocket = getLatestProjectSocket("proj-1");
 		expect(projectSocket).toBeDefined();
+		expect(new URL(projectSocket!.url).searchParams.get("scope")).toBe(
+			"project",
+		);
 		expect(new URL(projectSocket!.url).searchParams.get("lastEventId")).toBe(
 			"41",
 		);
+	});
+
+	test("includes the stored global cursor when connecting without a selected project", async () => {
+		sessionStorage.setItem(`${LAST_EVENT_ID_STORAGE_PREFIX}global`, "40");
+
+		renderHook(() => useWebSocket(), { wrapper });
+
+		await waitFor(() => {
+			expect(getLatestGlobalSocket()).toBeDefined();
+		});
+
+		const globalSocket = getLatestGlobalSocket();
+		expect(globalSocket).toBeDefined();
+		const url = new URL(globalSocket!.url);
+		expect(url.searchParams.get("scope")).toBe("global");
+		expect(url.searchParams.get("projectId")).toBeNull();
+		expect(url.searchParams.get("lastEventId")).toBe("40");
 	});
 
 	test("normalizes replay events and routes snapshots while advancing the project cursor", async () => {
@@ -161,9 +189,12 @@ describe("WebSocketProvider", () => {
 			});
 			projectSocket!.receive({
 				type: "event:replay",
+				scope: "project",
 				event: {
 					id: 43,
 					runId: "run-1",
+					projectId: "proj-1",
+					featureId: "feat-1",
 					eventType: "waiting_for_user",
 					step: "review",
 					data: JSON.stringify({ prompt: "Need approval" }),
@@ -172,9 +203,12 @@ describe("WebSocketProvider", () => {
 			});
 			projectSocket!.receive({
 				type: "state:snapshot",
+				scope: "project",
+				projectId: "proj-1",
 				runs: [
 					{
 						id: "run-1",
+						projectId: "proj-1",
 						flow: "build",
 						featureId: "feat-1",
 						projectPath: "/tmp/project",
@@ -224,5 +258,73 @@ describe("WebSocketProvider", () => {
 		expect(
 			new URL(reconnectedSocket!.url).searchParams.get("lastEventId"),
 		).toBe("55");
+	});
+
+	test("normalizes global replay events and advances global plus project cursors", async () => {
+		const receivedEvents: EventNotificationMessage[] = [];
+
+		const { result } = renderHook(() => useWebSocket(), { wrapper });
+
+		act(() => {
+			result.current.onEventNotification((message) => {
+				receivedEvents.push(message);
+			});
+		});
+
+		await waitFor(() => {
+			expect(getLatestGlobalSocket()).toBeDefined();
+		});
+
+		const globalSocket = getLatestGlobalSocket();
+		expect(globalSocket).toBeDefined();
+
+		act(() => {
+			globalSocket!.open();
+			globalSocket!.receive({
+				type: "event:notification",
+				eventId: 61,
+				eventType: "status_change",
+				runId: "run-1",
+				projectId: "proj-1",
+				featureId: "feat-1",
+				step: "build",
+				data: { status: "running" },
+				createdAt: "2026-04-14T00:00:00.000Z",
+			});
+			globalSocket!.receive({
+				type: "event:replay",
+				scope: "global",
+				event: {
+					id: 62,
+					runId: "run-2",
+					projectId: "proj-2",
+					featureId: "feat-2",
+					eventType: "waiting_for_user",
+					runStatus: "waiting",
+					step: "review",
+					data: JSON.stringify({ prompt: "Need approval" }),
+					createdAt: "2026-04-14T00:00:01.000Z",
+				},
+			});
+		});
+
+		expect(receivedEvents).toHaveLength(2);
+		expect(receivedEvents[1]).toMatchObject({
+			type: "event:notification",
+			eventId: 62,
+			projectId: "proj-2",
+			featureId: "feat-2",
+			runStatus: "waiting",
+			data: { prompt: "Need approval" },
+		});
+		expect(
+			sessionStorage.getItem(`${LAST_EVENT_ID_STORAGE_PREFIX}global`),
+		).toBe("62");
+		expect(
+			sessionStorage.getItem(`${LAST_EVENT_ID_STORAGE_PREFIX}proj-1`),
+		).toBe("61");
+		expect(
+			sessionStorage.getItem(`${LAST_EVENT_ID_STORAGE_PREFIX}proj-2`),
+		).toBe("62");
 	});
 });

--- a/cli/web-ui/src/__tests__/providers/WebSocketProvider.test.tsx
+++ b/cli/web-ui/src/__tests__/providers/WebSocketProvider.test.tsx
@@ -1,14 +1,33 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
+import { RuntimeProvider } from "@/providers/RuntimeProvider";
 import {
 	type EventNotificationMessage,
 	type StateSnapshotMessage,
 	useWebSocket,
 	WebSocketProvider,
 } from "@/providers/WebSocketProvider";
+import type { ArcadeRuntimeContract } from "@/types/runtime";
 
 const LAST_EVENT_ID_STORAGE_PREFIX = "rp1:last-event-id:";
+const TEST_RUNTIME: ArcadeRuntimeContract = {
+	schemaVersion: 1,
+	baseUrl: "http://127.0.0.1:7710",
+	hostMode: "browser",
+	version: "0.7.6",
+	buildId: "test-build",
+	cacheBust: "test-build",
+	reconnectPolicy: {
+		initialDelayMs: 2000,
+		maxDelayMs: 30000,
+		backoffFactor: 2,
+		heartbeatIntervalMs: 30000,
+		heartbeatMissThreshold: 3,
+		disconnectedRecoveryIntervalMs: 5000,
+		activityRecoveryLimit: 25,
+	},
+};
 
 class MockWebSocket {
 	static readonly CONNECTING = 0;
@@ -52,7 +71,11 @@ class MockWebSocket {
 }
 
 function wrapper({ children }: { children: ReactNode }) {
-	return <WebSocketProvider>{children}</WebSocketProvider>;
+	return (
+		<RuntimeProvider runtime={TEST_RUNTIME}>
+			<WebSocketProvider>{children}</WebSocketProvider>
+		</RuntimeProvider>
+	);
 }
 
 function getLatestProjectSocket(projectId: string): MockWebSocket | undefined {

--- a/cli/web-ui/src/__tests__/server/runtime-contract.test.ts
+++ b/cli/web-ui/src/__tests__/server/runtime-contract.test.ts
@@ -1,0 +1,110 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { handleV2RuntimeRequest } from "../../server/routes/v2-api";
+import { RUNTIME_CACHE_CONTROL } from "../../server/runtime-contract";
+import {
+	ARCADE_RUNTIME_MANIFEST_FILENAME,
+	type ArcadeRuntimeContract,
+	type ArcadeRuntimeManifest,
+	DEFAULT_ARCADE_RECONNECT_POLICY,
+} from "../../types/runtime";
+
+const manifest: ArcadeRuntimeManifest = {
+	version: "0.7.6",
+	gitCommit: "abc1234",
+	buildTime: "2026-05-04T00:00:00.000Z",
+	buildId: "build-abc1234",
+};
+
+function runtimeRequest(url: string): Request {
+	return new Request(url);
+}
+
+async function writeRuntimeManifest(root: string): Promise<void> {
+	const clientDir = join(root, "client");
+	await mkdir(clientDir, { recursive: true });
+	await Bun.write(
+		join(clientDir, ARCADE_RUNTIME_MANIFEST_FILENAME),
+		`${JSON.stringify(manifest)}\n`,
+	);
+}
+
+describe("Arcade runtime contract API", () => {
+	let tempDir: string;
+	let webUIDir: string;
+
+	beforeAll(async () => {
+		tempDir = await mkdtemp(join(tmpdir(), "rp1-runtime-contract-"));
+		webUIDir = join(tempDir, "web-ui");
+		await writeRuntimeManifest(webUIDir);
+	});
+
+	afterAll(async () => {
+		await rm(tempDir, { recursive: true, force: true });
+	});
+
+	test("returns browser host contract fields from the runtime manifest", async () => {
+		const response = await handleV2RuntimeRequest(
+			runtimeRequest("http://127.0.0.1:7710/api/v2/runtime"),
+			{
+				port: 7710,
+				startTime: 0,
+				webUIDir,
+				version: "fallback-version",
+			},
+		);
+
+		const body = (await response.json()) as ArcadeRuntimeContract;
+
+		expect(response.status).toBe(200);
+		expect(response.headers.get("Cache-Control")).toBe(RUNTIME_CACHE_CONTROL);
+		expect(body).toEqual({
+			schemaVersion: 1,
+			baseUrl: "http://127.0.0.1:7710",
+			hostMode: "browser",
+			version: manifest.version,
+			buildId: manifest.buildId,
+			cacheBust: manifest.buildId,
+			reconnectPolicy: DEFAULT_ARCADE_RECONNECT_POLICY,
+		});
+	});
+
+	test("returns native host mode and explicit cache bust query metadata", async () => {
+		const response = await handleV2RuntimeRequest(
+			runtimeRequest(
+				"http://127.0.0.1:7710/api/v2/runtime?hostMode=native&cacheBust=native-load-1",
+			),
+			{
+				port: 7710,
+				startTime: 0,
+				webUIDir,
+			},
+		);
+
+		const body = (await response.json()) as ArcadeRuntimeContract;
+
+		expect(response.status).toBe(200);
+		expect(body.hostMode).toBe("native");
+		expect(body.cacheBust).toBe("native-load-1");
+		expect(body.buildId).toBe(manifest.buildId);
+	});
+
+	test("rejects unsupported host mode inputs", async () => {
+		const response = await handleV2RuntimeRequest(
+			runtimeRequest("http://127.0.0.1:7710/api/v2/runtime?hostMode=mobile"),
+			{
+				port: 7710,
+				startTime: 0,
+				webUIDir,
+			},
+		);
+
+		const body = (await response.json()) as { error: string };
+
+		expect(response.status).toBe(400);
+		expect(response.headers.get("Cache-Control")).toBe(RUNTIME_CACHE_CONTROL);
+		expect(body.error).toBe("Unsupported Arcade host mode: mobile");
+	});
+});

--- a/cli/web-ui/src/__tests__/server/static-routes.test.ts
+++ b/cli/web-ui/src/__tests__/server/static-routes.test.ts
@@ -3,9 +3,11 @@ import { mkdir, mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { handleStaticRequest } from "../../server/routes/static";
+import { ARCADE_RUNTIME_MANIFEST_FILENAME } from "../../types/runtime";
 
 const HTML_CACHE_CONTROL = "no-store, no-cache, must-revalidate";
 const IMMUTABLE_CACHE_CONTROL = "public, max-age=31536000, immutable";
+const ASSET_MISSING_HEADER = "X-RP1-Asset-Missing";
 
 function request(pathname: string, headers?: HeadersInit): Request {
 	return new Request(`http://localhost${pathname}`, {
@@ -28,6 +30,10 @@ describe("handleStaticRequest", () => {
 			join(clientDir, "assets", "app-a1b2c3.js"),
 			"console.log('arcade');",
 		);
+		await Bun.write(
+			join(clientDir, ARCADE_RUNTIME_MANIFEST_FILENAME),
+			JSON.stringify({ buildId: "build-1" }),
+		);
 	});
 
 	afterAll(async () => {
@@ -42,7 +48,15 @@ describe("handleStaticRequest", () => {
 		);
 
 		expect(response.status).toBe(404);
-		expect(await response.text()).toBe("Not found");
+		expect(await response.text()).toBe(
+			[
+				"status=missing_asset",
+				"path=/assets/missing.js",
+				"message=Requested Arcade asset was not found.",
+				"",
+			].join("\n"),
+		);
+		expect(response.headers.get(ASSET_MISSING_HEADER)).toBe("true");
 		expect(response.headers.get("Content-Type")?.toLowerCase()).toBe(
 			"text/plain; charset=utf-8",
 		);
@@ -71,7 +85,8 @@ describe("handleStaticRequest", () => {
 		);
 
 		expect(response.status).toBe(404);
-		expect(await response.text()).toBe("Not found");
+		expect(await response.text()).toContain("path=/workspace/main.js");
+		expect(response.headers.get(ASSET_MISSING_HEADER)).toBe("true");
 	});
 
 	test("serves existing JavaScript assets with MIME and immutable cache headers", async () => {
@@ -102,5 +117,20 @@ describe("handleStaticRequest", () => {
 		);
 		expect(response.headers.get("Cache-Control")).toBe(HTML_CACHE_CONTROL);
 		expect(await response.text()).toContain("Arcade");
+	});
+
+	test("serves the runtime manifest with no-store cache headers", async () => {
+		const response = await handleStaticRequest(
+			request(`/${ARCADE_RUNTIME_MANIFEST_FILENAME}`, { Accept: "*/*" }),
+			false,
+			webUIDir,
+		);
+
+		expect(response.status).toBe(200);
+		expect(response.headers.get("Content-Type")).toBe(
+			"application/json; charset=utf-8",
+		);
+		expect(response.headers.get("Cache-Control")).toBe(HTML_CACHE_CONTROL);
+		expect(JSON.parse(await response.text())).toEqual({ buildId: "build-1" });
 	});
 });

--- a/cli/web-ui/src/__tests__/server/static-routes.test.ts
+++ b/cli/web-ui/src/__tests__/server/static-routes.test.ts
@@ -1,0 +1,106 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { handleStaticRequest } from "../../server/routes/static";
+
+const HTML_CACHE_CONTROL = "no-store, no-cache, must-revalidate";
+const IMMUTABLE_CACHE_CONTROL = "public, max-age=31536000, immutable";
+
+function request(pathname: string, headers?: HeadersInit): Request {
+	return new Request(`http://localhost${pathname}`, {
+		headers,
+	});
+}
+
+describe("handleStaticRequest", () => {
+	let webUIDir: string;
+
+	beforeAll(async () => {
+		webUIDir = await mkdtemp(join(tmpdir(), "rp1-static-routes-"));
+		const clientDir = join(webUIDir, "client");
+		await mkdir(join(clientDir, "assets"), { recursive: true });
+		await Bun.write(
+			join(clientDir, "index.html"),
+			'<!doctype html><div id="root">Arcade</div>',
+		);
+		await Bun.write(
+			join(clientDir, "assets", "app-a1b2c3.js"),
+			"console.log('arcade');",
+		);
+	});
+
+	afterAll(async () => {
+		await rm(webUIDir, { recursive: true, force: true });
+	});
+
+	test("returns 404 for missing JavaScript assets instead of the HTML shell", async () => {
+		const response = await handleStaticRequest(
+			request("/assets/missing.js", { Accept: "*/*" }),
+			false,
+			webUIDir,
+		);
+
+		expect(response.status).toBe(404);
+		expect(await response.text()).toBe("Not found");
+		expect(response.headers.get("Content-Type")?.toLowerCase()).toBe(
+			"text/plain; charset=utf-8",
+		);
+	});
+
+	test("falls back to index.html for HTML navigation routes", async () => {
+		const response = await handleStaticRequest(
+			request("/runs/run-1", { Accept: "text/html,application/xhtml+xml" }),
+			false,
+			webUIDir,
+		);
+
+		expect(response.status).toBe(200);
+		expect(response.headers.get("Content-Type")).toBe(
+			"text/html; charset=utf-8",
+		);
+		expect(response.headers.get("Cache-Control")).toBe(HTML_CACHE_CONTROL);
+		expect(await response.text()).toContain("Arcade");
+	});
+
+	test("returns 404 for missing extension-bearing paths outside assets", async () => {
+		const response = await handleStaticRequest(
+			request("/workspace/main.js", { Accept: "text/html" }),
+			false,
+			webUIDir,
+		);
+
+		expect(response.status).toBe(404);
+		expect(await response.text()).toBe("Not found");
+	});
+
+	test("serves existing JavaScript assets with MIME and immutable cache headers", async () => {
+		const response = await handleStaticRequest(
+			request("/assets/app-a1b2c3.js", { Accept: "*/*" }),
+			false,
+			webUIDir,
+		);
+
+		expect(response.status).toBe(200);
+		expect(response.headers.get("Content-Type")).toBe(
+			"application/javascript; charset=utf-8",
+		);
+		expect(response.headers.get("Cache-Control")).toBe(IMMUTABLE_CACHE_CONTROL);
+		expect(await response.text()).toBe("console.log('arcade');");
+	});
+
+	test("serves index.html with no-store cache headers", async () => {
+		const response = await handleStaticRequest(
+			request("/", { Accept: "text/html" }),
+			false,
+			webUIDir,
+		);
+
+		expect(response.status).toBe(200);
+		expect(response.headers.get("Content-Type")).toBe(
+			"text/html; charset=utf-8",
+		);
+		expect(response.headers.get("Cache-Control")).toBe(HTML_CACHE_CONTROL);
+		expect(await response.text()).toContain("Arcade");
+	});
+});

--- a/cli/web-ui/src/__tests__/server/websocket.test.ts
+++ b/cli/web-ui/src/__tests__/server/websocket.test.ts
@@ -1,13 +1,16 @@
 import { describe, expect, test } from "bun:test";
 import type { ServerWebSocket } from "bun";
 import { type ReplayProvider, WebSocketHub } from "../../server/websocket";
+import { DEFAULT_ARCADE_RECONNECT_POLICY } from "../../types/runtime";
 
 class MockServerWebSocket {
 	readonly sentMessages: string[] = [];
 	closed = false;
+	onSend?: (message: string) => void;
 
 	send(message: string): void {
 		this.sentMessages.push(message);
+		this.onSend?.(message);
 	}
 
 	close(): void {
@@ -17,14 +20,46 @@ class MockServerWebSocket {
 
 function asServerWebSocket(socket: MockServerWebSocket): ServerWebSocket<{
 	projectPath: string;
+	scope?: "global" | "project";
 	projectId?: string;
 	lastEventId?: number;
 }> {
 	return socket as unknown as ServerWebSocket<{
 		projectPath: string;
+		scope?: "global" | "project";
 		projectId?: string;
 		lastEventId?: number;
 	}>;
+}
+
+const FAST_HEARTBEAT_POLICY = {
+	...DEFAULT_ARCADE_RECONNECT_POLICY,
+	heartbeatIntervalMs: 5,
+	heartbeatMissThreshold: 2,
+};
+
+function wait(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitUntil(assertion: () => void): Promise<void> {
+	const deadline = Date.now() + 250;
+	let lastError: unknown;
+
+	while (Date.now() < deadline) {
+		try {
+			assertion();
+			return;
+		} catch (error) {
+			lastError = error;
+			await wait(5);
+		}
+	}
+
+	if (lastError) {
+		throw lastError;
+	}
+	assertion();
 }
 
 function buildReplayProvider(
@@ -169,6 +204,75 @@ describe("WebSocketHub replay", () => {
 					},
 				],
 			});
+		} finally {
+			hub.stop();
+		}
+	});
+});
+
+describe("WebSocketHub heartbeat acknowledgements", () => {
+	test("keeps passive clients connected while heartbeat acknowledgements succeed", async () => {
+		const hub = new WebSocketHub(FAST_HEARTBEAT_POLICY);
+		try {
+			const socket = new MockServerWebSocket();
+			const serverSocket = asServerWebSocket(socket);
+			socket.onSend = (message) => {
+				const parsed = JSON.parse(message) as {
+					type?: string;
+					heartbeatId?: string;
+				};
+				if (parsed.type === "heartbeat" && parsed.heartbeatId) {
+					hub.handleMessage(
+						serverSocket,
+						JSON.stringify({
+							type: "heartbeat:ack",
+							heartbeatId: parsed.heartbeatId,
+							receivedAt: new Date().toISOString(),
+						}),
+					);
+				}
+			};
+
+			hub.addClient(serverSocket, { scope: "global" });
+
+			await waitUntil(() => {
+				expect(socket.sentMessages.length).toBeGreaterThanOrEqual(2);
+			});
+			await wait(FAST_HEARTBEAT_POLICY.heartbeatIntervalMs * 2);
+
+			expect(socket.closed).toBe(false);
+			expect(hub.clientCount).toBe(1);
+			expect(JSON.parse(socket.sentMessages[0])).toMatchObject({
+				type: "heartbeat",
+				heartbeatId: expect.any(String),
+			});
+		} finally {
+			hub.stop();
+		}
+	});
+
+	test("closes clients after missed heartbeat acknowledgements despite unrelated messages", async () => {
+		const hub = new WebSocketHub(FAST_HEARTBEAT_POLICY);
+		try {
+			const socket = new MockServerWebSocket();
+			const serverSocket = asServerWebSocket(socket);
+
+			hub.addClient(serverSocket, { scope: "global" });
+
+			await waitUntil(() => {
+				expect(socket.sentMessages.length).toBeGreaterThanOrEqual(1);
+			});
+
+			hub.handleMessage(
+				serverSocket,
+				JSON.stringify({ type: "subscribe", path: "/tmp/project" }),
+			);
+
+			await waitUntil(() => {
+				expect(socket.closed).toBe(true);
+			});
+
+			expect(hub.clientCount).toBe(0);
 		} finally {
 			hub.stop();
 		}

--- a/cli/web-ui/src/__tests__/server/websocket.test.ts
+++ b/cli/web-ui/src/__tests__/server/websocket.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, test } from "bun:test";
+import type { ServerWebSocket } from "bun";
+import { type ReplayProvider, WebSocketHub } from "../../server/websocket";
+
+class MockServerWebSocket {
+	readonly sentMessages: string[] = [];
+	closed = false;
+
+	send(message: string): void {
+		this.sentMessages.push(message);
+	}
+
+	close(): void {
+		this.closed = true;
+	}
+}
+
+function asServerWebSocket(socket: MockServerWebSocket): ServerWebSocket<{
+	projectPath: string;
+	projectId?: string;
+	lastEventId?: number;
+}> {
+	return socket as unknown as ServerWebSocket<{
+		projectPath: string;
+		projectId?: string;
+		lastEventId?: number;
+	}>;
+}
+
+function buildReplayProvider(
+	overrides: Partial<ReplayProvider> = {},
+): ReplayProvider {
+	return {
+		getEventsSince: () => [],
+		getRunContext: (runId) => {
+			if (runId === "run-1") {
+				return {
+					projectId: "proj-1",
+					featureId: "feat-1",
+					runStatus: "running",
+				};
+			}
+			if (runId === "run-2") {
+				return {
+					projectId: "proj-2",
+					featureId: "feat-2",
+					runStatus: "waiting",
+				};
+			}
+			return null;
+		},
+		getRunStatus: () => null,
+		getActiveRunsSnapshot: () => [],
+		getMaxEventId: () => 0,
+		...overrides,
+	};
+}
+
+describe("WebSocketHub replay", () => {
+	test("filters project replay events and includes resolved project identity", () => {
+		const hub = new WebSocketHub();
+		try {
+			hub.setReplayProvider(
+				buildReplayProvider({
+					getEventsSince: () => [
+						{
+							id: 11,
+							runId: "run-1",
+							type: "status_change",
+							step: "build",
+							unit: null,
+							data: JSON.stringify({ status: "running" }),
+							createdAt: "2026-04-14T00:00:00.000Z",
+						},
+						{
+							id: 12,
+							runId: "run-2",
+							type: "waiting_for_user",
+							step: "review",
+							unit: null,
+							data: JSON.stringify({ prompt: "Need approval" }),
+							createdAt: "2026-04-14T00:00:01.000Z",
+						},
+					],
+				}),
+			);
+
+			const socket = new MockServerWebSocket();
+			hub.addClient(asServerWebSocket(socket), {
+				scope: "project",
+				projectId: "proj-1",
+				lastEventId: 10,
+			});
+
+			expect(socket.sentMessages).toHaveLength(1);
+			expect(JSON.parse(socket.sentMessages[0])).toMatchObject({
+				type: "event:replay",
+				scope: "project",
+				event: {
+					id: 11,
+					runId: "run-1",
+					projectId: "proj-1",
+					featureId: "feat-1",
+					runStatus: "running",
+				},
+			});
+		} finally {
+			hub.stop();
+		}
+	});
+
+	test("sends scoped snapshots with resolved project ids when replay exceeds the cap", () => {
+		const hub = new WebSocketHub();
+		try {
+			hub.setReplayProvider(
+				buildReplayProvider({
+					getEventsSince: () =>
+						Array.from({ length: 101 }, (_, index) => ({
+							id: index + 11,
+							runId: "run-1",
+							type: "status_change",
+							step: "build",
+							unit: null,
+							data: JSON.stringify({ status: "running" }),
+							createdAt: "2026-04-14T00:00:00.000Z",
+						})),
+					getActiveRunsSnapshot: () => [
+						{
+							id: "run-1",
+							flow: "build",
+							featureId: "feat-1",
+							projectPath: "/tmp/project-one",
+							status: "running",
+							steps: [{ step: "build", status: "running" }],
+							artifacts: [],
+						},
+						{
+							id: "run-2",
+							flow: "build",
+							featureId: "feat-2",
+							projectPath: "/tmp/project-two",
+							status: "waiting",
+							steps: [{ step: "review", status: "waiting" }],
+							artifacts: [],
+						},
+					],
+					getMaxEventId: () => 111,
+				}),
+			);
+
+			const socket = new MockServerWebSocket();
+			hub.addClient(asServerWebSocket(socket), {
+				scope: "project",
+				projectId: "proj-1",
+				lastEventId: 10,
+			});
+
+			expect(socket.sentMessages).toHaveLength(1);
+			expect(JSON.parse(socket.sentMessages[0])).toMatchObject({
+				type: "state:snapshot",
+				scope: "project",
+				projectId: "proj-1",
+				lastEventId: 111,
+				runs: [
+					{
+						id: "run-1",
+						projectId: "proj-1",
+						featureId: "feat-1",
+					},
+				],
+			});
+		} finally {
+			hub.stop();
+		}
+	});
+});

--- a/cli/web-ui/src/__tests__/version.test.ts
+++ b/cli/web-ui/src/__tests__/version.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, test } from "bun:test";
 import cliPackage from "../../../package.json";
-import viteConfig from "../../vite.config";
+import viteConfig, {
+	buildRuntimeManifest,
+	runtimeManifestAsset,
+} from "../../vite.config";
+import {
+	ARCADE_RUNTIME_MANIFEST_FILENAME,
+	type ArcadeRuntimeManifest,
+} from "../types/runtime";
 import { RP1_VERSION } from "../version";
 
 describe("web-ui version metadata", () => {
@@ -14,5 +21,40 @@ describe("web-ui version metadata", () => {
 		expect(config.define?.__RP1_WEB_UI_VERSION__).toBe(
 			JSON.stringify(cliPackage.version),
 		);
+	});
+
+	test("builds a deterministic runtime manifest identity", () => {
+		const first = buildRuntimeManifest({
+			version: "0.7.6",
+			gitCommit: "abc1234",
+			buildTime: "2026-05-04T00:00:00.000Z",
+		});
+		const second = buildRuntimeManifest({
+			version: "0.7.6",
+			gitCommit: "abc1234",
+			buildTime: "2026-05-04T00:01:00.000Z",
+		});
+
+		expect(first).toEqual({
+			version: "0.7.6",
+			gitCommit: "abc1234",
+			buildTime: "2026-05-04T00:00:00.000Z",
+			buildId: second.buildId,
+		});
+		expect(first.buildId).toHaveLength(12);
+	});
+
+	test("emits the runtime manifest asset into the client build", () => {
+		const manifest: ArcadeRuntimeManifest = {
+			version: "0.7.6",
+			gitCommit: "abc1234",
+			buildTime: "2026-05-04T00:00:00.000Z",
+			buildId: "build-abc1234",
+		};
+		const asset = runtimeManifestAsset(manifest);
+
+		expect(asset.type).toBe("asset");
+		expect(asset.fileName).toBe(ARCADE_RUNTIME_MANIFEST_FILENAME);
+		expect(JSON.parse(asset.source)).toEqual(manifest);
 	});
 });

--- a/cli/web-ui/src/__tests__/version.test.ts
+++ b/cli/web-ui/src/__tests__/version.test.ts
@@ -21,6 +21,9 @@ describe("web-ui version metadata", () => {
 		expect(config.define?.__RP1_WEB_UI_VERSION__).toBe(
 			JSON.stringify(cliPackage.version),
 		);
+		expect(
+			typeof JSON.parse(String(config.define?.__RP1_WEB_UI_BUILD_ID__)),
+		).toBe("string");
 	});
 
 	test("builds a deterministic runtime manifest identity", () => {

--- a/cli/web-ui/src/app/App.tsx
+++ b/cli/web-ui/src/app/App.tsx
@@ -2,6 +2,7 @@ import { RouterProvider } from "react-router-dom";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { DiagramFullscreenProvider } from "@/providers/DiagramFullscreenProvider";
+import { RuntimeProvider } from "@/providers/RuntimeProvider";
 import { ThemeProvider } from "@/providers/ThemeProvider";
 import { WebSocketProvider } from "@/providers/WebSocketProvider";
 import { router } from "./routes";
@@ -10,13 +11,15 @@ export function App() {
 	return (
 		<ErrorBoundary>
 			<ThemeProvider>
-				<WebSocketProvider>
-					<DiagramFullscreenProvider>
-						<TooltipProvider>
-							<RouterProvider router={router} />
-						</TooltipProvider>
-					</DiagramFullscreenProvider>
-				</WebSocketProvider>
+				<RuntimeProvider>
+					<WebSocketProvider>
+						<DiagramFullscreenProvider>
+							<TooltipProvider>
+								<RouterProvider router={router} />
+							</TooltipProvider>
+						</DiagramFullscreenProvider>
+					</WebSocketProvider>
+				</RuntimeProvider>
 			</ThemeProvider>
 		</ErrorBoundary>
 	);

--- a/cli/web-ui/src/components/ErrorBoundary.tsx
+++ b/cli/web-ui/src/components/ErrorBoundary.tsx
@@ -13,6 +13,32 @@ interface State {
 	errorInfo: ErrorInfo | null;
 }
 
+export function RuntimeLoadFailure({ message }: { message: string }) {
+	return (
+		<div
+			role="alert"
+			className="flex min-h-screen flex-col items-center justify-center bg-background p-6 text-foreground"
+		>
+			<div className="flex w-full max-w-lg flex-col items-center rounded-lg border border-destructive/30 bg-destructive/5 p-6 text-center">
+				<AlertTriangle className="mb-4 h-10 w-10 text-destructive" />
+				<h1 className="mb-2 text-lg font-semibold">
+					Arcade runtime failed to load
+				</h1>
+				<p className="mb-4 max-w-md text-sm text-muted-foreground">{message}</p>
+				<Button
+					type="button"
+					variant="outline"
+					size="sm"
+					onClick={() => window.location.reload()}
+				>
+					<RefreshCw className="mr-1.5 h-3.5 w-3.5" />
+					Reload page
+				</Button>
+			</div>
+		</div>
+	);
+}
+
 export class ErrorBoundary extends Component<Props, State> {
 	constructor(props: Props) {
 		super(props);

--- a/cli/web-ui/src/hooks/useFeed.ts
+++ b/cli/web-ui/src/hooks/useFeed.ts
@@ -4,6 +4,7 @@ import {
 	normalizeActivitySearchTokens,
 } from "@/lib/activity-search-fields";
 import { liveRunIndex } from "@/lib/live-run-index";
+import { useRuntimeContract } from "@/providers/RuntimeProvider";
 import {
 	RELEVANT_HIDDEN_RUN_STATUSES,
 	type Run,
@@ -34,6 +35,7 @@ interface FeedResponse {
 interface FetchFeedOptions {
 	readonly signal?: AbortSignal;
 	readonly showLoading?: boolean;
+	readonly reconcile?: boolean;
 }
 
 export interface UseFeedOptions extends Partial<RunsFilter> {
@@ -53,9 +55,14 @@ export interface UseFeedResult {
 const relevantHiddenRunStatusSet = new Set<Run["status"]>(
 	RELEVANT_HIDDEN_RUN_STATUSES,
 );
+const DEFAULT_FEED_LIMIT = 25;
 
 function activityTimestamp(run: Run): string {
 	return run.lastEventAt ?? run.startedAt;
+}
+
+function compareRunsByActivity(a: Run, b: Run): number {
+	return activityTimestamp(b).localeCompare(activityTimestamp(a));
 }
 
 function compareFeedItems(a: FeedItem, b: FeedItem): number {
@@ -163,6 +170,21 @@ function areFeedItemsEqual(
 	});
 }
 
+function mergeRunsById(runs: readonly Run[]): Run[] {
+	const runsById = new Map<string, Run>();
+	for (const run of runs) {
+		runsById.set(run.id, run);
+	}
+	return [...runsById.values()];
+}
+
+function recoveryFeedLimit(
+	limit: number | undefined,
+	activityRecoveryLimit: number,
+): number {
+	return (limit ?? DEFAULT_FEED_LIMIT) + activityRecoveryLimit;
+}
+
 function buildQueryParams(options: UseFeedOptions): URLSearchParams {
 	const params = new URLSearchParams();
 
@@ -208,10 +230,12 @@ function isAbortError(err: unknown): boolean {
 }
 
 export function useFeed(options: UseFeedOptions = {}): UseFeedResult {
+	const { reconnectPolicy } = useRuntimeContract();
 	const [items, setItems] = useState<FeedItem[]>([]);
 	const [total, setTotal] = useState(0);
 	const [isLoading, setIsLoading] = useState(true);
 	const [error, setError] = useState<Error | null>(null);
+	const itemsRef = useRef<FeedItem[]>([]);
 	const matchingRunIdsRef = useRef<Set<string>>(new Set());
 	const latestRequestIdRef = useRef(0);
 	useLiveRunIndexBridge();
@@ -219,8 +243,16 @@ export function useFeed(options: UseFeedOptions = {}): UseFeedResult {
 
 	const { view, status, projectId, dateRange, limit, offset, search } = options;
 
+	useEffect(() => {
+		itemsRef.current = items;
+	}, [items]);
+
 	const fetchFeed = useCallback(
-		async ({ signal, showLoading = false }: FetchFeedOptions = {}) => {
+		async ({
+			signal,
+			showLoading = false,
+			reconcile = false,
+		}: FetchFeedOptions = {}) => {
 			const requestId = latestRequestIdRef.current + 1;
 			latestRequestIdRef.current = requestId;
 			const isLatestRequest = () =>
@@ -236,7 +268,9 @@ export function useFeed(options: UseFeedOptions = {}): UseFeedResult {
 					status,
 					projectId,
 					dateRange,
-					limit,
+					limit: reconcile
+						? recoveryFeedLimit(limit, reconnectPolicy.activityRecoveryLimit)
+						: limit,
 					offset,
 					search,
 				});
@@ -254,20 +288,32 @@ export function useFeed(options: UseFeedOptions = {}): UseFeedResult {
 
 				liveRunIndex.upsertRuns(data.items.map((item) => item.run));
 				const filterOptions = { view, status, projectId, dateRange, search };
-				matchingRunIdsRef.current = new Set(
-					liveRunIndex
-						.getAllRuns()
-						.filter((run) => matchesFeedFilters(run, filterOptions))
-						.map((run) => run.id),
-				);
-				setItems(
-					data.items
+				const responseRuns = data.items
+					.map((item) => liveRunIndex.getRun(item.run.id) ?? item.run)
+					.filter((run) => matchesFeedFilters(run, filterOptions));
+
+				if (reconcile) {
+					const currentRuns = itemsRef.current
 						.map((item) => liveRunIndex.getRun(item.run.id) ?? item.run)
-						.filter((run) => matchesFeedFilters(run, filterOptions))
-						.map(toFeedItem)
-						.sort(compareFeedItems),
-				);
-				setTotal(data.total);
+						.filter((run) => matchesFeedFilters(run, filterOptions));
+					const mergedRuns = mergeRunsById([
+						...currentRuns,
+						...responseRuns,
+					]).sort(compareRunsByActivity);
+					const visibleRuns = mergedRuns.slice(0, limit ?? DEFAULT_FEED_LIMIT);
+					matchingRunIdsRef.current = new Set(currentRuns.map((run) => run.id));
+					setItems(visibleRuns.map(toFeedItem));
+					setTotal(Math.max(data.total, visibleRuns.length));
+				} else {
+					matchingRunIdsRef.current = new Set(
+						liveRunIndex
+							.getAllRuns()
+							.filter((run) => matchesFeedFilters(run, filterOptions))
+							.map((run) => run.id),
+					);
+					setItems(responseRuns.map(toFeedItem).sort(compareFeedItems));
+					setTotal(data.total);
+				}
 				setError(null);
 			} catch (err) {
 				if (isAbortError(err) || !isLatestRequest()) {
@@ -281,8 +327,21 @@ export function useFeed(options: UseFeedOptions = {}): UseFeedResult {
 				}
 			}
 		},
-		[view, status, projectId, dateRange, limit, offset, search],
+		[
+			view,
+			status,
+			projectId,
+			dateRange,
+			limit,
+			offset,
+			search,
+			reconnectPolicy.activityRecoveryLimit,
+		],
 	);
+
+	const reconcileFeed = useCallback(() => {
+		return fetchFeed({ reconcile: true });
+	}, [fetchFeed]);
 
 	useEffect(() => {
 		const controller = new AbortController();
@@ -341,9 +400,7 @@ export function useFeed(options: UseFeedOptions = {}): UseFeedResult {
 			}
 			addedCount = additions.length;
 			nextItems = [...nextLoadedItems, ...additions];
-			if (limit !== undefined) {
-				nextItems = nextItems.slice(0, limit);
-			}
+			nextItems = nextItems.slice(0, limit ?? DEFAULT_FEED_LIMIT);
 		}
 
 		if (!areFeedItemsEqual(currentItems, nextItems)) {
@@ -368,7 +425,7 @@ export function useFeed(options: UseFeedOptions = {}): UseFeedResult {
 		offset,
 	]);
 
-	useReconnectRecovery(fetchFeed);
+	useReconnectRecovery(reconcileFeed);
 
 	const refetch = useCallback(() => {
 		void fetchFeed({ showLoading: true });

--- a/cli/web-ui/src/hooks/useLiveRunIndex.ts
+++ b/cli/web-ui/src/hooks/useLiveRunIndex.ts
@@ -12,10 +12,15 @@ export function useLiveRunIndexBridge(): void {
 			void liveRunIndex.applyEvent(message);
 		});
 		const unsubscribeSnapshot = onStateSnapshot((message) => {
-			if (!projectId) {
+			if (message.scope === "global") {
+				liveRunIndex.applyGlobalSnapshot(message);
 				return;
 			}
-			liveRunIndex.applySnapshot(projectId, message);
+
+			const snapshotProjectId = message.projectId ?? projectId;
+			if (snapshotProjectId) {
+				liveRunIndex.applySnapshot(snapshotProjectId, message);
+			}
 		});
 
 		return () => {

--- a/cli/web-ui/src/hooks/useReconnectRecovery.ts
+++ b/cli/web-ui/src/hooks/useReconnectRecovery.ts
@@ -1,11 +1,11 @@
 import { useEffect, useRef } from "react";
+import { useRuntimeContract } from "@/providers/RuntimeProvider";
 import { useWebSocket } from "@/providers/WebSocketProvider";
-
-const POLLING_INTERVAL = 5000;
 
 export function useReconnectRecovery(
 	recover: () => void | Promise<void>,
 ): void {
+	const { reconnectPolicy } = useRuntimeContract();
 	const { status, subscribeToReconnect } = useWebSocket();
 	const recoverRef = useRef(recover);
 
@@ -26,10 +26,10 @@ export function useReconnectRecovery(
 
 		const intervalId = setInterval(() => {
 			void recoverRef.current();
-		}, POLLING_INTERVAL);
+		}, reconnectPolicy.disconnectedRecoveryIntervalMs);
 
 		return () => {
 			clearInterval(intervalId);
 		};
-	}, [status]);
+	}, [status, reconnectPolicy.disconnectedRecoveryIntervalMs]);
 }

--- a/cli/web-ui/src/hooks/useRuns.ts
+++ b/cli/web-ui/src/hooks/useRuns.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { liveRunIndex } from "@/lib/live-run-index";
+import { useRuntimeContract } from "@/providers/RuntimeProvider";
 import {
 	RELEVANT_HIDDEN_RUN_STATUSES,
 	type Run,
@@ -13,6 +14,11 @@ import { useReconnectRecovery } from "./useReconnectRecovery";
 interface RunsResponse {
 	runs: Run[];
 	total: number;
+}
+
+interface FetchRunsOptions {
+	readonly showLoading?: boolean;
+	readonly reconcile?: boolean;
 }
 
 interface UseRunsOptions extends Partial<RunsFilter> {
@@ -31,6 +37,7 @@ interface UseRunsResult {
 const relevantHiddenRunStatusSet = new Set<Run["status"]>(
 	RELEVANT_HIDDEN_RUN_STATUSES,
 );
+const DEFAULT_RUNS_LIMIT = 50;
 
 function activityTimestamp(run: Run): string {
 	return run.lastEventAt ?? run.startedAt;
@@ -111,6 +118,21 @@ function areRunsEqual(current: readonly Run[], next: readonly Run[]): boolean {
 	return current.every((run, index) => run === next[index]);
 }
 
+function mergeRunsById(runs: readonly Run[]): Run[] {
+	const runsById = new Map<string, Run>();
+	for (const run of runs) {
+		runsById.set(run.id, run);
+	}
+	return [...runsById.values()];
+}
+
+function recoveryRunsLimit(
+	limit: number | undefined,
+	activityRecoveryLimit: number,
+): number {
+	return (limit ?? DEFAULT_RUNS_LIMIT) + activityRecoveryLimit;
+}
+
 function buildQueryParams(options: UseRunsOptions): URLSearchParams {
 	const params = new URLSearchParams();
 
@@ -142,60 +164,102 @@ function buildQueryParams(options: UseRunsOptions): URLSearchParams {
 }
 
 export function useRuns(options: UseRunsOptions = {}): UseRunsResult {
+	const { reconnectPolicy } = useRuntimeContract();
 	const [runs, setRuns] = useState<Run[]>([]);
 	const [total, setTotal] = useState(0);
 	const [isLoading, setIsLoading] = useState(true);
 	const [error, setError] = useState<Error | null>(null);
+	const runsRef = useRef<Run[]>([]);
 	const matchingRunIdsRef = useRef<Set<string>>(new Set());
 	const liveSnapshot = useLiveRunIndexSnapshot();
 
 	// Destructure to use primitives as dependencies (avoid object reference changes)
 	const { view, status, projectId, dateRange, limit, offset } = options;
 
-	const fetchRuns = useCallback(async () => {
-		try {
-			const params = buildQueryParams({
-				view,
-				status,
-				projectId,
-				dateRange,
-				limit,
-				offset,
-			});
-			const url = `/api/v2/runs${params.toString() ? `?${params.toString()}` : ""}`;
-			const response = await fetch(url);
+	useEffect(() => {
+		runsRef.current = runs;
+	}, [runs]);
 
-			if (!response.ok) {
-				throw new Error(`Failed to fetch runs: ${response.statusText}`);
+	const fetchRuns = useCallback(
+		async ({
+			showLoading = false,
+			reconcile = false,
+		}: FetchRunsOptions = {}) => {
+			if (showLoading) {
+				setIsLoading(true);
 			}
 
-			const data = (await response.json()) as RunsResponse;
-			liveRunIndex.upsertRuns(data.runs);
-			const filterOptions = { view, status, projectId, dateRange };
-			matchingRunIdsRef.current = new Set(
-				liveRunIndex
-					.getAllRuns()
-					.filter((run) => matchesRunFilters(run, filterOptions))
-					.map((run) => run.id),
-			);
-			setRuns(
-				data.runs
+			try {
+				const params = buildQueryParams({
+					view,
+					status,
+					projectId,
+					dateRange,
+					limit: reconcile
+						? recoveryRunsLimit(limit, reconnectPolicy.activityRecoveryLimit)
+						: limit,
+					offset,
+				});
+				const url = `/api/v2/runs${params.toString() ? `?${params.toString()}` : ""}`;
+				const response = await fetch(url);
+
+				if (!response.ok) {
+					throw new Error(`Failed to fetch runs: ${response.statusText}`);
+				}
+
+				const data = (await response.json()) as RunsResponse;
+				liveRunIndex.upsertRuns(data.runs);
+				const filterOptions = { view, status, projectId, dateRange };
+				const responseRuns = data.runs
 					.map((run) => liveRunIndex.getRun(run.id) ?? run)
-					.filter((run) => matchesRunFilters(run, filterOptions))
-					.sort(compareRunsByActivity),
-			);
-			setTotal(data.total);
-			setError(null);
-		} catch (err) {
-			setError(err instanceof Error ? err : new Error(String(err)));
-		} finally {
-			setIsLoading(false);
-		}
-	}, [view, status, projectId, dateRange, limit, offset]);
+					.filter((run) => matchesRunFilters(run, filterOptions));
+
+				if (reconcile) {
+					const currentRuns = runsRef.current
+						.map((run) => liveRunIndex.getRun(run.id) ?? run)
+						.filter((run) => matchesRunFilters(run, filterOptions));
+					const mergedRuns = mergeRunsById([
+						...currentRuns,
+						...responseRuns,
+					]).sort(compareRunsByActivity);
+					const visibleRuns = mergedRuns.slice(0, limit ?? DEFAULT_RUNS_LIMIT);
+					matchingRunIdsRef.current = new Set(currentRuns.map((run) => run.id));
+					setRuns(visibleRuns);
+					setTotal(Math.max(data.total, visibleRuns.length));
+				} else {
+					matchingRunIdsRef.current = new Set(
+						liveRunIndex
+							.getAllRuns()
+							.filter((run) => matchesRunFilters(run, filterOptions))
+							.map((run) => run.id),
+					);
+					setRuns(responseRuns.sort(compareRunsByActivity));
+					setTotal(data.total);
+				}
+				setError(null);
+			} catch (err) {
+				setError(err instanceof Error ? err : new Error(String(err)));
+			} finally {
+				setIsLoading(false);
+			}
+		},
+		[
+			view,
+			status,
+			projectId,
+			dateRange,
+			limit,
+			offset,
+			reconnectPolicy.activityRecoveryLimit,
+		],
+	);
+
+	const reconcileRuns = useCallback(() => {
+		return fetchRuns({ reconcile: true });
+	}, [fetchRuns]);
 
 	useEffect(() => {
-		setIsLoading(true);
-		fetchRuns();
+		void fetchRuns({ showLoading: true });
 	}, [fetchRuns]);
 
 	useEffect(() => {
@@ -246,9 +310,7 @@ export function useRuns(options: UseRunsOptions = {}): UseRunsResult {
 			}
 			addedCount = additions.length;
 			nextRuns = [...nextLoadedRuns, ...additions].sort(compareRunsByActivity);
-			if (limit !== undefined) {
-				nextRuns = nextRuns.slice(0, limit);
-			}
+			nextRuns = nextRuns.slice(0, limit ?? DEFAULT_RUNS_LIMIT);
 		}
 
 		if (!areRunsEqual(currentRuns, nextRuns)) {
@@ -272,11 +334,10 @@ export function useRuns(options: UseRunsOptions = {}): UseRunsResult {
 		offset,
 	]);
 
-	useReconnectRecovery(fetchRuns);
+	useReconnectRecovery(reconcileRuns);
 
 	const refetch = useCallback(() => {
-		setIsLoading(true);
-		fetchRuns();
+		void fetchRuns({ showLoading: true });
 	}, [fetchRuns]);
 
 	return {

--- a/cli/web-ui/src/lib/live-run-index.ts
+++ b/cli/web-ui/src/lib/live-run-index.ts
@@ -43,6 +43,7 @@ export interface LiveRunIndex {
 	hydrateRun: (runId: string) => Promise<Run | null>;
 	applyEvent: (message: EventNotificationMessage) => Promise<void>;
 	applySnapshot: (projectId: string, message: StateSnapshotMessage) => void;
+	applyGlobalSnapshot: (message: StateSnapshotMessage) => void;
 	clear: () => void;
 }
 
@@ -461,6 +462,19 @@ export function createLiveRunIndex(
 				}
 			}
 
+			for (const snapshotRun of message.runs) {
+				const existing = runsById.get(snapshotRun.id);
+				if (existing) {
+					storeRun(reconcileRunWithSnapshot(existing, snapshotRun));
+					continue;
+				}
+
+				void this.hydrateRun(snapshotRun.id);
+			}
+
+			emitChange();
+		},
+		applyGlobalSnapshot(message: StateSnapshotMessage) {
 			for (const snapshotRun of message.runs) {
 				const existing = runsById.get(snapshotRun.id);
 				if (existing) {

--- a/cli/web-ui/src/providers/RuntimeProvider.tsx
+++ b/cli/web-ui/src/providers/RuntimeProvider.tsx
@@ -1,4 +1,3 @@
-import { AlertTriangle, RefreshCw } from "lucide-react";
 import {
 	createContext,
 	type ReactNode,
@@ -6,7 +5,7 @@ import {
 	useEffect,
 	useState,
 } from "react";
-import { Button } from "@/components/ui/button";
+import { RuntimeLoadFailure } from "@/components/ErrorBoundary";
 import {
 	ARCADE_RUNTIME_SCHEMA_VERSION,
 	type ArcadeReconnectPolicy,
@@ -14,10 +13,20 @@ import {
 	isArcadeHostMode,
 } from "@/types/runtime";
 
+declare const __RP1_WEB_UI_BUILD_ID__: string | undefined;
+declare const __RP1_WEB_UI_VERSION__: string | undefined;
+
+interface ClientRuntimeBuildMetadata {
+	readonly buildId: string | null;
+	readonly version: string | null;
+}
+
 interface RuntimeProviderProps {
 	children: ReactNode;
 	runtime?: ArcadeRuntimeContract;
 	loadRuntime?: () => Promise<ArcadeRuntimeContract>;
+	clientBuildMetadata?: ClientRuntimeBuildMetadata;
+	reloadRuntime?: (contract: ArcadeRuntimeContract) => void;
 }
 
 interface RuntimeLoadState {
@@ -26,6 +35,7 @@ interface RuntimeLoadState {
 }
 
 const RuntimeContext = createContext<ArcadeRuntimeContract | null>(null);
+const RUNTIME_RELOAD_STORAGE_PREFIX = "rp1:runtime-reload:";
 
 const RUNTIME_QUERY_KEYS = {
 	hostMode: ["hostMode", "host-mode"],
@@ -103,6 +113,102 @@ export function buildRuntimeEndpoint(locationSearch = window.location.search) {
 	return `/api/v2/runtime${queryString ? `?${queryString}` : ""}`;
 }
 
+function readBuildMetadataValue(value: unknown): string | null {
+	return typeof value === "string" && value.trim().length > 0 ? value : null;
+}
+
+export function readClientRuntimeBuildMetadata(): ClientRuntimeBuildMetadata {
+	return {
+		buildId: readBuildMetadataValue(
+			typeof __RP1_WEB_UI_BUILD_ID__ === "string"
+				? __RP1_WEB_UI_BUILD_ID__
+				: null,
+		),
+		version: readBuildMetadataValue(
+			typeof __RP1_WEB_UI_VERSION__ === "string"
+				? __RP1_WEB_UI_VERSION__
+				: null,
+		),
+	};
+}
+
+function getRuntimeMismatchMessage(
+	contract: ArcadeRuntimeContract,
+	clientBuildMetadata: ClientRuntimeBuildMetadata,
+): string | null {
+	if (contract.buildId === `dev-${contract.version}`) {
+		return null;
+	}
+
+	if (
+		clientBuildMetadata.buildId !== null &&
+		clientBuildMetadata.buildId !== contract.buildId
+	) {
+		return `Arcade runtime build changed from ${clientBuildMetadata.buildId} to ${contract.buildId}.`;
+	}
+
+	if (
+		clientBuildMetadata.buildId === null &&
+		clientBuildMetadata.version !== null &&
+		clientBuildMetadata.version !== contract.version
+	) {
+		return `Arcade runtime version changed from ${clientBuildMetadata.version} to ${contract.version}.`;
+	}
+
+	return null;
+}
+
+function runtimeReloadAttemptStorageKey(buildId: string): string {
+	return `${RUNTIME_RELOAD_STORAGE_PREFIX}${buildId}`;
+}
+
+function hasRuntimeReloadAttempt(buildId: string): boolean {
+	try {
+		return (
+			sessionStorage.getItem(runtimeReloadAttemptStorageKey(buildId)) === "1"
+		);
+	} catch {
+		return false;
+	}
+}
+
+function markRuntimeReloadAttempt(buildId: string): void {
+	try {
+		sessionStorage.setItem(runtimeReloadAttemptStorageKey(buildId), "1");
+	} catch {}
+}
+
+function reloadWithRuntimeCacheBust(contract: ArcadeRuntimeContract): void {
+	const url = new URL(window.location.href);
+	url.searchParams.set("cacheBust", contract.buildId);
+	window.location.assign(url.toString());
+}
+
+function prepareRuntimeContract(
+	contract: ArcadeRuntimeContract,
+	clientBuildMetadata: ClientRuntimeBuildMetadata,
+	reloadRuntime: (contract: ArcadeRuntimeContract) => void,
+): ArcadeRuntimeContract | null {
+	const mismatchMessage = getRuntimeMismatchMessage(
+		contract,
+		clientBuildMetadata,
+	);
+
+	if (mismatchMessage === null) {
+		return contract;
+	}
+
+	if (!hasRuntimeReloadAttempt(contract.buildId)) {
+		markRuntimeReloadAttempt(contract.buildId);
+		reloadRuntime(contract);
+		return null;
+	}
+
+	throw new Error(
+		`${mismatchMessage} A cache-busted reload did not resolve the mismatch.`,
+	);
+}
+
 function validateRuntimeContract(value: unknown): ArcadeRuntimeContract {
 	if (!isRecord(value)) {
 		throw new Error("Arcade runtime contract response is invalid.");
@@ -156,36 +262,12 @@ export async function fetchRuntimeContract(): Promise<ArcadeRuntimeContract> {
 	return validateRuntimeContract((await response.json()) as unknown);
 }
 
-function RuntimeLoadFailure({ message }: { message: string }) {
-	return (
-		<div
-			role="alert"
-			className="flex min-h-screen flex-col items-center justify-center bg-background p-6 text-foreground"
-		>
-			<div className="flex w-full max-w-lg flex-col items-center rounded-lg border border-destructive/30 bg-destructive/5 p-6 text-center">
-				<AlertTriangle className="mb-4 h-10 w-10 text-destructive" />
-				<h1 className="mb-2 text-lg font-semibold">
-					Arcade runtime failed to load
-				</h1>
-				<p className="mb-4 max-w-md text-sm text-muted-foreground">{message}</p>
-				<Button
-					type="button"
-					variant="outline"
-					size="sm"
-					onClick={() => window.location.reload()}
-				>
-					<RefreshCw className="mr-1.5 h-3.5 w-3.5" />
-					Reload page
-				</Button>
-			</div>
-		</div>
-	);
-}
-
 export function RuntimeProvider({
 	children,
 	runtime,
 	loadRuntime = fetchRuntimeContract,
+	clientBuildMetadata,
+	reloadRuntime = reloadWithRuntimeCacheBust,
 }: RuntimeProviderProps) {
 	const [state, setState] = useState<RuntimeLoadState>(() => ({
 		contract: runtime ?? null,
@@ -199,11 +281,20 @@ export function RuntimeProvider({
 		}
 
 		let cancelled = false;
+		const buildMetadata =
+			clientBuildMetadata ?? readClientRuntimeBuildMetadata();
 
 		loadRuntime()
 			.then((contract) => {
 				if (!cancelled) {
-					setState({ contract, error: null });
+					const preparedContract = prepareRuntimeContract(
+						contract,
+						buildMetadata,
+						reloadRuntime,
+					);
+					if (preparedContract !== null) {
+						setState({ contract: preparedContract, error: null });
+					}
 				}
 			})
 			.catch((error: unknown) => {
@@ -221,7 +312,7 @@ export function RuntimeProvider({
 		return () => {
 			cancelled = true;
 		};
-	}, [runtime, loadRuntime]);
+	}, [runtime, loadRuntime, clientBuildMetadata, reloadRuntime]);
 
 	if (state.error) {
 		return <RuntimeLoadFailure message={state.error} />;

--- a/cli/web-ui/src/providers/RuntimeProvider.tsx
+++ b/cli/web-ui/src/providers/RuntimeProvider.tsx
@@ -1,0 +1,247 @@
+import { AlertTriangle, RefreshCw } from "lucide-react";
+import {
+	createContext,
+	type ReactNode,
+	useContext,
+	useEffect,
+	useState,
+} from "react";
+import { Button } from "@/components/ui/button";
+import {
+	ARCADE_RUNTIME_SCHEMA_VERSION,
+	type ArcadeReconnectPolicy,
+	type ArcadeRuntimeContract,
+	isArcadeHostMode,
+} from "@/types/runtime";
+
+interface RuntimeProviderProps {
+	children: ReactNode;
+	runtime?: ArcadeRuntimeContract;
+	loadRuntime?: () => Promise<ArcadeRuntimeContract>;
+}
+
+interface RuntimeLoadState {
+	contract: ArcadeRuntimeContract | null;
+	error: string | null;
+}
+
+const RuntimeContext = createContext<ArcadeRuntimeContract | null>(null);
+
+const RUNTIME_QUERY_KEYS = {
+	hostMode: ["hostMode", "host-mode"],
+	cacheBust: ["cacheBust", "cache-bust"],
+} as const;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function isFiniteNumber(value: unknown): value is number {
+	return typeof value === "number" && Number.isFinite(value);
+}
+
+function isRuntimePolicy(value: unknown): value is ArcadeReconnectPolicy {
+	if (!isRecord(value)) {
+		return false;
+	}
+
+	const {
+		initialDelayMs,
+		maxDelayMs,
+		backoffFactor,
+		heartbeatIntervalMs,
+		heartbeatMissThreshold,
+		disconnectedRecoveryIntervalMs,
+		activityRecoveryLimit,
+	} = value;
+
+	return (
+		isFiniteNumber(initialDelayMs) &&
+		isFiniteNumber(maxDelayMs) &&
+		isFiniteNumber(backoffFactor) &&
+		isFiniteNumber(heartbeatIntervalMs) &&
+		isFiniteNumber(heartbeatMissThreshold) &&
+		isFiniteNumber(disconnectedRecoveryIntervalMs) &&
+		isFiniteNumber(activityRecoveryLimit) &&
+		initialDelayMs > 0 &&
+		maxDelayMs >= initialDelayMs &&
+		backoffFactor >= 1 &&
+		heartbeatIntervalMs > 0 &&
+		heartbeatMissThreshold > 0 &&
+		disconnectedRecoveryIntervalMs > 0 &&
+		activityRecoveryLimit > 0
+	);
+}
+
+function readRuntimeQueryValue(
+	source: URLSearchParams,
+	keys: readonly string[],
+): string | null {
+	for (const key of keys) {
+		const value = source.get(key);
+		if (value != null && value.trim().length > 0) {
+			return value;
+		}
+	}
+	return null;
+}
+
+export function buildRuntimeEndpoint(locationSearch = window.location.search) {
+	const source = new URLSearchParams(locationSearch);
+	const target = new URLSearchParams();
+	const hostMode = readRuntimeQueryValue(source, RUNTIME_QUERY_KEYS.hostMode);
+	const cacheBust = readRuntimeQueryValue(source, RUNTIME_QUERY_KEYS.cacheBust);
+
+	if (hostMode != null) {
+		target.set("hostMode", hostMode);
+	}
+	if (cacheBust != null) {
+		target.set("cacheBust", cacheBust);
+	}
+
+	const queryString = target.toString();
+	return `/api/v2/runtime${queryString ? `?${queryString}` : ""}`;
+}
+
+function validateRuntimeContract(value: unknown): ArcadeRuntimeContract {
+	if (!isRecord(value)) {
+		throw new Error("Arcade runtime contract response is invalid.");
+	}
+
+	if (value.schemaVersion !== ARCADE_RUNTIME_SCHEMA_VERSION) {
+		throw new Error("Arcade runtime schema version is unsupported.");
+	}
+
+	if (typeof value.hostMode !== "string" || !isArcadeHostMode(value.hostMode)) {
+		throw new Error(`Unsupported Arcade host mode: ${String(value.hostMode)}`);
+	}
+
+	if (
+		typeof value.baseUrl !== "string" ||
+		typeof value.version !== "string" ||
+		typeof value.buildId !== "string" ||
+		typeof value.cacheBust !== "string" ||
+		!isRuntimePolicy(value.reconnectPolicy)
+	) {
+		throw new Error("Arcade runtime contract response is incomplete.");
+	}
+
+	try {
+		new URL(value.baseUrl);
+	} catch {
+		throw new Error("Arcade runtime base URL is invalid.");
+	}
+
+	return value as unknown as ArcadeRuntimeContract;
+}
+
+async function readErrorMessage(response: Response): Promise<string> {
+	try {
+		const payload = (await response.json()) as unknown;
+		if (isRecord(payload) && typeof payload.error === "string") {
+			return payload.error;
+		}
+	} catch {}
+
+	return `Arcade runtime request failed with status ${response.status}.`;
+}
+
+export async function fetchRuntimeContract(): Promise<ArcadeRuntimeContract> {
+	const response = await fetch(buildRuntimeEndpoint(), { cache: "no-store" });
+
+	if (!response.ok) {
+		throw new Error(await readErrorMessage(response));
+	}
+
+	return validateRuntimeContract((await response.json()) as unknown);
+}
+
+function RuntimeLoadFailure({ message }: { message: string }) {
+	return (
+		<div
+			role="alert"
+			className="flex min-h-screen flex-col items-center justify-center bg-background p-6 text-foreground"
+		>
+			<div className="flex w-full max-w-lg flex-col items-center rounded-lg border border-destructive/30 bg-destructive/5 p-6 text-center">
+				<AlertTriangle className="mb-4 h-10 w-10 text-destructive" />
+				<h1 className="mb-2 text-lg font-semibold">
+					Arcade runtime failed to load
+				</h1>
+				<p className="mb-4 max-w-md text-sm text-muted-foreground">{message}</p>
+				<Button
+					type="button"
+					variant="outline"
+					size="sm"
+					onClick={() => window.location.reload()}
+				>
+					<RefreshCw className="mr-1.5 h-3.5 w-3.5" />
+					Reload page
+				</Button>
+			</div>
+		</div>
+	);
+}
+
+export function RuntimeProvider({
+	children,
+	runtime,
+	loadRuntime = fetchRuntimeContract,
+}: RuntimeProviderProps) {
+	const [state, setState] = useState<RuntimeLoadState>(() => ({
+		contract: runtime ?? null,
+		error: null,
+	}));
+
+	useEffect(() => {
+		if (runtime) {
+			setState({ contract: runtime, error: null });
+			return;
+		}
+
+		let cancelled = false;
+
+		loadRuntime()
+			.then((contract) => {
+				if (!cancelled) {
+					setState({ contract, error: null });
+				}
+			})
+			.catch((error: unknown) => {
+				if (!cancelled) {
+					setState({
+						contract: null,
+						error:
+							error instanceof Error
+								? error.message
+								: "Arcade runtime request failed.",
+					});
+				}
+			});
+
+		return () => {
+			cancelled = true;
+		};
+	}, [runtime, loadRuntime]);
+
+	if (state.error) {
+		return <RuntimeLoadFailure message={state.error} />;
+	}
+
+	if (!state.contract) {
+		return null;
+	}
+
+	return (
+		<RuntimeContext.Provider value={state.contract}>
+			{children}
+		</RuntimeContext.Provider>
+	);
+}
+
+export function useRuntimeContract(): ArcadeRuntimeContract {
+	const context = useContext(RuntimeContext);
+	if (!context) {
+		throw new Error("useRuntimeContract must be used within a RuntimeProvider");
+	}
+	return context;
+}

--- a/cli/web-ui/src/providers/WebSocketProvider.tsx
+++ b/cli/web-ui/src/providers/WebSocketProvider.tsx
@@ -14,6 +14,7 @@ import type {
 	EventNotificationMessage,
 	EventReplayMessage,
 	FileChangedMessage,
+	HeartbeatAckMessage,
 	NotificationMessage,
 	ProjectsChangedMessage,
 	ServerMessage,
@@ -293,7 +294,7 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
 			ws.onmessage = (event) => {
 				try {
 					const message = JSON.parse(event.data) as ServerMessage;
-					routeMessage(message);
+					routeMessage(message, ws);
 				} catch {
 					console.warn("Failed to parse WebSocket message");
 				}
@@ -302,7 +303,7 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
 			wsRef.current = ws;
 		}
 
-		function routeMessage(message: ServerMessage) {
+		function routeMessage(message: ServerMessage, socket: WebSocket) {
 			switch (message.type) {
 				case "file:changed":
 					for (const listener of fileChangeListenersRef.current) {
@@ -372,8 +373,17 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
 						listener(message);
 					}
 					break;
-				case "heartbeat":
+				case "heartbeat": {
+					if (socket.readyState === WebSocket.OPEN) {
+						const acknowledgement: HeartbeatAckMessage = {
+							type: "heartbeat:ack",
+							heartbeatId: message.heartbeatId,
+							receivedAt: new Date().toISOString(),
+						};
+						socket.send(JSON.stringify(acknowledgement));
+					}
 					break;
+				}
 			}
 		}
 

--- a/cli/web-ui/src/providers/WebSocketProvider.tsx
+++ b/cli/web-ui/src/providers/WebSocketProvider.tsx
@@ -20,6 +20,7 @@ import type {
 	StateSnapshotCallback,
 	TreeChangedMessage,
 } from "../types/websocket";
+import { useRuntimeContract } from "./RuntimeProvider";
 
 export type {
 	ConnectionStatus,
@@ -54,9 +55,6 @@ interface WebSocketContextValue {
 
 const WebSocketContext = createContext<WebSocketContextValue | null>(null);
 
-const INITIAL_RECONNECT_DELAY = 2000;
-const MAX_RECONNECT_DELAY = 30000;
-const RECONNECT_BACKOFF_FACTOR = 2;
 const LAST_EVENT_ID_STORAGE_PREFIX = "rp1:last-event-id:";
 
 interface WebSocketProviderProps {
@@ -64,10 +62,12 @@ interface WebSocketProviderProps {
 }
 
 export function WebSocketProvider({ children }: WebSocketProviderProps) {
+	const runtime = useRuntimeContract();
+	const reconnectPolicy = runtime.reconnectPolicy;
 	const [status, setStatus] = useState<ConnectionStatus>("disconnected");
 	const [projectId, setProjectIdState] = useState<string | null>(null);
 	const wsRef = useRef<WebSocket | null>(null);
-	const reconnectDelayRef = useRef(INITIAL_RECONNECT_DELAY);
+	const reconnectDelayRef = useRef(reconnectPolicy.initialDelayMs);
 	const reconnectTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
 		null,
 	);
@@ -207,7 +207,8 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
 			setStatus("connecting");
 
 			const currentProjectId = projectIdRef.current;
-			const wsProto = window.location.protocol === "https:" ? "wss" : "ws";
+			const runtimeBaseUrl = new URL(runtime.baseUrl);
+			const wsProto = runtimeBaseUrl.protocol === "https:" ? "wss" : "ws";
 			const wsUrl = (() => {
 				const query = new URLSearchParams();
 				if (currentProjectId) {
@@ -218,7 +219,7 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
 					}
 				}
 				const queryString = query.toString();
-				return `${wsProto}://${window.location.host}/ws${queryString ? `?${queryString}` : ""}`;
+				return `${wsProto}://${runtimeBaseUrl.host}/ws${queryString ? `?${queryString}` : ""}`;
 			})();
 			const ws = new WebSocket(wsUrl);
 
@@ -228,7 +229,7 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
 					return;
 				}
 				setStatus("connected");
-				reconnectDelayRef.current = INITIAL_RECONNECT_DELAY;
+				reconnectDelayRef.current = reconnectPolicy.initialDelayMs;
 
 				for (const path of subscriptionsRef.current) {
 					ws.send(JSON.stringify({ type: "subscribe", path }));
@@ -337,8 +338,8 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
 				reconnectTimeoutRef.current = null;
 				if (!mountedRef.current) return;
 				reconnectDelayRef.current = Math.min(
-					reconnectDelayRef.current * RECONNECT_BACKOFF_FACTOR,
-					MAX_RECONNECT_DELAY,
+					reconnectDelayRef.current * reconnectPolicy.backoffFactor,
+					reconnectPolicy.maxDelayMs,
 				);
 				connect();
 			}, reconnectDelayRef.current);
@@ -363,6 +364,10 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
 		emitEventNotification,
 		normalizeReplayMessage,
 		readStoredLastEventId,
+		reconnectPolicy.backoffFactor,
+		reconnectPolicy.initialDelayMs,
+		reconnectPolicy.maxDelayMs,
+		runtime.baseUrl,
 	]);
 
 	const subscribe = useCallback((path: string) => {

--- a/cli/web-ui/src/providers/WebSocketProvider.tsx
+++ b/cli/web-ui/src/providers/WebSocketProvider.tsx
@@ -19,6 +19,7 @@ import type {
 	ServerMessage,
 	StateSnapshotCallback,
 	TreeChangedMessage,
+	WebSocketActivityScope,
 } from "../types/websocket";
 import { useRuntimeContract } from "./RuntimeProvider";
 
@@ -56,6 +57,25 @@ interface WebSocketContextValue {
 const WebSocketContext = createContext<WebSocketContextValue | null>(null);
 
 const LAST_EVENT_ID_STORAGE_PREFIX = "rp1:last-event-id:";
+const GLOBAL_ACTIVITY_SCOPE_KEY = "global";
+
+interface ActivitySocketScope {
+	readonly scope: WebSocketActivityScope;
+	readonly storageKey: string;
+	readonly projectId: string | null;
+}
+
+function getActivitySocketScope(projectId: string | null): ActivitySocketScope {
+	if (projectId) {
+		return { scope: "project", storageKey: projectId, projectId };
+	}
+
+	return {
+		scope: "global",
+		storageKey: GLOBAL_ACTIVITY_SCOPE_KEY,
+		projectId: null,
+	};
+}
 
 interface WebSocketProviderProps {
 	children: ReactNode;
@@ -73,7 +93,7 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
 	);
 	const mountedRef = useRef(true);
 	const projectIdRef = useRef<string | null>(null);
-	const lastEventIdByProjectRef = useRef<Map<string, number>>(new Map());
+	const lastEventIdByScopeRef = useRef<Map<string, number>>(new Map());
 	const fileChangeListenersRef = useRef<Set<(msg: FileChangedMessage) => void>>(
 		new Set(),
 	);
@@ -98,15 +118,15 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
 	const notifyReconnectRef = useRef(false);
 
 	const readStoredLastEventId = useCallback(
-		(targetProjectId: string): number | null => {
-			const cached = lastEventIdByProjectRef.current.get(targetProjectId);
+		(storageKey: string): number | null => {
+			const cached = lastEventIdByScopeRef.current.get(storageKey);
 			if (cached != null) {
 				return cached;
 			}
 
 			try {
 				const storedValue = sessionStorage.getItem(
-					`${LAST_EVENT_ID_STORAGE_PREFIX}${targetProjectId}`,
+					`${LAST_EVENT_ID_STORAGE_PREFIX}${storageKey}`,
 				);
 				if (storedValue == null) {
 					return null;
@@ -115,7 +135,7 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
 				if (Number.isNaN(parsedValue)) {
 					return null;
 				}
-				lastEventIdByProjectRef.current.set(targetProjectId, parsedValue);
+				lastEventIdByScopeRef.current.set(storageKey, parsedValue);
 				return parsedValue;
 			} catch {
 				return null;
@@ -125,16 +145,16 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
 	);
 
 	const advanceLastEventId = useCallback(
-		(targetProjectId: string, eventId: number) => {
-			const currentValue = readStoredLastEventId(targetProjectId);
+		(storageKey: string, eventId: number) => {
+			const currentValue = readStoredLastEventId(storageKey);
 			if (currentValue != null && currentValue >= eventId) {
 				return;
 			}
 
-			lastEventIdByProjectRef.current.set(targetProjectId, eventId);
+			lastEventIdByScopeRef.current.set(storageKey, eventId);
 			try {
 				sessionStorage.setItem(
-					`${LAST_EVENT_ID_STORAGE_PREFIX}${targetProjectId}`,
+					`${LAST_EVENT_ID_STORAGE_PREFIX}${storageKey}`,
 					String(eventId),
 				);
 			} catch {}
@@ -165,7 +185,8 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
 			message: EventReplayMessage,
 			targetProjectId: string | null,
 		): EventNotificationMessage | null => {
-			if (targetProjectId == null) {
+			const messageProjectId = message.event.projectId ?? targetProjectId;
+			if (messageProjectId == null) {
 				return null;
 			}
 
@@ -174,8 +195,8 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
 				eventId: message.event.id,
 				eventType: message.event.eventType,
 				runId: message.event.runId,
-				projectId: targetProjectId,
-				featureId: "",
+				projectId: messageProjectId,
+				featureId: message.event.featureId ?? "",
 				runStatus: message.event.runStatus ?? null,
 				step: message.event.step,
 				unit: message.event.unit ?? null,
@@ -184,6 +205,18 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
 			};
 		},
 		[parseReplayEventData],
+	);
+
+	const advanceEventCursors = useCallback(
+		(message: EventNotificationMessage, scope: WebSocketActivityScope) => {
+			if (scope === "global") {
+				advanceLastEventId(GLOBAL_ACTIVITY_SCOPE_KEY, message.eventId);
+			}
+			if (message.projectId) {
+				advanceLastEventId(message.projectId, message.eventId);
+			}
+		},
+		[advanceLastEventId],
 	);
 
 	const emitEventNotification = useCallback(
@@ -207,16 +240,18 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
 			setStatus("connecting");
 
 			const currentProjectId = projectIdRef.current;
+			const activityScope = getActivitySocketScope(currentProjectId);
 			const runtimeBaseUrl = new URL(runtime.baseUrl);
 			const wsProto = runtimeBaseUrl.protocol === "https:" ? "wss" : "ws";
 			const wsUrl = (() => {
 				const query = new URLSearchParams();
-				if (currentProjectId) {
-					query.set("projectId", currentProjectId);
-					const lastEventId = readStoredLastEventId(currentProjectId);
-					if (lastEventId != null) {
-						query.set("lastEventId", String(lastEventId));
-					}
+				query.set("scope", activityScope.scope);
+				if (activityScope.projectId) {
+					query.set("projectId", activityScope.projectId);
+				}
+				const lastEventId = readStoredLastEventId(activityScope.storageKey);
+				if (lastEventId != null) {
+					query.set("lastEventId", String(lastEventId));
 				}
 				const queryString = query.toString();
 				return `${wsProto}://${runtimeBaseUrl.host}/ws${queryString ? `?${queryString}` : ""}`;
@@ -280,7 +315,10 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
 					}
 					break;
 				case "event:notification":
-					advanceLastEventId(message.projectId, message.eventId);
+					advanceEventCursors(
+						message,
+						getActivitySocketScope(projectIdRef.current).scope,
+					);
 					emitEventNotification(message);
 					break;
 				case "event:replay": {
@@ -289,22 +327,31 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
 						projectIdRef.current,
 					);
 					if (normalizedMessage) {
-						advanceLastEventId(
-							normalizedMessage.projectId,
-							normalizedMessage.eventId,
+						advanceEventCursors(
+							normalizedMessage,
+							message.scope ??
+								getActivitySocketScope(projectIdRef.current).scope,
 						);
 						emitEventNotification(normalizedMessage);
 					}
 					break;
 				}
-				case "state:snapshot":
-					if (projectIdRef.current != null) {
-						advanceLastEventId(projectIdRef.current, message.lastEventId);
+				case "state:snapshot": {
+					const snapshotScope =
+						message.scope ?? getActivitySocketScope(projectIdRef.current).scope;
+					if (snapshotScope === "global") {
+						advanceLastEventId(GLOBAL_ACTIVITY_SCOPE_KEY, message.lastEventId);
+					} else {
+						const snapshotProjectId = message.projectId ?? projectIdRef.current;
+						if (snapshotProjectId != null) {
+							advanceLastEventId(snapshotProjectId, message.lastEventId);
+						}
 					}
 					for (const listener of snapshotListenersRef.current) {
 						listener(message);
 					}
 					break;
+				}
 				case "projects:changed":
 					for (const listener of projectsChangeListenersRef.current) {
 						listener(message);
@@ -361,6 +408,7 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
 	}, [
 		projectId,
 		advanceLastEventId,
+		advanceEventCursors,
 		emitEventNotification,
 		normalizeReplayMessage,
 		readStoredLastEventId,

--- a/cli/web-ui/src/server.ts
+++ b/cli/web-ui/src/server.ts
@@ -161,7 +161,6 @@ export function createServer(options: ServerOptions) {
 	const setupReplayProvider = async () => {
 		const {
 			getEmitDatabase,
-			countEventsSince,
 			getEventsSince,
 			getRunById,
 			getActiveRunsSnapshot,
@@ -178,10 +177,34 @@ export function createServer(options: ServerOptions) {
 		}
 
 		const db = dbResult.right;
+		const projects = await getAllProjects(db);
+		const projectLookup = buildProjectLookup(projects);
+		const getRunContext = (runId: string) => {
+			const run = getRunById(db, runId);
+			if (!run) {
+				return null;
+			}
+
+			const project = findProjectByIdentity(projectLookup, {
+				projectId: run.projectId,
+				rp1ProjectRoot: run.rp1ProjectRoot,
+				projectPath: run.projectPath,
+			});
+			if (!project) {
+				return null;
+			}
+
+			return {
+				projectId: project.id,
+				featureId: run.featureId,
+				runStatus: run.status,
+			};
+		};
+
 		websocketHub.setReplayProvider({
-			countEventsSince: (afterId: number) => countEventsSince(db, afterId),
 			getEventsSince: (afterId: number, limit?: number) =>
 				getEventsSince(db, afterId, limit),
+			getRunContext,
 			getRunStatus: (runId: string) => getRunById(db, runId)?.status ?? null,
 			getActiveRunsSnapshot: () => {
 				void reclassifyInactiveRunsWithBroadcast(db, websocketHub).catch(

--- a/cli/web-ui/src/server/http.ts
+++ b/cli/web-ui/src/server/http.ts
@@ -170,6 +170,11 @@ async function handleV2ApiRequest(
 		return handleV2HealthRequest(apiContext);
 	}
 
+	if (pathname === "/api/v2/runtime" && method === "GET") {
+		const { handleV2RuntimeRequest } = await import("./routes/v2-api");
+		return handleV2RuntimeRequest(req, apiContext);
+	}
+
 	if (pathname === "/api/v2/shutdown" && method === "POST") {
 		const { handleV2ShutdownRequest } = await import("./routes/v2-api");
 		return handleV2ShutdownRequest(req, apiContext);

--- a/cli/web-ui/src/server/http.ts
+++ b/cli/web-ui/src/server/http.ts
@@ -1,10 +1,11 @@
 import type { ServerWebSocket } from "bun";
 import type { FileWatcherPool } from "./file-watcher";
 import type { ApiContext } from "./routes/content-utils";
-import type { WebSocketHub } from "./websocket";
+import type { WebSocketActivityScope, WebSocketHub } from "./websocket";
 
 interface WebSocketData {
 	projectPath: string;
+	scope?: WebSocketActivityScope;
 	projectId?: string;
 	lastEventId?: number;
 }
@@ -60,7 +61,26 @@ export function startServer(config: ServerConfig): AppServer {
 			const pathname = url.pathname;
 
 			if (pathname === "/ws") {
+				const scopeParam = url.searchParams.get("scope");
 				const projectIdParam = url.searchParams.get("projectId");
+				if (
+					scopeParam != null &&
+					scopeParam !== "global" &&
+					scopeParam !== "project"
+				) {
+					return new Response("Invalid WebSocket scope", { status: 400 });
+				}
+
+				const scope: WebSocketActivityScope =
+					scopeParam === "project" || (scopeParam == null && projectIdParam)
+						? "project"
+						: "global";
+				if (scope === "project" && !projectIdParam) {
+					return new Response("Project WebSocket scope requires projectId", {
+						status: 400,
+					});
+				}
+
 				const lastEventIdParam = url.searchParams.get("lastEventId");
 				const lastEventId =
 					lastEventIdParam != null
@@ -69,7 +89,9 @@ export function startServer(config: ServerConfig): AppServer {
 				const upgraded = server.upgrade(req, {
 					data: {
 						projectPath,
-						projectId: projectIdParam ?? undefined,
+						scope,
+						projectId:
+							scope === "project" ? (projectIdParam ?? undefined) : undefined,
 						lastEventId:
 							lastEventId != null && !Number.isNaN(lastEventId)
 								? lastEventId
@@ -90,10 +112,12 @@ export function startServer(config: ServerConfig): AppServer {
 		},
 		websocket: {
 			open(ws: ServerWebSocket<WebSocketData>) {
+				const scope =
+					ws.data.scope ?? (ws.data.projectId ? "project" : "global");
 				const projectId = ws.data.projectId;
 				const lastEventId = ws.data.lastEventId;
-				websocketHub.addClient(ws, projectId, lastEventId);
-				if (projectId && fileWatcherPool) {
+				websocketHub.addClient(ws, { scope, projectId, lastEventId });
+				if (scope === "project" && projectId && fileWatcherPool) {
 					import("../../../src/agent-tools/emit/database.js").then(
 						async ({ getEmitDatabase }) => {
 							const dbResult = await getEmitDatabase()();

--- a/cli/web-ui/src/server/routes/static.ts
+++ b/cli/web-ui/src/server/routes/static.ts
@@ -1,7 +1,9 @@
 import { extname, join, resolve } from "node:path";
+import { ARCADE_RUNTIME_MANIFEST_FILENAME } from "../../types/runtime";
 
 const HTML_CACHE_CONTROL = "no-store, no-cache, must-revalidate";
 const IMMUTABLE_CACHE_CONTROL = "public, max-age=31536000, immutable";
+const ASSET_MISSING_HEADER = "X-RP1-Asset-Missing";
 
 const MIME_TYPES: Record<string, string> = {
 	".html": "text/html; charset=utf-8",
@@ -36,6 +38,10 @@ function hasFileExtension(pathname: string): boolean {
 	return extname(pathname) !== "";
 }
 
+function isRuntimeManifestPath(pathname: string): boolean {
+	return pathname === `/${ARCADE_RUNTIME_MANIFEST_FILENAME}`;
+}
+
 function acceptsHtml(req: Request): boolean {
 	const accept = req.headers.get("Accept");
 	return accept?.toLowerCase().includes("text/html") ?? false;
@@ -51,7 +57,10 @@ function shouldServeSpaFallback(req: Request, pathname: string): boolean {
 }
 
 function cacheControlForPath(pathname: string, filePath: string): string {
-	if (extname(filePath).toLowerCase() === ".html") {
+	if (
+		extname(filePath).toLowerCase() === ".html" ||
+		isRuntimeManifestPath(pathname)
+	) {
 		return HTML_CACHE_CONTROL;
 	}
 
@@ -60,6 +69,24 @@ function cacheControlForPath(pathname: string, filePath: string): string {
 	}
 
 	return "no-cache";
+}
+
+function missingAssetResponse(pathname: string): Response {
+	return new Response(
+		[
+			"status=missing_asset",
+			`path=${pathname}`,
+			"message=Requested Arcade asset was not found.",
+			"",
+		].join("\n"),
+		{
+			status: 404,
+			headers: {
+				[ASSET_MISSING_HEADER]: "true",
+				"Content-Type": "text/plain; charset=utf-8",
+			},
+		},
+	);
 }
 
 export async function handleStaticRequest(
@@ -106,6 +133,10 @@ export async function handleStaticRequest(
 					"Content-Type": "text/html; charset=utf-8",
 				},
 			});
+		}
+
+		if (hasFileExtension(pathname)) {
+			return missingAssetResponse(pathname);
 		}
 
 		return new Response("Not found", {

--- a/cli/web-ui/src/server/routes/static.ts
+++ b/cli/web-ui/src/server/routes/static.ts
@@ -1,5 +1,8 @@
 import { extname, join, resolve } from "node:path";
 
+const HTML_CACHE_CONTROL = "no-store, no-cache, must-revalidate";
+const IMMUTABLE_CACHE_CONTROL = "public, max-age=31536000, immutable";
+
 const MIME_TYPES: Record<string, string> = {
 	".html": "text/html; charset=utf-8",
 	".css": "text/css; charset=utf-8",
@@ -23,6 +26,40 @@ const MIME_TYPES: Record<string, string> = {
 function getMimeType(filePath: string): string {
 	const ext = extname(filePath).toLowerCase();
 	return MIME_TYPES[ext] ?? "application/octet-stream";
+}
+
+function isAssetPath(pathname: string): boolean {
+	return pathname === "/assets" || pathname.startsWith("/assets/");
+}
+
+function hasFileExtension(pathname: string): boolean {
+	return extname(pathname) !== "";
+}
+
+function acceptsHtml(req: Request): boolean {
+	const accept = req.headers.get("Accept");
+	return accept?.toLowerCase().includes("text/html") ?? false;
+}
+
+function shouldServeSpaFallback(req: Request, pathname: string): boolean {
+	return (
+		req.method === "GET" &&
+		acceptsHtml(req) &&
+		!isAssetPath(pathname) &&
+		!hasFileExtension(pathname)
+	);
+}
+
+function cacheControlForPath(pathname: string, filePath: string): string {
+	if (extname(filePath).toLowerCase() === ".html") {
+		return HTML_CACHE_CONTROL;
+	}
+
+	if (isAssetPath(pathname)) {
+		return IMMUTABLE_CACHE_CONTROL;
+	}
+
+	return "no-cache";
 }
 
 export async function handleStaticRequest(
@@ -62,17 +99,26 @@ export async function handleStaticRequest(
 		const indexFile = Bun.file(join(distDir, "index.html"));
 		const indexExists = await indexFile.exists();
 
-		if (indexExists) {
-			return new Response(indexFile, {
-				headers: { "Content-Type": "text/html; charset=utf-8" },
+		if (indexExists && shouldServeSpaFallback(req, pathname)) {
+			return new Response(indexFile.stream(), {
+				headers: {
+					"Cache-Control": HTML_CACHE_CONTROL,
+					"Content-Type": "text/html; charset=utf-8",
+				},
 			});
 		}
 
-		return new Response("Not found", { status: 404 });
+		return new Response("Not found", {
+			status: 404,
+			headers: { "Content-Type": "text/plain; charset=utf-8" },
+		});
 	}
 
-	return new Response(file, {
-		headers: { "Content-Type": getMimeType(filePath) },
+	return new Response(file.stream(), {
+		headers: {
+			"Cache-Control": cacheControlForPath(pathname, filePath),
+			"Content-Type": getMimeType(filePath),
+		},
 	});
 }
 

--- a/cli/web-ui/src/server/routes/v2-api.ts
+++ b/cli/web-ui/src/server/routes/v2-api.ts
@@ -109,6 +109,12 @@ import {
 	registerProject,
 	removeProject,
 } from "../registry";
+import {
+	buildArcadeRuntimeContract,
+	RuntimeManifestError,
+	runtimeJsonResponse,
+	UnsupportedArcadeHostModeError,
+} from "../runtime-contract";
 import type { WebSocketHub } from "../websocket";
 import {
 	type ApiContext,
@@ -2165,6 +2171,32 @@ export async function handleV2HealthRequest(
 		isDev: ctx.isDev ?? false,
 		...(ctx.version && { version: ctx.version }),
 	});
+}
+
+/**
+ * GET /api/v2/runtime - browser/native runtime contract.
+ */
+export async function handleV2RuntimeRequest(
+	req: Request,
+	ctx: ApiContext,
+): Promise<Response> {
+	try {
+		const contract = await buildArcadeRuntimeContract(ctx, req.url);
+		return runtimeJsonResponse(contract);
+	} catch (error) {
+		if (error instanceof UnsupportedArcadeHostModeError) {
+			return runtimeJsonResponse({ error: error.message }, 400);
+		}
+
+		if (error instanceof RuntimeManifestError) {
+			return runtimeJsonResponse({ error: error.message }, 500);
+		}
+
+		return runtimeJsonResponse(
+			{ error: `Failed to build Arcade runtime contract: ${String(error)}` },
+			500,
+		);
+	}
 }
 
 /**

--- a/cli/web-ui/src/server/runtime-contract.ts
+++ b/cli/web-ui/src/server/runtime-contract.ts
@@ -1,0 +1,147 @@
+import { join } from "node:path";
+import {
+	ARCADE_RUNTIME_MANIFEST_FILENAME,
+	ARCADE_RUNTIME_SCHEMA_VERSION,
+	type ArcadeHostMode,
+	type ArcadeRuntimeContract,
+	type ArcadeRuntimeManifest,
+	DEFAULT_ARCADE_RECONNECT_POLICY,
+	isArcadeHostMode,
+} from "../types/runtime";
+import { RP1_VERSION } from "../version";
+import type { ApiContext } from "./routes/content-utils";
+
+export const RUNTIME_CACHE_CONTROL = "no-store, no-cache, must-revalidate";
+
+export class UnsupportedArcadeHostModeError extends Error {
+	readonly hostMode: string;
+
+	constructor(hostMode: string) {
+		super(`Unsupported Arcade host mode: ${hostMode}`);
+		this.name = "UnsupportedArcadeHostModeError";
+		this.hostMode = hostMode;
+	}
+}
+
+export class RuntimeManifestError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "RuntimeManifestError";
+	}
+}
+
+function isRuntimeManifest(value: unknown): value is ArcadeRuntimeManifest {
+	if (value === null || typeof value !== "object") {
+		return false;
+	}
+
+	const candidate = value as Partial<ArcadeRuntimeManifest>;
+	return (
+		typeof candidate.version === "string" &&
+		typeof candidate.gitCommit === "string" &&
+		typeof candidate.buildTime === "string" &&
+		typeof candidate.buildId === "string"
+	);
+}
+
+function fallbackRuntimeManifest(ctx: ApiContext): ArcadeRuntimeManifest {
+	const version = ctx.version ?? RP1_VERSION;
+	const buildId = ctx.isDev ? `dev-${version}` : version;
+
+	return {
+		version,
+		gitCommit: "unknown",
+		buildTime: "development",
+		buildId,
+	};
+}
+
+function runtimeManifestPath(ctx: ApiContext): string {
+	const clientDir = ctx.webUIDir
+		? join(ctx.webUIDir, "client")
+		: join(import.meta.dir, "../../dist/client");
+	return join(clientDir, ARCADE_RUNTIME_MANIFEST_FILENAME);
+}
+
+export async function readArcadeRuntimeManifest(
+	ctx: ApiContext,
+): Promise<ArcadeRuntimeManifest> {
+	const manifestPath = runtimeManifestPath(ctx);
+	const manifestFile = Bun.file(manifestPath);
+
+	if (!(await manifestFile.exists())) {
+		if (ctx.isDev || !ctx.webUIDir) {
+			return fallbackRuntimeManifest(ctx);
+		}
+		throw new RuntimeManifestError(
+			`Arcade runtime manifest not found at ${manifestPath}`,
+		);
+	}
+
+	try {
+		const parsed = JSON.parse(await manifestFile.text()) as unknown;
+		if (!isRuntimeManifest(parsed)) {
+			throw new RuntimeManifestError(
+				`Arcade runtime manifest is invalid at ${manifestPath}`,
+			);
+		}
+		return parsed;
+	} catch (error) {
+		if (error instanceof RuntimeManifestError) {
+			throw error;
+		}
+		throw new RuntimeManifestError(
+			`Failed to read Arcade runtime manifest at ${manifestPath}`,
+		);
+	}
+}
+
+export function resolveArcadeHostMode(url: URL): ArcadeHostMode {
+	const rawHostMode =
+		url.searchParams.get("hostMode") ?? url.searchParams.get("host-mode");
+
+	if (rawHostMode === null) {
+		return "browser";
+	}
+
+	if (isArcadeHostMode(rawHostMode)) {
+		return rawHostMode;
+	}
+
+	throw new UnsupportedArcadeHostModeError(rawHostMode);
+}
+
+function resolveCacheBust(url: URL, manifest: ArcadeRuntimeManifest): string {
+	const rawCacheBust =
+		url.searchParams.get("cacheBust") ?? url.searchParams.get("cache-bust");
+	const cacheBust = rawCacheBust?.trim();
+	return cacheBust && cacheBust.length > 0 ? cacheBust : manifest.buildId;
+}
+
+export async function buildArcadeRuntimeContract(
+	ctx: ApiContext,
+	requestUrl: string | URL,
+): Promise<ArcadeRuntimeContract> {
+	const url = requestUrl instanceof URL ? requestUrl : new URL(requestUrl);
+	const manifest = await readArcadeRuntimeManifest(ctx);
+
+	return {
+		schemaVersion: ARCADE_RUNTIME_SCHEMA_VERSION,
+		baseUrl: url.origin,
+		hostMode: resolveArcadeHostMode(url),
+		version: manifest.version,
+		buildId: manifest.buildId,
+		cacheBust: resolveCacheBust(url, manifest),
+		reconnectPolicy: DEFAULT_ARCADE_RECONNECT_POLICY,
+	};
+}
+
+export function runtimeJsonResponse(data: unknown, status = 200): Response {
+	return new Response(JSON.stringify(data), {
+		status,
+		headers: {
+			"Cache-Control": RUNTIME_CACHE_CONTROL,
+			"Content-Type": "application/json",
+		},
+	});
+}

--- a/cli/web-ui/src/server/websocket.ts
+++ b/cli/web-ui/src/server/websocket.ts
@@ -1,6 +1,11 @@
+import { randomUUID } from "node:crypto";
 import type { ServerWebSocket } from "bun";
 import type { ArtifactLocationKind, Status } from "../../../shared/events.js";
 import type { Annotation, AnnotationReply } from "../types/annotations";
+import {
+	type ArcadeReconnectPolicy,
+	DEFAULT_ARCADE_RECONNECT_POLICY,
+} from "../types/runtime";
 
 export type WebSocketActivityScope = "global" | "project";
 
@@ -20,6 +25,7 @@ export interface TreeChangedMessage {
 
 export interface HeartbeatMessage {
 	type: "heartbeat";
+	heartbeatId: string;
 	timestamp: string;
 }
 
@@ -106,6 +112,12 @@ export interface SwitchProjectMessage {
 	projectId: string;
 }
 
+export interface HeartbeatAckMessage {
+	type: "heartbeat:ack";
+	heartbeatId: string;
+	receivedAt: string;
+}
+
 export interface EventReplayMessage {
 	type: "event:replay";
 	scope: WebSocketActivityScope;
@@ -168,7 +180,8 @@ export type ServerMessage =
 export type ClientMessage =
 	| SubscribeMessage
 	| UnsubscribeMessage
-	| SwitchProjectMessage;
+	| SwitchProjectMessage
+	| HeartbeatAckMessage;
 
 interface ClientData {
 	projectPath: string;
@@ -182,7 +195,9 @@ interface ClientState {
 	scope: WebSocketActivityScope;
 	projectId: string | null;
 	subscriptions: Set<string>;
-	lastPing: number;
+	lastHeartbeatAckAt: number;
+	pendingHeartbeatId: string | null;
+	missedHeartbeatCount: number;
 	lastEventId: number | null;
 }
 
@@ -238,10 +253,14 @@ export class WebSocketHub {
 	private clients: Map<ServerWebSocket<ClientData>, ClientState> = new Map();
 	private heartbeatInterval: ReturnType<typeof setInterval> | null = null;
 	private replayProvider: ReplayProvider | null = null;
+	private readonly reconnectPolicy: ArcadeReconnectPolicy;
 
 	private static readonly REPLAY_EVENT_CAP = 100;
 
-	constructor() {
+	constructor(
+		reconnectPolicy: ArcadeReconnectPolicy = DEFAULT_ARCADE_RECONNECT_POLICY,
+	) {
+		this.reconnectPolicy = reconnectPolicy;
 		this.startHeartbeat();
 	}
 
@@ -265,7 +284,9 @@ export class WebSocketHub {
 			scope,
 			projectId,
 			subscriptions: new Set(),
-			lastPing: Date.now(),
+			lastHeartbeatAckAt: Date.now(),
+			pendingHeartbeatId: null,
+			missedHeartbeatCount: 0,
 			lastEventId: lastEventId ?? null,
 		});
 		const scopeLabel =
@@ -450,8 +471,6 @@ export class WebSocketHub {
 		const state = this.clients.get(ws);
 		if (!state) return;
 
-		state.lastPing = Date.now();
-
 		try {
 			const msgStr =
 				typeof message === "string"
@@ -472,6 +491,13 @@ export class WebSocketHub {
 					state.scope = "project";
 					state.projectId = parsed.projectId;
 					console.log(`Client switched to project: ${parsed.projectId}`);
+					break;
+				case "heartbeat:ack":
+					if (parsed.heartbeatId === state.pendingHeartbeatId) {
+						state.pendingHeartbeatId = null;
+						state.missedHeartbeatCount = 0;
+						state.lastHeartbeatAckAt = Date.now();
+					}
 					break;
 			}
 		} catch {
@@ -590,20 +616,19 @@ export class WebSocketHub {
 	}
 
 	private startHeartbeat(): void {
-		const HEARTBEAT_INTERVAL = 30_000;
-		const STALE_THRESHOLD = 90_000;
+		const { heartbeatIntervalMs, heartbeatMissThreshold } =
+			this.reconnectPolicy;
 
 		this.heartbeatInterval = setInterval(() => {
-			const now = Date.now();
-			const heartbeat: HeartbeatMessage = {
-				type: "heartbeat",
-				timestamp: new Date().toISOString(),
-			};
-			const data = JSON.stringify(heartbeat);
-
 			for (const [ws, state] of this.clients.entries()) {
-				if (now - state.lastPing > STALE_THRESHOLD) {
-					console.log("Closing stale WebSocket connection");
+				if (state.pendingHeartbeatId !== null) {
+					state.missedHeartbeatCount += 1;
+				}
+
+				if (state.missedHeartbeatCount >= heartbeatMissThreshold) {
+					console.log(
+						"Closing WebSocket connection after missed heartbeat acknowledgements",
+					);
 					try {
 						ws.close();
 					} catch {
@@ -613,13 +638,20 @@ export class WebSocketHub {
 					continue;
 				}
 
+				const heartbeat: HeartbeatMessage = {
+					type: "heartbeat",
+					heartbeatId: randomUUID(),
+					timestamp: new Date().toISOString(),
+				};
+				state.pendingHeartbeatId = heartbeat.heartbeatId;
+
 				try {
-					ws.send(data);
+					ws.send(JSON.stringify(heartbeat));
 				} catch {
 					this.removeClient(ws);
 				}
 			}
-		}, HEARTBEAT_INTERVAL);
+		}, heartbeatIntervalMs);
 	}
 
 	stop(): void {

--- a/cli/web-ui/src/server/websocket.ts
+++ b/cli/web-ui/src/server/websocket.ts
@@ -2,6 +2,8 @@ import type { ServerWebSocket } from "bun";
 import type { ArtifactLocationKind, Status } from "../../../shared/events.js";
 import type { Annotation, AnnotationReply } from "../types/annotations";
 
+export type WebSocketActivityScope = "global" | "project";
+
 export interface FileChangedMessage {
 	type: "file:changed";
 	projectId: string;
@@ -106,9 +108,12 @@ export interface SwitchProjectMessage {
 
 export interface EventReplayMessage {
 	type: "event:replay";
+	scope: WebSocketActivityScope;
 	event: {
 		id: number;
 		runId: string;
+		projectId: string;
+		featureId: string;
 		eventType: string;
 		runStatus?: Status | null;
 		step: string | null;
@@ -120,8 +125,11 @@ export interface EventReplayMessage {
 
 export interface StateSnapshotMessage {
 	type: "state:snapshot";
+	scope: WebSocketActivityScope;
+	projectId: string | null;
 	runs: Array<{
 		id: string;
+		projectId: string;
 		flow: string;
 		featureId: string;
 		projectPath: string;
@@ -164,19 +172,32 @@ export type ClientMessage =
 
 interface ClientData {
 	projectPath: string;
+	scope?: WebSocketActivityScope;
+	projectId?: string;
 	lastEventId?: number;
 }
 
 interface ClientState {
 	ws: ServerWebSocket<ClientData>;
+	scope: WebSocketActivityScope;
 	projectId: string | null;
 	subscriptions: Set<string>;
 	lastPing: number;
 	lastEventId: number | null;
 }
 
+interface ReplayRunContext {
+	projectId: string;
+	featureId: string;
+	runStatus: Status | null;
+}
+
+interface ReplayEventWithContext {
+	event: ReturnType<ReplayProvider["getEventsSince"]>[number];
+	context: ReplayRunContext;
+}
+
 export interface ReplayProvider {
-	countEventsSince(afterId: number): number;
 	getEventsSince(
 		afterId: number,
 		limit?: number,
@@ -189,6 +210,7 @@ export interface ReplayProvider {
 		data: string | null;
 		createdAt: string;
 	}>;
+	getRunContext?: (runId: string) => ReplayRunContext | null;
 	getRunStatus?: (runId: string) => Status | null;
 	getActiveRunsSnapshot(): Array<{
 		id: string;
@@ -229,23 +251,81 @@ export class WebSocketHub {
 
 	addClient(
 		ws: ServerWebSocket<ClientData>,
-		projectId?: string,
-		lastEventId?: number,
+		options: {
+			scope?: WebSocketActivityScope;
+			projectId?: string;
+			lastEventId?: number;
+		} = {},
 	): void {
+		const scope = options.scope ?? (options.projectId ? "project" : "global");
+		const projectId = scope === "project" ? (options.projectId ?? null) : null;
+		const lastEventId = options.lastEventId;
 		this.clients.set(ws, {
 			ws,
-			projectId: projectId ?? null,
+			scope,
+			projectId,
 			subscriptions: new Set(),
 			lastPing: Date.now(),
 			lastEventId: lastEventId ?? null,
 		});
+		const scopeLabel =
+			scope === "project" && projectId ? `project ${projectId}` : "global";
 		console.log(
-			`WebSocket client connected${projectId ? ` for project ${projectId}` : ""}. Total clients: ${this.clients.size}`,
+			`WebSocket client connected for ${scopeLabel}. Total clients: ${this.clients.size}`,
 		);
 
 		if (lastEventId != null && this.replayProvider) {
 			this.replayEventsForClient(ws, lastEventId);
 		}
+	}
+
+	private clientReceivesProject(
+		state: ClientState,
+		projectId: string,
+	): boolean {
+		return state.scope === "global" || state.projectId === projectId;
+	}
+
+	private resolveReplayRunContext(
+		runId: string,
+		state: ClientState,
+	): ReplayRunContext | null {
+		if (!this.replayProvider) return null;
+
+		const context = this.replayProvider.getRunContext?.(runId);
+		if (context) {
+			return context;
+		}
+
+		if (state.scope === "project" && state.projectId) {
+			return {
+				projectId: state.projectId,
+				featureId: "",
+				runStatus: this.replayProvider.getRunStatus?.(runId) ?? null,
+			};
+		}
+
+		return null;
+	}
+
+	private getReplayEventsForClient(
+		state: ClientState,
+		lastEventId: number,
+	): ReplayEventWithContext[] {
+		if (!this.replayProvider) return [];
+
+		const events = this.replayProvider.getEventsSince(lastEventId);
+		const replayableEvents: ReplayEventWithContext[] = [];
+
+		for (const event of events) {
+			const context = this.resolveReplayRunContext(event.runId, state);
+			if (!context || !this.clientReceivesProject(state, context.projectId)) {
+				continue;
+			}
+			replayableEvents.push({ event, context });
+		}
+
+		return replayableEvents;
 	}
 
 	private replayEventsForClient(
@@ -258,23 +338,25 @@ export class WebSocketHub {
 		if (!state) return;
 
 		try {
-			const missedCount = this.replayProvider.countEventsSince(lastEventId);
+			const replayEvents = this.getReplayEventsForClient(state, lastEventId);
+			const missedCount = replayEvents.length;
 
 			if (missedCount === 0) {
 				return;
 			}
 
 			if (missedCount <= WebSocketHub.REPLAY_EVENT_CAP) {
-				const events = this.replayProvider.getEventsSince(lastEventId);
-				for (const event of events) {
+				for (const { event, context } of replayEvents) {
 					const message: EventReplayMessage = {
 						type: "event:replay",
+						scope: state.scope,
 						event: {
 							id: event.id,
 							runId: event.runId,
+							projectId: context.projectId,
+							featureId: context.featureId,
 							eventType: event.type,
-							runStatus:
-								this.replayProvider.getRunStatus?.(event.runId) ?? null,
+							runStatus: context.runStatus,
 							step: event.step,
 							unit: event.unit,
 							data: event.data,
@@ -289,20 +371,42 @@ export class WebSocketHub {
 						return;
 					}
 				}
-				console.log(`[replay] Replayed ${events.length} events for client`);
+				console.log(
+					`[replay] Replayed ${replayEvents.length} events for ${state.scope} client`,
+				);
 			} else {
-				const runs = this.replayProvider.getActiveRunsSnapshot();
+				const runs = this.replayProvider
+					.getActiveRunsSnapshot()
+					.flatMap((run) => {
+						const context = this.resolveReplayRunContext(run.id, state);
+						if (
+							!context ||
+							!this.clientReceivesProject(state, context.projectId)
+						) {
+							return [];
+						}
+
+						return [
+							{
+								run,
+								context,
+							},
+						];
+					});
 				const maxEventId = this.replayProvider.getMaxEventId();
 				const message: StateSnapshotMessage = {
 					type: "state:snapshot",
-					runs: runs.map((r) => ({
-						id: r.id,
-						flow: r.flow,
-						featureId: r.featureId,
-						projectPath: r.projectPath,
-						status: r.status,
-						steps: r.steps.map((s) => ({ step: s.step, status: s.status })),
-						artifacts: r.artifacts.map((a) => ({
+					scope: state.scope,
+					projectId: state.scope === "project" ? state.projectId : null,
+					runs: runs.map(({ run, context }) => ({
+						id: run.id,
+						projectId: context.projectId,
+						flow: run.flow,
+						featureId: context.featureId,
+						projectPath: run.projectPath,
+						status: run.status,
+						steps: run.steps.map((s) => ({ step: s.step, status: s.status })),
+						artifacts: run.artifacts.map((a) => ({
 							docId: a.docId,
 							path: a.path,
 							type: a.type,
@@ -365,6 +469,7 @@ export class WebSocketHub {
 					state.subscriptions.delete(parsed.path);
 					break;
 				case "switch-project":
+					state.scope = "project";
 					state.projectId = parsed.projectId;
 					console.log(`Client switched to project: ${parsed.projectId}`);
 					break;
@@ -400,8 +505,7 @@ export class WebSocketHub {
 
 		const data = JSON.stringify(message);
 		for (const state of this.clients.values()) {
-			const isProjectMatch =
-				state.projectId === null || state.projectId === projectId;
+			const isProjectMatch = this.clientReceivesProject(state, projectId);
 			const isSubscribed =
 				state.subscriptions.size === 0 || state.subscriptions.has(path);
 
@@ -424,8 +528,7 @@ export class WebSocketHub {
 
 		const data = JSON.stringify(message);
 		for (const state of this.clients.values()) {
-			const isProjectMatch =
-				state.projectId === null || state.projectId === projectId;
+			const isProjectMatch = this.clientReceivesProject(state, projectId);
 
 			if (isProjectMatch) {
 				try {
@@ -473,8 +576,7 @@ export class WebSocketHub {
 
 		const serialized = JSON.stringify(message);
 		for (const state of this.clients.values()) {
-			const isProjectMatch =
-				state.projectId === null || state.projectId === projectId;
+			const isProjectMatch = this.clientReceivesProject(state, projectId);
 
 			if (isProjectMatch) {
 				try {
@@ -627,8 +729,7 @@ export class WebSocketHub {
 		for (const state of this.clients.values()) {
 			const isProjectMatch =
 				notification.projectId === null ||
-				state.projectId === null ||
-				state.projectId === notification.projectId;
+				this.clientReceivesProject(state, notification.projectId);
 
 			if (isProjectMatch) {
 				try {

--- a/cli/web-ui/src/types/runtime.ts
+++ b/cli/web-ui/src/types/runtime.ts
@@ -1,0 +1,47 @@
+export const ARCADE_RUNTIME_SCHEMA_VERSION = 1;
+export const ARCADE_RUNTIME_MANIFEST_FILENAME = "rp1-runtime-manifest.json";
+
+export const VALID_ARCADE_HOST_MODES = ["browser", "native"] as const;
+
+export type ArcadeHostMode = (typeof VALID_ARCADE_HOST_MODES)[number];
+
+export interface ArcadeReconnectPolicy {
+	readonly initialDelayMs: number;
+	readonly maxDelayMs: number;
+	readonly backoffFactor: number;
+	readonly heartbeatIntervalMs: number;
+	readonly heartbeatMissThreshold: number;
+	readonly disconnectedRecoveryIntervalMs: number;
+	readonly activityRecoveryLimit: number;
+}
+
+export interface ArcadeRuntimeManifest {
+	readonly version: string;
+	readonly gitCommit: string;
+	readonly buildTime: string;
+	readonly buildId: string;
+}
+
+export interface ArcadeRuntimeContract {
+	readonly schemaVersion: typeof ARCADE_RUNTIME_SCHEMA_VERSION;
+	readonly baseUrl: string;
+	readonly hostMode: ArcadeHostMode;
+	readonly version: string;
+	readonly buildId: string;
+	readonly cacheBust: string;
+	readonly reconnectPolicy: ArcadeReconnectPolicy;
+}
+
+export const DEFAULT_ARCADE_RECONNECT_POLICY: ArcadeReconnectPolicy = {
+	initialDelayMs: 2000,
+	maxDelayMs: 30_000,
+	backoffFactor: 2,
+	heartbeatIntervalMs: 30_000,
+	heartbeatMissThreshold: 3,
+	disconnectedRecoveryIntervalMs: 5000,
+	activityRecoveryLimit: 25,
+};
+
+export function isArcadeHostMode(value: string): value is ArcadeHostMode {
+	return (VALID_ARCADE_HOST_MODES as readonly string[]).includes(value);
+}

--- a/cli/web-ui/src/types/websocket.ts
+++ b/cli/web-ui/src/types/websocket.ts
@@ -25,7 +25,15 @@ export interface TreeChangedMessage {
 /** Server heartbeat */
 export interface HeartbeatMessage {
 	type: "heartbeat";
+	heartbeatId: string;
 	timestamp: string;
+}
+
+/** Client heartbeat acknowledgement */
+export interface HeartbeatAckMessage {
+	type: "heartbeat:ack";
+	heartbeatId: string;
+	receivedAt: string;
 }
 
 /** Project registry changed notification */

--- a/cli/web-ui/src/types/websocket.ts
+++ b/cli/web-ui/src/types/websocket.ts
@@ -6,6 +6,8 @@
 import type { ArtifactLocationKind, Status } from "../../../shared/events";
 import type { Annotation, AnnotationReply } from "./annotations";
 
+export type WebSocketActivityScope = "global" | "project";
+
 /** File change notification */
 export interface FileChangedMessage {
 	type: "file:changed";
@@ -50,9 +52,12 @@ export interface EventNotificationMessage {
 /** Replayed event for reconnection recovery */
 export interface EventReplayMessage {
 	type: "event:replay";
+	scope?: WebSocketActivityScope;
 	event: {
 		id: number;
 		runId: string;
+		projectId?: string;
+		featureId?: string;
 		eventType: string;
 		runStatus?: Status | null;
 		step: string | null;
@@ -65,8 +70,11 @@ export interface EventReplayMessage {
 /** Full state snapshot for reconnection recovery */
 export interface StateSnapshotMessage {
 	type: "state:snapshot";
+	scope?: WebSocketActivityScope;
+	projectId?: string | null;
 	runs: Array<{
 		id: string;
+		projectId?: string | null;
 		flow: string;
 		featureId: string;
 		projectPath: string;

--- a/cli/web-ui/vite.config.ts
+++ b/cli/web-ui/vite.config.ts
@@ -1,7 +1,12 @@
 import { execSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import path from "node:path";
 import react from "@vitejs/plugin-react";
-import { defineConfig } from "vite";
+import { defineConfig, type Plugin } from "vite";
+import {
+	ARCADE_RUNTIME_MANIFEST_FILENAME,
+	type ArcadeRuntimeManifest,
+} from "./src/types/runtime";
 import { RP1_VERSION } from "./src/version";
 
 const getGitCommit = (): string => {
@@ -15,12 +20,73 @@ const getGitCommit = (): string => {
 	}
 };
 
+interface RuntimeManifestInput {
+	readonly version: string;
+	readonly gitCommit: string;
+	readonly buildTime: string;
+}
+
+export interface RuntimeManifestAsset {
+	readonly type: "asset";
+	readonly fileName: typeof ARCADE_RUNTIME_MANIFEST_FILENAME;
+	readonly source: string;
+}
+
+export function createRuntimeBuildId(
+	input: Pick<RuntimeManifestInput, "version" | "gitCommit">,
+): string {
+	return createHash("sha256")
+		.update(`${input.version}:${input.gitCommit}`)
+		.digest("hex")
+		.slice(0, 12);
+}
+
+export function buildRuntimeManifest(
+	input: RuntimeManifestInput,
+): ArcadeRuntimeManifest {
+	return {
+		...input,
+		buildId: createRuntimeBuildId(input),
+	};
+}
+
+export function serializeRuntimeManifest(
+	manifest: ArcadeRuntimeManifest,
+): string {
+	return `${JSON.stringify(manifest, null, 2)}\n`;
+}
+
+export function runtimeManifestAsset(
+	manifest: ArcadeRuntimeManifest,
+): RuntimeManifestAsset {
+	return {
+		type: "asset",
+		fileName: ARCADE_RUNTIME_MANIFEST_FILENAME,
+		source: serializeRuntimeManifest(manifest),
+	};
+}
+
+export function runtimeManifestPlugin(manifest: ArcadeRuntimeManifest): Plugin {
+	return {
+		name: "rp1-runtime-manifest",
+		generateBundle() {
+			this.emitFile(runtimeManifestAsset(manifest));
+		},
+	};
+}
+
+const runtimeManifest = buildRuntimeManifest({
+	version: RP1_VERSION,
+	gitCommit: getGitCommit(),
+	buildTime: new Date().toISOString(),
+});
+
 export default defineConfig({
-	plugins: [react()],
+	plugins: [react(), runtimeManifestPlugin(runtimeManifest)],
 	define: {
-		__RP1_WEB_UI_BUILD_TIME__: JSON.stringify(new Date().toISOString()),
-		__RP1_WEB_UI_GIT_COMMIT__: JSON.stringify(getGitCommit()),
-		__RP1_WEB_UI_VERSION__: JSON.stringify(RP1_VERSION),
+		__RP1_WEB_UI_BUILD_TIME__: JSON.stringify(runtimeManifest.buildTime),
+		__RP1_WEB_UI_GIT_COMMIT__: JSON.stringify(runtimeManifest.gitCommit),
+		__RP1_WEB_UI_VERSION__: JSON.stringify(runtimeManifest.version),
 	},
 	resolve: {
 		alias: {

--- a/cli/web-ui/vite.config.ts
+++ b/cli/web-ui/vite.config.ts
@@ -84,6 +84,7 @@ const runtimeManifest = buildRuntimeManifest({
 export default defineConfig({
 	plugins: [react(), runtimeManifestPlugin(runtimeManifest)],
 	define: {
+		__RP1_WEB_UI_BUILD_ID__: JSON.stringify(runtimeManifest.buildId),
 		__RP1_WEB_UI_BUILD_TIME__: JSON.stringify(runtimeManifest.buildTime),
 		__RP1_WEB_UI_GIT_COMMIT__: JSON.stringify(runtimeManifest.gitCommit),
 		__RP1_WEB_UI_VERSION__: JSON.stringify(runtimeManifest.version),

--- a/docs/arcade/dashboard.md
+++ b/docs/arcade/dashboard.md
@@ -129,17 +129,29 @@ planned search-row work without rebuilding it.
 When there is no feed data, Arcade shows `No activity yet.` and a link to the
 first-workflow guide.
 
-### Refresh
+### Activity Freshness and Reconnect Recovery
 
-There is no dedicated refresh button on the home page. The feed updates through
-project-scoped workflow events emitted through `rp1 agent-tools emit`, so the
-browser patches only the affected run rows, project summaries, attention
-groups, and open run workspaces during normal operation.
+There is no dedicated refresh button on the home page. During normal
+operation, the feed updates through workflow events emitted by
+`rp1 agent-tools emit`, so the browser patches only the affected run rows,
+project summaries, attention groups, and open run workspaces.
 
-Broad collection refetches are reserved for recovery cases such as reconnecting
-after a replay gap that requires snapshot reconciliation, or for an explicit
-manual reload. File watching still refreshes artifact and file content, but it
-is not the normal path for workflow-status visibility.
+Activity keeps replay cursors in `sessionStorage`. The global feed uses
+`rp1:last-event-id:global`; project-scoped feeds use
+`rp1:last-event-id:<projectId>`. On reconnect, Arcade sends the appropriate
+scope and cursor to `/ws`. The daemon replays missed events when the gap is
+bounded, including each event's real project identity, so global Activity can
+catch up without selecting a project.
+
+If replay cannot cover the gap, the daemon sends a scoped snapshot. Project
+snapshots replace that project's active-run subset; global snapshots hydrate
+recent runs without pruning unrelated projects. After reconnect, the feed and
+run lists also run a bounded REST reconciliation using the runtime policy's
+`activityRecoveryLimit`, merging rows by stable run identity so replay and REST
+overlap does not duplicate Activity records.
+
+File watching still refreshes artifact and file content, but it is not the
+normal path for workflow-status visibility.
 
 ---
 

--- a/native-app/electrobun.config.ts
+++ b/native-app/electrobun.config.ts
@@ -1,5 +1,7 @@
 import type { ElectrobunConfig } from "electrobun";
 
+const BRAND_NATIVE_ICON_ROOT = "../assets/brand/native";
+
 export default {
 	app: {
 		name: "rp1 Arcade",
@@ -20,13 +22,13 @@ export default {
 		mac: {
 			bundleCEF: false,
 			defaultRenderer: "native",
-			icons: "assets/icon.iconset",
+			icons: `${BRAND_NATIVE_ICON_ROOT}/icon.iconset`,
 		},
 		win: {
-			icon: "assets/icon.ico",
+			icon: `${BRAND_NATIVE_ICON_ROOT}/icon.ico`,
 		},
 		linux: {
-			icon: "assets/icon.png",
+			icon: `${BRAND_NATIVE_ICON_ROOT}/icon.png`,
 		},
 		watch: ["src/views"],
 	},

--- a/native-app/src/__tests__/launch-state.test.ts
+++ b/native-app/src/__tests__/launch-state.test.ts
@@ -228,7 +228,7 @@ describe("native launch state", () => {
 		]);
 	});
 
-	test("configures checked-in platform app icons", () => {
+	test("configures checked-in brand platform app icons", () => {
 		const iconPaths = {
 			mac: electrobunConfig.build?.mac?.icons,
 			win: electrobunConfig.build?.win?.icon,
@@ -236,9 +236,9 @@ describe("native launch state", () => {
 		};
 
 		expect(iconPaths).toEqual({
-			mac: "assets/icon.iconset",
-			win: "assets/icon.ico",
-			linux: "assets/icon.png",
+			mac: "../assets/brand/native/icon.iconset",
+			win: "../assets/brand/native/icon.ico",
+			linux: "../assets/brand/native/icon.png",
 		});
 
 		const appRoot = join(import.meta.dir, "../..");

--- a/native-app/src/__tests__/launch-state.test.ts
+++ b/native-app/src/__tests__/launch-state.test.ts
@@ -3,6 +3,7 @@ import { existsSync, statSync } from "node:fs";
 import { join } from "node:path";
 import cliPackage from "../../../cli/package.json";
 import electrobunConfig from "../../electrobun.config.ts";
+import { appendArcadeRuntimeQuery } from "../bun/runtime-url";
 
 class MockDaemonExecutableResolutionError extends Error {
 	readonly checkedLocations: readonly unknown[];
@@ -113,6 +114,19 @@ const parseLaunchViewHtmlState = (html: string): Record<string, string> => {
 	const match = html.match(/window\.__RP1_LAUNCH_STATE__=(.*?);<\/script>/);
 	if (!match) throw new Error("Expected launch state script");
 	return JSON.parse(match[1] ?? "{}") as Record<string, string>;
+};
+
+const expectNativeArcadeUrl = (
+	url: string | undefined,
+	pathname: string,
+): URL => {
+	expect(url).toBeDefined();
+	const parsed = new URL(url ?? "");
+	expect(parsed.origin).toBe("http://127.0.0.1:7710");
+	expect(parsed.pathname).toBe(pathname);
+	expect(parsed.searchParams.get("hostMode")).toBe("native");
+	expect(parsed.searchParams.get("cacheBust")).toMatch(/^native-[0-9a-z]+$/);
+	return parsed;
 };
 
 const runNativeEntrypoint = async (
@@ -245,6 +259,24 @@ describe("native launch state", () => {
 		expect(statSync(linuxIcon).size).toBeGreaterThan(0);
 	});
 
+	test("appends native runtime metadata without dropping existing URL parameters", () => {
+		const url = appendArcadeRuntimeQuery(
+			"http://127.0.0.1:7710/projects?view=activity#recent",
+			{
+				hostMode: "native",
+				cacheBust: "native-load-1",
+			},
+		);
+		const parsed = new URL(url);
+
+		expect(parsed.origin).toBe("http://127.0.0.1:7710");
+		expect(parsed.pathname).toBe("/projects");
+		expect(parsed.hash).toBe("#recent");
+		expect(parsed.searchParams.get("view")).toBe("activity");
+		expect(parsed.searchParams.get("hostMode")).toBe("native");
+		expect(parsed.searchParams.get("cacheBust")).toBe("native-load-1");
+	});
+
 	test("loads the project-list route when no project path is supplied", async () => {
 		const window = await runNativeEntrypoint();
 		const initialState = parseLaunchViewHtmlState(window.loadedHtml[0] ?? "");
@@ -253,7 +285,8 @@ describe("native launch state", () => {
 		expect(initialState.status).toBe("loading");
 		expect(initialState.message).toBe("Loading registered projects.");
 		expect(window.navigationRules[0]).toContain("http://127.0.0.1:*/*");
-		expect(window.loadedUrls).toEqual(["http://127.0.0.1:7710/projects"]);
+		expect(window.loadedUrls).toHaveLength(1);
+		expectNativeArcadeUrl(window.loadedUrls[0], "/projects");
 		expect(window.title).toBe("rp1 Arcade");
 		expect(launchArcadeMock).toHaveBeenCalledWith({
 			projectPath: undefined,
@@ -287,7 +320,7 @@ describe("native launch state", () => {
 			kind: "project" as const,
 			projectId: "project-1",
 			projectName: "Example Project",
-			url: "http://127.0.0.1:7710/projects/project-1",
+			url: "http://127.0.0.1:7710/projects/project-1?view=activity",
 			action: "started" as const,
 			wasRunning: false,
 			daemonPort: 7710,
@@ -295,9 +328,12 @@ describe("native launch state", () => {
 
 		const window = await runNativeEntrypoint(["--project", "/tmp/project"]);
 
-		expect(window.loadedUrls).toEqual([
-			"http://127.0.0.1:7710/projects/project-1",
-		]);
+		expect(window.loadedUrls).toHaveLength(1);
+		const loadedUrl = expectNativeArcadeUrl(
+			window.loadedUrls[0],
+			"/projects/project-1",
+		);
+		expect(loadedUrl.searchParams.get("view")).toBe("activity");
 		expect(window.title).toBe("rp1 Arcade");
 	});
 

--- a/native-app/src/bun/index.ts
+++ b/native-app/src/bun/index.ts
@@ -12,6 +12,10 @@ import {
 	DaemonExecutableResolutionError,
 	resolveDaemonExecutablePath,
 } from "../../../cli/web-ui/src/daemon/executable.js";
+import {
+	appendArcadeRuntimeQuery,
+	createNativeArcadeCacheBust,
+} from "./runtime-url.js";
 
 type LaunchStatus = "loading" | "failure";
 type NativeWindow = InstanceType<typeof BrowserWindow>;
@@ -372,8 +376,13 @@ const launchNativeShell = async (
 		throw new Error(`Arcade returned a non-loopback URL: ${result.url}`);
 	}
 
+	const arcadeUrl = appendArcadeRuntimeQuery(result.url, {
+		hostMode: "native",
+		cacheBust: createNativeArcadeCacheBust(),
+	});
+
 	setVisibleWindowTitle(window);
-	loadWindowUrl(window, result.url);
+	loadWindowUrl(window, arcadeUrl);
 };
 
 const launchOptions = parseLaunchOptions();

--- a/native-app/src/bun/runtime-url.ts
+++ b/native-app/src/bun/runtime-url.ts
@@ -1,0 +1,20 @@
+import type { ArcadeHostMode } from "../../../cli/web-ui/src/types/runtime";
+
+export interface ArcadeRuntimeQueryMetadata {
+	readonly hostMode: ArcadeHostMode;
+	readonly cacheBust: string;
+}
+
+export const createNativeArcadeCacheBust = (
+	now: Date = new Date(),
+): string => `native-${now.getTime().toString(36)}`;
+
+export const appendArcadeRuntimeQuery = (
+	url: string,
+	metadata: ArcadeRuntimeQueryMetadata,
+): string => {
+	const parsed = new URL(url);
+	parsed.searchParams.set("hostMode", metadata.hostMode);
+	parsed.searchParams.set("cacheBust", metadata.cacheBust);
+	return parsed.toString();
+};


### PR DESCRIPTION
## Summary
- Harden Arcade static serving/cache behavior so missing assets do not fall back to HTML.
- Add shared runtime contract metadata for browser/native Arcade launches.
- Improve Activity freshness with global replay cursors, heartbeat acknowledgements, and bounded reconnect reconciliation.
- Add runtime failure handling, Chromium smoke coverage, native launch metadata, and related docs/tests.
- Include native brand icon path cleanup.

## Verification
- Pre-push hooks passed: no-artifactory, eval-verify, catalog, typecheck-cli, typecheck-webui.
- Focused retained CLI tests passed: 47 pass, 0 fail.
- Feature task builders/reviewers reported focused web-ui/native/smoke checks passing during implementation.

## Notes
- Native/WebKit parity remains a documented manual release-validation path because WebKit/native-like automation was rejected as unavailable in the current repo/tooling setup.
