### PR TITLE
feat(dev): add slide-ready walkthrough contract

### DIFF
--- a/catalog/agents.yaml
+++ b/catalog/agents.yaml
@@ -188,9 +188,9 @@ agents:
     plugin: dev
     last_checksum: ad7bff389fb454da2d343914d00e5130f5855a3961334a893dbd4e03f227138a
   - name: rp1-dev:pr-walkthrough-reporter
-    description: "Generate an evidence-grounded plain markdown walkthrough for a pull request"
+    description: "Generate an evidence-grounded slide-ready markdown walkthrough for a pull request"
     plugin: dev
-    last_checksum: f63c5410d20dcb23877d2c3adb4aa27519c83adebe14911d7da0cfc3d8cccd85
+    last_checksum: bd895d0baf134a07dd8a03772dd68b4f62445902c82eae14d1dbf9f2853d52ac
   - name: rp1-dev:prd-archiver
     description: "Archives completed PRDs to .rp1/work/archives/prds/, archives associated completed features, checks KB staleness, and generates closure summaries"
     plugin: dev

--- a/cli/src/__tests__/build/pr-walkthrough-contracts.test.ts
+++ b/cli/src/__tests__/build/pr-walkthrough-contracts.test.ts
@@ -20,6 +20,50 @@ const extractFrontmatter = (content: string): Record<string, unknown> => {
 	return parseYaml(match[1]) as Record<string, unknown>;
 };
 
+const stripLeadingFrontmatter = (content: string): string =>
+	content.replace(/^---\r?\n[\s\S]*?\r?\n---\r?\n/, "");
+
+const slideMarkers = [
+	"<!-- rp1-slide: horizontal -->",
+	"<!-- rp1-slide: vertical -->",
+	"<!-- rp1-notes -->",
+] as const;
+
+type SlideMarker = (typeof slideMarkers)[number];
+
+const collectControlMarkers = (content: string): SlideMarker[] => {
+	const markers = new Set<string>(slideMarkers);
+	const controlMarkers: SlideMarker[] = [];
+	let inFence = false;
+
+	for (const line of content.split(/\r?\n/)) {
+		const trimmed = line.trim();
+
+		if (/^(`{3,}|~{3,})/.test(trimmed)) {
+			inFence = !inFence;
+			continue;
+		}
+
+		if (!inFence && markers.has(trimmed)) {
+			controlMarkers.push(trimmed as SlideMarker);
+		}
+	}
+
+	return controlMarkers;
+};
+
+const collectSlideMetadata = (
+	content: string,
+): Array<Record<string, unknown>> =>
+	[...content.matchAll(/<!-- rp1-slide-meta\r?\n([\s\S]*?)\r?\n-->/g)].map(
+		(match) => parseYaml(match[1] ?? "") as Record<string, unknown>,
+	);
+
+const collectEvidenceIndexIds = (content: string): string[] =>
+	[...content.matchAll(/^\| (E-[A-Z]+-\d{3}) \|/gm)].map(
+		(match) => match[1] ?? "",
+	);
+
 describe("pr-walkthrough build contracts", () => {
 	test("catalog exposes the walkthrough as a fresh review workflow", async () => {
 		const { entries } = await collectCatalogEntries(projectRoot);
@@ -90,9 +134,25 @@ describe("pr-walkthrough build contracts", () => {
 		expect(skill.content).toContain("It must start with `pr-walkthroughs/`.");
 		expect(skill.content).toContain("It must end with `.md`.");
 		expect(skill.content).toContain("It must not contain `..`.");
+
+		expect(skill.content).toContain("slide-ready markdown");
+		expect(skill.content).toContain("plain markdown fallback");
+		expect(skill.content).toContain(
+			"Do not reject an otherwise valid reporter artifact because it contains the canonical slide-ready markdown contract fields",
+		);
+		expect(skill.content).toContain(
+			"reserved `<!-- rp1-slide: ... -->` markers",
+		);
+		expect(skill.content).toContain("slide metadata blocks");
+		expect(skill.content).toContain(
+			"`<!-- rp1-notes -->` speaker-note sections",
+		);
+		expect(skill.content).toContain(
+			"Strip or forbid the canonical slide-ready markdown contract metadata",
+		);
 	});
 
-	test("reporter requires evidence-indexed markdown output", async () => {
+	test("reporter requires evidence-indexed slide-ready markdown output", async () => {
 		const agentPath = join(
 			projectRoot,
 			"plugins/dev/agents/pr-walkthrough-reporter.md",
@@ -115,6 +175,36 @@ describe("pr-walkthrough build contracts", () => {
 		expect(agent.content).toContain(
 			"Major purpose, change, reviewer-focus, and risk claims must cite one or more IDs inline.",
 		);
+		expect(agent.content).toContain("Use the canonical template:");
+		expect(agent.content).toContain("Slide Contract Requirements");
+		expect(agent.content).toContain(
+			"YAML frontmatter must declare `rp1_contract`, `rp1_contract_version`, `rp1_source_type`, `rp1_review_id`, `rp1_source`, `rp1_generation`, `rp1_slide_markers`, and `rp1_evidence_ids`.",
+		);
+		expect(agent.content).toContain("`<!-- rp1-slide: horizontal -->`");
+		expect(agent.content).toContain("`<!-- rp1-slide: vertical -->`");
+		expect(agent.content).toContain("`<!-- rp1-notes -->`");
+		expect(agent.content).toContain(
+			"Horizontal slide metadata uses `depth: 0`",
+		);
+		expect(agent.content).toContain(
+			"vertical detail under the same topic uses `depth: 1` or greater",
+		);
+		expect(agent.content).toContain(
+			"Every substantive claim on slide faces, vertical details, and speaker notes must cite or sit adjacent to an Evidence Index ID.",
+		);
+		expect(agent.content).toContain("Pre-Write Compliance Self-Check");
+		expect(agent.content).toContain(
+			"Marker collisions: scan line by line while tracking fenced code blocks",
+		);
+		expect(agent.content).toContain(
+			"Evidence resolution: every ID in `rp1_evidence_ids`, slide metadata, slide faces, vertical details, and notes appears in the Evidence Index table.",
+		);
+		expect(agent.content).toContain(
+			"Notes citation: every substantive notes claim cites or is adjacent to an Evidence Index ID.",
+		);
+		expect(agent.content).toContain(
+			"Fallback readability: top-to-bottom markdown still explains purpose, scope, change map, walkthrough, reviewer focus, and risks/questions coherently.",
+		);
 		expect(agent.content).toContain(
 			"pr-walkthroughs/{REVIEW_ID}-walkthrough-{NNN}.md",
 		);
@@ -134,7 +224,7 @@ describe("pr-walkthrough build contracts", () => {
 		}
 	});
 
-	test("artifact template index points to a valid plain markdown template", async () => {
+	test("artifact template index points to a valid slide-ready markdown template", async () => {
 		const templateIndex = await readProjectFile(
 			"plugins/base/skills/artifact-templates/SKILL.md",
 		);
@@ -149,7 +239,9 @@ describe("pr-walkthrough build contracts", () => {
 
 		const template = await readProjectFile(templatePath);
 		const frontmatter = extractFrontmatter(template);
-		const body = template.replace(/^---\r?\n[\s\S]*?\r?\n---\r?\n/, "");
+		const templateBody = stripLeadingFrontmatter(template).trimStart();
+		const artifactFrontmatter = extractFrontmatter(templateBody);
+		const body = stripLeadingFrontmatter(templateBody);
 
 		expect(frontmatter).toMatchObject({
 			scope: "workRoot",
@@ -158,6 +250,46 @@ describe("pr-walkthrough build contracts", () => {
 			type: "document",
 			strictness: "flexible",
 		});
+
+		expect(artifactFrontmatter).toMatchObject({
+			rp1_contract: "pr-walkthrough-slide-source",
+			rp1_contract_version: "1.0.0",
+			rp1_source_type: "{source_type}",
+			rp1_review_id: "{REVIEW_ID}",
+			rp1_source: {
+				target: "{source_target}",
+				base_branch: "{base_branch}",
+				head_ref: "{head_ref}",
+				pr_number: "{pr_number}",
+				pr_url: "{PR_URL}",
+			},
+			rp1_generation: {
+				created_at: "{TIMESTAMP}",
+				generator: "rp1-dev pr-walkthrough",
+				artifact_id: "{REVIEW_ID}-walkthrough-{NNN}",
+			},
+			rp1_slide_markers: {
+				horizontal: "<!-- rp1-slide: horizontal -->",
+				vertical: "<!-- rp1-slide: vertical -->",
+				notes: "<!-- rp1-notes -->",
+				metadata_open: "<!-- rp1-slide-meta",
+				metadata_close: "-->",
+			},
+			rp1_evidence_ids: [
+				"E-PR-001",
+				"E-FILE-001",
+				"E-DIFF-001",
+				"E-COMMIT-001",
+			],
+		});
+		expect(Object.keys(artifactFrontmatter)).toEqual(
+			expect.arrayContaining([
+				"rp1_source",
+				"rp1_generation",
+				"rp1_slide_markers",
+				"rp1_evidence_ids",
+			]),
+		);
 
 		for (const section of [
 			"## At A Glance",
@@ -170,17 +302,119 @@ describe("pr-walkthrough build contracts", () => {
 			expect(body).toContain(section);
 		}
 
-		for (const evidenceId of [
+		const frontmatterEvidenceIds = artifactFrontmatter.rp1_evidence_ids;
+		expect(frontmatterEvidenceIds).toEqual([
 			"E-PR-001",
 			"E-FILE-001",
 			"E-DIFF-001",
 			"E-COMMIT-001",
-		]) {
+		]);
+
+		const evidenceIndexIds = collectEvidenceIndexIds(body);
+		expect(evidenceIndexIds).toEqual([
+			"E-PR-001",
+			"E-FILE-001",
+			"E-DIFF-001",
+			"E-COMMIT-001",
+		]);
+
+		for (const evidenceId of evidenceIndexIds) {
 			expect(body).toContain(evidenceId);
+			expect(body).toContain(`| ${evidenceId} |`);
 		}
 
-		expect(body).not.toContain("---\n---");
-		expect(body).not.toContain("speaker notes");
-		expect(body).not.toContain("Reveal.js");
+		const controlMarkers = collectControlMarkers(body);
+		expect(
+			controlMarkers.filter((marker) => marker === slideMarkers[0]),
+		).toHaveLength(6);
+		expect(
+			controlMarkers.filter((marker) => marker === slideMarkers[1]),
+		).toHaveLength(2);
+		expect(
+			controlMarkers.filter((marker) => marker === slideMarkers[2]),
+		).toHaveLength(3);
+
+		const slideMetadata = collectSlideMetadata(body);
+		expect(slideMetadata).toHaveLength(8);
+		for (const metadata of slideMetadata) {
+			expect(Object.keys(metadata)).toEqual(
+				expect.arrayContaining(["id", "role", "depth", "evidence"]),
+			);
+			expect(Array.isArray(metadata.evidence)).toBe(true);
+			for (const evidenceId of metadata.evidence as string[]) {
+				expect(frontmatterEvidenceIds).toContain(evidenceId);
+				expect(evidenceIndexIds).toContain(evidenceId);
+			}
+		}
+		expect(slideMetadata).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					id: "slide-001",
+					role: "at-a-glance",
+					depth: 0,
+					evidence: ["E-PR-001", "E-FILE-001"],
+				}),
+				expect.objectContaining({
+					id: "slide-003-detail-001",
+					role: "change-detail",
+					depth: 1,
+					evidence: ["E-DIFF-001"],
+				}),
+			]),
+		);
+
+		expect(body).toContain("<!-- rp1-notes -->\nNotes:");
+		expect(body).toContain(
+			"Every ID listed in `rp1_evidence_ids`, slide metadata `evidence` arrays, inline citations, notes, and vertical detail must resolve to a row in this table.",
+		);
+		expect(body).not.toMatch(/^\s*---\s*$/m);
+		expect(body).not.toMatch(/^\s*--\s*$/m);
+	});
+
+	test("reserved markers are slide controls only when line-alone outside fenced code blocks", () => {
+		const artifact = `---
+rp1_contract: pr-walkthrough-slide-source
+---
+
+<!-- rp1-slide: horizontal -->
+<!-- rp1-slide-meta
+id: slide-001
+role: at-a-glance
+depth: 0
+evidence: [E-PR-001]
+-->
+## At A Glance
+
+Generated prose can mention <!-- rp1-slide: vertical --> inline without creating structure.
+
+\`\`\`markdown
+<!-- rp1-slide: horizontal -->
+---
+--
+<!-- rp1-notes -->
+\`\`\`
+
+<!-- rp1-notes -->
+Notes:
+
+- Notes cite E-PR-001 and may quote separator-like source text.
+
+<!-- rp1-slide: vertical -->
+<!-- rp1-slide-meta
+id: slide-001-detail-001
+role: detail
+depth: 1
+evidence: [E-PR-001]
+-->
+### Detail
+
+The vertical slide stays under the parent topic. [E-PR-001]
+`;
+
+		expect(collectControlMarkers(artifact)).toEqual([
+			"<!-- rp1-slide: horizontal -->",
+			"<!-- rp1-notes -->",
+			"<!-- rp1-slide: vertical -->",
+		]);
 	});
 });

--- a/docs/reference/dev/pr-walkthrough.md
+++ b/docs/reference/dev/pr-walkthrough.md
@@ -1,6 +1,6 @@
 # pr-walkthrough
 
-Generate a plain markdown walkthrough that explains a pull request from direct PR evidence.
+Generate a slide-ready markdown walkthrough that explains a pull request from direct PR evidence and remains readable as plain markdown.
 
 ---
 
@@ -26,9 +26,9 @@ Generate a plain markdown walkthrough that explains a pull request from direct P
 
 ## Description
 
-The `pr-walkthrough` command creates a reviewer-orientation artifact for a pull request. It gathers PR metadata, changed files, diffs, and commit summaries with `gh` and `git`, then writes an evidence-grounded markdown walkthrough.
+The `pr-walkthrough` command creates a reviewer-orientation artifact for a pull request. It gathers PR metadata, changed files, diffs, and commit summaries with `gh` and `git`, then writes an evidence-grounded slide-ready markdown walkthrough.
 
-The walkthrough is not a review verdict, does not post PR comments, and does not use existing `pr-review` artifacts as source material. It is designed to be useful as normal markdown, without Reveal.js separators, speaker notes, or slide metadata.
+The walkthrough is not a review verdict, does not post PR comments, and does not use existing `pr-review` artifacts as source material. It includes contract frontmatter, reserved slide markers, slide metadata, speaker notes, vertical detail, and an Evidence Index, while staying coherent when opened as normal markdown. This command does not provide or require a slide reader.
 
 ## Parameters
 
@@ -60,13 +60,15 @@ stateDiagram-v2
 | Step | What Happens |
 |------|--------------|
 | `collecting` | Resolves the target, gathers direct `gh` or `git` evidence, and assigns evidence IDs |
-| `publishing` | Generates the markdown walkthrough and registers it as a work artifact |
+| `publishing` | Generates the slide-ready markdown walkthrough and registers it as a work artifact |
 
 ## Evidence And Scope
 
-The generated walkthrough includes an Evidence Index that maps evidence IDs to PR metadata, changed files, diff excerpts, or commits. Major purpose, change, reviewer-focus, and risk claims cite those IDs inline so reviewers can spot-check the artifact against the source PR evidence.
+The generated walkthrough includes an Evidence Index that maps evidence IDs to PR metadata, changed files, diff excerpts, or commits. Major purpose, change, reviewer-focus, risk, speaker-note, and vertical-detail claims cite those IDs so reviewers can spot-check the artifact against the source PR evidence.
 
-Top-level sections include:
+The artifact declares the `pr-walkthrough-slide-source` contract in frontmatter. Slide structure is represented with line-alone HTML comment markers such as `<!-- rp1-slide: horizontal -->`, `<!-- rp1-slide: vertical -->`, `<!-- rp1-notes -->`, and per-slide metadata blocks. These markers are part of the markdown source contract; PR excerpts stay fenced or quoted so separator-like source text is not treated as slide structure.
+
+Horizontal slide groups include:
 
 - `At A Glance`
 - `Evidence Index`
@@ -74,6 +76,8 @@ Top-level sections include:
 - `Walkthrough`
 - `Reviewer Focus`
 - `Risks And Questions`
+
+Overflow detail appears as vertical depth under the related topic, and supporting context appears in notes after the slide face. When read without slide rendering, the parent summary appears before its notes and deeper detail.
 
 ## Examples
 
@@ -133,12 +137,16 @@ Top-level sections include:
 
 **Contents:**
 
+- Contract frontmatter identifying the walkthrough as `pr-walkthrough-slide-source`
+- Reserved slide markers, slide metadata blocks, speaker notes, and vertical detail
 - PR purpose and size at a glance
-- Evidence Index with source references
+- Evidence Index with source references and evidence IDs used by slide metadata and claims
 - Reviewable change map
 - Narrative walkthrough of major changes
 - Reviewer focus areas
 - Risks and questions grounded in evidence
+
+The artifact is slide-ready markdown source, not a rendered presentation. Opened in a plain markdown viewer, the visible metadata and markers should not block the top-to-bottom walkthrough.
 
 The artifact is registered with `storageRoot: "work_dir"` and appears in the workflow run artifacts.
 

--- a/plugins/base/skills/artifact-templates/templates/pr-walkthrough-reporter/pr-walkthrough.md
+++ b/plugins/base/skills/artifact-templates/templates/pr-walkthrough-reporter/pr-walkthrough.md
@@ -3,8 +3,36 @@ scope: workRoot
 path_pattern: "pr-walkthroughs/{REVIEW_ID}-walkthrough-{NNN}.md"
 producer: pr-walkthrough-reporter
 type: document
-description: "Plain markdown PR walkthrough generated from direct PR evidence by /pr-walkthrough."
+description: "Slide-ready markdown PR walkthrough generated from direct PR evidence by /pr-walkthrough."
 strictness: flexible
+---
+
+---
+rp1_contract: pr-walkthrough-slide-source
+rp1_contract_version: "1.0.0"
+rp1_source_type: "{source_type}"
+rp1_review_id: "{REVIEW_ID}"
+rp1_source:
+  target: "{source_target}"
+  base_branch: "{base_branch}"
+  head_ref: "{head_ref}"
+  pr_number: "{pr_number}"
+  pr_url: "{PR_URL}"
+rp1_generation:
+  created_at: "{TIMESTAMP}"
+  generator: "rp1-dev pr-walkthrough"
+  artifact_id: "{REVIEW_ID}-walkthrough-{NNN}"
+rp1_slide_markers:
+  horizontal: "<!-- rp1-slide: horizontal -->"
+  vertical: "<!-- rp1-slide: vertical -->"
+  notes: "<!-- rp1-notes -->"
+  metadata_open: "<!-- rp1-slide-meta"
+  metadata_close: "-->"
+rp1_evidence_ids:
+  - E-PR-001
+  - E-FILE-001
+  - E-DIFF-001
+  - E-COMMIT-001
 ---
 
 # PR Walkthrough: {PR_TITLE}
@@ -13,6 +41,13 @@ strictness: flexible
 **Created**: {TIMESTAMP}
 **Review ID**: {REVIEW_ID}-walkthrough-{NNN}
 
+<!-- rp1-slide: horizontal -->
+<!-- rp1-slide-meta
+id: slide-001
+role: at-a-glance
+depth: 0
+evidence: [E-PR-001, E-FILE-001]
+-->
 ## At A Glance
 
 - **Purpose**: {purpose_summary_with_evidence_ids}
@@ -20,6 +55,18 @@ strictness: flexible
 - **Size**: {changed_files_count} files, +{additions}/-{deletions}
 - **Review posture**: {reviewer_context_with_evidence_ids}
 
+<!-- rp1-notes -->
+Notes:
+
+- {supporting_context_or_generation_caveat_with_evidence_ids}
+
+<!-- rp1-slide: horizontal -->
+<!-- rp1-slide-meta
+id: slide-002
+role: evidence-index
+depth: 0
+evidence: [E-PR-001, E-FILE-001, E-DIFF-001, E-COMMIT-001]
+-->
 ## Evidence Index
 
 | ID | Source | Reference | Supports |
@@ -29,24 +76,92 @@ strictness: flexible
 | E-DIFF-001 | Diff hunk | `{path}:{line_or_hunk_reference}` | {diff_backed_change_or_risk_claim} |
 | E-COMMIT-001 | Commit summary | `{commit_sha_or_subject}` | {intent_or_sequence_claim} |
 
+### Evidence Rules
+
+Every ID listed in `rp1_evidence_ids`, slide metadata `evidence` arrays, inline citations, notes, and vertical detail must resolve to a row in this table. Unsupported claims are omitted or framed as reviewer questions.
+
+<!-- rp1-slide: horizontal -->
+<!-- rp1-slide-meta
+id: slide-003
+role: change-map
+depth: 0
+evidence: [E-FILE-001, E-DIFF-001]
+-->
 ## Change Map
 
 | Area | Files | What Changed | Evidence |
 |------|-------|--------------|----------|
 | {reviewable_area} | `{path}`, `{path}` | {concise_change_summary} | {evidence_ids} |
 
+<!-- rp1-slide: vertical -->
+<!-- rp1-slide-meta
+id: slide-003-detail-001
+role: change-detail
+depth: 1
+evidence: [E-DIFF-001]
+-->
+### Change Detail
+
+{focused_detail_that_supports_the_change_map_with_inline_evidence_ids}
+
+```text
+{source_excerpt_or_separator_like_text_quoted_from_pr}
+```
+
+<!-- rp1-notes -->
+Notes:
+
+- {why_this_detail_matters_for_review_with_evidence_ids}
+
+<!-- rp1-slide: horizontal -->
+<!-- rp1-slide-meta
+id: slide-004
+role: walkthrough
+depth: 0
+evidence: [E-FILE-001, E-DIFF-001]
+-->
 ## Walkthrough
 
 ### {Reviewable Area}
 
 {narrative_explanation_of_the_change_area_with_inline_evidence_ids}
 
+<!-- rp1-slide: vertical -->
+<!-- rp1-slide-meta
+id: slide-004-detail-001
+role: implementation-depth
+depth: 1
+evidence: [E-FILE-001, E-DIFF-001]
+-->
+### {Reviewable Area} Depth
+
+{deeper_context_kept_under_the_parent_topic_with_inline_evidence_ids}
+
+<!-- rp1-slide: horizontal -->
+<!-- rp1-slide-meta
+id: slide-005
+role: reviewer-focus
+depth: 0
+evidence: [E-PR-001, E-FILE-001, E-DIFF-001]
+-->
 ## Reviewer Focus
 
 - **Start here**: {highest_value_review_entry_point_with_evidence_ids}
 - **Check carefully**: {contracts_or_paths_that_need_attention_with_evidence_ids}
 - **Useful context**: {context_that_reduces_review_setup_time_with_evidence_ids}
 
+<!-- rp1-notes -->
+Notes:
+
+- {review_strategy_context_with_evidence_ids}
+
+<!-- rp1-slide: horizontal -->
+<!-- rp1-slide-meta
+id: slide-006
+role: risks-and-questions
+depth: 0
+evidence: [E-DIFF-001, E-COMMIT-001]
+-->
 ## Risks And Questions
 
 | Risk Or Question | Why It Matters | Evidence |

--- a/plugins/base/skills/guide/WORKFLOWS.md
+++ b/plugins/base/skills/guide/WORKFLOWS.md
@@ -91,13 +91,13 @@ Each iteration delegates to a general sub-agent. If the request is too large, it
 
 | Step | Skill | Input | Output |
 |------|-------|-------|--------|
-| 0 | `/pr-walkthrough [target]` | PR number, URL, or branch | Plain markdown walkthrough under `.rp1/work/pr-walkthroughs/` |
+| 0 | `/pr-walkthrough [target]` | PR number, URL, or branch | Slide-ready markdown walkthrough with plain markdown fallback under `.rp1/work/pr-walkthroughs/` |
 | 1 | `/pr-review [target]` | PR number, URL, or branch | Review comments posted to the PR |
 | 2 | `/address-pr-feedback [pr]` | PR with review comments | Resolved comments, updated code |
 
 **How they chain**:
 
-- `/pr-walkthrough` is an optional orientation step. It gathers direct PR metadata, changed files, diffs, and commits, then registers a markdown-only walkthrough with evidence IDs. It does not use existing `pr-review` artifacts, post comments, or require slide rendering.
+- `/pr-walkthrough` is an optional orientation step. It gathers direct PR metadata, changed files, diffs, and commits, then registers a slide-ready markdown walkthrough with contract metadata, reserved slide markers, speaker notes, vertical detail, and evidence IDs. The artifact remains readable as plain markdown; it does not use existing `pr-review` artifacts, post comments, or provide slide rendering.
 - `/pr-review` splits the diff into logical review units, analyzes each in parallel with specialized sub-reviewers, synthesizes findings, deduplicates overlapping comments, and posts them to the PR. Includes optional visual diagram generation (`/pr-visual`).
 - `/address-pr-feedback` reads all unresolved review comments from the PR, triages them (must-fix vs. nice-to-have vs. dismiss), and fixes them in priority order. Supports `--afk` for unattended resolution.
 - After fixing, re-run `/pr-review` to verify the fixes if needed.

--- a/plugins/dev/agents/pr-walkthrough-reporter.md
+++ b/plugins/dev/agents/pr-walkthrough-reporter.md
@@ -1,6 +1,6 @@
 ---
 name: pr-walkthrough-reporter
-description: Generate an evidence-grounded plain markdown walkthrough for a pull request
+description: Generate an evidence-grounded slide-ready markdown walkthrough for a pull request
 tools: Read, Write, Glob, Bash
 model: inherit
 arguments:
@@ -28,7 +28,7 @@ arguments:
 
 # PR Walkthrough Reporter
 
-Generate one plain markdown PR walkthrough from direct PR evidence. Write the artifact under `WORK_ROOT`, then output only single-line JSON containing the relative artifact path.
+Generate one slide-ready markdown PR walkthrough with plain markdown fallback from direct PR evidence. Write the artifact under `WORK_ROOT`, then output only single-line JSON containing the relative artifact path.
 
 <evidence_json>
 {{EVIDENCE_JSON from prompt}}
@@ -94,13 +94,13 @@ Use the canonical template:
 1. Read `rp1-base:artifact-templates` SKILL.md.
 2. Locate the row where **Producer** = `pr-walkthrough-reporter` and **Artifact** = `pr-walkthrough.md`.
 3. Read the template file at the listed **Template Path**.
-4. Use the template's section order and path contract. The template is flexible; fill placeholders with concrete markdown and remove any unused placeholder text.
+4. Use the template's frontmatter, slide markers, slide metadata blocks, notes marker, vertical-depth structure, Evidence Index rules, section order, and path contract. The template is flexible; fill placeholders with concrete markdown and remove any unused placeholder text.
 
 Missing template is a blocking error. Do not write a partial artifact if the template cannot be read.
 
 ## 4. Synthesize Walkthrough
 
-Generate markdown with exactly these top-level sections after the title metadata:
+Generate markdown by filling the canonical slide-ready walkthrough template. Preserve exactly these top-level sections after the artifact frontmatter and title metadata:
 
 - `## At A Glance`
 - `## Evidence Index`
@@ -125,6 +125,18 @@ Where possible, include:
 - Reviewer focus bullets that point to the highest-value starting paths and contracts.
 - Risks or questions only when evidence supports them; otherwise state that no specific risk was evident from the supplied evidence.
 
+### Slide Contract Requirements
+
+- YAML frontmatter must declare `rp1_contract`, `rp1_contract_version`, `rp1_source_type`, `rp1_review_id`, `rp1_source`, `rp1_generation`, `rp1_slide_markers`, and `rp1_evidence_ids`.
+- Use line-alone reserved markers from the template:
+  - `<!-- rp1-slide: horizontal -->` for each top-level slide group.
+  - `<!-- rp1-slide: vertical -->` for overflow detail beneath the relevant parent topic.
+  - `<!-- rp1-notes -->` for supporting speaker notes.
+- Put a `<!-- rp1-slide-meta ... -->` block immediately after each slide marker.
+- Horizontal slide metadata uses `depth: 0`; vertical detail under the same topic uses `depth: 1` or greater.
+- Keep main slide faces concise. Put supporting rationale in notes, and longer related detail in vertical slides under the parent topic.
+- Preserve markdown fallback order: parent summary first, then notes or vertical detail, then the next horizontal topic.
+
 ### Grouping Guidance
 
 - Small PRs: keep one or two reviewable areas; avoid artificial fragmentation.
@@ -132,21 +144,38 @@ Where possible, include:
 - Each Change Map row must include at least one file or diff evidence ID.
 - Each Walkthrough subsection must include inline IDs in the prose.
 - Each risk/question row must include evidence IDs or be omitted.
+- Every substantive claim on slide faces, vertical details, and speaker notes must cite or sit adjacent to an Evidence Index ID.
+- Every ID in `rp1_evidence_ids`, slide metadata `evidence` arrays, inline citations, notes, and vertical detail must resolve to a row in the Evidence Index table.
+- Unsupported claims are omitted or phrased as reviewer questions rather than presented as verified facts.
 
-### Plain Markdown Constraints
+### Marker Collision Safety
+
+- Reserved control markers are valid only when they appear on their own line outside fenced code blocks.
+- Keep PR excerpts inside fenced code blocks or quoted markdown so separator-like source text cannot become structure.
+- If PR content or generated prose includes marker-like text, keep it quoted/fenced and do not place it on a control-marker line.
+- Do not use default Reveal.js markdown separators (`---` or `--`) as slide boundaries.
 
 Do not produce:
 
-- Reveal.js separators
-- speaker notes
-- slide metadata
-- HTML/CSS/JavaScript
-- approval/request-changes verdicts
-- PR comments or suggested review replies
+- HTML/CSS/JavaScript beyond the reserved HTML comment contract markers.
+- Approval/request-changes verdicts.
+- PR comments or suggested review replies.
 
 The artifact must be useful when opened as normal markdown.
 
-## 5. Write Artifact
+## 5. Pre-Write Compliance Self-Check
+
+Before writing, self-check the complete markdown. If any check fails, revise the markdown once before writing.
+
+- Template compliance: required frontmatter fields, slide markers, slide metadata blocks, notes marker, vertical depth, top-level sections, and Evidence Index are present.
+- Marker collisions: scan line by line while tracking fenced code blocks; the only line-alone reserved markers outside fences are intentional control lines.
+- Evidence resolution: every ID in `rp1_evidence_ids`, slide metadata, slide faces, vertical details, and notes appears in the Evidence Index table.
+- Notes citation: every substantive notes claim cites or is adjacent to an Evidence Index ID.
+- Depth ordering: every vertical slide follows its parent horizontal slide, and parent summaries precede supporting detail in markdown fallback.
+- Fallback readability: top-to-bottom markdown still explains purpose, scope, change map, walkthrough, reviewer focus, and risks/questions coherently.
+- Unsupported claims: omitted or framed as reviewer questions.
+
+## 6. Write Artifact
 
 1. Ensure the output directory exists:
 
@@ -180,7 +209,7 @@ The artifact must be useful when opened as normal markdown.
 
 Use `Write` for the markdown artifact. Do not write outside `{WORK_ROOT}/pr-walkthroughs`.
 
-## 6. Output
+## 7. Output
 
 After writing, output only this JSON on one line:
 

--- a/plugins/dev/skills/pr-walkthrough/SKILL.md
+++ b/plugins/dev/skills/pr-walkthrough/SKILL.md
@@ -33,7 +33,7 @@ metadata:
 
 # PR Walkthrough
 
-Generate a plain markdown walkthrough from direct pull request evidence. The output is a reviewer-orientation artifact, not a verdict and not a slide deck.
+Generate a slide-ready markdown walkthrough from direct pull request evidence. The output is a reviewer-orientation artifact with plain markdown fallback, not a review verdict or rendered slide reader.
 
 Use the pre-resolved `projectRoot`, `kbRoot`, `workRoot`, and `codeRoot` values from the generated Workflow Bootstrap section. Run all source-control commands from `codeRoot`, and write generated artifacts only under `workRoot`.
 
@@ -164,7 +164,7 @@ Derive `review_id` as `pr-{number}` for PR targets. For branch-only targets, san
 After evidence collection succeeds, emit `publishing` running and dispatch the reporter:
 
 {% dispatch_agent "rp1-dev:pr-walkthrough-reporter" %}
-Generate an evidence-grounded markdown PR walkthrough.
+Generate an evidence-grounded slide-ready markdown PR walkthrough with plain markdown fallback.
   EVIDENCE_JSON: {{stringify(EVIDENCE_JSON)}}
   KB_ROOT: {kbRoot}
   WORK_ROOT: {workRoot}
@@ -187,6 +187,8 @@ Validate the returned path before registration:
 - It must start with `pr-walkthroughs/`.
 - It must end with `.md`.
 - It must not contain `..`.
+
+Do not reject an otherwise valid reporter artifact because it contains the canonical slide-ready markdown contract fields, reserved `<!-- rp1-slide: ... -->` markers, slide metadata blocks, or `<!-- rp1-notes -->` speaker-note sections.
 
 ## 3. Register Artifact
 
@@ -232,4 +234,5 @@ Single pass. Do not:
 - Read existing `pr-review` artifacts.
 - Dispatch the reporter more than once.
 - Register more than one artifact.
-- Produce slide separators, speaker notes, Reveal.js metadata, or a review verdict.
+- Strip or forbid the canonical slide-ready markdown contract metadata, reserved slide markers, slide metadata blocks, or speaker notes.
+- Produce a rendered slide reader, alternate artifact path, extra artifact, or review verdict.


### PR DESCRIPTION
## Summary
- Upgrade `/pr-walkthrough` output from plain markdown to a slide-ready markdown contract with frontmatter, reserved slide markers, slide metadata, speaker notes, vertical detail, and evidence mapping.
- Update the reporter prompt, artifact template, workflow skill wording, docs, guide copy, and generated catalog metadata.
- Extend build-contract coverage for the new slide-ready guarantees and marker parsing behavior.

## Verification
- `just catalog-check`
- `cd cli && bun test src/__tests__/build/pr-walkthrough-contracts.test.ts`
- Pre-push hooks completed; output showed stale Claude Code attestations for `rp1-dev:build` and `rp1-dev:build-fast` as a warning.

## Known Pending Validation
- Full rp1 code-check report is not green yet: `.rp1/work/features/walkthrough-slide-markdown-contract/code_check_report_1.md`.
- Manual validation pending: generate/read a real walkthrough as raw markdown and spot-check PR excerpts against source evidence.
