### PR TITLE
fix(web-ui): improve artifact links

### DIFF
--- a/cli/web-ui/src/__tests__/components/v2/ArtifactSidebar.test.tsx
+++ b/cli/web-ui/src/__tests__/components/v2/ArtifactSidebar.test.tsx
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { ArtifactSidebar } from "@/components/v2/ArtifactSidebar";
+import type { Artifact } from "@/types/runs";
+
+function fileArtifact(docId: string, path: string): Artifact {
+	return {
+		docId,
+		path,
+		absolutePath: `/repo/${path}`,
+		type: "markdown",
+		updatedDuringRun: false,
+		isNew: false,
+		step: "build",
+	};
+}
+
+function linkArtifact(): Artifact {
+	return {
+		docId: "link-reviewed-pr",
+		locationKind: "url",
+		path: "https://github.com/example/repo/pull/376",
+		absolutePath: "https://github.com/example/repo/pull/376",
+		type: "other",
+		url: "https://github.com/example/repo/pull/376",
+		label: "376",
+		relationship: "reviewed_pr",
+		sourceContext: null,
+		sourceArtifactPath: null,
+		updatedDuringRun: false,
+		isNew: false,
+		step: "build",
+	};
+}
+
+describe("ArtifactSidebar", () => {
+	afterEach(() => {
+		cleanup();
+	});
+
+	test("renders link artifacts with meaningful labels, Link icons, and file-first order", () => {
+		const firstFile = fileArtifact("doc-a", "reports/summary.md");
+		const secondFile = fileArtifact("doc-b", "reports/details.md");
+		const link = linkArtifact();
+		const onSelect = mock(() => {});
+
+		render(
+			<ArtifactSidebar
+				artifacts={[link, firstFile, secondFile]}
+				selectedPath={firstFile.path}
+				onSelect={onSelect}
+			/>,
+		);
+
+		const options = screen.getAllByRole("option");
+		expect(options.map((option) => option.textContent)).toEqual([
+			"summary.mdreports",
+			"details.mdreports",
+			"Reviewed PR #376https://github.com/example/repo/pull/376",
+		]);
+		expect(options[2]?.querySelector(".lucide-link")).toBeTruthy();
+		expect(options[2]?.querySelector(".lucide-external-link")).toBeNull();
+
+		fireEvent.click(options[2] as HTMLElement);
+
+		expect(onSelect).toHaveBeenCalledWith(link);
+	});
+});

--- a/cli/web-ui/src/__tests__/components/v2/LinkSidebar.test.tsx
+++ b/cli/web-ui/src/__tests__/components/v2/LinkSidebar.test.tsx
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, render, screen, within } from "@testing-library/react";
+import { LinkSidebar } from "@/components/v2/LinkSidebar";
+import type { Artifact } from "@/types/runs";
+
+function linkArtifact(): Artifact {
+	const url =
+		"https://github.com/rp1-run/rp1/pull/377/files/cli/web-ui/src/components/v2/LinkSidebar.tsx?discussion_r=1234567890#diff-very-long-anchor";
+
+	return {
+		docId: "link-reviewed-pr",
+		locationKind: "url",
+		path: url,
+		absolutePath: url,
+		type: "other",
+		url,
+		label:
+			"Reviewed PR #377 with a deliberately long label that should wrap inside the links panel",
+		relationship: "reviewed_pr",
+		sourceContext:
+			"Generated from the quick-build implementation summary and should remain fully visible in the row.",
+		sourceArtifactPath: "quick-builds/2026-05-05-links-panel-copy-tweaks-1.md",
+		updatedDuringRun: false,
+		isNew: false,
+		step: "build",
+	};
+}
+
+function expectWrappingText(element: HTMLElement): void {
+	expect(element.classList.contains("truncate")).toBe(false);
+	expect(element.classList.contains("whitespace-normal")).toBe(true);
+	expect(element.classList.contains("break-words")).toBe(true);
+}
+
+describe("LinkSidebar", () => {
+	afterEach(() => {
+		cleanup();
+	});
+
+	test("keeps the header icon but renders link rows without repeated link icons or truncated text", () => {
+		const artifact = linkArtifact();
+
+		render(
+			<LinkSidebar
+				artifacts={[artifact]}
+				onClose={mock(() => {})}
+				onOpenLink={mock(() => {})}
+			/>,
+		);
+
+		const panel = screen.getByLabelText("Links panel");
+		const header = panel.querySelector("header");
+		expect(header?.querySelector(".lucide-link")).toBeTruthy();
+
+		const openButton = within(panel).getByRole("button", {
+			name: `Open ${artifact.label}`,
+		});
+		expect(openButton.querySelector(".lucide-link")).toBeNull();
+		expect(openButton.querySelector(".lucide-external-link")).toBeTruthy();
+
+		expectWrappingText(within(openButton).getByText(artifact.label ?? ""));
+		expectWrappingText(within(openButton).getByText(artifact.url ?? ""));
+		expectWrappingText(
+			within(openButton).getByText(artifact.sourceContext ?? ""),
+		);
+	});
+});

--- a/cli/web-ui/src/__tests__/components/v2/RunArtifactsPanel.test.tsx
+++ b/cli/web-ui/src/__tests__/components/v2/RunArtifactsPanel.test.tsx
@@ -23,6 +23,7 @@ interface MockArtifactContentSurfaceProps {
 		controls: ArtifactContentSurfaceControls,
 	) => ReactNode;
 	readonly footer?: ReactNode;
+	readonly sidePanel?: ReactNode;
 }
 
 mock.module("@/components/v2/ArtifactContentSurface", () => ({
@@ -33,6 +34,7 @@ mock.module("@/components/v2/ArtifactContentSurface", () => ({
 		emptyMessage,
 		renderHeader,
 		footer,
+		sidePanel,
 	}: MockArtifactContentSurfaceProps) => (
 		<section
 			data-testid="artifact-content-surface"
@@ -47,10 +49,12 @@ mock.module("@/components/v2/ArtifactContentSurface", () => ({
 				toggleTableOfContents: () => {},
 				showAnnotationToggle: selectedArtifact !== null,
 				toggleAnnotations: () => {},
+				closeSecondaryPanels: () => {},
 			})}
 			<div data-testid="surface-body">
 				{selectedArtifact?.path ?? emptyMessage ?? ""}
 			</div>
+			{sidePanel}
 			{footer}
 		</section>
 	),
@@ -622,12 +626,14 @@ describe("RunArtifactsPanel", () => {
 			within(artifactList).getByRole("button", { name: "pr-123-review.md" }),
 		).toBeTruthy();
 
-		const externalLinks = screen.getByRole("region", {
-			name: "External links",
-		});
-		expect(within(externalLinks).getByText("Reviewed PR #123")).toBeTruthy();
-		expect(externalLinks.querySelector(".lucide-link")).toBeTruthy();
-		expect(externalLinks.querySelector(".lucide-external-link")).toBeNull();
+		expect(screen.queryByLabelText("Links panel")).toBeNull();
+		fireEvent.click(screen.getByRole("button", { name: "Open links panel" }));
+
+		const linksPanel = screen.getByLabelText("Links panel");
+		expect(within(linksPanel).getByText("Reviewed PR #123")).toBeTruthy();
+		expect(within(linksPanel).getByText("1 link")).toBeTruthy();
+		expect(linksPanel.querySelector(".lucide-link")).toBeTruthy();
+		expect(linksPanel.querySelector(".lucide-external-link")).toBeTruthy();
 
 		fireEvent.click(
 			screen.getByRole("button", { name: "Copy URL for Reviewed PR #123" }),
@@ -646,7 +652,9 @@ describe("RunArtifactsPanel", () => {
 		);
 
 		fireEvent.click(
-			within(externalLinks).getByRole("button", { name: "Reviewed PR #123" }),
+			within(linksPanel).getByRole("button", {
+				name: "Open Reviewed PR #123",
+			}),
 		);
 
 		expect(onArtifactSelect).toHaveBeenCalledWith(reviewedPrArtifact);

--- a/cli/web-ui/src/__tests__/components/v2/RunArtifactsPanel.test.tsx
+++ b/cli/web-ui/src/__tests__/components/v2/RunArtifactsPanel.test.tsx
@@ -4,6 +4,7 @@ import {
 	fireEvent,
 	render,
 	screen,
+	waitFor,
 	within,
 } from "@testing-library/react";
 import type { ReactNode } from "react";
@@ -21,6 +22,7 @@ interface MockArtifactContentSurfaceProps {
 	readonly renderHeader?: (
 		controls: ArtifactContentSurfaceControls,
 	) => ReactNode;
+	readonly footer?: ReactNode;
 }
 
 mock.module("@/components/v2/ArtifactContentSurface", () => ({
@@ -30,6 +32,7 @@ mock.module("@/components/v2/ArtifactContentSurface", () => ({
 		showFrontmatter,
 		emptyMessage,
 		renderHeader,
+		footer,
 	}: MockArtifactContentSurfaceProps) => (
 		<section
 			data-testid="artifact-content-surface"
@@ -48,6 +51,7 @@ mock.module("@/components/v2/ArtifactContentSurface", () => ({
 			<div data-testid="surface-body">
 				{selectedArtifact?.path ?? emptyMessage ?? ""}
 			</div>
+			{footer}
 		</section>
 	),
 }));
@@ -100,6 +104,7 @@ function urlArtifact(
 	docId: string,
 	stepId: string | null,
 	url: string,
+	label = "Reviewed PR",
 ): Artifact {
 	return {
 		docId,
@@ -108,7 +113,7 @@ function urlArtifact(
 		absolutePath: url,
 		type: "other",
 		url,
-		label: "Reviewed PR",
+		label,
 		relationship: "reviewed_pr",
 		sourceContext: "PR review input resolution",
 		sourceArtifactPath: "pr-reviews/pr-123-review.md",
@@ -596,7 +601,9 @@ describe("RunArtifactsPanel", () => {
 			"link-reviewed-pr",
 			"posting",
 			"https://github.com/example/repo/pull/123",
+			"123",
 		);
+		const onArtifactSelect = mock(() => {});
 
 		await renderPanel({
 			artifactGroups: [
@@ -606,20 +613,42 @@ describe("RunArtifactsPanel", () => {
 				]),
 			],
 			selectedArtifact: reviewedPrArtifact,
+			onArtifactSelect,
 		});
 
+		const artifactList = screen.getByRole("list", { name: "Artifacts" });
+		expect(within(artifactList).queryByText("Reviewed PR #123")).toBeNull();
+		expect(
+			within(artifactList).getByRole("button", { name: "pr-123-review.md" }),
+		).toBeTruthy();
+
+		const externalLinks = screen.getByRole("region", {
+			name: "External links",
+		});
+		expect(within(externalLinks).getByText("Reviewed PR #123")).toBeTruthy();
+		expect(externalLinks.querySelector(".lucide-link")).toBeTruthy();
+		expect(externalLinks.querySelector(".lucide-external-link")).toBeNull();
+
 		fireEvent.click(
-			screen.getByRole("button", { name: "Copy URL for Reviewed PR" }),
+			screen.getByRole("button", { name: "Copy URL for Reviewed PR #123" }),
 		);
 
-		expect(writeText).toHaveBeenCalledWith(
-			"https://github.com/example/repo/pull/123",
-		);
+		await waitFor(() => {
+			expect(writeText).toHaveBeenCalledWith(
+				"https://github.com/example/repo/pull/123",
+			);
+		});
 		expect(screen.getByTestId("artifact-content-surface").dataset.docId).toBe(
 			"doc-report",
 		);
 		expect(screen.getByTestId("surface-body").textContent).toBe(
 			fileArtifact.path,
 		);
+
+		fireEvent.click(
+			within(externalLinks).getByRole("button", { name: "Reviewed PR #123" }),
+		);
+
+		expect(onArtifactSelect).toHaveBeenCalledWith(reviewedPrArtifact);
 	});
 });

--- a/cli/web-ui/src/__tests__/lib/link-artifacts.test.ts
+++ b/cli/web-ui/src/__tests__/lib/link-artifacts.test.ts
@@ -107,4 +107,49 @@ describe("link artifacts", () => {
 			payload: { url: "https://github.com/example/repo/pull/376" },
 		});
 	});
+
+	test("uses the native bridge when SPA navigation has dropped host mode query params", () => {
+		const openWindow = mock(() => null);
+		const postMessage = mock((_message: string) => {});
+
+		Object.defineProperty(window, "__electrobunBunBridge", {
+			configurable: true,
+			value: { postMessage },
+		});
+
+		openExternalUrl("https://github.com/example/repo/pull/376", {
+			openWindow,
+		});
+
+		expect(openWindow).not.toHaveBeenCalled();
+		expect(postMessage).toHaveBeenCalledTimes(1);
+		expect(JSON.parse(String(postMessage.mock.calls[0]?.[0]))).toEqual({
+			type: "message",
+			id: "rp1:open-external-url",
+			payload: { url: "https://github.com/example/repo/pull/376" },
+		});
+
+		Object.defineProperty(window, "__electrobunBunBridge", {
+			configurable: true,
+			value: undefined,
+		});
+	});
+
+	test("keeps explicit browser-mode links in a new tab even if a bridge is injected", () => {
+		const openWindow = mock(() => null);
+		const postMessage = mock((_message: string) => {});
+
+		openExternalUrl("https://github.com/example/repo/pull/376", {
+			hostMode: "browser",
+			nativeBridge: { postMessage },
+			openWindow,
+		});
+
+		expect(postMessage).not.toHaveBeenCalled();
+		expect(openWindow).toHaveBeenCalledWith(
+			"https://github.com/example/repo/pull/376",
+			"_blank",
+			"noopener,noreferrer",
+		);
+	});
 });

--- a/cli/web-ui/src/__tests__/lib/link-artifacts.test.ts
+++ b/cli/web-ui/src/__tests__/lib/link-artifacts.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, mock, test } from "bun:test";
+import {
+	getLinkArtifactContext,
+	getLinkArtifactLabel,
+	openExternalUrl,
+	orderArtifactsWithLinksLast,
+} from "../../lib/link-artifacts";
+import type { Artifact } from "../../types/runs";
+
+function fileArtifact(docId: string, path = `${docId}.md`): Artifact {
+	return {
+		docId,
+		path,
+		absolutePath: `/repo/${path}`,
+		type: "markdown",
+		updatedDuringRun: false,
+		isNew: false,
+		step: "build",
+	};
+}
+
+function linkArtifact(overrides: Partial<Artifact> = {}): Artifact {
+	return {
+		docId: "link-reviewed-pr",
+		locationKind: "url",
+		path: "https://github.com/example/repo/pull/376",
+		absolutePath: "https://github.com/example/repo/pull/376",
+		type: "other",
+		url: "https://github.com/example/repo/pull/376",
+		label: "Reviewed PR",
+		relationship: "reviewed_pr",
+		sourceContext: null,
+		sourceArtifactPath: null,
+		updatedDuringRun: false,
+		isNew: false,
+		step: "build",
+		...overrides,
+	};
+}
+
+describe("link artifacts", () => {
+	test("derives meaningful labels when persisted labels are opaque", () => {
+		expect(getLinkArtifactLabel(linkArtifact({ label: "376" }))).toBe(
+			"Reviewed PR #376",
+		);
+		expect(
+			getLinkArtifactLabel(
+				linkArtifact({
+					label: "https://github.com/example/repo/pull/376",
+					relationship: null,
+				}),
+			),
+		).toBe("GitHub PR #376");
+	});
+
+	test("keeps the target URL as secondary context", () => {
+		const artifact = linkArtifact();
+
+		expect(getLinkArtifactLabel(artifact)).toBe("Reviewed PR");
+		expect(getLinkArtifactContext(artifact)).toBe(
+			"https://github.com/example/repo/pull/376",
+		);
+	});
+
+	test("orders external links after file artifacts", () => {
+		const link = linkArtifact();
+		const firstFile = fileArtifact("first");
+		const secondFile = fileArtifact("second");
+
+		expect(orderArtifactsWithLinksLast([link, firstFile, secondFile])).toEqual([
+			firstFile,
+			secondFile,
+			link,
+		]);
+	});
+
+	test("opens browser-mode links in a new tab", () => {
+		const openWindow = mock(() => null);
+
+		openExternalUrl("https://github.com/example/repo/pull/376", {
+			hostMode: "browser",
+			openWindow,
+		});
+
+		expect(openWindow).toHaveBeenCalledWith(
+			"https://github.com/example/repo/pull/376",
+			"_blank",
+			"noopener,noreferrer",
+		);
+	});
+
+	test("sends native-mode links to the native default-browser bridge", () => {
+		const openWindow = mock(() => null);
+		const postMessage = mock((_message: string) => {});
+
+		openExternalUrl("https://github.com/example/repo/pull/376", {
+			hostMode: "native",
+			nativeBridge: { postMessage },
+			openWindow,
+		});
+
+		expect(openWindow).not.toHaveBeenCalled();
+		expect(postMessage).toHaveBeenCalledTimes(1);
+		expect(JSON.parse(String(postMessage.mock.calls[0]?.[0]))).toEqual({
+			type: "message",
+			id: "rp1:open-external-url",
+			payload: { url: "https://github.com/example/repo/pull/376" },
+		});
+	});
+});

--- a/cli/web-ui/src/__tests__/pages/v2/ArtifactViewerPage.test.tsx
+++ b/cli/web-ui/src/__tests__/pages/v2/ArtifactViewerPage.test.tsx
@@ -5,6 +5,7 @@ import {
 	render,
 	screen,
 	waitFor,
+	within,
 } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
@@ -473,6 +474,68 @@ describe("ArtifactViewerPage", () => {
 		);
 		expect(screen.getByTestId("artifact-renderer").textContent).toBe(
 			"docs/tasks.md:# Tasks",
+		);
+	});
+
+	test("renders external links after file content as secondary information", async () => {
+		const openMock = mock(() => null);
+		Object.defineProperty(window, "open", {
+			configurable: true,
+			value: openMock,
+		});
+		run = {
+			...baseRun,
+			artifacts: [
+				...baseRun.artifacts,
+				{
+					docId: "link-reviewed-pr",
+					locationKind: "url",
+					path: "https://github.com/example/repo/pull/456",
+					absolutePath: "https://github.com/example/repo/pull/456",
+					type: "other",
+					url: "https://github.com/example/repo/pull/456",
+					label: "456",
+					relationship: "reviewed_pr",
+					sourceContext: "PR review input resolution",
+					sourceArtifactPath: "pr-reviews/pr-456-review.md",
+					updatedDuringRun: true,
+					isNew: false,
+					step: "build",
+				},
+			],
+		};
+
+		await renderArtifactViewerPage();
+
+		await waitFor(() => {
+			expect(screen.getByTestId("artifact-renderer").textContent).toBe(
+				"docs/tasks.md:# Tasks",
+			);
+		});
+
+		const renderer = screen.getByTestId("artifact-renderer");
+		const externalLinks = screen.getByRole("region", {
+			name: "External links",
+		});
+		expect(
+			Boolean(
+				renderer.compareDocumentPosition(externalLinks) &
+					Node.DOCUMENT_POSITION_FOLLOWING,
+			),
+		).toBe(true);
+		expect(within(externalLinks).getByText("Reviewed PR #456")).toBeTruthy();
+		expect(externalLinks.querySelector(".lucide-link")).toBeTruthy();
+
+		fireEvent.click(
+			within(externalLinks).getByRole("button", {
+				name: /Reviewed PR #456/,
+			}),
+		);
+
+		expect(openMock).toHaveBeenCalledWith(
+			"https://github.com/example/repo/pull/456",
+			"_blank",
+			"noopener,noreferrer",
 		);
 	});
 

--- a/cli/web-ui/src/__tests__/pages/v2/ArtifactViewerPage.test.tsx
+++ b/cli/web-ui/src/__tests__/pages/v2/ArtifactViewerPage.test.tsx
@@ -265,6 +265,24 @@ function readStoredTabs() {
 		: null;
 }
 
+function deferred<T>() {
+	let resolve!: (value: T) => void;
+	let reject!: (reason?: unknown) => void;
+	const promise = new Promise<T>((promiseResolve, promiseReject) => {
+		resolve = promiseResolve;
+		reject = promiseReject;
+	});
+	return { promise, resolve, reject };
+}
+
+function contentResponse(content: string): Response {
+	return {
+		ok: true,
+		statusText: "OK",
+		json: async () => ({ content }),
+	} as Response;
+}
+
 async function renderArtifactViewerPage(
 	initialEntry = "/runs/run-1/artifacts/docs/tasks.md",
 ) {
@@ -349,6 +367,65 @@ describe("ArtifactViewerPage", () => {
 		expect(breadcrumbApi.setActiveArtifact).toHaveBeenCalledWith(
 			"run-1",
 			"docs/tasks.md",
+		);
+	});
+
+	test("ignores stale artifact content when artifact fetches resolve out of order", async () => {
+		const firstArtifact: Artifact = {
+			...baseRun.artifacts[0],
+			docId: "doc-first",
+			path: "docs/first.md",
+			absolutePath: "/repo/docs/first.md",
+			label: "First Artifact",
+		};
+		const secondArtifact: Artifact = {
+			...baseRun.artifacts[0],
+			docId: "doc-second",
+			path: "docs/second.md",
+			absolutePath: "/repo/docs/second.md",
+			label: "Second Artifact",
+		};
+		const firstFetch = deferred<Response>();
+		const secondFetch = deferred<Response>();
+		run = {
+			...baseRun,
+			artifacts: [firstArtifact, secondArtifact],
+		};
+		global.fetch = mock((input: RequestInfo | URL) => {
+			const url = String(input);
+			if (url.includes(encodeURIComponent(firstArtifact.path))) {
+				return firstFetch.promise;
+			}
+			if (url.includes(encodeURIComponent(secondArtifact.path))) {
+				return secondFetch.promise;
+			}
+			return Promise.reject(new Error(`Unexpected artifact request: ${url}`));
+		}) as unknown as typeof fetch;
+
+		await renderArtifactViewerPage("/runs/run-1/artifacts/docs/first.md");
+
+		await waitFor(() => {
+			expect(global.fetch).toHaveBeenCalledTimes(1);
+		});
+
+		fireEvent.click(screen.getByRole("button", { name: "Second Artifact" }));
+
+		await waitFor(() => {
+			expect(global.fetch).toHaveBeenCalledTimes(2);
+		});
+
+		secondFetch.resolve(contentResponse("# Second artifact"));
+		await waitFor(() => {
+			expect(screen.getByTestId("artifact-renderer").textContent).toBe(
+				"docs/second.md:# Second artifact",
+			);
+		});
+
+		firstFetch.resolve(contentResponse("# First artifact"));
+		await new Promise((resolve) => setTimeout(resolve, 0));
+
+		expect(screen.getByTestId("artifact-renderer").textContent).toBe(
+			"docs/second.md:# Second artifact",
 		);
 	});
 

--- a/cli/web-ui/src/__tests__/pages/v2/ArtifactViewerPage.test.tsx
+++ b/cli/web-ui/src/__tests__/pages/v2/ArtifactViewerPage.test.tsx
@@ -7,7 +7,7 @@ import {
 	waitFor,
 	within,
 } from "@testing-library/react";
-import type { ReactNode } from "react";
+import type { ButtonHTMLAttributes, ReactNode } from "react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import {
 	WORKSPACE_TABS_STORAGE_KEY,
@@ -143,11 +143,11 @@ mock.module("@/components/ui/button", () => ({
 	Button: ({
 		children,
 		onClick,
+		...props
 	}: {
 		children?: ReactNode;
-		onClick?: () => void;
-	}) => (
-		<button type="button" onClick={onClick}>
+	} & ButtonHTMLAttributes<HTMLButtonElement>) => (
+		<button type="button" onClick={onClick} {...props}>
 			{children}
 		</button>
 	),
@@ -477,7 +477,7 @@ describe("ArtifactViewerPage", () => {
 		);
 	});
 
-	test("renders external links after file content as secondary information", async () => {
+	test("renders external links in a dedicated links panel", async () => {
 		const openMock = mock(() => null);
 		Object.defineProperty(window, "open", {
 			configurable: true,
@@ -513,22 +513,18 @@ describe("ArtifactViewerPage", () => {
 			);
 		});
 
-		const renderer = screen.getByTestId("artifact-renderer");
-		const externalLinks = screen.getByRole("region", {
-			name: "External links",
-		});
-		expect(
-			Boolean(
-				renderer.compareDocumentPosition(externalLinks) &
-					Node.DOCUMENT_POSITION_FOLLOWING,
-			),
-		).toBe(true);
-		expect(within(externalLinks).getByText("Reviewed PR #456")).toBeTruthy();
-		expect(externalLinks.querySelector(".lucide-link")).toBeTruthy();
+		expect(screen.queryByLabelText("Links panel")).toBeNull();
+		fireEvent.click(screen.getByRole("button", { name: "Open links panel" }));
+
+		const linksPanel = screen.getByLabelText("Links panel");
+		expect(within(linksPanel).getByText("Reviewed PR #456")).toBeTruthy();
+		expect(within(linksPanel).getByText("1 link")).toBeTruthy();
+		expect(linksPanel.querySelector(".lucide-link")).toBeTruthy();
+		expect(screen.queryByTestId("annotation-sidebar")).toBeNull();
 
 		fireEvent.click(
-			within(externalLinks).getByRole("button", {
-				name: /Reviewed PR #456/,
+			within(linksPanel).getByRole("button", {
+				name: "Open Reviewed PR #456",
 			}),
 		);
 

--- a/cli/web-ui/src/components/v2/ArtifactContentSurface.tsx
+++ b/cli/web-ui/src/components/v2/ArtifactContentSurface.tsx
@@ -25,6 +25,7 @@ export interface ArtifactContentSurfaceControls {
 	readonly toggleTableOfContents: () => void;
 	readonly showAnnotationToggle: boolean;
 	readonly toggleAnnotations: () => void;
+	readonly closeSecondaryPanels: () => void;
 }
 
 export interface ArtifactContentSurfaceProps {
@@ -37,6 +38,8 @@ export interface ArtifactContentSurfaceProps {
 		controls: ArtifactContentSurfaceControls,
 	) => ReactNode;
 	readonly footer?: ReactNode;
+	readonly sidePanel?: ReactNode;
+	readonly onSecondaryPanelOpen?: () => void;
 }
 
 function ArtifactContentSurfaceInner({
@@ -47,6 +50,8 @@ function ArtifactContentSurfaceInner({
 	className,
 	renderHeader,
 	footer,
+	sidePanel,
+	onSecondaryPanelOpen,
 }: ArtifactContentSurfaceProps) {
 	const artifactPath = selectedArtifact?.path ?? null;
 	const artifactCacheKey =
@@ -179,21 +184,32 @@ function ArtifactContentSurfaceInner({
 		}
 	}, []);
 
+	const closeSecondaryPanels = useCallback(() => {
+		setTocOpen(false);
+		setAnnotationSidebarOpen(false);
+	}, []);
+
 	const handleToggleToc = useCallback(() => {
 		setTocOpen((prev) => {
 			const next = !prev;
-			if (next) setAnnotationSidebarOpen(false);
+			if (next) {
+				setAnnotationSidebarOpen(false);
+				onSecondaryPanelOpen?.();
+			}
 			return next;
 		});
-	}, []);
+	}, [onSecondaryPanelOpen]);
 
 	const handleToggleAnnotations = useCallback(() => {
 		setAnnotationSidebarOpen((prev) => {
 			const next = !prev;
-			if (next) setTocOpen(false);
+			if (next) {
+				setTocOpen(false);
+				onSecondaryPanelOpen?.();
+			}
 			return next;
 		});
-	}, []);
+	}, [onSecondaryPanelOpen]);
 
 	const controls: ArtifactContentSurfaceControls = {
 		selectedArtifact,
@@ -202,6 +218,7 @@ function ArtifactContentSurfaceInner({
 		toggleTableOfContents: handleToggleToc,
 		showAnnotationToggle: selectedArtifact !== null,
 		toggleAnnotations: handleToggleAnnotations,
+		closeSecondaryPanels,
 	};
 
 	return (
@@ -250,6 +267,8 @@ function ArtifactContentSurfaceInner({
 						/>
 					</div>
 				)}
+
+				{sidePanel}
 			</div>
 
 			{footer}

--- a/cli/web-ui/src/components/v2/ArtifactContentSurface.tsx
+++ b/cli/web-ui/src/components/v2/ArtifactContentSurface.tsx
@@ -36,6 +36,7 @@ export interface ArtifactContentSurfaceProps {
 	readonly renderHeader?: (
 		controls: ArtifactContentSurfaceControls,
 	) => ReactNode;
+	readonly footer?: ReactNode;
 }
 
 function ArtifactContentSurfaceInner({
@@ -45,6 +46,7 @@ function ArtifactContentSurfaceInner({
 	emptyMessage = "No content to display.",
 	className,
 	renderHeader,
+	footer,
 }: ArtifactContentSurfaceProps) {
 	const artifactPath = selectedArtifact?.path ?? null;
 	const artifactCacheKey =
@@ -249,6 +251,8 @@ function ArtifactContentSurfaceInner({
 					</div>
 				)}
 			</div>
+
+			{footer}
 		</div>
 	);
 }

--- a/cli/web-ui/src/components/v2/ArtifactList.tsx
+++ b/cli/web-ui/src/components/v2/ArtifactList.tsx
@@ -6,18 +6,26 @@ import {
 	FileImage,
 	FileSpreadsheet,
 	FileText,
+	type LucideIcon,
 } from "lucide-react";
 import { useCallback, useRef } from "react";
 import {
 	type VirtualizedListRef as KeyboardNavListRef,
 	useKeyboardNav,
 } from "@/hooks/useKeyboardNav";
+import {
+	getLinkArtifactContext,
+	getLinkArtifactLabel,
+	isLinkArtifact,
+	LINK_ARTIFACT_CONFIG,
+	orderArtifactsWithLinksLast,
+} from "@/lib/link-artifacts";
 import { cn } from "@/lib/utils";
 import type { Artifact, ArtifactType } from "@/types/runs";
 import { VirtualizedList, type VirtualizedListRef } from "./VirtualizedList";
 
 interface ArtifactConfig {
-	icon: React.ComponentType<{ className?: string }>;
+	icon: LucideIcon;
 	label: string;
 }
 
@@ -48,15 +56,6 @@ const artifactConfigs: Record<ArtifactType, ArtifactConfig> = {
 	},
 };
 
-const urlArtifactConfig: ArtifactConfig = {
-	icon: ExternalLink,
-	label: "Link",
-};
-
-function isUrlArtifact(artifact: Artifact): boolean {
-	return artifact.locationKind === "url";
-}
-
 function getFileName(path: string): string {
 	return path.split("/").pop() || path;
 }
@@ -69,24 +68,24 @@ function getDirectory(path: string): string {
 }
 
 function getArtifactName(artifact: Artifact): string {
-	if (isUrlArtifact(artifact)) {
-		return artifact.label || artifact.url || artifact.path;
+	if (isLinkArtifact(artifact)) {
+		return getLinkArtifactLabel(artifact);
 	}
 
 	return getFileName(artifact.path);
 }
 
 function getArtifactContext(artifact: Artifact): string {
-	if (isUrlArtifact(artifact)) {
-		return artifact.url || artifact.path;
+	if (isLinkArtifact(artifact)) {
+		return getLinkArtifactContext(artifact);
 	}
 
 	return getDirectory(artifact.path);
 }
 
 function getArtifactConfig(artifact: Artifact): ArtifactConfig {
-	if (isUrlArtifact(artifact)) {
-		return urlArtifactConfig;
+	if (isLinkArtifact(artifact)) {
+		return LINK_ARTIFACT_CONFIG;
 	}
 
 	return artifactConfigs[artifact.type] ?? artifactConfigs.other;
@@ -185,7 +184,8 @@ export function ArtifactList({
 	className,
 }: ArtifactListProps) {
 	const virtualizedListRef = useRef<VirtualizedListRef>(null);
-	const useVirtualization = artifacts.length > VIRTUALIZATION_THRESHOLD;
+	const orderedArtifacts = orderArtifactsWithLinksLast(artifacts);
+	const useVirtualization = orderedArtifacts.length > VIRTUALIZATION_THRESHOLD;
 
 	const handleSelect = useCallback(
 		(artifact: Artifact) => {
@@ -196,11 +196,11 @@ export function ArtifactList({
 
 	// Use external selectedIndex if provided, otherwise use internal keyboard nav
 	const { selectedIndex: internalSelectedIndex } = useKeyboardNav({
-		items: artifacts,
+		items: orderedArtifacts,
 		onSelect: handleSelect,
 		onDrillIn: handleSelect,
 		enabled:
-			artifacts.length > 0 &&
+			orderedArtifacts.length > 0 &&
 			!!onArtifactClick &&
 			externalSelectedIndex === undefined,
 		listRef: virtualizedListRef as React.RefObject<KeyboardNavListRef | null>,
@@ -224,7 +224,7 @@ export function ArtifactList({
 		[],
 	);
 
-	if (artifacts.length === 0) {
+	if (orderedArtifacts.length === 0) {
 		return (
 			<div className={cn("text-sm text-muted-foreground p-4", className)}>
 				No artifacts produced
@@ -236,7 +236,7 @@ export function ArtifactList({
 		return (
 			<VirtualizedList
 				ref={virtualizedListRef}
-				items={artifacts}
+				items={orderedArtifacts}
 				estimateSize={ARTIFACT_ITEM_HEIGHT}
 				overscan={3}
 				renderItem={renderArtifactItem}
@@ -251,7 +251,7 @@ export function ArtifactList({
 
 	return (
 		<ul className={cn("space-y-1", className)} aria-label="Artifacts">
-			{artifacts.map((artifact, index) => (
+			{orderedArtifacts.map((artifact, index) => (
 				<li key={artifact.docId || artifact.path}>
 					<ArtifactItem
 						artifact={artifact}

--- a/cli/web-ui/src/components/v2/ArtifactSidebar.tsx
+++ b/cli/web-ui/src/components/v2/ArtifactSidebar.tsx
@@ -1,18 +1,25 @@
 import {
-	ExternalLink,
 	File,
 	FileCode,
 	FileDiff,
 	FileImage,
 	FileSpreadsheet,
 	FileText,
+	type LucideIcon,
 } from "lucide-react";
 import { useKeyboardNav } from "@/hooks/useKeyboardNav";
+import {
+	getLinkArtifactContext,
+	getLinkArtifactLabel,
+	isLinkArtifact,
+	LINK_ARTIFACT_CONFIG,
+	orderArtifactsWithLinksLast,
+} from "@/lib/link-artifacts";
 import { cn } from "@/lib/utils";
 import type { Artifact, ArtifactType } from "@/types/runs";
 
 interface ArtifactConfig {
-	icon: React.ComponentType<{ className?: string }>;
+	icon: LucideIcon;
 	label: string;
 }
 
@@ -43,15 +50,6 @@ const artifactConfigs: Record<ArtifactType, ArtifactConfig> = {
 	},
 };
 
-const urlArtifactConfig: ArtifactConfig = {
-	icon: ExternalLink,
-	label: "Link",
-};
-
-function isUrlArtifact(artifact: Artifact): boolean {
-	return artifact.locationKind === "url";
-}
-
 function getFileName(path: string): string {
 	return path.split("/").pop() || path;
 }
@@ -64,24 +62,24 @@ function getDirectory(path: string): string {
 }
 
 function getArtifactName(artifact: Artifact): string {
-	if (isUrlArtifact(artifact)) {
-		return artifact.label || artifact.url || artifact.path;
+	if (isLinkArtifact(artifact)) {
+		return getLinkArtifactLabel(artifact);
 	}
 
 	return getFileName(artifact.path);
 }
 
 function getArtifactContext(artifact: Artifact): string {
-	if (isUrlArtifact(artifact)) {
-		return artifact.url || artifact.path;
+	if (isLinkArtifact(artifact)) {
+		return getLinkArtifactContext(artifact);
 	}
 
 	return getDirectory(artifact.path);
 }
 
 function getArtifactConfig(artifact: Artifact): ArtifactConfig {
-	if (isUrlArtifact(artifact)) {
-		return urlArtifactConfig;
+	if (isLinkArtifact(artifact)) {
+		return LINK_ARTIFACT_CONFIG;
 	}
 
 	return artifactConfigs[artifact.type] ?? artifactConfigs.other;
@@ -100,8 +98,9 @@ export function ArtifactSidebar({
 	onSelect,
 	className,
 }: ArtifactSidebarProps) {
+	const orderedArtifacts = orderArtifactsWithLinksLast(artifacts);
 	const { getItemProps, containerProps, setSelectedIndex } = useKeyboardNav({
-		items: artifacts,
+		items: orderedArtifacts,
 		onSelect: (artifact) => {
 			onSelect(artifact);
 		},
@@ -110,9 +109,11 @@ export function ArtifactSidebar({
 	});
 
 	// Sync selection from selectedPath prop to keyboard nav state
-	const selectedIndex = artifacts.findIndex((a) => a.path === selectedPath);
+	const selectedIndex = orderedArtifacts.findIndex(
+		(a) => a.path === selectedPath,
+	);
 
-	if (artifacts.length === 0) {
+	if (orderedArtifacts.length === 0) {
 		return (
 			<div className={cn("text-sm text-muted-foreground p-4", className)}>
 				No artifacts produced
@@ -141,7 +142,7 @@ export function ArtifactSidebar({
 					}
 				}}
 			>
-				{artifacts.map((artifact, index) => {
+				{orderedArtifacts.map((artifact, index) => {
 					const config = getArtifactConfig(artifact);
 					const Icon = config.icon;
 					const artifactName = getArtifactName(artifact);

--- a/cli/web-ui/src/components/v2/LinkSidebar.tsx
+++ b/cli/web-ui/src/components/v2/LinkSidebar.tsx
@@ -1,0 +1,151 @@
+import { Check, Copy, ExternalLink, X } from "lucide-react";
+import { useState } from "react";
+import {
+	getLinkArtifactContext,
+	getLinkArtifactLabel,
+	LINK_ARTIFACT_CONFIG,
+	openLinkArtifact,
+} from "@/lib/link-artifacts";
+import { cn } from "@/lib/utils";
+import type { Artifact } from "@/types/runs";
+import { PanelHeader, PanelHeaderIconButton } from "./PanelHeader";
+
+export interface LinkSidebarProps {
+	readonly artifacts: readonly Artifact[];
+	readonly onClose: () => void;
+	readonly onOpenLink?: (artifact: Artifact) => void;
+	readonly className?: string;
+}
+
+export function LinkSidebar({
+	artifacts,
+	onClose,
+	onOpenLink = openLinkArtifact,
+	className,
+}: LinkSidebarProps) {
+	const [copiedArtifactId, setCopiedArtifactId] = useState<string | null>(null);
+	const LinkIcon = LINK_ARTIFACT_CONFIG.icon;
+
+	const handleCopy = (artifact: Artifact) => {
+		const target = getLinkArtifactContext(artifact);
+		if (!navigator.clipboard?.writeText) return;
+
+		void navigator.clipboard
+			.writeText(target)
+			.then(() => {
+				setCopiedArtifactId(artifact.docId);
+				setTimeout(() => setCopiedArtifactId(null), 2000);
+			})
+			.catch(() => {});
+	};
+
+	return (
+		<aside
+			className={cn("flex h-full flex-col", className)}
+			aria-label="Links panel"
+		>
+			<PanelHeader
+				icon={LinkIcon}
+				title="Links"
+				meta={
+					<span className="type-secondary text-fg-ghost tabular-nums">
+						{artifacts.length}
+					</span>
+				}
+				actions={
+					<PanelHeaderIconButton
+						icon={X}
+						ariaLabel="Close links panel"
+						onClick={onClose}
+					/>
+				}
+			/>
+
+			<div className="min-h-0 flex-1 overflow-y-auto">
+				{artifacts.length === 0 ? (
+					<div className="flex flex-col items-center justify-center py-8 text-center">
+						<LinkIcon
+							className="mb-2 h-8 w-8 text-muted-foreground/50"
+							aria-hidden="true"
+						/>
+						<p className="text-sm text-muted-foreground">No links</p>
+					</div>
+				) : (
+					<ul className="space-y-1 p-2">
+						{artifacts.map((artifact) => {
+							const label = getLinkArtifactLabel(artifact);
+							const target = getLinkArtifactContext(artifact);
+							const isCopied = copiedArtifactId === artifact.docId;
+							const CopyIcon = isCopied ? Check : Copy;
+							const sourceContext = artifact.sourceContext?.trim() ?? "";
+
+							return (
+								<li key={artifact.docId}>
+									<div
+										className={cn(
+											"flex w-full items-start gap-2 rounded-md border border-transparent px-2 py-1.5 text-left transition-colors",
+											"hover:border-border hover:bg-muted/50",
+										)}
+									>
+										<button
+											type="button"
+											onClick={() => onOpenLink(artifact)}
+											className="min-w-0 flex-1 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-sm"
+											aria-label={`Open ${label}`}
+											title={target}
+										>
+											<div className="flex items-start gap-2">
+												<LinkIcon
+													className="mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground"
+													strokeWidth={1.5}
+													aria-hidden="true"
+												/>
+												<span className="min-w-0 flex-1">
+													<span className="block truncate text-sm text-fg">
+														{label}
+													</span>
+													<span className="mt-0.5 block truncate text-xs text-muted-foreground">
+														{target}
+													</span>
+													{sourceContext && (
+														<span className="mt-1 block truncate text-xs text-fg-muted">
+															{sourceContext}
+														</span>
+													)}
+												</span>
+												<ExternalLink
+													className="mt-0.5 h-3 w-3 shrink-0 text-muted-foreground"
+													strokeWidth={1.5}
+													aria-hidden="true"
+												/>
+											</div>
+										</button>
+										<button
+											type="button"
+											onClick={() => handleCopy(artifact)}
+											className="mt-0.5 shrink-0 text-fg-ghost transition-colors duration-150 hover:text-fg focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-border"
+											aria-label={`Copy URL for ${label}`}
+											title={target}
+										>
+											<CopyIcon
+												className="h-3.5 w-3.5"
+												strokeWidth={1.5}
+												aria-hidden="true"
+											/>
+										</button>
+									</div>
+								</li>
+							);
+						})}
+					</ul>
+				)}
+			</div>
+
+			<footer className="shrink-0 border-t border-border px-3 py-2">
+				<p className="text-xs text-muted-foreground">
+					{artifacts.length} link{artifacts.length !== 1 ? "s" : ""}
+				</p>
+			</footer>
+		</aside>
+	);
+}

--- a/cli/web-ui/src/components/v2/LinkSidebar.tsx
+++ b/cli/web-ui/src/components/v2/LinkSidebar.tsx
@@ -95,20 +95,15 @@ export function LinkSidebar({
 											title={target}
 										>
 											<div className="flex items-start gap-2">
-												<LinkIcon
-													className="mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground"
-													strokeWidth={1.5}
-													aria-hidden="true"
-												/>
 												<span className="min-w-0 flex-1">
-													<span className="block truncate text-sm text-fg">
+													<span className="block whitespace-normal break-words text-sm leading-snug text-fg">
 														{label}
 													</span>
-													<span className="mt-0.5 block truncate text-xs text-muted-foreground">
+													<span className="mt-0.5 block whitespace-normal break-words text-xs leading-snug text-muted-foreground">
 														{target}
 													</span>
 													{sourceContext && (
-														<span className="mt-1 block truncate text-xs text-fg-muted">
+														<span className="mt-1 block whitespace-normal break-words text-xs leading-snug text-fg-muted">
 															{sourceContext}
 														</span>
 													)}

--- a/cli/web-ui/src/components/v2/RunArtifactsPanel.tsx
+++ b/cli/web-ui/src/components/v2/RunArtifactsPanel.tsx
@@ -1,4 +1,4 @@
-import { Check, ExternalLink, FileText, List } from "lucide-react";
+import { Check, FileText, List } from "lucide-react";
 import { type ReactNode, useState } from "react";
 import { AnnotationToggleBtn } from "@/components/v2/AnnotationToggleBtn";
 import {
@@ -8,6 +8,14 @@ import {
 import { ArtifactEmptyState } from "@/components/v2/ArtifactEmptyState";
 import { SaveStatusIndicator } from "@/components/v2/UnifiedContentRenderer";
 import type { ArtifactGroup } from "@/lib/artifact-groups";
+import {
+	getLinkArtifactContext,
+	getLinkArtifactLabel,
+	getLinkArtifactTarget,
+	isLinkArtifact,
+	LINK_ARTIFACT_CONFIG,
+	partitionArtifactsByLinkKind,
+} from "@/lib/link-artifacts";
 import { cn } from "@/lib/utils";
 import type { Artifact } from "@/types/runs";
 
@@ -27,21 +35,17 @@ function getFileName(path: string): string {
 	return path.split("/").pop() || path;
 }
 
-function isUrlArtifact(artifact: Artifact): boolean {
-	return artifact.locationKind === "url";
-}
-
 function getArtifactName(artifact: Artifact): string {
-	if (isUrlArtifact(artifact)) {
-		return artifact.label || artifact.url || artifact.path;
+	if (isLinkArtifact(artifact)) {
+		return getLinkArtifactLabel(artifact);
 	}
 
 	return getFileName(artifact.path);
 }
 
 function getArtifactTarget(artifact: Artifact): string {
-	if (isUrlArtifact(artifact)) {
-		return artifact.url || artifact.path;
+	if (isLinkArtifact(artifact)) {
+		return getLinkArtifactTarget(artifact);
 	}
 
 	return artifact.absolutePath ?? artifact.path;
@@ -67,8 +71,10 @@ export function RunArtifactsPanel({
 
 	const groups = artifactGroups.filter((group) => group.artifacts.length > 0);
 	const artifacts = flattenArtifacts(groups);
+	const { fileArtifacts, linkArtifacts } =
+		partitionArtifactsByLinkKind(artifacts);
 	const firstFileArtifact =
-		artifacts.find((artifact) => !isUrlArtifact(artifact)) ?? null;
+		fileArtifacts.find((artifact) => artifact.docId) ?? null;
 
 	const renderLeadingControl = () =>
 		leadingControl ? (
@@ -120,7 +126,7 @@ export function RunArtifactsPanel({
 	}
 
 	const effectiveSelectedArtifact =
-		selectedArtifact && !isUrlArtifact(selectedArtifact)
+		selectedArtifact && !isLinkArtifact(selectedArtifact)
 			? selectedArtifact
 			: firstFileArtifact;
 
@@ -132,60 +138,119 @@ export function RunArtifactsPanel({
 		});
 	};
 
-	const renderArtifactList = () => (
-		<ul
-			aria-label="Artifacts"
-			className="flex min-w-0 flex-1 flex-wrap items-center gap-x-1 gap-y-1"
-		>
-			{artifacts.map((artifact) => {
-				const artifactName = getArtifactName(artifact);
-				const isSelected = effectiveSelectedArtifact?.docId === artifact.docId;
-				const isCopied = copiedArtifactId === artifact.docId;
-				const IconComponent = isCopied
-					? Check
-					: isUrlArtifact(artifact)
-						? ExternalLink
-						: FileText;
-				const artifactTarget = getArtifactTarget(artifact);
-				const copyLabel = isUrlArtifact(artifact) ? "Copy URL" : "Copy path";
+	const renderArtifactList = () =>
+		fileArtifacts.length > 0 ? (
+			<ul
+				aria-label="Artifacts"
+				className="flex min-w-0 flex-1 flex-wrap items-center gap-x-1 gap-y-1"
+			>
+				{fileArtifacts.map((artifact) => {
+					const artifactName = getArtifactName(artifact);
+					const isSelected =
+						effectiveSelectedArtifact?.docId === artifact.docId;
+					const isCopied = copiedArtifactId === artifact.docId;
+					const IconComponent = isCopied ? Check : FileText;
+					const artifactTarget = getArtifactTarget(artifact);
 
-				return (
-					<li key={artifact.docId} className="max-w-full shrink-0">
-						<span
-							className={cn(
-								"inline-flex h-7 max-w-[14rem] items-center gap-1 rounded-sm px-2 type-secondary font-medium transition-colors duration-150",
-								isSelected
-									? "text-fg"
-									: "text-fg-ghost hover:bg-surface-base/70 hover:text-fg",
-							)}
-						>
-							<button
-								type="button"
-								title={artifactTarget}
-								aria-label={`${copyLabel} for ${artifactName}`}
-								onClick={(e) => {
-									e.stopPropagation();
-									handleCopyArtifact(artifact);
-								}}
-								className="shrink-0 transition-colors duration-150 hover:text-fg focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-border"
+					return (
+						<li key={artifact.docId} className="max-w-full shrink-0">
+							<span
+								className={cn(
+									"inline-flex h-7 max-w-[14rem] items-center gap-1 rounded-sm px-2 type-secondary font-medium transition-colors duration-150",
+									isSelected
+										? "text-fg"
+										: "text-fg-ghost hover:bg-surface-base/70 hover:text-fg",
+								)}
 							>
-								<IconComponent className="h-3 w-3 shrink-0" strokeWidth={1.5} />
-							</button>
-							<button
-								type="button"
-								aria-current={isSelected ? "page" : undefined}
-								title={artifactTarget}
-								onClick={() => onArtifactSelect?.(artifact)}
-								className="min-w-0 truncate transition-colors duration-150 hover:opacity-80 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-border"
-							>
-								{artifactName}
-							</button>
-						</span>
-					</li>
-				);
-			})}
-		</ul>
-	);
+								<button
+									type="button"
+									title={artifactTarget}
+									aria-label={`Copy path for ${artifactName}`}
+									onClick={(e) => {
+										e.stopPropagation();
+										handleCopyArtifact(artifact);
+									}}
+									className="shrink-0 transition-colors duration-150 hover:text-fg focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-border"
+								>
+									<IconComponent
+										className="h-3 w-3 shrink-0"
+										strokeWidth={1.5}
+									/>
+								</button>
+								<button
+									type="button"
+									aria-current={isSelected ? "page" : undefined}
+									title={artifactTarget}
+									onClick={() => onArtifactSelect?.(artifact)}
+									className="min-w-0 truncate transition-colors duration-150 hover:opacity-80 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-border"
+								>
+									{artifactName}
+								</button>
+							</span>
+						</li>
+					);
+				})}
+			</ul>
+		) : null;
+
+	const renderExternalLinks = () => {
+		if (linkArtifacts.length === 0) return null;
+		const LinkIcon = LINK_ARTIFACT_CONFIG.icon;
+
+		return (
+			<section
+				className="shrink-0 border-t border-border/60 bg-surface-void/50 px-4 py-2"
+				aria-label="External links"
+			>
+				<div className="flex min-w-0 flex-col gap-1">
+					<h2 className="type-secondary font-medium text-fg-ghost">
+						External links
+					</h2>
+					<ul className="flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1">
+						{linkArtifacts.map((artifact) => {
+							const artifactName = getArtifactName(artifact);
+							const artifactTarget = getArtifactTarget(artifact);
+							const isCopied = copiedArtifactId === artifact.docId;
+							const IconComponent = isCopied ? Check : LinkIcon;
+
+							return (
+								<li key={artifact.docId} className="min-w-0 max-w-full">
+									<span className="inline-flex max-w-full items-center gap-1 type-secondary text-fg-ghost">
+										<button
+											type="button"
+											title={artifactTarget}
+											aria-label={`Copy URL for ${artifactName}`}
+											onClick={(e) => {
+												e.stopPropagation();
+												handleCopyArtifact(artifact);
+											}}
+											className="shrink-0 transition-colors duration-150 hover:text-fg focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-border"
+										>
+											<IconComponent
+												className="h-3 w-3 shrink-0"
+												strokeWidth={1.5}
+											/>
+										</button>
+										<button
+											type="button"
+											title={artifactTarget}
+											onClick={() => onArtifactSelect?.(artifact)}
+											className="min-w-0 truncate transition-colors duration-150 hover:text-fg focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-border"
+										>
+											{artifactName}
+										</button>
+										<span className="min-w-0 max-w-[18rem] truncate text-fg-muted">
+											{getLinkArtifactContext(artifact)}
+										</span>
+									</span>
+								</li>
+							);
+						})}
+					</ul>
+				</div>
+			</section>
+		);
+	};
 
 	const renderHeader = (controls: ArtifactContentSurfaceControls) =>
 		renderHeaderShell(
@@ -222,8 +287,13 @@ export function RunArtifactsPanel({
 			selectedArtifact={effectiveSelectedArtifact}
 			runId={runId}
 			showFrontmatter={showFrontmatter}
-			emptyMessage="Select an artifact to view."
+			emptyMessage={
+				fileArtifacts.length > 0
+					? "Select an artifact to view."
+					: "No file artifacts to preview."
+			}
 			renderHeader={renderHeader}
+			footer={renderExternalLinks()}
 		/>
 	);
 }

--- a/cli/web-ui/src/components/v2/RunArtifactsPanel.tsx
+++ b/cli/web-ui/src/components/v2/RunArtifactsPanel.tsx
@@ -1,23 +1,27 @@
 import { Check, FileText, List } from "lucide-react";
 import { type ReactNode, useState } from "react";
+import { Drawer } from "@/components/ui/drawer";
 import { AnnotationToggleBtn } from "@/components/v2/AnnotationToggleBtn";
 import {
 	ArtifactContentSurface,
 	type ArtifactContentSurfaceControls,
 } from "@/components/v2/ArtifactContentSurface";
 import { ArtifactEmptyState } from "@/components/v2/ArtifactEmptyState";
+import { LinkSidebar } from "@/components/v2/LinkSidebar";
 import { SaveStatusIndicator } from "@/components/v2/UnifiedContentRenderer";
+import { useIsMobile } from "@/hooks/useMediaQuery";
 import type { ArtifactGroup } from "@/lib/artifact-groups";
 import {
-	getLinkArtifactContext,
 	getLinkArtifactLabel,
 	getLinkArtifactTarget,
 	isLinkArtifact,
 	LINK_ARTIFACT_CONFIG,
+	openLinkArtifact,
 	partitionArtifactsByLinkKind,
 } from "@/lib/link-artifacts";
 import { cn } from "@/lib/utils";
 import type { Artifact } from "@/types/runs";
+import { PanelHeaderIconButton } from "./PanelHeader";
 
 export interface RunArtifactsPanelProps {
 	readonly artifactGroups: readonly ArtifactGroup[];
@@ -68,6 +72,8 @@ export function RunArtifactsPanel({
 	headerActions,
 }: RunArtifactsPanelProps) {
 	const [copiedArtifactId, setCopiedArtifactId] = useState<string | null>(null);
+	const [linksPanelOpen, setLinksPanelOpen] = useState(false);
+	const isMobile = useIsMobile();
 
 	const groups = artifactGroups.filter((group) => group.artifacts.length > 0);
 	const artifacts = flattenArtifacts(groups);
@@ -138,6 +144,17 @@ export function RunArtifactsPanel({
 		});
 	};
 
+	const handleOpenLinkArtifact = (artifact: Artifact) => {
+		if (onArtifactSelect) {
+			onArtifactSelect(artifact);
+		} else {
+			openLinkArtifact(artifact);
+		}
+		if (isMobile) {
+			setLinksPanelOpen(false);
+		}
+	};
+
 	const renderArtifactList = () =>
 		fileArtifacts.length > 0 ? (
 			<ul
@@ -193,65 +210,6 @@ export function RunArtifactsPanel({
 			</ul>
 		) : null;
 
-	const renderExternalLinks = () => {
-		if (linkArtifacts.length === 0) return null;
-		const LinkIcon = LINK_ARTIFACT_CONFIG.icon;
-
-		return (
-			<section
-				className="shrink-0 border-t border-border/60 bg-surface-void/50 px-4 py-2"
-				aria-label="External links"
-			>
-				<div className="flex min-w-0 flex-col gap-1">
-					<h2 className="type-secondary font-medium text-fg-ghost">
-						External links
-					</h2>
-					<ul className="flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1">
-						{linkArtifacts.map((artifact) => {
-							const artifactName = getArtifactName(artifact);
-							const artifactTarget = getArtifactTarget(artifact);
-							const isCopied = copiedArtifactId === artifact.docId;
-							const IconComponent = isCopied ? Check : LinkIcon;
-
-							return (
-								<li key={artifact.docId} className="min-w-0 max-w-full">
-									<span className="inline-flex max-w-full items-center gap-1 type-secondary text-fg-ghost">
-										<button
-											type="button"
-											title={artifactTarget}
-											aria-label={`Copy URL for ${artifactName}`}
-											onClick={(e) => {
-												e.stopPropagation();
-												handleCopyArtifact(artifact);
-											}}
-											className="shrink-0 transition-colors duration-150 hover:text-fg focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-border"
-										>
-											<IconComponent
-												className="h-3 w-3 shrink-0"
-												strokeWidth={1.5}
-											/>
-										</button>
-										<button
-											type="button"
-											title={artifactTarget}
-											onClick={() => onArtifactSelect?.(artifact)}
-											className="min-w-0 truncate transition-colors duration-150 hover:text-fg focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-border"
-										>
-											{artifactName}
-										</button>
-										<span className="min-w-0 max-w-[18rem] truncate text-fg-muted">
-											{getLinkArtifactContext(artifact)}
-										</span>
-									</span>
-								</li>
-							);
-						})}
-					</ul>
-				</div>
-			</section>
-		);
-	};
-
 	const renderHeader = (controls: ArtifactContentSurfaceControls) =>
 		renderHeaderShell(
 			<div className="flex min-w-0 items-start gap-2">
@@ -260,6 +218,26 @@ export function RunArtifactsPanel({
 			</div>,
 			<div className="flex h-7 shrink-0 items-center gap-3">
 				<SaveStatusIndicator status={controls.saveStatus} />
+				{linkArtifacts.length > 0 && (
+					<PanelHeaderIconButton
+						icon={LINK_ARTIFACT_CONFIG.icon}
+						ariaLabel={
+							linksPanelOpen ? "Close links panel" : "Open links panel"
+						}
+						ariaExpanded={linksPanelOpen}
+						ariaPressed={linksPanelOpen}
+						onClick={() => {
+							setLinksPanelOpen((prev) => {
+								const next = !prev;
+								if (next) {
+									controls.closeSecondaryPanels();
+								}
+								return next;
+							});
+						}}
+						className={cn(linksPanelOpen && "text-fg")}
+					/>
+				)}
 				{controls.showTableOfContentsToggle && (
 					<button
 						type="button"
@@ -282,18 +260,47 @@ export function RunArtifactsPanel({
 			renderLeadingControl(),
 		);
 
+	const linksSidebar =
+		linksPanelOpen && linkArtifacts.length > 0 ? (
+			<LinkSidebar
+				artifacts={linkArtifacts}
+				onOpenLink={handleOpenLinkArtifact}
+				onClose={() => setLinksPanelOpen(false)}
+				className="h-full"
+			/>
+		) : null;
+
 	return (
-		<ArtifactContentSurface
-			selectedArtifact={effectiveSelectedArtifact}
-			runId={runId}
-			showFrontmatter={showFrontmatter}
-			emptyMessage={
-				fileArtifacts.length > 0
-					? "Select an artifact to view."
-					: "No file artifacts to preview."
-			}
-			renderHeader={renderHeader}
-			footer={renderExternalLinks()}
-		/>
+		<>
+			<ArtifactContentSurface
+				selectedArtifact={effectiveSelectedArtifact}
+				runId={runId}
+				showFrontmatter={showFrontmatter}
+				emptyMessage={
+					fileArtifacts.length > 0
+						? "Select an artifact to view."
+						: "No file artifacts to preview."
+				}
+				renderHeader={renderHeader}
+				sidePanel={
+					!isMobile && linksSidebar ? (
+						<div className="w-[280px] shrink-0 border-l border-border overflow-y-auto">
+							{linksSidebar}
+						</div>
+					) : null
+				}
+				onSecondaryPanelOpen={() => setLinksPanelOpen(false)}
+			/>
+			{isMobile && (
+				<Drawer
+					open={linksPanelOpen}
+					onClose={() => setLinksPanelOpen(false)}
+					side="right"
+					title="Links"
+				>
+					{linksSidebar}
+				</Drawer>
+			)}
+		</>
 	);
 }

--- a/cli/web-ui/src/components/v2/RunDetailSurface.tsx
+++ b/cli/web-ui/src/components/v2/RunDetailSurface.tsx
@@ -37,6 +37,11 @@ import {
 	buildArtifactRoute,
 	groupArtifactsByWorkflowStep,
 } from "@/lib/artifact-groups";
+import {
+	getLinkArtifactLabel,
+	isLinkArtifact,
+	openLinkArtifact,
+} from "@/lib/link-artifacts";
 import { resolveRunDisplayName } from "@/lib/run-display";
 import {
 	getSocraticDuelStepLabel,
@@ -78,19 +83,6 @@ export interface RunDetailSurfaceProps {
 export interface RunDetailTarget {
 	readonly stepId: string;
 	readonly artifact: Artifact | null;
-}
-
-function isUrlArtifact(artifact: Artifact | null): boolean {
-	return artifact?.locationKind === "url";
-}
-
-function getUrlArtifactTarget(artifact: Artifact): string {
-	return artifact.url || artifact.path;
-}
-
-function openUrlArtifact(artifact: Artifact): void {
-	if (typeof window === "undefined") return;
-	window.open(getUrlArtifactTarget(artifact), "_blank", "noopener,noreferrer");
 }
 
 function MobileStepSelector({
@@ -154,10 +146,10 @@ export function selectDefaultRunTarget(run: Run): RunDetailTarget | null {
 			(candidate) =>
 				candidate.step === targetStep.id &&
 				candidate.docId &&
-				!isUrlArtifact(candidate),
+				!isLinkArtifact(candidate),
 		) ??
 		run.artifacts.find(
-			(candidate) => candidate.docId && !isUrlArtifact(candidate),
+			(candidate) => candidate.docId && !isLinkArtifact(candidate),
 		) ??
 		null;
 
@@ -239,15 +231,13 @@ export function RunDetailSurface({
 	const workspaceSubtitle = useMemo(() => {
 		if (!run) return null;
 		const artifactName = selectedArtifact
-			? isUrlArtifact(selectedArtifact)
-				? (selectedArtifact.label ??
-					selectedArtifact.url ??
-					selectedArtifact.path)
+			? isLinkArtifact(selectedArtifact)
+				? getLinkArtifactLabel(selectedArtifact)
 				: (selectedArtifact.path.split("/").at(-1) ?? null)
 			: null;
 		return artifactName ?? run.projectName;
 	}, [run, selectedArtifact]);
-	const selectedFileArtifact = isUrlArtifact(selectedArtifact)
+	const selectedFileArtifact = isLinkArtifact(selectedArtifact)
 		? null
 		: selectedArtifact;
 
@@ -449,8 +439,8 @@ export function RunDetailSurface({
 	const handleArtifactSelect = useCallback(
 		(artifact: Artifact) => {
 			setFocusedStepId(artifact.step ?? null);
-			if (isUrlArtifact(artifact)) {
-				openUrlArtifact(artifact);
+			if (isLinkArtifact(artifact)) {
+				openLinkArtifact(artifact);
 				return;
 			}
 			if (!runId) return;

--- a/cli/web-ui/src/components/v2/VerticalStepList.tsx
+++ b/cli/web-ui/src/components/v2/VerticalStepList.tsx
@@ -3,7 +3,6 @@ import {
 	Check,
 	Circle,
 	Code,
-	ExternalLink,
 	File,
 	FileText,
 	GitCompare,
@@ -11,6 +10,13 @@ import {
 	Minus,
 } from "lucide-react";
 import { useCallback, useMemo, useState } from "react";
+import {
+	getLinkArtifactLabel,
+	getLinkArtifactTarget,
+	isLinkArtifact,
+	LINK_ARTIFACT_CONFIG,
+	orderArtifactsWithLinksLast,
+} from "@/lib/link-artifacts";
 import { cn } from "@/lib/utils";
 import type {
 	AgentTask,
@@ -40,21 +46,17 @@ const artifactIconMap: Record<ArtifactType, typeof FileText> = {
 	other: File,
 };
 
-function isUrlArtifact(artifact: Artifact): boolean {
-	return artifact.locationKind === "url";
-}
-
 function getArtifactName(artifact: Artifact): string {
-	if (isUrlArtifact(artifact)) {
-		return artifact.label || artifact.url || artifact.path;
+	if (isLinkArtifact(artifact)) {
+		return getLinkArtifactLabel(artifact);
 	}
 
 	return artifact.path.split("/").pop() ?? artifact.path;
 }
 
 function getArtifactTarget(artifact: Artifact): string {
-	if (isUrlArtifact(artifact)) {
-		return artifact.url || artifact.path;
+	if (isLinkArtifact(artifact)) {
+		return getLinkArtifactTarget(artifact);
 	}
 
 	return artifact.absolutePath ?? artifact.path;
@@ -279,7 +281,9 @@ export function VerticalStepList({
 			<ol className="relative ml-[9px] border-l border-border">
 				{steps.map((step, index) => {
 					const isSelected = step.id === selectedStepId;
-					const stepArtifacts = artifactsByStep.get(step.id) ?? [];
+					const stepArtifacts = orderArtifactsWithLinksLast(
+						artifactsByStep.get(step.id) ?? [],
+					);
 					const subTasks = agentSteps?.[step.id] ?? null;
 					const isComposite = subTasks !== null && subTasks.length > 0;
 					const isCompositeExpanded = expandedComposites.has(step.id);
@@ -354,12 +358,12 @@ export function VerticalStepList({
 							{isSelected && stepArtifacts.length > 0 && (
 								<ul className="ml-md pl-md py-xs border-l border-transparent">
 									{stepArtifacts.map((artifact) => {
-										const IconComponent = isUrlArtifact(artifact)
-											? ExternalLink
+										const IconComponent = isLinkArtifact(artifact)
+											? LINK_ARTIFACT_CONFIG.icon
 											: (artifactIconMap[artifact.type] ?? File);
 										const artifactName = getArtifactName(artifact);
 										const artifactTarget = getArtifactTarget(artifact);
-										const copyLabel = isUrlArtifact(artifact)
+										const copyLabel = isLinkArtifact(artifact)
 											? "Copy URL"
 											: "Copy path";
 										return (

--- a/cli/web-ui/src/components/v2/index.ts
+++ b/cli/web-ui/src/components/v2/index.ts
@@ -65,6 +65,7 @@ export {
 	NAV_HINTS_NO_BACK,
 	VIEWER_HINTS,
 } from "./KeyHints";
+export { LinkSidebar, type LinkSidebarProps } from "./LinkSidebar";
 export {
 	MobileTabBar,
 	type MobileTabBarProps,

--- a/cli/web-ui/src/lib/link-artifacts.ts
+++ b/cli/web-ui/src/lib/link-artifacts.ts
@@ -208,13 +208,12 @@ export function orderArtifactsWithLinksLast(
 	return [...fileArtifacts, ...linkArtifacts];
 }
 
-function readHostModeFromLocation(): ArcadeHostMode {
-	if (typeof window === "undefined") return "browser";
+function readHostModeFromLocation(): ArcadeHostMode | null {
+	if (typeof window === "undefined") return null;
 	const params = new URLSearchParams(window.location.search);
-	return params.get("hostMode") === "native" ||
-		params.get("host-mode") === "native"
-		? "native"
-		: "browser";
+	const hostMode = params.get("hostMode") ?? params.get("host-mode");
+	if (hostMode === "native" || hostMode === "browser") return hostMode;
+	return null;
 }
 
 function resolveNativeBridge(
@@ -232,20 +231,18 @@ export function openExternalUrl(
 	if (typeof window === "undefined") return;
 
 	const hostMode = options.hostMode ?? readHostModeFromLocation();
-	if (hostMode === "native") {
-		const bridge = resolveNativeBridge(options);
-		if (bridge) {
-			try {
-				bridge.postMessage(
-					JSON.stringify({
-						type: "message",
-						id: NATIVE_OPEN_EXTERNAL_MESSAGE,
-						payload: { url },
-					}),
-				);
-				return;
-			} catch {}
-		}
+	const bridge = resolveNativeBridge(options);
+	if (bridge && (hostMode === "native" || hostMode === null)) {
+		try {
+			bridge.postMessage(
+				JSON.stringify({
+					type: "message",
+					id: NATIVE_OPEN_EXTERNAL_MESSAGE,
+					payload: { url },
+				}),
+			);
+			return;
+		} catch {}
 	}
 
 	const openWindow = options.openWindow ?? window.open.bind(window);

--- a/cli/web-ui/src/lib/link-artifacts.ts
+++ b/cli/web-ui/src/lib/link-artifacts.ts
@@ -1,0 +1,260 @@
+import { Link as LinkArtifactIcon, type LucideIcon } from "lucide-react";
+import type { Artifact } from "@/types/runs";
+import type { ArcadeHostMode } from "@/types/runtime";
+
+export const NATIVE_OPEN_EXTERNAL_MESSAGE = "rp1:open-external-url";
+
+export interface LinkArtifactConfig {
+	readonly icon: LucideIcon;
+	readonly label: string;
+}
+
+export interface ArtifactPartition {
+	readonly fileArtifacts: readonly Artifact[];
+	readonly linkArtifacts: readonly Artifact[];
+}
+
+interface NativeOpenExternalBridge {
+	readonly postMessage: (message: string) => void;
+}
+
+export interface OpenExternalUrlOptions {
+	readonly hostMode?: ArcadeHostMode;
+	readonly nativeBridge?: NativeOpenExternalBridge | null;
+	readonly openWindow?: Window["open"];
+}
+
+declare global {
+	interface Window {
+		readonly __electrobunBunBridge__?: NativeOpenExternalBridge;
+		readonly __electrobunBunBridge?: NativeOpenExternalBridge;
+	}
+}
+
+const RELATIONSHIP_LABELS: Readonly<Record<string, string>> = {
+	reviewed_pr: "Reviewed PR",
+	pull_request: "Pull request",
+	pr: "PR",
+	source: "Source",
+	reference: "Reference",
+	related: "Related link",
+};
+
+const OPAQUE_ID_PATTERN =
+	/^(?:[0-9]+|[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12})$/i;
+
+export const LINK_ARTIFACT_CONFIG: LinkArtifactConfig = {
+	icon: LinkArtifactIcon,
+	label: "Link",
+};
+
+export function isLinkArtifact(artifact: Artifact | null | undefined): boolean {
+	return artifact?.locationKind === "url";
+}
+
+export function getLinkArtifactTarget(artifact: Artifact): string {
+	return (artifact.url?.trim() || artifact.path.trim()) ?? artifact.path;
+}
+
+function titleCaseRelationship(value: string): string {
+	return value
+		.split(/[_\-\s]+/)
+		.filter(Boolean)
+		.map((part) => (part.toLowerCase() === "pr" ? "PR" : titleCase(part)))
+		.join(" ");
+}
+
+function titleCase(value: string): string {
+	return value.length === 0
+		? value
+		: `${value[0]?.toUpperCase() ?? ""}${value.slice(1).toLowerCase()}`;
+}
+
+function relationshipLabel(
+	relationship: string | null | undefined,
+): string | null {
+	const normalized = relationship?.trim();
+	if (!normalized) return null;
+	return RELATIONSHIP_LABELS[normalized] ?? titleCaseRelationship(normalized);
+}
+
+function parseUrl(target: string): URL | null {
+	try {
+		return new URL(target);
+	} catch {
+		return null;
+	}
+}
+
+function githubLabel(parsed: URL): string | null {
+	if (!/(^|\.)github\.com$/i.test(parsed.hostname)) {
+		return null;
+	}
+
+	const parts = parsed.pathname.split("/").filter(Boolean);
+	const pullIndex = parts.indexOf("pull");
+	if (pullIndex >= 0) {
+		const number = parts[pullIndex + 1];
+		if (number && /^[0-9]+$/.test(number)) {
+			return `GitHub PR #${number}`;
+		}
+	}
+
+	const issueIndex = parts.indexOf("issues");
+	if (issueIndex >= 0) {
+		const number = parts[issueIndex + 1];
+		if (number && /^[0-9]+$/.test(number)) {
+			return `GitHub issue #${number}`;
+		}
+	}
+
+	return null;
+}
+
+function pullRequestNumber(target: string): string | null {
+	const parsed = parseUrl(target);
+	if (!parsed) return null;
+	const parts = parsed.pathname.split("/").filter(Boolean);
+	const pullIndex = parts.indexOf("pull");
+	if (pullIndex < 0) return null;
+	const number = parts[pullIndex + 1];
+	return number && /^[0-9]+$/.test(number) ? number : null;
+}
+
+function urlFallbackLabel(target: string): string {
+	const parsed = parseUrl(target);
+	if (!parsed) return "External link";
+
+	const gitHubLabel = githubLabel(parsed);
+	if (gitHubLabel) return gitHubLabel;
+
+	const host = parsed.hostname.replace(/^www\./, "");
+	const finalSegment = parsed.pathname
+		.split("/")
+		.filter(Boolean)
+		.at(-1)
+		?.trim();
+
+	if (finalSegment && !OPAQUE_ID_PATTERN.test(finalSegment)) {
+		return `${host}: ${decodeURIComponent(finalSegment).replace(/[-_]+/g, " ")}`;
+	}
+
+	return `${host} link`;
+}
+
+function isMeaningfulLabel(
+	label: string | null | undefined,
+	artifact: Artifact,
+	target: string,
+): label is string {
+	const trimmed = label?.trim();
+	if (!trimmed) return false;
+	if (
+		trimmed === target ||
+		trimmed === artifact.path ||
+		trimmed === artifact.url
+	) {
+		return false;
+	}
+	if (trimmed === artifact.docId || OPAQUE_ID_PATTERN.test(trimmed)) {
+		return false;
+	}
+	return true;
+}
+
+export function getLinkArtifactLabel(artifact: Artifact): string {
+	const target = getLinkArtifactTarget(artifact);
+	if (isMeaningfulLabel(artifact.label, artifact, target)) {
+		return artifact.label.trim();
+	}
+
+	const relatedLabel = relationshipLabel(artifact.relationship);
+	if (relatedLabel) {
+		const prNumber = pullRequestNumber(target);
+		return prNumber && /\b(?:pr|pull request)\b/i.test(relatedLabel)
+			? `${relatedLabel} #${prNumber}`
+			: relatedLabel;
+	}
+
+	return urlFallbackLabel(target);
+}
+
+export function getLinkArtifactContext(artifact: Artifact): string {
+	return getLinkArtifactTarget(artifact);
+}
+
+export function partitionArtifactsByLinkKind(
+	artifacts: readonly Artifact[],
+): ArtifactPartition {
+	const fileArtifacts: Artifact[] = [];
+	const linkArtifacts: Artifact[] = [];
+
+	for (const artifact of artifacts) {
+		if (isLinkArtifact(artifact)) {
+			linkArtifacts.push(artifact);
+		} else {
+			fileArtifacts.push(artifact);
+		}
+	}
+
+	return { fileArtifacts, linkArtifacts };
+}
+
+export function orderArtifactsWithLinksLast(
+	artifacts: readonly Artifact[],
+): readonly Artifact[] {
+	const { fileArtifacts, linkArtifacts } =
+		partitionArtifactsByLinkKind(artifacts);
+	return [...fileArtifacts, ...linkArtifacts];
+}
+
+function readHostModeFromLocation(): ArcadeHostMode {
+	if (typeof window === "undefined") return "browser";
+	const params = new URLSearchParams(window.location.search);
+	return params.get("hostMode") === "native" ||
+		params.get("host-mode") === "native"
+		? "native"
+		: "browser";
+}
+
+function resolveNativeBridge(
+	options: OpenExternalUrlOptions,
+): NativeOpenExternalBridge | null {
+	if (options.nativeBridge !== undefined) return options.nativeBridge;
+	if (typeof window === "undefined") return null;
+	return window.__electrobunBunBridge ?? window.__electrobunBunBridge__ ?? null;
+}
+
+export function openExternalUrl(
+	url: string,
+	options: OpenExternalUrlOptions = {},
+): void {
+	if (typeof window === "undefined") return;
+
+	const hostMode = options.hostMode ?? readHostModeFromLocation();
+	if (hostMode === "native") {
+		const bridge = resolveNativeBridge(options);
+		if (bridge) {
+			try {
+				bridge.postMessage(
+					JSON.stringify({
+						type: "message",
+						id: NATIVE_OPEN_EXTERNAL_MESSAGE,
+						payload: { url },
+					}),
+				);
+				return;
+			} catch {}
+		}
+	}
+
+	const openWindow = options.openWindow ?? window.open.bind(window);
+	openWindow(url, "_blank", "noopener,noreferrer");
+}
+
+export function openLinkArtifact(
+	artifact: Artifact,
+	options?: OpenExternalUrlOptions,
+): void {
+	openExternalUrl(getLinkArtifactTarget(artifact), options);
+}

--- a/cli/web-ui/src/pages/v2/ArtifactViewerPage.tsx
+++ b/cli/web-ui/src/pages/v2/ArtifactViewerPage.tsx
@@ -2,7 +2,6 @@ import {
 	AlertCircle,
 	ArrowLeft,
 	ChevronRight,
-	ExternalLink,
 	List,
 	Loader2,
 	MessageSquare,
@@ -47,6 +46,15 @@ import { useIsMobile } from "@/hooks/useMediaQuery";
 import { useReconnectRecovery } from "@/hooks/useReconnectRecovery";
 import { useRunDetail } from "@/hooks/useRunDetail";
 import { useWorkspaceDescriptor } from "@/hooks/useWorkspaceDescriptor";
+import {
+	getLinkArtifactContext,
+	getLinkArtifactLabel,
+	getLinkArtifactTarget,
+	isLinkArtifact,
+	LINK_ARTIFACT_CONFIG,
+	openLinkArtifact,
+	orderArtifactsWithLinksLast,
+} from "@/lib/link-artifacts";
 import { resolveRunDisplayName } from "@/lib/run-display";
 
 import { AnnotationProvider } from "@/providers/AnnotationProvider";
@@ -61,19 +69,6 @@ interface ArtifactContent {
 	path: string;
 	content: string;
 	docId?: string;
-}
-
-function isUrlArtifact(artifact: Artifact | null): boolean {
-	return artifact?.locationKind === "url";
-}
-
-function getUrlArtifactTarget(artifact: Artifact): string {
-	return artifact.url || artifact.path;
-}
-
-function openUrlArtifact(artifact: Artifact): void {
-	if (typeof window === "undefined") return;
-	window.open(getUrlArtifactTarget(artifact), "_blank", "noopener,noreferrer");
 }
 
 function isSameArtifactContent(
@@ -239,22 +234,28 @@ export function ArtifactViewerPage() {
 		);
 	}, [run, selectedArtifactPath]);
 	const selectedUrlArtifact =
-		selectedArtifact && isUrlArtifact(selectedArtifact)
+		selectedArtifact && isLinkArtifact(selectedArtifact)
 			? selectedArtifact
 			: null;
 	const selectedFileArtifact = selectedUrlArtifact ? null : selectedArtifact;
 	const selectedFileArtifactPath = selectedFileArtifact?.path ?? "";
+	const orderedArtifacts = useMemo(
+		() => (run ? orderArtifactsWithLinksLast(run.artifacts) : []),
+		[run],
+	);
+	const linkArtifacts = useMemo(
+		() => orderedArtifacts.filter(isLinkArtifact),
+		[orderedArtifacts],
+	);
+	const selectedArtifactName = selectedArtifact
+		? isLinkArtifact(selectedArtifact)
+			? getLinkArtifactLabel(selectedArtifact)
+			: (selectedArtifact.path.split("/").at(-1) ?? selectedArtifact.path)
+		: null;
 	const workspaceSubtitle = useMemo(() => {
 		if (!run) return null;
-		const artifactName = selectedArtifact
-			? isUrlArtifact(selectedArtifact)
-				? (selectedArtifact.label ??
-					selectedArtifact.url ??
-					selectedArtifact.path)
-				: (selectedArtifact.path.split("/").at(-1) ?? null)
-			: null;
-		return artifactName ?? run.projectName;
-	}, [run, selectedArtifact]);
+		return selectedArtifactName ?? run.projectName;
+	}, [run, selectedArtifactName]);
 
 	useEffect(() => {
 		if (run?.projectName && run?.projectId) {
@@ -286,7 +287,7 @@ export function ArtifactViewerPage() {
 	}, [run, setRunInfo]);
 
 	useEffect(() => {
-		if (selectedArtifact && !isUrlArtifact(selectedArtifact) && runId) {
+		if (selectedArtifact && !isLinkArtifact(selectedArtifact) && runId) {
 			setActiveArtifact(runId, selectedArtifact.path);
 		} else {
 			setActiveArtifact(runId ?? "", null);
@@ -349,8 +350,8 @@ export function ArtifactViewerPage() {
 
 	const handleArtifactSelect = useCallback(
 		(artifact: Artifact) => {
-			if (isUrlArtifact(artifact)) {
-				openUrlArtifact(artifact);
+			if (isLinkArtifact(artifact)) {
+				openLinkArtifact(artifact);
 				if (isMobile) {
 					setSidebarDrawerOpen(false);
 				}
@@ -424,7 +425,7 @@ export function ArtifactViewerPage() {
 				setArtifactContent(null);
 				return;
 			}
-			if (isUrlArtifact(selectedArtifact)) {
+			if (isLinkArtifact(selectedArtifact)) {
 				savedScrollState.current = null;
 				setContentLoading(false);
 				setContentError(null);
@@ -531,7 +532,7 @@ export function ArtifactViewerPage() {
 	}, [artifactContent]);
 
 	useEffect(() => {
-		if (!selectedArtifact || isUrlArtifact(selectedArtifact)) return;
+		if (!selectedArtifact || isLinkArtifact(selectedArtifact)) return;
 
 		const normalizedPath = selectedArtifact.path.replace(/^\.rp1\//, "");
 
@@ -756,6 +757,43 @@ export function ArtifactViewerPage() {
 		);
 	}
 
+	const LinkIcon = LINK_ARTIFACT_CONFIG.icon;
+	const externalLinksFooter =
+		linkArtifacts.length > 0 && !selectedUrlArtifact ? (
+			<section
+				className="mt-8 border-t border-border pt-4"
+				aria-label="External links"
+			>
+				<h2 className="mb-2 text-sm font-medium text-muted-foreground">
+					External links
+				</h2>
+				<ul className="space-y-2">
+					{linkArtifacts.map((artifact) => (
+						<li key={artifact.docId} className="min-w-0">
+							<button
+								type="button"
+								onClick={() => openLinkArtifact(artifact)}
+								className="group flex max-w-full items-start gap-2 text-left"
+							>
+								<LinkIcon
+									className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground transition-colors group-hover:text-foreground"
+									aria-hidden="true"
+								/>
+								<span className="min-w-0">
+									<span className="block truncate text-sm font-medium text-foreground">
+										{getLinkArtifactLabel(artifact)}
+									</span>
+									<span className="block truncate text-xs text-muted-foreground">
+										{getLinkArtifactContext(artifact)}
+									</span>
+								</span>
+							</button>
+						</li>
+					))}
+				</ul>
+			</section>
+		) : null;
+
 	const contentArea = (
 		<>
 			{contentLoading ? (
@@ -766,24 +804,21 @@ export function ArtifactViewerPage() {
 			) : selectedUrlArtifact ? (
 				<div className="flex h-64 flex-col items-center justify-center gap-3 text-center">
 					<h2 className="text-base font-medium text-foreground">
-						{selectedUrlArtifact.label ??
-							selectedUrlArtifact.url ??
-							selectedUrlArtifact.path}
+						{getLinkArtifactLabel(selectedUrlArtifact)}
 					</h2>
-					<a
-						href={getUrlArtifactTarget(selectedUrlArtifact)}
-						target="_blank"
-						rel="noreferrer"
+					<button
+						type="button"
+						onClick={() => openLinkArtifact(selectedUrlArtifact)}
 						className="max-w-full truncate text-sm text-primary underline-offset-4 hover:underline"
 					>
-						{getUrlArtifactTarget(selectedUrlArtifact)}
-					</a>
+						{getLinkArtifactTarget(selectedUrlArtifact)}
+					</button>
 					<Button
 						variant="outline"
 						size="sm"
-						onClick={() => openUrlArtifact(selectedUrlArtifact)}
+						onClick={() => openLinkArtifact(selectedUrlArtifact)}
 					>
-						<ExternalLink className="mr-2 h-4 w-4" aria-hidden="true" />
+						<LinkIcon className="mr-2 h-4 w-4" aria-hidden="true" />
 						Open link
 					</Button>
 				</div>
@@ -855,9 +890,7 @@ export function ArtifactViewerPage() {
 						)}
 						<li aria-current="page">
 							<span className="text-foreground truncate max-w-[100px]">
-								{selectedArtifactPath
-									? selectedArtifactPath.split("/").pop()
-									: "Artifacts"}
+								{selectedArtifactName ?? "Artifacts"}
 							</span>
 						</li>
 					</ol>
@@ -925,12 +958,13 @@ export function ArtifactViewerPage() {
 							className="p-4"
 							onScroll={handleScroll as unknown as React.UIEventHandler}
 							aria-label={
-								selectedArtifactPath
-									? `Content of ${selectedArtifactPath.split("/").pop()}`
+								selectedArtifactName
+									? `Content of ${selectedArtifactName}`
 									: "Artifact content"
 							}
 						>
 							{contentArea}
+							{externalLinksFooter}
 						</article>
 					</ScrollArea>
 
@@ -945,7 +979,7 @@ export function ArtifactViewerPage() {
 				>
 					<ScrollArea className="h-full">
 						<ArtifactSidebar
-							artifacts={run.artifacts}
+							artifacts={orderedArtifacts}
 							selectedPath={selectedArtifactPath}
 							onSelect={handleArtifactSelect}
 						/>
@@ -1041,7 +1075,8 @@ export function ArtifactViewerPage() {
 							</li>
 							<li aria-current="page">
 								<span className="text-foreground truncate max-w-[200px]">
-									{selectedArtifactPath.split("/").pop()}
+									{selectedArtifactName ??
+										selectedArtifactPath.split("/").pop()}
 								</span>
 							</li>
 						</>
@@ -1064,7 +1099,7 @@ export function ArtifactViewerPage() {
 					<aside aria-label="Artifact list" className="h-full">
 						<ScrollArea className="h-full">
 							<ArtifactSidebar
-								artifacts={run.artifacts}
+								artifacts={orderedArtifacts}
 								selectedPath={selectedArtifactPath}
 								onSelect={handleArtifactSelect}
 							/>
@@ -1121,12 +1156,13 @@ export function ArtifactViewerPage() {
 								className="p-6 min-w-0 max-w-full"
 								onScroll={handleScroll as unknown as React.UIEventHandler}
 								aria-label={
-									selectedArtifactPath
-										? `Content of ${selectedArtifactPath.split("/").pop()}`
+									selectedArtifactName
+										? `Content of ${selectedArtifactName}`
 										: "Artifact content"
 								}
 							>
 								{contentArea}
+								{externalLinksFooter}
 							</article>
 						</ScrollArea>
 

--- a/cli/web-ui/src/pages/v2/ArtifactViewerPage.tsx
+++ b/cli/web-ui/src/pages/v2/ArtifactViewerPage.tsx
@@ -212,6 +212,7 @@ export function ArtifactViewerPage() {
 		scrollTop: number;
 		scrollHeight: number;
 	} | null>(null);
+	const latestContentRequestIdRef = useRef(0);
 
 	const {
 		followMode,
@@ -405,13 +406,20 @@ export function ArtifactViewerPage() {
 
 	const fetchArtifactContentWithScrollPreservation = useCallback(
 		async (preserveScroll: boolean) => {
+			const requestId = latestContentRequestIdRef.current + 1;
+			latestContentRequestIdRef.current = requestId;
+			const isLatestContentRequest = () =>
+				latestContentRequestIdRef.current === requestId;
+
 			if (!run || !selectedArtifactPath) {
 				savedScrollState.current = null;
+				setContentLoading(false);
 				setArtifactContent(null);
 				return;
 			}
 			if (!selectedArtifact) {
 				savedScrollState.current = null;
+				setContentLoading(false);
 				setContentError("Artifact not found");
 				setArtifactContent(null);
 				return;
@@ -446,6 +454,9 @@ export function ArtifactViewerPage() {
 				const response = await fetch(
 					`/api/v2/runs/${runId}/artifacts/${encodeURIComponent(selectedArtifact.path)}`,
 				);
+				if (!isLatestContentRequest()) {
+					return;
+				}
 				if (!response.ok) {
 					let errorMessage = `Failed to fetch artifact: ${response.statusText}`;
 					try {
@@ -461,6 +472,9 @@ export function ArtifactViewerPage() {
 					throw new Error(errorMessage);
 				}
 				const data = (await response.json()) as { content: string };
+				if (!isLatestContentRequest()) {
+					return;
+				}
 				const nextContent = {
 					path: selectedArtifact.path,
 					content: data.content,
@@ -477,11 +491,14 @@ export function ArtifactViewerPage() {
 					return nextContent;
 				});
 			} catch (err) {
+				if (!isLatestContentRequest()) {
+					return;
+				}
 				savedScrollState.current = null;
 				setContentError(err instanceof Error ? err.message : String(err));
 				setArtifactContent(null);
 			} finally {
-				if (!preserveScroll) {
+				if (isLatestContentRequest()) {
 					setContentLoading(false);
 				}
 			}

--- a/cli/web-ui/src/pages/v2/ArtifactViewerPage.tsx
+++ b/cli/web-ui/src/pages/v2/ArtifactViewerPage.tsx
@@ -34,6 +34,7 @@ import { AnnotationSidebar } from "@/components/v2/AnnotationSidebar";
 import { ArtifactSidebar } from "@/components/v2/ArtifactSidebar";
 import { FollowModeToggle } from "@/components/v2/FollowModeToggle";
 import { KeyHints, VIEWER_HINTS } from "@/components/v2/KeyHints";
+import { LinkSidebar } from "@/components/v2/LinkSidebar";
 import { NewUpdatesChip } from "@/components/v2/NewUpdatesChip";
 import { TableOfContents } from "@/components/v2/TableOfContents";
 import { UnifiedContentRenderer } from "@/components/v2/UnifiedContentRenderer";
@@ -47,7 +48,6 @@ import { useReconnectRecovery } from "@/hooks/useReconnectRecovery";
 import { useRunDetail } from "@/hooks/useRunDetail";
 import { useWorkspaceDescriptor } from "@/hooks/useWorkspaceDescriptor";
 import {
-	getLinkArtifactContext,
 	getLinkArtifactLabel,
 	getLinkArtifactTarget,
 	isLinkArtifact,
@@ -163,6 +163,46 @@ function MobileAnnotationButton({
 	);
 }
 
+function LinksToggleButton({
+	count,
+	isOpen,
+	onClick,
+	ariaLabel,
+}: {
+	count: number;
+	isOpen?: boolean;
+	onClick: () => void;
+	ariaLabel: string;
+}) {
+	const LinkIcon = LINK_ARTIFACT_CONFIG.icon;
+
+	return (
+		<TooltipProvider>
+			<Tooltip>
+				<TooltipTrigger asChild>
+					<Button
+						variant="ghost"
+						size="icon"
+						className="h-8 w-8 relative"
+						onClick={onClick}
+						aria-label={ariaLabel}
+						aria-expanded={isOpen}
+						aria-pressed={isOpen}
+					>
+						<LinkIcon className="h-4 w-4" aria-hidden="true" />
+						<span className="absolute -right-1 -top-1 flex h-4 min-w-[1rem] items-center justify-center rounded-full bg-primary px-1 text-[10px] font-medium text-primary-foreground">
+							{count > 99 ? "99+" : count}
+						</span>
+					</Button>
+				</TooltipTrigger>
+				<TooltipContent>
+					<p>Links ({count})</p>
+				</TooltipContent>
+			</Tooltip>
+		</TooltipProvider>
+	);
+}
+
 export function ArtifactViewerPage() {
 	const { runId, "*": artifactPathParam } = useParams();
 	const navigate = useNavigate();
@@ -194,9 +234,11 @@ export function ArtifactViewerPage() {
 			return stored !== "true";
 		},
 	);
+	const [linksPanelOpen, setLinksPanelOpen] = useState(false);
 	const [sidebarDrawerOpen, setSidebarDrawerOpen] = useState(false);
 	const [tocDrawerOpen, setTocDrawerOpen] = useState(false);
 	const [annotationDrawerOpen, setAnnotationDrawerOpen] = useState(false);
+	const [linksDrawerOpen, setLinksDrawerOpen] = useState(false);
 	const [liveAnnouncement, setLiveAnnouncement] = useState<string>("");
 
 	const scrollViewportRef = useRef<HTMLDivElement>(null);
@@ -299,6 +341,7 @@ export function ArtifactViewerPage() {
 		setAnnotationSidebarOpen(false);
 		setAnnotationDrawerOpen(false);
 		setTocDrawerOpen(false);
+		setLinksDrawerOpen(false);
 		setHeadings([]);
 		setActiveHeadingId(null);
 	}, [selectedUrlArtifact]);
@@ -314,6 +357,7 @@ export function ArtifactViewerPage() {
 			const newValue = !prev;
 			if (!newValue) {
 				setAnnotationSidebarOpen(false);
+				setLinksPanelOpen(false);
 				if (typeof window !== "undefined") {
 					sessionStorage.setItem(STORAGE_KEY_ANNOTATIONS_COLLAPSED, "true");
 				}
@@ -329,6 +373,7 @@ export function ArtifactViewerPage() {
 		setAnnotationSidebarOpen(open);
 		if (open) {
 			setTocCollapsed(true);
+			setLinksPanelOpen(false);
 			if (typeof window !== "undefined") {
 				sessionStorage.setItem(STORAGE_KEY_TOC_COLLAPSED, "true");
 			}
@@ -337,6 +382,34 @@ export function ArtifactViewerPage() {
 			sessionStorage.setItem(STORAGE_KEY_ANNOTATIONS_COLLAPSED, String(!open));
 		}
 	}, []);
+
+	const handleToggleLinksPanel = useCallback((open: boolean) => {
+		setLinksPanelOpen(open);
+		if (open) {
+			setTocCollapsed(true);
+			setAnnotationSidebarOpen(false);
+			if (typeof window !== "undefined") {
+				sessionStorage.setItem(STORAGE_KEY_TOC_COLLAPSED, "true");
+				sessionStorage.setItem(STORAGE_KEY_ANNOTATIONS_COLLAPSED, "true");
+			}
+		}
+	}, []);
+
+	const handleOpenLinksDrawer = useCallback(() => {
+		setLinksDrawerOpen(true);
+		setTocDrawerOpen(false);
+		setAnnotationDrawerOpen(false);
+	}, []);
+
+	const handleOpenPanelLink = useCallback(
+		(artifact: Artifact) => {
+			openLinkArtifact(artifact);
+			if (isMobile) {
+				setLinksDrawerOpen(false);
+			}
+		},
+		[isMobile],
+	);
 
 	const handleToggleFrontmatter = useCallback(() => {
 		setShowFrontmatter((prev) => {
@@ -758,41 +831,6 @@ export function ArtifactViewerPage() {
 	}
 
 	const LinkIcon = LINK_ARTIFACT_CONFIG.icon;
-	const externalLinksFooter =
-		linkArtifacts.length > 0 && !selectedUrlArtifact ? (
-			<section
-				className="mt-8 border-t border-border pt-4"
-				aria-label="External links"
-			>
-				<h2 className="mb-2 text-sm font-medium text-muted-foreground">
-					External links
-				</h2>
-				<ul className="space-y-2">
-					{linkArtifacts.map((artifact) => (
-						<li key={artifact.docId} className="min-w-0">
-							<button
-								type="button"
-								onClick={() => openLinkArtifact(artifact)}
-								className="group flex max-w-full items-start gap-2 text-left"
-							>
-								<LinkIcon
-									className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground transition-colors group-hover:text-foreground"
-									aria-hidden="true"
-								/>
-								<span className="min-w-0">
-									<span className="block truncate text-sm font-medium text-foreground">
-										{getLinkArtifactLabel(artifact)}
-									</span>
-									<span className="block truncate text-xs text-muted-foreground">
-										{getLinkArtifactContext(artifact)}
-									</span>
-								</span>
-							</button>
-						</li>
-					))}
-				</ul>
-			</section>
-		) : null;
 
 	const contentArea = (
 		<>
@@ -932,6 +970,13 @@ export function ArtifactViewerPage() {
 									onClick={() => setAnnotationDrawerOpen(true)}
 								/>
 							)}
+							{linkArtifacts.length > 0 && (
+								<LinksToggleButton
+									count={linkArtifacts.length}
+									onClick={handleOpenLinksDrawer}
+									ariaLabel="Open links"
+								/>
+							)}
 							<TooltipProvider>
 								<Tooltip>
 									<TooltipTrigger asChild>
@@ -964,7 +1009,6 @@ export function ArtifactViewerPage() {
 							}
 						>
 							{contentArea}
-							{externalLinksFooter}
 						</article>
 					</ScrollArea>
 
@@ -1009,6 +1053,22 @@ export function ArtifactViewerPage() {
 						<AnnotationSidebar
 							artifactPath={selectedFileArtifactPath}
 							onClose={() => setAnnotationDrawerOpen(false)}
+							className="border-l-0 w-full"
+						/>
+					</Drawer>
+				)}
+
+				{linkArtifacts.length > 0 && (
+					<Drawer
+						open={linksDrawerOpen}
+						onClose={() => setLinksDrawerOpen(false)}
+						side="right"
+						title="Links"
+					>
+						<LinkSidebar
+							artifacts={linkArtifacts}
+							onOpenLink={handleOpenPanelLink}
+							onClose={() => setLinksDrawerOpen(false)}
 							className="border-l-0 w-full"
 						/>
 					</Drawer>
@@ -1140,6 +1200,16 @@ export function ArtifactViewerPage() {
 									</Tooltip>
 								</TooltipProvider>
 							)}
+							{linkArtifacts.length > 0 && (
+								<LinksToggleButton
+									count={linkArtifacts.length}
+									isOpen={linksPanelOpen}
+									onClick={() => handleToggleLinksPanel(!linksPanelOpen)}
+									ariaLabel={
+										linksPanelOpen ? "Close links panel" : "Open links panel"
+									}
+								/>
+							)}
 							{selectedFileArtifact && !annotationSidebarOpen && (
 								<AnnotationToggleButton
 									selectedArtifactPath={selectedFileArtifactPath}
@@ -1162,7 +1232,6 @@ export function ArtifactViewerPage() {
 								}
 							>
 								{contentArea}
-								{externalLinksFooter}
 							</article>
 						</ScrollArea>
 
@@ -1205,6 +1274,26 @@ export function ArtifactViewerPage() {
 							<AnnotationSidebar
 								artifactPath={selectedFileArtifactPath}
 								onClose={() => handleToggleAnnotationSidebar(false)}
+								className="h-full"
+							/>
+						</ResizablePanel>
+					</>
+				)}
+
+				{linkArtifacts.length > 0 && linksPanelOpen && (
+					<>
+						<ResizableHandle withHandle aria-label="Resize links panel" />
+						<ResizablePanel
+							defaultSize={15}
+							minSize={12}
+							maxSize={25}
+							collapsible
+							className="bg-card"
+						>
+							<LinkSidebar
+								artifacts={linkArtifacts}
+								onOpenLink={handleOpenPanelLink}
+								onClose={() => handleToggleLinksPanel(false)}
 								className="h-full"
 							/>
 						</ResizablePanel>

--- a/native-app/src/__tests__/launch-state.test.ts
+++ b/native-app/src/__tests__/launch-state.test.ts
@@ -22,6 +22,7 @@ interface CapturedWindow {
 	readonly loadedUrls: string[];
 	readonly navigationRules: string[][];
 	readonly webviewHandlers: Record<string, Array<(event: unknown) => void>>;
+	readonly rpc?: unknown;
 	title: string;
 }
 
@@ -39,7 +40,11 @@ class MockBrowserWindow {
 
 	readonly captured: CapturedWindow;
 
-	constructor(options: { readonly title: string; readonly html?: string }) {
+	constructor(options: {
+		readonly title: string;
+		readonly html?: string;
+		readonly rpc?: unknown;
+	}) {
 		this.captured = {
 			initialHtml: options.html,
 			executedScripts: [],
@@ -47,6 +52,7 @@ class MockBrowserWindow {
 			loadedUrls: [],
 			navigationRules: [],
 			webviewHandlers: {},
+			rpc: options.rpc,
 			title: options.title,
 		};
 		capturedWindows.push(this.captured);
@@ -88,12 +94,20 @@ const launchArcadeMock = mock(async () => ({
 const setApplicationMenuMock = mock((menu: unknown) => {
 	capturedApplicationMenus.push(menu);
 });
+const defineRPCMock = mock((config: unknown) => config);
+const openExternalMock = mock((_url: string) => true);
 
 mock.module("electrobun/bun", () => ({
 	ApplicationMenu: {
 		setApplicationMenu: setApplicationMenuMock,
 	},
+	BrowserView: {
+		defineRPC: defineRPCMock,
+	},
 	BrowserWindow: MockBrowserWindow,
+	Utils: {
+		openExternal: openExternalMock,
+	},
 }));
 
 mock.module("../../../cli/web-ui/src/daemon/executable.js", () => ({
@@ -177,6 +191,8 @@ describe("native launch state", () => {
 		resolveDaemonExecutablePathMock.mockClear();
 		launchArcadeMock.mockClear();
 		setApplicationMenuMock.mockClear();
+		defineRPCMock.mockClear();
+		openExternalMock.mockClear();
 		resolveDaemonExecutablePathMock.mockImplementation(() => "/tmp/rp1");
 		launchArcadeMock.mockImplementation(async () => ({
 			kind: "project-list" as const,
@@ -296,6 +312,27 @@ describe("native launch state", () => {
 		});
 	});
 
+	test("opens link artifact URLs through the default browser bridge", async () => {
+		const window = await runNativeEntrypoint();
+		const rpcConfig = window.rpc as {
+			readonly handlers: {
+				readonly messages: Record<string, (payload: unknown) => void>;
+			};
+		};
+		const openExternal = rpcConfig.handlers.messages["rp1:open-external-url"];
+
+		expect(defineRPCMock).toHaveBeenCalledTimes(1);
+		expect(openExternal).toBeDefined();
+
+		openExternal?.({ url: "https://github.com/example/repo/pull/376" });
+		openExternal?.({ url: "javascript:alert(1)" });
+
+		expect(openExternalMock).toHaveBeenCalledTimes(1);
+		expect(openExternalMock).toHaveBeenCalledWith(
+			"https://github.com/example/repo/pull/376",
+		);
+	});
+
 	test("pins the visible title across webview navigations", async () => {
 		const window = await runNativeEntrypoint();
 		const domReadyHandlers = window.webviewHandlers["dom-ready"] ?? [];
@@ -357,7 +394,9 @@ describe("native launch state", () => {
 		});
 
 		const window = await runNativeEntrypoint();
-		const failureState = parseLaunchViewHtmlState(window.loadedHtml.at(-1) ?? "");
+		const failureState = parseLaunchViewHtmlState(
+			window.loadedHtml.at(-1) ?? "",
+		);
 
 		expect(failureState.status).toBe("failure");
 		expect(failureState.title).toBe("RP1 executable not found");
@@ -375,7 +414,9 @@ describe("native launch state", () => {
 		});
 
 		const window = await runNativeEntrypoint(["--project", "/tmp/not-rp1"]);
-		const failureState = parseLaunchViewHtmlState(window.loadedHtml.at(-1) ?? "");
+		const failureState = parseLaunchViewHtmlState(
+			window.loadedHtml.at(-1) ?? "",
+		);
 
 		expect(failureState.status).toBe("failure");
 		expect(failureState.title).toBe("Project cannot be opened");
@@ -392,7 +433,9 @@ describe("native launch state", () => {
 		});
 
 		const window = await runNativeEntrypoint(["--project", "/tmp/project"]);
-		const failureState = parseLaunchViewHtmlState(window.loadedHtml.at(-1) ?? "");
+		const failureState = parseLaunchViewHtmlState(
+			window.loadedHtml.at(-1) ?? "",
+		);
 
 		expect(failureState.status).toBe("failure");
 		expect(failureState.title).toBe("Arcade port is unavailable");
@@ -405,7 +448,9 @@ describe("native launch state", () => {
 		});
 
 		const window = await runNativeEntrypoint(["--project", "/tmp/project"]);
-		const failureState = parseLaunchViewHtmlState(window.loadedHtml.at(-1) ?? "");
+		const failureState = parseLaunchViewHtmlState(
+			window.loadedHtml.at(-1) ?? "",
+		);
 
 		expect(failureState.status).toBe("failure");
 		expect(failureState.title).toBe("Arcade launch failed");
@@ -422,7 +467,9 @@ describe("native launch state", () => {
 		});
 
 		const window = await runNativeEntrypoint(["--project", "/tmp/project"]);
-		const failureState = parseLaunchViewHtmlState(window.loadedHtml.at(-1) ?? "");
+		const failureState = parseLaunchViewHtmlState(
+			window.loadedHtml.at(-1) ?? "",
+		);
 
 		expect(failureState.status).toBe("failure");
 		expect(failureState.message).toBe(

--- a/native-app/src/__tests__/launch-state.test.ts
+++ b/native-app/src/__tests__/launch-state.test.ts
@@ -320,12 +320,39 @@ describe("native launch state", () => {
 			};
 		};
 		const openExternal = rpcConfig.handlers.messages["rp1:open-external-url"];
+		const dispatchBridgeMessage = (message: unknown) => {
+			if (
+				typeof message !== "object" ||
+				message === null ||
+				!("type" in message) ||
+				!("id" in message)
+			) {
+				return;
+			}
+			const packet = message as {
+				readonly type?: unknown;
+				readonly id?: unknown;
+				readonly payload?: unknown;
+			};
+			if (packet.type !== "message" || typeof packet.id !== "string") {
+				return;
+			}
+			rpcConfig.handlers.messages[packet.id]?.(packet.payload);
+		};
 
 		expect(defineRPCMock).toHaveBeenCalledTimes(1);
 		expect(openExternal).toBeDefined();
 
-		openExternal?.({ url: "https://github.com/example/repo/pull/376" });
-		openExternal?.({ url: "javascript:alert(1)" });
+		dispatchBridgeMessage({
+			type: "message",
+			id: "rp1:open-external-url",
+			payload: { url: "https://github.com/example/repo/pull/376" },
+		});
+		dispatchBridgeMessage({
+			type: "message",
+			id: "rp1:open-external-url",
+			payload: { url: "javascript:alert(1)" },
+		});
 
 		expect(openExternalMock).toHaveBeenCalledTimes(1);
 		expect(openExternalMock).toHaveBeenCalledWith(

--- a/native-app/src/bun/index.ts
+++ b/native-app/src/bun/index.ts
@@ -2,8 +2,10 @@ import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import {
 	ApplicationMenu,
-	BrowserWindow,
 	type ApplicationMenuItemConfig,
+	BrowserView,
+	BrowserWindow,
+	Utils,
 } from "electrobun/bun";
 import cliPackage from "../../../cli/package.json";
 import { type CLIError, formatError } from "../../../cli/shared/errors.js";
@@ -45,6 +47,21 @@ interface LaunchViewState {
 	readonly detail?: string;
 }
 
+type NativeBridgeRpcSchema = {
+	readonly bun: {
+		readonly requests: Record<never, never>;
+		readonly messages: {
+			readonly "rp1:open-external-url": {
+				readonly url?: unknown;
+			};
+		};
+	};
+	readonly webview: {
+		readonly requests: Record<never, never>;
+		readonly messages: Record<never, never>;
+	};
+};
+
 const LAUNCH_VIEW_TEMPLATE = readFileSync(
 	resolve(import.meta.dir, "../views/launch/index.html"),
 	"utf8",
@@ -54,6 +71,7 @@ const APP_NAME = "rp1 Arcade";
 const WINDOW_TITLE = "rp1 Arcade";
 const WEB_DOCUMENT_TITLE = APP_NAME;
 const OPENING_TITLE = `Opening ${APP_NAME}`;
+const NATIVE_OPEN_EXTERNAL_MESSAGE = "rp1:open-external-url";
 const ARCADE_NAVIGATION_RULES = [
 	"^*",
 	"views://launch/*",
@@ -289,6 +307,40 @@ const isLoopbackArcadeUrl = (url: string): boolean => {
 	}
 };
 
+const readExternalUrl = (payload: unknown): string | null => {
+	if (typeof payload !== "object" || payload === null || !("url" in payload)) {
+		return null;
+	}
+
+	const url = (payload as { readonly url?: unknown }).url;
+	if (typeof url !== "string" || url.trim().length === 0) {
+		return null;
+	}
+
+	try {
+		const parsed = new URL(url);
+		return parsed.protocol === "http:" || parsed.protocol === "https:"
+			? parsed.toString()
+			: null;
+	} catch {
+		return null;
+	}
+};
+
+const createNativeBridgeRpc = () =>
+	BrowserView.defineRPC<NativeBridgeRpcSchema>({
+		handlers: {
+			messages: {
+				[NATIVE_OPEN_EXTERNAL_MESSAGE]: (payload: unknown) => {
+					const url = readExternalUrl(payload);
+					if (url) {
+						Utils.openExternal(url);
+					}
+				},
+			},
+		},
+	});
+
 const isCliError = (error: unknown): error is CLIError =>
 	typeof error === "object" &&
 	error !== null &&
@@ -392,6 +444,7 @@ ApplicationMenu.setApplicationMenu(APPLICATION_MENU);
 
 const mainWindow = new BrowserWindow({
 	title: WINDOW_TITLE,
+	rpc: createNativeBridgeRpc(),
 	frame: {
 		width: 1280,
 		height: 860,


### PR DESCRIPTION
## Summary
- Prevent stale artifact fetches from rendering content for the wrong selected artifact.
- Display link artifacts in a dedicated sidebar-style links panel with meaningful wrapping text.
- Open link artifacts correctly in browser and native modes.

## Tests
- Focused web-ui and native tests pass.
- Typecheck, lint, build, and pre-push hooks pass.