### PR TITLE
fix(web-ui): install dependencies before build

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -141,7 +141,7 @@ build-plugins-check:
 
 # Build the web-ui
 build-web-ui:
-    cd cli/web-ui && bun run build
+    cd cli && bun run build:web-ui
 
 # Clear web-ui cache (needed when testing local builds)
 

--- a/cli/bun.lock
+++ b/cli/bun.lock
@@ -7,6 +7,8 @@
       "dependencies": {
         "@inquirer/prompts": "^8.0.2",
         "@octokit/rest": "^22.0.1",
+        "baseline-browser-mapping": "^2.10.27",
+        "caniuse-lite": "^1.0.30001791",
         "chalk": "^5.6.2",
         "commander": "^14.0.2",
         "consola": "^3.4.2",
@@ -166,6 +168,8 @@
 
     "bare-url": ["bare-url@2.3.2", "", { "dependencies": { "bare-path": "^3.0.0" } }, "sha512-ZMq4gd9ngV5aTMa5p9+UfY0b3skwhHELaDkhEHetMdX0LRkW9kzaym4oo/Eh+Ghm0CCDuMTsRIGM/ytUc1ZYmw=="],
 
+    "baseline-browser-mapping": ["baseline-browser-mapping@2.10.27", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-zEs/ufmZoUd7WftKpKyXaT6RFxpQ5Qm9xytKRHvJfxFV9DFJkZph9RvJ1LcOUi0Z1ZVijMte65JbILeV+8QQEA=="],
+
     "basic-ftp": ["basic-ftp@5.0.5", "", {}, "sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg=="],
 
     "before-after-hook": ["before-after-hook@4.0.0", "", {}, "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ=="],
@@ -175,6 +179,8 @@
     "bun-types": ["bun-types@1.3.3", "", { "dependencies": { "@types/node": "*" } }, "sha512-z3Xwlg7j2l9JY27x5Qn3Wlyos8YAp0kKRlrePAOjgjMGS5IG6E7Jnlx736vH9UVI4wUICwwhC9anYL++XeOgTQ=="],
 
     "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
+
+    "caniuse-lite": ["caniuse-lite@1.0.30001791", "", {}, "sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ=="],
 
     "chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -38,7 +38,7 @@
 	"scripts": {
 		"postinstall": "bun run scripts/postinstall.ts",
 		"build": "bun build src/main.ts --outdir dist --target node",
-		"build:web-ui": "cd web-ui && bun run build",
+		"build:web-ui": "cd web-ui && bun install --frozen-lockfile && bun run build",
 		"build:opencode": "bun run scripts/build-opencode.ts",
 		"build:platforms": "bun run scripts/build-platforms.ts",
 		"build:all": "bun run build && bun run build:web-ui && bun run build:platforms",

--- a/cli/package.json
+++ b/cli/package.json
@@ -61,6 +61,8 @@
 	"dependencies": {
 		"@inquirer/prompts": "^8.0.2",
 		"@octokit/rest": "^22.0.1",
+		"baseline-browser-mapping": "^2.10.27",
+		"caniuse-lite": "^1.0.30001791",
 		"chalk": "^5.6.2",
 		"commander": "^14.0.2",
 		"consola": "^3.4.2",


### PR DESCRIPTION
## Summary

- Make the `cli` `build:web-ui` script install `cli/web-ui` dependencies from `bun.lock` before running Vite.
- Have the root `just build-web-ui` recipe delegate to the shared package script.
- Cherry-picked `a1a5b9ec` to add current browser baseline packages, with lockfile registry URLs normalized for the public repo.

Root cause: `reveal.js` was already declared in `cli/web-ui/package.json` and `bun.lock`, but a stale local `cli/web-ui/node_modules` tree did not contain it. The build recipe invoked Vite directly, so Rollup could not resolve `reveal.js/reveal.css`.

## Test Plan

- `git diff --check`
- `cd cli && bun install --frozen-lockfile`
- `just build-web-ui`
- `just check-no-artifactory`
- Pre-push hooks completed while pushing `codex/fix-web-ui-build-deps`.

## Related Issues

- None