### PR TITLE
fix: win plus arcade win fixes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,24 @@
+# Default: detect text/binary, store with LF, check out with LF
+# regardless of user's core.autocrlf setting.
+* text=auto eol=lf
+
+# Explicit binary entries (no eol conversion, no diff)
+*.exe binary
+*.dll binary
+*.dylib binary
+*.so binary
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.icns binary
+*.zst binary
+*.zip binary
+*.tar binary
+*.gz binary
+
+# Windows shell scripts need CRLF to be runnable
+*.bat text eol=crlf
+*.cmd text eol=crlf
+*.ps1 text eol=crlf

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -94,7 +94,7 @@ See [DEVELOPMENT.md](../DEVELOPMENT.md) for detailed project architecture and te
 
 ## Line Endings
 
-This repo uses `.gitattributes` to enforce LF line endings on text files regardless of platform. On Windows, the git installer defaults to `core.autocrlf=true`, which can fight `.gitattributes` and produce CRLF↔LF diff churn. Run this once after cloning to align your local git config:
+This repo uses `.gitattributes` to enforce LF line endings by default for text files, with explicit CRLF checkout for Windows shell scripts (`*.bat`, `*.cmd`, `*.ps1`). On Windows, the git installer defaults to `core.autocrlf=true`, which can fight `.gitattributes` and produce CRLF↔LF diff churn. Run this once after cloning to align your local git config:
 
 ```bash
 just setup-git

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -92,6 +92,16 @@ See [DEVELOPMENT.md](../DEVELOPMENT.md) for detailed project architecture and te
 4. Push and create PR: `git push origin feat/your-feature`
 5. After PR approval and merge, automation handles the release
 
+## Line Endings
+
+This repo uses `.gitattributes` to enforce LF line endings on text files regardless of platform. On Windows, the git installer defaults to `core.autocrlf=true`, which can fight `.gitattributes` and produce CRLF↔LF diff churn. Run this once after cloning to align your local git config:
+
+```bash
+just setup-git
+```
+
+It runs `git config --local core.autocrlf false` and `git config --local core.eol lf` for this clone. Cross-platform contributors — especially on Windows — should do this. For a permanent posture across every repo on your machine, set the same values with `--global` instead.
+
 ## Git Hooks (Optional)
 
 This project uses [Lefthook](https://github.com/evilmartians/lefthook) for local git hooks. Installing it is optional but recommended.

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ cli/src/config/supported-tools.generated.ts
 
 # local rp1 binary
 bin/rp1
+bin/rp1.exe
 
 # Native app generated output
 native-app/build/
@@ -59,3 +60,9 @@ native-app/artifacts/
 # rp1 directory
 !.rp1/project_id
 cli/coverage/
+
+# Local Claude Code settings (per-user permissions)
+.claude/settings.local.json
+
+# Git Bash crash dumps (Windows)
+*.stackdump

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -261,15 +261,15 @@ that an rp1 skill addresses, briefly suggest it.
 ### Skill Categories
 | Category | Skills | Suggest When |
 |----------|--------|--------------|
-| Development | /build, /build-fast, /speedrun | User starts new feature or describes a change |
-| Investigation | /code-investigate | User is debugging or examining errors |
-| Quality | /code-check, /code-audit, /code-clean-comments | User finishes implementation |
-| Review | /pr-review, /pr-visual, /address-pr-feedback | User prepares or responds to PR |
-| Documentation | /write-content, /generate-user-docs | User writes or updates docs |
-| Knowledge | /knowledge-build | User needs codebase context or KB is stale |
-| Strategy | /strategize, /deep-research, /analyse-security | User faces architectural or security decisions |
-| Planning | /blueprint, /blueprint-audit | User plans a project or audits progress |
-| Prompt | /prompt-writer, /tersify-prompt | User authors or rewrites prompts |
+| Development | /task, /bootstrap, /build, /build-fast, /feature-archive, /feature-edit, /feature-unarchive, /phase-plan, /speedrun | User starts a new feature, describes a change, or needs to scaffold a project |
+| Investigation | /code-investigate, /validate-hypothesis | User is debugging, examining errors, or testing a design hypothesis |
+| Quality | /code-comments, /code-audit, /code-check, /code-clean-comments | User finishes implementation and needs hygiene checks, audits, or comment cleanup |
+| Review | /address-pr-feedback, /arcade-collab, /pr-review, /pr-visual, /pr-walkthrough | User prepares a PR, receives review feedback, or needs visual diff understanding |
+| Documentation | /fix-mermaid, /generate-user-docs, /markdown-preview, /mermaid, /project-birds-eye-view, /write-content | User writes, updates, or previews docs, diagrams, or project overviews |
+| Knowledge | /guide, /knowledge-build, /knowledge-load, /self-update | User needs codebase context, KB is stale, or wants KB templates |
+| Strategy | /analyse-security, /deep-research, /socratic-duel, /socratic-duel-run, /strategize | User faces architectural decisions, security concerns, or needs deep research |
+| Planning | /blueprint, /blueprint-archive, /blueprint-audit | User plans a project, audits a PRD, or manages blueprint lifecycle |
+| Prompt | /prompt-writer | User authors, rewrites, or evaluates agent prompts |
 
 ### Suggestion Rules
 - Limit to 1 suggestion per turn. Format: skill name, one sentence why, offer to run.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,15 +35,15 @@ that an rp1 skill addresses, briefly suggest it.
 ### Skill Categories
 | Category | Skills | Suggest When |
 |----------|--------|--------------|
-| Development | /build, /build-fast, /speedrun | User starts new feature or describes a change |
-| Investigation | /code-investigate | User is debugging or examining errors |
-| Quality | /code-check, /code-audit, /code-clean-comments | User finishes implementation |
-| Review | /pr-review, /pr-visual, /address-pr-feedback | User prepares or responds to PR |
-| Documentation | /write-content, /generate-user-docs | User writes or updates docs |
-| Knowledge | /knowledge-build | User needs codebase context or KB is stale |
-| Strategy | /strategize, /deep-research, /analyse-security | User faces architectural or security decisions |
-| Planning | /blueprint, /blueprint-audit | User plans a project or audits progress |
-| Prompt | /prompt-writer, /tersify-prompt | User authors or rewrites prompts |
+| Development | /task, /bootstrap, /build, /build-fast, /feature-archive, /feature-edit, /feature-unarchive, /phase-plan, /speedrun | User starts a new feature, describes a change, or needs to scaffold a project |
+| Investigation | /code-investigate, /validate-hypothesis | User is debugging, examining errors, or testing a design hypothesis |
+| Quality | /code-comments, /code-audit, /code-check, /code-clean-comments | User finishes implementation and needs hygiene checks, audits, or comment cleanup |
+| Review | /address-pr-feedback, /arcade-collab, /pr-review, /pr-visual, /pr-walkthrough | User prepares a PR, receives review feedback, or needs visual diff understanding |
+| Documentation | /fix-mermaid, /generate-user-docs, /markdown-preview, /mermaid, /project-birds-eye-view, /write-content | User writes, updates, or previews docs, diagrams, or project overviews |
+| Knowledge | /guide, /knowledge-build, /knowledge-load, /self-update | User needs codebase context, KB is stale, or wants KB templates |
+| Strategy | /analyse-security, /deep-research, /socratic-duel, /socratic-duel-run, /strategize | User faces architectural decisions, security concerns, or needs deep research |
+| Planning | /blueprint, /blueprint-archive, /blueprint-audit | User plans a project, audits a PRD, or manages blueprint lifecycle |
+| Prompt | /prompt-writer | User authors, rewrites, or evaluates agent prompts |
 
 ### Suggestion Rules
 - Limit to 1 suggestion per turn. Format: skill name, one sentence why, offer to run.

--- a/Justfile
+++ b/Justfile
@@ -13,6 +13,22 @@ default:
     @just --list
 
 # ─────────────────────────────────────────────────────────────────────────────
+# Local Setup
+# ─────────────────────────────────────────────────────────────────────────────
+
+# Align local git config with this repo's .gitattributes policy (LF line
+# endings). Recommended after first clone, especially on Windows where the
+# git installer defaults to core.autocrlf=true. Idempotent.
+setup-git:
+    @echo "Aligning local git config with .gitattributes (LF line endings)..."
+    git config --local core.autocrlf false
+    git config --local core.eol lf
+    @echo ""
+    @echo "Local git config set. Optionally also install lefthook hooks:"
+    @echo "  brew install lefthook   # or: scoop install lefthook"
+    @echo "  lefthook install"
+
+# ─────────────────────────────────────────────────────────────────────────────
 # Docker Environment
 # ─────────────────────────────────────────────────────────────────────────────
 # Start the Stable Tester container (clean room with harness CLIs, no rp1 installed)

--- a/Justfile
+++ b/Justfile
@@ -162,7 +162,7 @@ clean-web-ui-cache:
 
 # RP1_BUILD_INTERNAL=1 includes utils (internal-only plugin) in the dev build
 build-local-dev: build-web-ui clean-web-ui-cache
-    cd cli && RP1_BUILD_INTERNAL=1 bun run scripts/build-opencode.ts && RP1_BUILD_INTERNAL=1 bun run scripts/build-codex.ts && RP1_BUILD_INTERNAL=1 bun run scripts/build-claude-code.ts && RP1_BUILD_INTERNAL=1 bun run scripts/build-copilot.ts && bun run generate:assets && bun build ./src/main.ts --compile --outfile ../bin/rp1 --define __RP1_DEV_BUILD__=true
+    cd cli && bun install --frozen-lockfile && RP1_BUILD_INTERNAL=1 bun run scripts/build-opencode.ts && RP1_BUILD_INTERNAL=1 bun run scripts/build-codex.ts && RP1_BUILD_INTERNAL=1 bun run scripts/build-claude-code.ts && RP1_BUILD_INTERNAL=1 bun run scripts/build-copilot.ts && bun run generate:assets && bun build ./src/main.ts --compile --outfile ../bin/rp1 --define __RP1_DEV_BUILD__=true
 
 # Build the macOS native Arcade shell target without opening it
 build-native-app: install

--- a/cli/scripts/generate-asset-imports.ts
+++ b/cli/scripts/generate-asset-imports.ts
@@ -17,7 +17,7 @@
 import { execSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { readdir, readFile, stat, writeFile } from "node:fs/promises";
-import { basename, dirname, join, relative, resolve } from "node:path";
+import { basename, dirname, join, relative, resolve, sep } from "node:path";
 import { parse as parseYaml } from "yaml";
 import type { BundleManifest } from "../src/build/models.js";
 import {
@@ -97,7 +97,7 @@ interface AssetImport {
  */
 function getImportPath(assetPath: string): string {
 	const outputDir = dirname(OUTPUT_FILE);
-	return relative(outputDir, assetPath);
+	return relative(outputDir, assetPath).split(sep).join("/");
 }
 
 /**
@@ -258,7 +258,7 @@ async function collectWebUIAssets(): Promise<AssetImport[]> {
 				if (item.isDirectory()) {
 					await walk(fullPath);
 				} else {
-					const relPath = relative(WEBUI_DIST, fullPath);
+					const relPath = relative(WEBUI_DIST, fullPath).split(sep).join("/");
 					imports.push({
 						varName: toVarName("webui", relPath),
 						importPath: getImportPath(fullPath),

--- a/cli/src/__tests__/agent-tools/command-cli.test.ts
+++ b/cli/src/__tests__/agent-tools/command-cli.test.ts
@@ -694,9 +694,7 @@ describe("agent-tools command adapter", () => {
 		const projectRoot = await createProject();
 		// Pre-fix bug: Commander rejected this with parent's "required option '--type'"
 		// before subcommand dispatch. Post-fix: the parent's required-option
-		// gate no longer fires, the call reaches resume-run's action, and the
-		// action accepts the project path on every platform (path.isAbsolute
-		// handles both `/foo` and `C:\foo`).
+		// gate no longer fires and the call reaches resume-run's action.
 		await expectExit(
 			[
 				"emit",
@@ -717,17 +715,20 @@ describe("agent-tools command adapter", () => {
 		expect(joinedErrors).not.toMatch(/Project path must be absolute/);
 	});
 
+	test("resume-run project path validation recognizes Windows absolute paths", async () => {
+		const { isPlatformAbsoluteProjectPath } = await import(
+			"../../agent-tools/command.js"
+		);
+
+		expect(isPlatformAbsoluteProjectPath("C:\\code\\rp1", "win32")).toBe(true);
+		expect(isPlatformAbsoluteProjectPath("/tmp/rp1", "linux")).toBe(true);
+		expect(isPlatformAbsoluteProjectPath("relative\\rp1", "win32")).toBe(false);
+	});
+
 	test("emit end-run without --run-id fails via action guard, not Commander", async () => {
 		const projectRoot = await createProject();
 		await expectExit(
-			[
-				"emit",
-				"end-run",
-				"--outcome",
-				"cancelled",
-				"--project",
-				projectRoot,
-			],
+			["emit", "end-run", "--outcome", "cancelled", "--project", projectRoot],
 			1,
 		);
 		const joinedErrors = errors.join("\n");

--- a/cli/src/__tests__/agent-tools/command-cli.test.ts
+++ b/cli/src/__tests__/agent-tools/command-cli.test.ts
@@ -650,4 +650,121 @@ describe("agent-tools command adapter", () => {
 		expect(rejected.data.reason).toContain("second participant is present");
 		expect(rejected.data.status).toBe("ACTIVE");
 	});
+
+	test("emit end-run with valid args does not fail on parent required options", async () => {
+		const projectRoot = await createProject();
+		const runId = "550e8400-e29b-41d4-a716-446655440099";
+		await expectExit(
+			[
+				"emit",
+				"--workflow",
+				"build",
+				"--type",
+				"status_change",
+				"--run-id",
+				runId,
+				"--step",
+				"requirements",
+				"--project",
+				projectRoot,
+				"--data",
+				'{"status":"running"}',
+			],
+			0,
+		);
+
+		await expectExit(
+			[
+				"emit",
+				"end-run",
+				"--run-id",
+				runId,
+				"--outcome",
+				"cancelled",
+				"--reason",
+				"regression test",
+				"--project",
+				projectRoot,
+			],
+			0,
+		);
+	});
+
+	test("emit resume-run with valid args dispatches to its action (cross-platform)", async () => {
+		const projectRoot = await createProject();
+		// Pre-fix bug: Commander rejected this with parent's "required option '--type'"
+		// before subcommand dispatch. Post-fix: the parent's required-option
+		// gate no longer fires, the call reaches resume-run's action, and the
+		// action accepts the project path on every platform (path.isAbsolute
+		// handles both `/foo` and `C:\foo`).
+		await expectExit(
+			[
+				"emit",
+				"resume-run",
+				"--feature",
+				"some-feature",
+				"--flow",
+				"build",
+				"--project",
+				projectRoot,
+			],
+			0,
+		);
+		const joinedErrors = errors.join("\n");
+		expect(joinedErrors).not.toMatch(/required option '--type'/);
+		expect(joinedErrors).not.toMatch(/required option '--run-id'/);
+		expect(joinedErrors).not.toMatch(/required option '--workflow'/);
+		expect(joinedErrors).not.toMatch(/Project path must be absolute/);
+	});
+
+	test("emit end-run without --run-id fails via action guard, not Commander", async () => {
+		const projectRoot = await createProject();
+		await expectExit(
+			[
+				"emit",
+				"end-run",
+				"--outcome",
+				"cancelled",
+				"--project",
+				projectRoot,
+			],
+			1,
+		);
+		const joinedErrors = errors.join("\n");
+		expect(joinedErrors).not.toMatch(/required option '--run-id'/);
+		const errorPayload = errors.at(-1);
+		expect(errorPayload).toBeDefined();
+		const parsed = JSON.parse(errorPayload as string) as {
+			tool: string;
+			errors: { message: string }[];
+		};
+		expect(parsed.tool).toBe("emit");
+		expect(parsed.errors[0]?.message).toMatch(/run.?id/i);
+	});
+
+	test("bare emit without --run-id still errors via validateEmitOptions, not Commander", async () => {
+		const projectRoot = await createProject();
+		await expectExit(
+			[
+				"emit",
+				"--workflow",
+				"build",
+				"--type",
+				"status_change",
+				"--step",
+				"requirements",
+				"--project",
+				projectRoot,
+			],
+			1,
+		);
+		const errorPayload = errors.at(-1);
+		expect(errorPayload).toBeDefined();
+		const parsed = JSON.parse(errorPayload as string) as {
+			tool: string;
+			errors: { message: string }[];
+		};
+		expect(parsed.tool).toBe("emit");
+		expect(parsed.errors[0]?.message).toMatch(/run.?id/i);
+	});
 });

--- a/cli/src/__tests__/build/frontmatter-crlf.test.ts
+++ b/cli/src/__tests__/build/frontmatter-crlf.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import * as E from "fp-ts/lib/Either.js";
+import { validateCodexSkill } from "../../build/codex/validator.js";
 import { extractFrontmatter } from "../../build/parser.js";
+import { validateCommandSyntax, validateSkill } from "../../build/validator.js";
 
 const SAMPLE_FRONTMATTER_LF = [
 	"---",
@@ -21,7 +23,7 @@ const SAMPLE_FRONTMATTER_CRLF = SAMPLE_FRONTMATTER_LF.replace(/\n/g, "\r\n");
 const SAMPLE_FRONTMATTER_MIXED = [
 	"---\r\n",
 	"name: mixed\r\n",
-	"description: \"mixed endings\"\n",
+	'description: "mixed endings"\n',
 	"metadata:\r\n",
 	"  is_workflow: false\n",
 	"---\r\n",
@@ -31,10 +33,7 @@ const SAMPLE_FRONTMATTER_MIXED = [
 
 describe("extractFrontmatter line-ending tolerance", () => {
 	test("parses LF-only frontmatter (baseline)", () => {
-		const result = extractFrontmatter(
-			SAMPLE_FRONTMATTER_LF,
-			"test-lf.md",
-		);
+		const result = extractFrontmatter(SAMPLE_FRONTMATTER_LF, "test-lf.md");
 		expect(E.isRight(result)).toBe(true);
 		if (E.isRight(result)) {
 			expect(result.right.metadata.name).toBe("artifact-templates");
@@ -51,10 +50,7 @@ describe("extractFrontmatter line-ending tolerance", () => {
 	});
 
 	test("parses CRLF frontmatter without error", () => {
-		const result = extractFrontmatter(
-			SAMPLE_FRONTMATTER_CRLF,
-			"test-crlf.md",
-		);
+		const result = extractFrontmatter(SAMPLE_FRONTMATTER_CRLF, "test-crlf.md");
 		expect(E.isRight(result)).toBe(true);
 		if (E.isRight(result)) {
 			expect(result.right.metadata.name).toBe("artifact-templates");
@@ -100,5 +96,37 @@ describe("extractFrontmatter line-ending tolerance", () => {
 		const malformed = "name: foo\r\nno frontmatter here";
 		const result = extractFrontmatter(malformed, "malformed.md");
 		expect(E.isLeft(result)).toBe(true);
+	});
+
+	test("OpenCode skill validator accepts CRLF frontmatter", () => {
+		const result = validateSkill(SAMPLE_FRONTMATTER_CRLF, "sample/SKILL.md");
+		expect(E.isRight(result)).toBe(true);
+	});
+
+	test("OpenCode command syntax accepts CRLF frontmatter", () => {
+		const command = [
+			"---",
+			"description: Command description long enough",
+			"---",
+			"",
+			"Run the command.",
+		].join("\r\n");
+
+		const result = validateCommandSyntax(command, "sample.md");
+		expect(E.isRight(result)).toBe(true);
+	});
+
+	test("Codex skill validator accepts CRLF frontmatter", () => {
+		const skill = [
+			"---",
+			"name: codex-sample",
+			"description: Description long enough for Codex validation",
+			"---",
+			"",
+			"# Body",
+		].join("\r\n");
+
+		const result = validateCodexSkill(skill, "codex/SKILL.md");
+		expect(E.isRight(result)).toBe(true);
 	});
 });

--- a/cli/src/__tests__/build/frontmatter-crlf.test.ts
+++ b/cli/src/__tests__/build/frontmatter-crlf.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, test } from "bun:test";
+import * as E from "fp-ts/lib/Either.js";
+import { extractFrontmatter } from "../../build/parser.js";
+
+const SAMPLE_FRONTMATTER_LF = [
+	"---",
+	"name: artifact-templates",
+	'description: "Sample skill description"',
+	"metadata:",
+	"  category: knowledge",
+	"  is_workflow: false",
+	"---",
+	"",
+	"# Body",
+	"Body text.",
+	"",
+].join("\n");
+
+const SAMPLE_FRONTMATTER_CRLF = SAMPLE_FRONTMATTER_LF.replace(/\n/g, "\r\n");
+
+const SAMPLE_FRONTMATTER_MIXED = [
+	"---\r\n",
+	"name: mixed\r\n",
+	"description: \"mixed endings\"\n",
+	"metadata:\r\n",
+	"  is_workflow: false\n",
+	"---\r\n",
+	"\n",
+	"# Body\r\n",
+].join("");
+
+describe("extractFrontmatter line-ending tolerance", () => {
+	test("parses LF-only frontmatter (baseline)", () => {
+		const result = extractFrontmatter(
+			SAMPLE_FRONTMATTER_LF,
+			"test-lf.md",
+		);
+		expect(E.isRight(result)).toBe(true);
+		if (E.isRight(result)) {
+			expect(result.right.metadata.name).toBe("artifact-templates");
+			expect(result.right.metadata.description).toBe(
+				"Sample skill description",
+			);
+			const metadata = result.right.metadata.metadata as {
+				category: string;
+				is_workflow: boolean;
+			};
+			expect(metadata.category).toBe("knowledge");
+			expect(metadata.is_workflow).toBe(false);
+		}
+	});
+
+	test("parses CRLF frontmatter without error", () => {
+		const result = extractFrontmatter(
+			SAMPLE_FRONTMATTER_CRLF,
+			"test-crlf.md",
+		);
+		expect(E.isRight(result)).toBe(true);
+		if (E.isRight(result)) {
+			expect(result.right.metadata.name).toBe("artifact-templates");
+			const metadata = result.right.metadata.metadata as {
+				category: string;
+				is_workflow: boolean;
+			};
+			expect(metadata.category).toBe("knowledge");
+			expect(metadata.is_workflow).toBe(false);
+		}
+	});
+
+	test("parses mixed CRLF/LF frontmatter", () => {
+		const result = extractFrontmatter(
+			SAMPLE_FRONTMATTER_MIXED,
+			"test-mixed.md",
+		);
+		expect(E.isRight(result)).toBe(true);
+		if (E.isRight(result)) {
+			expect(result.right.metadata.name).toBe("mixed");
+		}
+	});
+
+	test("preserves body content across CRLF input", () => {
+		const result = extractFrontmatter(
+			SAMPLE_FRONTMATTER_CRLF,
+			"test-crlf-body.md",
+		);
+		expect(E.isRight(result)).toBe(true);
+		if (E.isRight(result)) {
+			expect(result.right.body).toContain("# Body");
+			expect(result.right.body).toContain("Body text.");
+		}
+	});
+
+	test("still rejects missing closing ---", () => {
+		const malformed = "---\r\nname: foo\r\nbody without close";
+		const result = extractFrontmatter(malformed, "malformed.md");
+		expect(E.isLeft(result)).toBe(true);
+	});
+
+	test("still rejects content without opening ---", () => {
+		const malformed = "name: foo\r\nno frontmatter here";
+		const result = extractFrontmatter(malformed, "malformed.md");
+		expect(E.isLeft(result)).toBe(true);
+	});
+});

--- a/cli/src/__tests__/commands/arcade-runtime-branch.test.ts
+++ b/cli/src/__tests__/commands/arcade-runtime-branch.test.ts
@@ -28,6 +28,10 @@ describe("arcade command runtime branches", () => {
 		process.exit = originalExit;
 		console.error = originalError;
 		mock.restore();
+		mock.module("../../../shared/runtime.js", () => ({
+			detectRuntime: () => ({ runtime: "bun" as const, version: Bun.version }),
+			isBun: () => true,
+		}));
 	});
 
 	test("prints Bun runtime guidance before daemon work in Node-like runtimes", async () => {

--- a/cli/src/__tests__/commands/arcade-runtime-branch.test.ts
+++ b/cli/src/__tests__/commands/arcade-runtime-branch.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
+import * as childProcess from "node:child_process";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -27,10 +28,6 @@ describe("arcade command runtime branches", () => {
 		process.exit = originalExit;
 		console.error = originalError;
 		mock.restore();
-		mock.module("../../../shared/runtime.js", () => ({
-			detectRuntime: () => ({ runtime: "bun" as const, version: Bun.version }),
-			isBun: () => true,
-		}));
 	});
 
 	test("prints Bun runtime guidance before daemon work in Node-like runtimes", async () => {
@@ -81,9 +78,27 @@ describe("arcade command runtime branches", () => {
 				},
 			}));
 			mock.module("node:child_process", () => ({
-				spawn: (command: string, args: string[]) => {
-					spawned.push({ command, args });
-					return { unref: () => undefined };
+				...childProcess,
+				spawn: (
+					command: string,
+					args?: readonly string[],
+					options?: childProcess.SpawnOptions,
+				) => {
+					const spawnArgs = Array.from(args ?? []);
+					const url = "http://127.0.0.1:8131/projects/project-1";
+					const opensExpectedUrl =
+						(command === "open" && spawnArgs[0] === url) ||
+						(command === "cmd" && spawnArgs.at(-1) === url) ||
+						(command === "xdg-open" && spawnArgs[0] === url);
+
+					if (opensExpectedUrl) {
+						spawned.push({ command, args: spawnArgs });
+						return { unref: () => undefined };
+					}
+
+					return options === undefined
+						? childProcess.spawn(command, spawnArgs)
+						: childProcess.spawn(command, spawnArgs, options);
 				},
 			}));
 

--- a/cli/src/__tests__/daemon/health-check-regression.test.ts
+++ b/cli/src/__tests__/daemon/health-check-regression.test.ts
@@ -1,0 +1,458 @@
+import { describe, expect, test } from "bun:test";
+import { platform } from "node:os";
+
+/**
+ * Regression tests for cross-platform health check behavior.
+ * Ensures that Windows fixes do not degrade macOS and Linux performance.
+ */
+describe("health-check-regression", () => {
+	describe("platform timeout configuration", () => {
+		test("macOS timeout is 5000ms (unchanged)", () => {
+			const expectedMacOSTimeout = 5000;
+			expect(expectedMacOSTimeout).toBe(5000);
+		});
+
+		test("Linux timeout is 5000ms (unchanged)", () => {
+			const expectedLinuxTimeout = 5000;
+			expect(expectedLinuxTimeout).toBe(5000);
+		});
+
+		test("Windows timeout is 60000ms (extended for diagnostics)", () => {
+			const expectedWindowsTimeout = 60000;
+			expect(expectedWindowsTimeout).toBe(60000);
+		});
+
+		test("Windows timeout is 12x Unix timeout (justified for debugging)", () => {
+			const windowsTimeout = 60000;
+			const unixTimeout = 5000;
+			const ratio = windowsTimeout / unixTimeout;
+
+			expect(ratio).toBe(12);
+		});
+	});
+
+	describe("baseline health check timing", () => {
+		test("healthy macOS system completes in <2s", () => {
+			const macOSHealthyHealthCheckTime = 800; // milliseconds
+			expect(macOSHealthyHealthCheckTime).toBeLessThan(2000);
+		});
+
+		test("healthy Linux system completes in <2s", () => {
+			const linuxHealthyHealthCheckTime = 750; // milliseconds
+			expect(linuxHealthyHealthCheckTime).toBeLessThan(2000);
+		});
+
+		test("healthy Windows system completes in <5s (even with extended timeout)", () => {
+			const windowsHealthyHealthCheckTime = 3000; // milliseconds
+			expect(windowsHealthyHealthCheckTime).toBeLessThan(5000);
+		});
+
+		test("all platforms have sub-100ms asset check on healthy systems", () => {
+			const assetCheckTimings = {
+				macOS: 5,
+				linux: 8,
+				windows: 15, // May be slightly slower on Windows
+			};
+
+			for (const [platform, timing] of Object.entries(assetCheckTimings)) {
+				expect(timing).toBeLessThan(100);
+			}
+		});
+
+		test("database initialization timing consistent across platforms", () => {
+			const dbInitTimings = {
+				macOS: 20,
+				linux: 25,
+				windows: 30,
+			};
+
+			// All should be under 100ms
+			for (const [platform, timing] of Object.entries(dbInitTimings)) {
+				expect(timing).toBeLessThan(100);
+			}
+		});
+
+		test("project count query timing consistent across platforms", () => {
+			const projectCountTimings = {
+				macOS: 8,
+				linux: 10,
+				windows: 12,
+			};
+
+			// All should be under 100ms
+			for (const [platform, timing] of Object.entries(projectCountTimings)) {
+				expect(timing).toBeLessThan(100);
+			}
+		});
+	});
+
+	describe("retry logic does not add unwanted latency", () => {
+		test("happy path (asset available on first check) <10ms on Unix", () => {
+			const happyPathAssetCheckMs = 5;
+			expect(happyPathAssetCheckMs).toBeLessThan(10);
+		});
+
+		test("happy path (asset available on first check) <50ms on Windows", () => {
+			const happyPathAssetCheckMs = 15;
+			expect(happyPathAssetCheckMs).toBeLessThan(50);
+		});
+
+		test("asset not ready path with retries takes ~385ms (sum of backoff delays)", () => {
+			const backoffDelays = [10, 25, 50, 100, 200];
+			const totalBackoffMs = backoffDelays.reduce((a, b) => a + b, 0);
+			expect(totalBackoffMs).toBe(385);
+		});
+
+		test("unhealthy path still completes within timeout on Unix", () => {
+			const unixTimeout = 5000;
+			const unhealthyCheckTime = 4900; // Just under timeout
+
+			expect(unhealthyCheckTime).toBeLessThan(unixTimeout);
+		});
+
+		test("unhealthy path still completes within timeout on Windows", () => {
+			const windowsTimeout = 60000;
+			const unhealthyCheckTime = 59900; // Just under timeout
+
+			expect(unhealthyCheckTime).toBeLessThan(windowsTimeout);
+		});
+	});
+
+	describe("response header presence across platforms", () => {
+		test("all platforms include X-Health-Check-Time header", () => {
+			const headers = {
+				macOS: "42",
+				linux: "38",
+				windows: "85",
+			};
+
+			for (const [platform, headerValue] of Object.entries(headers)) {
+				expect(headerValue).toBeDefined();
+				const timing = Number.parseInt(headerValue, 10);
+				expect(Number.isNaN(timing)).toBe(false);
+			}
+		});
+
+		test("all platforms include X-Asset-Check-Time header", () => {
+			const headers = {
+				macOS: "5",
+				linux: "8",
+				windows: "15",
+			};
+
+			for (const [platform, headerValue] of Object.entries(headers)) {
+				expect(headerValue).toBeDefined();
+				const timing = Number.parseInt(headerValue, 10);
+				expect(Number.isNaN(timing)).toBe(false);
+			}
+		});
+
+		test("all platforms include X-Database-Init-Time header", () => {
+			const headers = {
+				macOS: "20",
+				linux: "25",
+				windows: "30",
+			};
+
+			for (const [platform, headerValue] of Object.entries(headers)) {
+				expect(headerValue).toBeDefined();
+				const timing = Number.parseInt(headerValue, 10);
+				expect(Number.isNaN(timing)).toBe(false);
+			}
+		});
+
+		test("all platforms include X-Project-Count-Time header", () => {
+			const headers = {
+				macOS: "8",
+				linux: "10",
+				windows: "12",
+			};
+
+			for (const [platform, headerValue] of Object.entries(headers)) {
+				expect(headerValue).toBeDefined();
+				const timing = Number.parseInt(headerValue, 10);
+				expect(Number.isNaN(timing)).toBe(false);
+			}
+		});
+
+		test("header values are reasonable across all platforms", () => {
+			const maxReasonableHealthCheckTime = 5000; // 5 seconds
+
+			const timingsByCPlatform = {
+				macOS: { health: 42, asset: 5, db: 20, count: 8 },
+				linux: { health: 38, asset: 8, db: 25, count: 10 },
+				windows: { health: 85, asset: 15, db: 30, count: 12 },
+			};
+
+			for (const [plat, timings] of Object.entries(timingsByCPlatform)) {
+				for (const [phase, timing] of Object.entries(timings)) {
+					expect(timing).toBeLessThanOrEqual(maxReasonableHealthCheckTime);
+					expect(timing).toBeGreaterThanOrEqual(0);
+				}
+			}
+		});
+	});
+
+	describe("polling loop behavior across platforms", () => {
+		test("Unix platform completes within 5s timeout", () => {
+			const unixTimeout = 5000;
+			const unixHealthCheckTime = 2500;
+
+			expect(unixHealthCheckTime).toBeLessThan(unixTimeout);
+		});
+
+		test("Windows platform completes within 60s timeout", () => {
+			const windowsTimeout = 60000;
+			const windowsHealthCheckTime = 30000;
+
+			expect(windowsHealthCheckTime).toBeLessThan(windowsTimeout);
+		});
+
+		test("polling interval is 100ms on all platforms", () => {
+			const pollingInterval = 100;
+			expect(pollingInterval).toBe(100);
+		});
+
+		test("expected attempt count within timeout is reasonable", () => {
+			const unixAttempts = Math.floor(5000 / 100);
+			const windowsAttempts = Math.floor(60000 / 100);
+
+			expect(unixAttempts).toBe(50);
+			expect(windowsAttempts).toBe(600);
+		});
+
+		test("early success on healthy systems requires few attempts", () => {
+			// Healthy system responds quickly, typically within 5-10 attempts
+			const healthyHealthCheckTime = 500; // milliseconds
+			const pollingInterval = 100;
+			const expectedAttempts = Math.ceil(healthyHealthCheckTime / pollingInterval);
+
+			expect(expectedAttempts).toBeLessThanOrEqual(10);
+		});
+	});
+
+	describe("diagnostic events across platforms", () => {
+		test("asset check attempt events are logged on all platforms", () => {
+			const eventTypes = [
+				"asset_check_attempt",
+				"asset_check_complete",
+			];
+
+			for (const eventType of eventTypes) {
+				expect(eventType).toBeDefined();
+			}
+		});
+
+		test("health check poll events are logged on all platforms", () => {
+			const eventType = "health_check_poll";
+			expect(eventType).toBeDefined();
+		});
+
+		test("health check succeeded events include timing on all platforms", () => {
+			const successEvent = {
+				event_type: "health_check_succeeded",
+				attemptCount: 3,
+				elapsedMs: 300,
+				projectCount: 1,
+				uptime: 10,
+			};
+
+			expect(successEvent.attemptCount).toBeGreaterThan(0);
+			expect(successEvent.elapsedMs).toBeGreaterThan(0);
+		});
+
+		test("health check timeout events document final attempt count", () => {
+			const unixTimeoutEvent = {
+				attemptCount: 50,
+				finalElapsedMs: 5000,
+				timeoutMs: 5000,
+			};
+
+			const windowsTimeoutEvent = {
+				attemptCount: 600,
+				finalElapsedMs: 60000,
+				timeoutMs: 60000,
+			};
+
+			expect(unixTimeoutEvent.attemptCount).toBeGreaterThan(0);
+			expect(windowsTimeoutEvent.attemptCount).toBeGreaterThan(
+				unixTimeoutEvent.attemptCount,
+			);
+		});
+	});
+
+	describe("no regression on timing logic", () => {
+		test("timing calculations sum phases correctly", () => {
+			const timing = {
+				asset_check_ms: 10,
+				database_init_ms: 25,
+				project_count_ms: 8,
+				total_ms: 43,
+			};
+
+			const sum =
+				timing.asset_check_ms +
+				timing.database_init_ms +
+				timing.project_count_ms;
+			expect(timing.total_ms).toBeGreaterThanOrEqual(sum);
+		});
+
+		test("timing values are non-negative across all platforms", () => {
+			const allTimings = [0, 5, 10, 20, 100, 1000, 5000];
+
+			for (const timing of allTimings) {
+				expect(timing).toBeGreaterThanOrEqual(0);
+			}
+		});
+
+		test("timing precision is millisecond resolution", () => {
+			const msValues = [1, 5, 10, 42, 100, 500, 1000];
+
+			for (const ms of msValues) {
+				expect(Number.isInteger(ms)).toBe(true);
+			}
+		});
+	});
+
+	describe("response structure consistency across platforms", () => {
+		test("200 OK response includes all required fields", () => {
+			const response200 = {
+				status: "ok",
+				uptime: 10,
+				port: 7710,
+				projectCount: 2,
+				isDev: false,
+				version: "0.7.1",
+				timing: {
+					asset_check_ms: 5,
+					database_init_ms: 20,
+					project_count_ms: 8,
+					total_ms: 33,
+				},
+			};
+
+			expect(response200.status).toBe("ok");
+			expect(response200.timing).toBeDefined();
+			expect(response200.timing.total_ms).toBeGreaterThan(0);
+		});
+
+		test("503 response includes timing for asset failure", () => {
+			const response503 = {
+				status: "starting",
+				reason: "assets not ready",
+				timing: {
+					asset_check_ms: 385,
+					database_init_ms: 0,
+					project_count_ms: 0,
+					total_ms: 385,
+				},
+			};
+
+			expect(response503.status).toBe("starting");
+			expect(response503.timing.asset_check_ms).toBeGreaterThan(0);
+		});
+
+		test("response structure is identical across platforms", () => {
+			const responses = {
+				macOS: {
+					status: "ok",
+					timing: {
+						asset_check_ms: 5,
+						database_init_ms: 20,
+						project_count_ms: 8,
+						total_ms: 33,
+					},
+				},
+				linux: {
+					status: "ok",
+					timing: {
+						asset_check_ms: 8,
+						database_init_ms: 25,
+						project_count_ms: 10,
+						total_ms: 43,
+					},
+				},
+				windows: {
+					status: "ok",
+					timing: {
+						asset_check_ms: 15,
+						database_init_ms: 30,
+						project_count_ms: 12,
+						total_ms: 57,
+					},
+				},
+			};
+
+			for (const [plat, response] of Object.entries(responses)) {
+				expect(response.status).toBe("ok");
+				expect(response.timing).toBeDefined();
+				expect(response.timing.asset_check_ms).toBeGreaterThanOrEqual(0);
+				expect(response.timing.database_init_ms).toBeGreaterThanOrEqual(0);
+				expect(response.timing.project_count_ms).toBeGreaterThanOrEqual(0);
+				expect(response.timing.total_ms).toBeGreaterThanOrEqual(0);
+			}
+		});
+	});
+
+	describe("baseline timing comparison", () => {
+		test("baseline: healthy macOS startup timing", () => {
+			// Historical baseline for regression detection
+			const baselineHealthyMacOS = {
+				asset_check_ms: 5,
+				database_init_ms: 20,
+				project_count_ms: 8,
+				total_ms: 33,
+			};
+
+			// Verify structure for baseline
+			expect(baselineHealthyMacOS.total_ms).toBeLessThan(1000);
+		});
+
+		test("baseline: healthy Linux startup timing", () => {
+			// Historical baseline for regression detection
+			const baselineHealthyLinux = {
+				asset_check_ms: 8,
+				database_init_ms: 25,
+				project_count_ms: 10,
+				total_ms: 43,
+			};
+
+			// Verify structure for baseline
+			expect(baselineHealthyLinux.total_ms).toBeLessThan(1000);
+		});
+
+		test("baseline: healthy Windows startup timing", () => {
+			// Historical baseline for regression detection
+			const baselineHealthyWindows = {
+				asset_check_ms: 15,
+				database_init_ms: 30,
+				project_count_ms: 12,
+				total_ms: 57,
+			};
+
+			// Verify structure for baseline; slightly slower than Unix
+			expect(baselineHealthyWindows.total_ms).toBeLessThan(1000);
+		});
+
+		test("no regression: macOS startup remains <2s", () => {
+			const maxMacOSHealthyTime = 2000;
+			const observedMacOSTime = 500; // milliseconds
+
+			expect(observedMacOSTime).toBeLessThan(maxMacOSHealthyTime);
+		});
+
+		test("no regression: Linux startup remains <2s", () => {
+			const maxLinuxHealthyTime = 2000;
+			const observedLinuxTime = 550; // milliseconds
+
+			expect(observedLinuxTime).toBeLessThan(maxLinuxHealthyTime);
+		});
+
+		test("no regression: Windows startup remains <5s on healthy systems", () => {
+			const maxWindowsHealthyTime = 5000;
+			const observedWindowsTime = 1000; // milliseconds
+
+			expect(observedWindowsTime).toBeLessThan(maxWindowsHealthyTime);
+		});
+	});
+});

--- a/cli/src/__tests__/daemon/health-check-regression.test.ts
+++ b/cli/src/__tests__/daemon/health-check-regression.test.ts
@@ -1,458 +1,89 @@
-import { describe, expect, test } from "bun:test";
-import { platform } from "node:os";
+import {
+	afterAll,
+	beforeAll,
+	beforeEach,
+	describe,
+	expect,
+	mock,
+	test,
+} from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ApiContext } from "../../../web-ui/src/server/routes/content-utils.js";
 
-/**
- * Regression tests for cross-platform health check behavior.
- * Ensures that Windows fixes do not degrade macOS and Linux performance.
- */
-describe("health-check-regression", () => {
-	describe("platform timeout configuration", () => {
-		test("macOS timeout is 5000ms (unchanged)", () => {
-			const expectedMacOSTimeout = 5000;
-			expect(expectedMacOSTimeout).toBe(5000);
-		});
+type V2ApiModule = typeof import("../../../web-ui/src/server/routes/v2-api.js");
 
-		test("Linux timeout is 5000ms (unchanged)", () => {
-			const expectedLinuxTimeout = 5000;
-			expect(expectedLinuxTimeout).toBe(5000);
-		});
+const events: Array<{ event: string; data: Record<string, unknown> }> = [];
 
-		test("Windows timeout is 60000ms (extended for diagnostics)", () => {
-			const expectedWindowsTimeout = 60000;
-			expect(expectedWindowsTimeout).toBe(60000);
-		});
+const loadV2Api = async (): Promise<V2ApiModule> =>
+	(await import(
+		`../../../web-ui/src/server/routes/v2-api.ts?health-regression=${Date.now()}-${Math.random()}`
+	)) as V2ApiModule;
 
-		test("Windows timeout is 12x Unix timeout (justified for debugging)", () => {
-			const windowsTimeout = 60000;
-			const unixTimeout = 5000;
-			const ratio = windowsTimeout / unixTimeout;
+const apiContext = (webUIDir: string): ApiContext => ({
+	port: 7710,
+	startTime: Date.now(),
+	isDev: false,
+	webUIDir,
+});
 
-			expect(ratio).toBe(12);
-		});
+describe("health-check regression behavior", () => {
+	let tempDir: string;
+
+	beforeAll(async () => {
+		tempDir = await mkdtemp(join(tmpdir(), "rp1-health-regression-"));
+		const diagnosticsMock = {
+			logDaemonEvent: (event: string, data: Record<string, unknown> = {}) => {
+				events.push({ event, data });
+			},
+		};
+		mock.module(
+			"../../../web-ui/src/daemon/diagnostics",
+			() => diagnosticsMock,
+		);
+		mock.module(
+			"../../../web-ui/src/daemon/diagnostics.js",
+			() => diagnosticsMock,
+		);
 	});
 
-	describe("baseline health check timing", () => {
-		test("healthy macOS system completes in <2s", () => {
-			const macOSHealthyHealthCheckTime = 800; // milliseconds
-			expect(macOSHealthyHealthCheckTime).toBeLessThan(2000);
-		});
-
-		test("healthy Linux system completes in <2s", () => {
-			const linuxHealthyHealthCheckTime = 750; // milliseconds
-			expect(linuxHealthyHealthCheckTime).toBeLessThan(2000);
-		});
-
-		test("healthy Windows system completes in <5s (even with extended timeout)", () => {
-			const windowsHealthyHealthCheckTime = 3000; // milliseconds
-			expect(windowsHealthyHealthCheckTime).toBeLessThan(5000);
-		});
-
-		test("all platforms have sub-100ms asset check on healthy systems", () => {
-			const assetCheckTimings = {
-				macOS: 5,
-				linux: 8,
-				windows: 15, // May be slightly slower on Windows
-			};
-
-			for (const [platform, timing] of Object.entries(assetCheckTimings)) {
-				expect(timing).toBeLessThan(100);
-			}
-		});
-
-		test("database initialization timing consistent across platforms", () => {
-			const dbInitTimings = {
-				macOS: 20,
-				linux: 25,
-				windows: 30,
-			};
-
-			// All should be under 100ms
-			for (const [platform, timing] of Object.entries(dbInitTimings)) {
-				expect(timing).toBeLessThan(100);
-			}
-		});
-
-		test("project count query timing consistent across platforms", () => {
-			const projectCountTimings = {
-				macOS: 8,
-				linux: 10,
-				windows: 12,
-			};
-
-			// All should be under 100ms
-			for (const [platform, timing] of Object.entries(projectCountTimings)) {
-				expect(timing).toBeLessThan(100);
-			}
-		});
+	beforeEach(() => {
+		events.length = 0;
 	});
 
-	describe("retry logic does not add unwanted latency", () => {
-		test("happy path (asset available on first check) <10ms on Unix", () => {
-			const happyPathAssetCheckMs = 5;
-			expect(happyPathAssetCheckMs).toBeLessThan(10);
-		});
-
-		test("happy path (asset available on first check) <50ms on Windows", () => {
-			const happyPathAssetCheckMs = 15;
-			expect(happyPathAssetCheckMs).toBeLessThan(50);
-		});
-
-		test("asset not ready path with retries takes ~385ms (sum of backoff delays)", () => {
-			const backoffDelays = [10, 25, 50, 100, 200];
-			const totalBackoffMs = backoffDelays.reduce((a, b) => a + b, 0);
-			expect(totalBackoffMs).toBe(385);
-		});
-
-		test("unhealthy path still completes within timeout on Unix", () => {
-			const unixTimeout = 5000;
-			const unhealthyCheckTime = 4900; // Just under timeout
-
-			expect(unhealthyCheckTime).toBeLessThan(unixTimeout);
-		});
-
-		test("unhealthy path still completes within timeout on Windows", () => {
-			const windowsTimeout = 60000;
-			const unhealthyCheckTime = 59900; // Just under timeout
-
-			expect(unhealthyCheckTime).toBeLessThan(windowsTimeout);
-		});
+	afterAll(async () => {
+		mock.restore();
+		await rm(tempDir, { recursive: true, force: true });
 	});
 
-	describe("response header presence across platforms", () => {
-		test("all platforms include X-Health-Check-Time header", () => {
-			const headers = {
-				macOS: "42",
-				linux: "38",
-				windows: "85",
-			};
+	test("asset-not-ready health response includes bounded retry timing and completion diagnostics", async () => {
+		const { handleV2HealthRequest } = await loadV2Api();
+		const webUIDir = join(tempDir, `missing-${Date.now()}`);
 
-			for (const [platform, headerValue] of Object.entries(headers)) {
-				expect(headerValue).toBeDefined();
-				const timing = Number.parseInt(headerValue, 10);
-				expect(Number.isNaN(timing)).toBe(false);
-			}
-		});
+		const response = await handleV2HealthRequest(apiContext(webUIDir));
+		const body = (await response.json()) as {
+			status: string;
+			reason: string;
+			timing: { asset_check_ms: number; total_ms: number };
+		};
 
-		test("all platforms include X-Asset-Check-Time header", () => {
-			const headers = {
-				macOS: "5",
-				linux: "8",
-				windows: "15",
-			};
-
-			for (const [platform, headerValue] of Object.entries(headers)) {
-				expect(headerValue).toBeDefined();
-				const timing = Number.parseInt(headerValue, 10);
-				expect(Number.isNaN(timing)).toBe(false);
-			}
-		});
-
-		test("all platforms include X-Database-Init-Time header", () => {
-			const headers = {
-				macOS: "20",
-				linux: "25",
-				windows: "30",
-			};
-
-			for (const [platform, headerValue] of Object.entries(headers)) {
-				expect(headerValue).toBeDefined();
-				const timing = Number.parseInt(headerValue, 10);
-				expect(Number.isNaN(timing)).toBe(false);
-			}
-		});
-
-		test("all platforms include X-Project-Count-Time header", () => {
-			const headers = {
-				macOS: "8",
-				linux: "10",
-				windows: "12",
-			};
-
-			for (const [platform, headerValue] of Object.entries(headers)) {
-				expect(headerValue).toBeDefined();
-				const timing = Number.parseInt(headerValue, 10);
-				expect(Number.isNaN(timing)).toBe(false);
-			}
-		});
-
-		test("header values are reasonable across all platforms", () => {
-			const maxReasonableHealthCheckTime = 5000; // 5 seconds
-
-			const timingsByCPlatform = {
-				macOS: { health: 42, asset: 5, db: 20, count: 8 },
-				linux: { health: 38, asset: 8, db: 25, count: 10 },
-				windows: { health: 85, asset: 15, db: 30, count: 12 },
-			};
-
-			for (const [plat, timings] of Object.entries(timingsByCPlatform)) {
-				for (const [phase, timing] of Object.entries(timings)) {
-					expect(timing).toBeLessThanOrEqual(maxReasonableHealthCheckTime);
-					expect(timing).toBeGreaterThanOrEqual(0);
-				}
-			}
-		});
-	});
-
-	describe("polling loop behavior across platforms", () => {
-		test("Unix platform completes within 5s timeout", () => {
-			const unixTimeout = 5000;
-			const unixHealthCheckTime = 2500;
-
-			expect(unixHealthCheckTime).toBeLessThan(unixTimeout);
-		});
-
-		test("Windows platform completes within 60s timeout", () => {
-			const windowsTimeout = 60000;
-			const windowsHealthCheckTime = 30000;
-
-			expect(windowsHealthCheckTime).toBeLessThan(windowsTimeout);
-		});
-
-		test("polling interval is 100ms on all platforms", () => {
-			const pollingInterval = 100;
-			expect(pollingInterval).toBe(100);
-		});
-
-		test("expected attempt count within timeout is reasonable", () => {
-			const unixAttempts = Math.floor(5000 / 100);
-			const windowsAttempts = Math.floor(60000 / 100);
-
-			expect(unixAttempts).toBe(50);
-			expect(windowsAttempts).toBe(600);
-		});
-
-		test("early success on healthy systems requires few attempts", () => {
-			// Healthy system responds quickly, typically within 5-10 attempts
-			const healthyHealthCheckTime = 500; // milliseconds
-			const pollingInterval = 100;
-			const expectedAttempts = Math.ceil(healthyHealthCheckTime / pollingInterval);
-
-			expect(expectedAttempts).toBeLessThanOrEqual(10);
-		});
-	});
-
-	describe("diagnostic events across platforms", () => {
-		test("asset check attempt events are logged on all platforms", () => {
-			const eventTypes = [
-				"asset_check_attempt",
-				"asset_check_complete",
-			];
-
-			for (const eventType of eventTypes) {
-				expect(eventType).toBeDefined();
-			}
-		});
-
-		test("health check poll events are logged on all platforms", () => {
-			const eventType = "health_check_poll";
-			expect(eventType).toBeDefined();
-		});
-
-		test("health check succeeded events include timing on all platforms", () => {
-			const successEvent = {
-				event_type: "health_check_succeeded",
-				attemptCount: 3,
-				elapsedMs: 300,
-				projectCount: 1,
-				uptime: 10,
-			};
-
-			expect(successEvent.attemptCount).toBeGreaterThan(0);
-			expect(successEvent.elapsedMs).toBeGreaterThan(0);
-		});
-
-		test("health check timeout events document final attempt count", () => {
-			const unixTimeoutEvent = {
-				attemptCount: 50,
-				finalElapsedMs: 5000,
-				timeoutMs: 5000,
-			};
-
-			const windowsTimeoutEvent = {
-				attemptCount: 600,
-				finalElapsedMs: 60000,
-				timeoutMs: 60000,
-			};
-
-			expect(unixTimeoutEvent.attemptCount).toBeGreaterThan(0);
-			expect(windowsTimeoutEvent.attemptCount).toBeGreaterThan(
-				unixTimeoutEvent.attemptCount,
-			);
-		});
-	});
-
-	describe("no regression on timing logic", () => {
-		test("timing calculations sum phases correctly", () => {
-			const timing = {
-				asset_check_ms: 10,
-				database_init_ms: 25,
-				project_count_ms: 8,
-				total_ms: 43,
-			};
-
-			const sum =
-				timing.asset_check_ms +
-				timing.database_init_ms +
-				timing.project_count_ms;
-			expect(timing.total_ms).toBeGreaterThanOrEqual(sum);
-		});
-
-		test("timing values are non-negative across all platforms", () => {
-			const allTimings = [0, 5, 10, 20, 100, 1000, 5000];
-
-			for (const timing of allTimings) {
-				expect(timing).toBeGreaterThanOrEqual(0);
-			}
-		});
-
-		test("timing precision is millisecond resolution", () => {
-			const msValues = [1, 5, 10, 42, 100, 500, 1000];
-
-			for (const ms of msValues) {
-				expect(Number.isInteger(ms)).toBe(true);
-			}
-		});
-	});
-
-	describe("response structure consistency across platforms", () => {
-		test("200 OK response includes all required fields", () => {
-			const response200 = {
-				status: "ok",
-				uptime: 10,
-				port: 7710,
-				projectCount: 2,
-				isDev: false,
-				version: "0.7.1",
-				timing: {
-					asset_check_ms: 5,
-					database_init_ms: 20,
-					project_count_ms: 8,
-					total_ms: 33,
-				},
-			};
-
-			expect(response200.status).toBe("ok");
-			expect(response200.timing).toBeDefined();
-			expect(response200.timing.total_ms).toBeGreaterThan(0);
-		});
-
-		test("503 response includes timing for asset failure", () => {
-			const response503 = {
-				status: "starting",
-				reason: "assets not ready",
-				timing: {
-					asset_check_ms: 385,
-					database_init_ms: 0,
-					project_count_ms: 0,
-					total_ms: 385,
-				},
-			};
-
-			expect(response503.status).toBe("starting");
-			expect(response503.timing.asset_check_ms).toBeGreaterThan(0);
-		});
-
-		test("response structure is identical across platforms", () => {
-			const responses = {
-				macOS: {
-					status: "ok",
-					timing: {
-						asset_check_ms: 5,
-						database_init_ms: 20,
-						project_count_ms: 8,
-						total_ms: 33,
-					},
-				},
-				linux: {
-					status: "ok",
-					timing: {
-						asset_check_ms: 8,
-						database_init_ms: 25,
-						project_count_ms: 10,
-						total_ms: 43,
-					},
-				},
-				windows: {
-					status: "ok",
-					timing: {
-						asset_check_ms: 15,
-						database_init_ms: 30,
-						project_count_ms: 12,
-						total_ms: 57,
-					},
-				},
-			};
-
-			for (const [plat, response] of Object.entries(responses)) {
-				expect(response.status).toBe("ok");
-				expect(response.timing).toBeDefined();
-				expect(response.timing.asset_check_ms).toBeGreaterThanOrEqual(0);
-				expect(response.timing.database_init_ms).toBeGreaterThanOrEqual(0);
-				expect(response.timing.project_count_ms).toBeGreaterThanOrEqual(0);
-				expect(response.timing.total_ms).toBeGreaterThanOrEqual(0);
-			}
-		});
-	});
-
-	describe("baseline timing comparison", () => {
-		test("baseline: healthy macOS startup timing", () => {
-			// Historical baseline for regression detection
-			const baselineHealthyMacOS = {
-				asset_check_ms: 5,
-				database_init_ms: 20,
-				project_count_ms: 8,
-				total_ms: 33,
-			};
-
-			// Verify structure for baseline
-			expect(baselineHealthyMacOS.total_ms).toBeLessThan(1000);
-		});
-
-		test("baseline: healthy Linux startup timing", () => {
-			// Historical baseline for regression detection
-			const baselineHealthyLinux = {
-				asset_check_ms: 8,
-				database_init_ms: 25,
-				project_count_ms: 10,
-				total_ms: 43,
-			};
-
-			// Verify structure for baseline
-			expect(baselineHealthyLinux.total_ms).toBeLessThan(1000);
-		});
-
-		test("baseline: healthy Windows startup timing", () => {
-			// Historical baseline for regression detection
-			const baselineHealthyWindows = {
-				asset_check_ms: 15,
-				database_init_ms: 30,
-				project_count_ms: 12,
-				total_ms: 57,
-			};
-
-			// Verify structure for baseline; slightly slower than Unix
-			expect(baselineHealthyWindows.total_ms).toBeLessThan(1000);
-		});
-
-		test("no regression: macOS startup remains <2s", () => {
-			const maxMacOSHealthyTime = 2000;
-			const observedMacOSTime = 500; // milliseconds
-
-			expect(observedMacOSTime).toBeLessThan(maxMacOSHealthyTime);
-		});
-
-		test("no regression: Linux startup remains <2s", () => {
-			const maxLinuxHealthyTime = 2000;
-			const observedLinuxTime = 550; // milliseconds
-
-			expect(observedLinuxTime).toBeLessThan(maxLinuxHealthyTime);
-		});
-
-		test("no regression: Windows startup remains <5s on healthy systems", () => {
-			const maxWindowsHealthyTime = 5000;
-			const observedWindowsTime = 1000; // milliseconds
-
-			expect(observedWindowsTime).toBeLessThan(maxWindowsHealthyTime);
-		});
+		expect(response.status).toBe(503);
+		expect(body.status).toBe("starting");
+		expect(body.reason).toBe("assets not ready");
+		expect(body.timing.asset_check_ms).toBeGreaterThanOrEqual(380);
+		expect(
+			Number(response.headers.get("X-Asset-Check-Time")),
+		).toBeGreaterThanOrEqual(380);
+		expect(Number(response.headers.get("X-Database-Init-Time"))).toBe(0);
+		expect(events).toContainEqual(
+			expect.objectContaining({
+				event: "health_check_complete",
+				data: expect.objectContaining({
+					status: "starting",
+					reason: "assets not ready",
+				}),
+			}),
+		);
 	});
 });

--- a/cli/src/__tests__/daemon/health-check-windows.test.ts
+++ b/cli/src/__tests__/daemon/health-check-windows.test.ts
@@ -1,426 +1,63 @@
-import { describe, expect, test, beforeEach, afterEach } from "bun:test";
-import { mkdtemp, rmdir, writeFile, mkdir } from "node:fs/promises";
-import { tmpdir, platform } from "node:os";
-import { join } from "node:path";
-import type { HealthCheckResult } from "../../../web-ui/src/daemon/ipc.js";
+import { describe, expect, test } from "bun:test";
 import { checkHealthWithHeaders } from "../../../web-ui/src/daemon/ipc.js";
+import { getHealthCheckTimeoutMs } from "../../../web-ui/src/daemon/manager.js";
 
-/**
- * Mock DaemonConnection for testing.
- */
-interface MockDaemonConnection {
-	baseUrl: string;
-}
-
-/**
- * Helper to create a mock daemon connection.
- */
-function createMockConnection(port: number): MockDaemonConnection {
-	return {
-		baseUrl: `http://localhost:${port}`,
-	};
-}
-
-/**
- * Helper to assert header values are valid integers.
- */
-function assertHeadersAreValidIntegers(
-	headers: Record<string, string | undefined>,
-): void {
-	for (const [key, value] of Object.entries(headers)) {
-		if (value !== undefined) {
-			const num = Number.parseInt(value, 10);
-			expect(Number.isNaN(num)).toBe(false);
-			expect(num).toBeGreaterThanOrEqual(0);
-		}
-	}
-}
-
-describe("health-check-windows", () => {
-	describe("timeout configuration", () => {
-		const originalEnv = { ...process.env };
-
-		beforeEach(() => {
-			// Reset env var
-			delete process.env.RP1_HEALTH_CHECK_TIMEOUT_MS;
-		});
-
-		afterEach(() => {
-			// Restore env
-			process.env = { ...originalEnv };
-		});
-
-		test("returns 60000ms on Windows platform", () => {
-			// This test runs on all platforms and verifies the platform-conditional logic
-			// In actual Windows environment, platform() === "win32"
-			const expectedTimeout =
-				platform() === "win32" ? 60000 : 5000;
-			const isWindows = platform() === "win32";
-			expect(isWindows).toBe(isWindows); // Verify we can detect platform
-		});
-
-		test("respects RP1_HEALTH_CHECK_TIMEOUT_MS env var when set", () => {
-			process.env.RP1_HEALTH_CHECK_TIMEOUT_MS = "30000";
-			const parsed = Number.parseInt(
-				process.env.RP1_HEALTH_CHECK_TIMEOUT_MS,
-				10,
-			);
-			expect(parsed).toBe(30000);
-		});
-
-		test("handles invalid env var gracefully", () => {
-			process.env.RP1_HEALTH_CHECK_TIMEOUT_MS = "invalid";
-			const parsed = Number.parseInt(
-				process.env.RP1_HEALTH_CHECK_TIMEOUT_MS,
-				10,
-			);
-			expect(Number.isNaN(parsed)).toBe(true);
-		});
-
-		test("handles negative env var gracefully", () => {
-			process.env.RP1_HEALTH_CHECK_TIMEOUT_MS = "-5000";
-			const parsed = Number.parseInt(
-				process.env.RP1_HEALTH_CHECK_TIMEOUT_MS,
-				10,
-			);
-			expect(parsed).toBe(-5000);
-		});
+describe("health-check windows behavior", () => {
+	test("uses Windows default timeout and honors valid overrides", () => {
+		expect(getHealthCheckTimeoutMs("win32")).toBe(60_000);
+		expect(getHealthCheckTimeoutMs("darwin")).toBe(5_000);
+		expect(getHealthCheckTimeoutMs("linux", "30000")).toBe(30_000);
+		expect(getHealthCheckTimeoutMs("win32", "invalid")).toBe(60_000);
+		expect(getHealthCheckTimeoutMs("win32", "-5000")).toBe(60_000);
 	});
 
-	describe("health check response headers", () => {
-		test("X-Health-Check-Time header is present and valid integer", async () => {
-			// This is a structural test of header format
-			// In real scenario, this would come from handleV2HealthRequest
-			const mockHeaders = {
-				"x-health-check-time": "42",
-				"x-asset-check-time": "10",
-				"x-database-init-time": "20",
-				"x-project-count-time": "12",
-			};
-
-			assertHeadersAreValidIntegers(mockHeaders);
-			expect(mockHeaders["x-health-check-time"]).toBeDefined();
+	test("preserves health timing headers from startup responses", async () => {
+		const server = Bun.serve({
+			port: 0,
+			fetch() {
+				return new Response(
+					JSON.stringify({
+						status: "starting",
+						reason: "assets not ready",
+						timing: {
+							asset_check_ms: 385,
+							database_init_ms: 0,
+							project_count_ms: 0,
+							total_ms: 385,
+						},
+					}),
+					{
+						status: 503,
+						headers: {
+							"Content-Type": "application/json",
+							"X-Health-Check-Time": "385",
+							"X-Asset-Check-Time": "385",
+							"X-Database-Init-Time": "0",
+							"X-Project-Count-Time": "0",
+						},
+					},
+				);
+			},
 		});
 
-		test("all timing headers are valid integers", () => {
-			const timingHeaders = {
-				"x-health-check-time": "105",
-				"x-asset-check-time": "15",
-				"x-database-init-time": "35",
-				"x-project-count-time": "55",
-			};
-
-			assertHeadersAreValidIntegers(timingHeaders);
-
-			// Verify each header individually
-			expect(Number.parseInt(timingHeaders["x-health-check-time"], 10)).toBe(
-				105,
-			);
-			expect(Number.parseInt(timingHeaders["x-asset-check-time"], 10)).toBe(
-				15,
-			);
-			expect(
-				Number.parseInt(timingHeaders["x-database-init-time"], 10),
-			).toBe(35);
-			expect(
-				Number.parseInt(timingHeaders["x-project-count-time"], 10),
-			).toBe(55);
-		});
-
-		test("response body includes timing object", () => {
-			// Structural test of expected response body format
-			const mockResponseBody = {
-				status: "ok",
-				uptime: 10,
-				port: 7710,
-				projectCount: 2,
-				isDev: false,
-				version: "0.7.1",
-				timing: {
-					asset_check_ms: 5,
-					database_init_ms: 15,
-					project_count_ms: 8,
-					total_ms: 28,
-				},
-			};
-
-			expect(mockResponseBody.timing).toBeDefined();
-			expect(mockResponseBody.timing.asset_check_ms).toBeGreaterThanOrEqual(0);
-			expect(mockResponseBody.timing.database_init_ms).toBeGreaterThanOrEqual(0);
-			expect(mockResponseBody.timing.project_count_ms).toBeGreaterThanOrEqual(0);
-			expect(mockResponseBody.timing.total_ms).toBeGreaterThanOrEqual(0);
-
-			// Verify total is sum of parts
-			const calculatedTotal =
-				mockResponseBody.timing.asset_check_ms +
-				mockResponseBody.timing.database_init_ms +
-				mockResponseBody.timing.project_count_ms;
-			expect(mockResponseBody.timing.total_ms).toBeGreaterThanOrEqual(
-				calculatedTotal,
-			);
-		});
-
-		test("503 response includes timing for asset failure", () => {
-			// Test 503 response structure when assets not ready
-			const mockResponseBody503 = {
-				status: "starting",
-				reason: "assets not ready",
-				timing: {
-					asset_check_ms: 385,
-					database_init_ms: 0,
-					project_count_ms: 0,
-					total_ms: 385,
-				},
-			};
-
-			expect(mockResponseBody503.status).toBe("starting");
-			expect(mockResponseBody503.timing.asset_check_ms).toBeGreaterThan(0);
-			expect(mockResponseBody503.timing.database_init_ms).toBe(0);
-			expect(mockResponseBody503.timing.project_count_ms).toBe(0);
-		});
-	});
-
-	describe("asset availability retry logic", () => {
-		test("retry backoff delays are [10, 25, 50, 100, 200]ms", () => {
-			// Verify expected backoff sequence
-			const expectedDelays = [10, 25, 50, 100, 200];
-			const sum = expectedDelays.reduce((a, b) => a + b, 0);
-			expect(sum).toBe(385); // Total delay across all retries
-		});
-
-		test("maximum 5 retry attempts before failure", () => {
-			const maxAttempts = 5;
-			expect(maxAttempts).toBe(5);
-		});
-
-		test("total backoff time with all retries is ~385ms", () => {
-			const delays = [10, 25, 50, 100, 200];
-			const total = delays.reduce((a, b) => a + b, 0);
-			expect(total).toBe(385);
-		});
-
-		test("retry timing matches exponential pattern", () => {
-			const delays = [10, 25, 50, 100, 200];
-			// Verify each delay is less than the next
-			for (let i = 0; i < delays.length - 1; i++) {
-				expect(delays[i]).toBeLessThan(delays[i + 1]);
+		try {
+			const port = server.port;
+			if (port === undefined) {
+				throw new Error("Expected Bun.serve to assign a port");
 			}
-		});
-	});
 
-	describe("health check result structure", () => {
-		test("HealthCheckResult with headers has correct interface", () => {
-			const result: HealthCheckResult = {
-				health: {
-					status: "ok",
-					uptime: 5,
-					port: 7710,
-					projectCount: 1,
-					isDev: false,
-				},
-				headers: {
-					"x-health-check-time": "42",
-					"x-asset-check-time": "5",
-					"x-database-init-time": "15",
-					"x-project-count-time": "22",
-				},
-			};
-
-			expect(result.health).toBeDefined();
-			expect(result.headers).toBeDefined();
-			expect(result.headers?.["x-health-check-time"]).toBe("42");
-		});
-
-		test("HealthCheckResult without headers is valid", () => {
-			const result: HealthCheckResult = {
-				health: null,
-			};
+			const result = await checkHealthWithHeaders({
+				port,
+				baseUrl: `http://127.0.0.1:${port}`,
+			});
 
 			expect(result.health).toBeNull();
-			expect(result.headers).toBeUndefined();
-		});
-	});
-
-	describe("timing instrumentation", () => {
-		test("timing values capture phase durations correctly", () => {
-			// Simulate timing capture as done in handleV2HealthRequest
-			const healthCheckStartTime = Date.now();
-			const assetCheckMs = 10;
-			const databaseInitMs = 25;
-			const projectCountMs = 8;
-			const totalMs = Date.now() - healthCheckStartTime;
-
-			expect(totalMs).toBeGreaterThanOrEqual(0);
-			expect(assetCheckMs).toBeGreaterThanOrEqual(0);
-			expect(databaseInitMs).toBeGreaterThanOrEqual(0);
-			expect(projectCountMs).toBeGreaterThanOrEqual(0);
-		});
-
-		test("timing object sums to total correctly", () => {
-			const timing = {
-				asset_check_ms: 10,
-				database_init_ms: 25,
-				project_count_ms: 8,
-				total_ms: 43,
-			};
-
-			const sum =
-				timing.asset_check_ms +
-				timing.database_init_ms +
-				timing.project_count_ms;
-			expect(timing.total_ms).toBeGreaterThanOrEqual(sum);
-		});
-
-		test("timing is measured in milliseconds with non-negative values", () => {
-			const timings = [0, 1, 10, 100, 1000, 5000, 60000];
-
-			for (const timing of timings) {
-				expect(timing).toBeGreaterThanOrEqual(0);
-				expect(Number.isInteger(timing)).toBe(true);
-			}
-		});
-	});
-
-	describe("diagnostic event logging", () => {
-		test("diagnostic events include attempt count and timing", () => {
-			// Structure test for expected event data
-			const assetCheckAttemptEvent = {
-				event_type: "asset_check_attempt",
-				attempt: 1,
-				result: "success",
-				timingMs: 5,
-				timestamp: Date.now(),
-			};
-
-			expect(assetCheckAttemptEvent.event_type).toBe("asset_check_attempt");
-			expect(assetCheckAttemptEvent.attempt).toBeGreaterThan(0);
-			expect(assetCheckAttemptEvent.timingMs).toBeGreaterThanOrEqual(0);
-		});
-
-		test("health check poll event structure", () => {
-			const pollEvent = {
-				event_type: "health_check_poll",
-				attempt: 2,
-				elapsedMs: 110,
-				result: "no_response",
-				"x-health-check-time": "100",
-				"x-asset-check-time": "25",
-				"x-database-init-time": "50",
-				"x-project-count-time": "25",
-			};
-
-			expect(pollEvent.event_type).toBe("health_check_poll");
-			expect(pollEvent.attempt).toBeGreaterThan(0);
-			expect(pollEvent.elapsedMs).toBeGreaterThanOrEqual(0);
-		});
-
-		test("health check succeeded event includes all timing headers", () => {
-			const successEvent = {
-				event_type: "health_check_succeeded",
-				attemptCount: 3,
-				elapsedMs: 250,
-				projectCount: 2,
-				uptime: 15,
-				"x-health-check-time": "210",
-				"x-asset-check-time": "50",
-				"x-database-init-time": "100",
-				"x-project-count-time": "60",
-			};
-
-			expect(successEvent.event_type).toBe("health_check_succeeded");
-			expect(successEvent["x-health-check-time"]).toBeDefined();
-			expect(successEvent["x-asset-check-time"]).toBeDefined();
-			expect(successEvent["x-database-init-time"]).toBeDefined();
-			expect(successEvent["x-project-count-time"]).toBeDefined();
-		});
-
-		test("health check timeout event documents final state", () => {
-			const timeoutEvent = {
-				event_type: "health_check_timeout",
-				attemptCount: 50,
-				finalElapsedMs: 60000,
-				timeoutMs: 60000,
-			};
-
-			expect(timeoutEvent.event_type).toBe("health_check_timeout");
-			expect(timeoutEvent.attemptCount).toBeGreaterThan(0);
-			expect(timeoutEvent.finalElapsedMs).toBeGreaterThanOrEqual(
-				timeoutEvent.timeoutMs,
-			);
-		});
-	});
-
-	describe("platform-specific timeout behavior", () => {
-		test("Windows timeout (60s) vs Unix timeout (5s) constants", () => {
-			const windowsTimeout = 60000;
-			const unixTimeout = 5000;
-
-			expect(windowsTimeout).toBe(60000);
-			expect(unixTimeout).toBe(5000);
-			expect(windowsTimeout).toBeGreaterThan(unixTimeout);
-		});
-
-		test("polling interval remains constant across platforms", () => {
-			const pollingInterval = 100;
-			expect(pollingInterval).toBe(100);
-		});
-
-		test("health check completion within Windows timeout is acceptable", () => {
-			// If health check completes in <= 60s on Windows, consider success
-			const windowsTimeout = 60000;
-			const healthCheckTime = 15000; // 15 seconds
-
-			expect(healthCheckTime).toBeLessThanOrEqual(windowsTimeout);
-		});
-
-		test("health check completion within Unix timeout is acceptable", () => {
-			// If health check completes in <= 5s on Unix, consider success
-			const unixTimeout = 5000;
-			const healthCheckTime = 2000; // 2 seconds
-
-			expect(healthCheckTime).toBeLessThanOrEqual(unixTimeout);
-		});
-	});
-
-	describe("response timing assertions", () => {
-		test("fast health check on healthy system (<100ms per phase)", () => {
-			const healthySystemTiming = {
-				asset_check_ms: 5,
-				database_init_ms: 20,
-				project_count_ms: 15,
-				total_ms: 40,
-			};
-
-			expect(healthySystemTiming.asset_check_ms).toBeLessThan(100);
-			expect(healthySystemTiming.database_init_ms).toBeLessThan(100);
-			expect(healthySystemTiming.project_count_ms).toBeLessThan(100);
-			expect(healthySystemTiming.total_ms).toBeLessThan(100);
-		});
-
-		test("slow asset check on slow system (>300ms per phase)", () => {
-			const slowSystemTiming = {
-				asset_check_ms: 385, // After 5 retries with backoff
-				database_init_ms: 150,
-				project_count_ms: 100,
-				total_ms: 635,
-			};
-
-			expect(slowSystemTiming.asset_check_ms).toBeGreaterThan(300);
-			expect(slowSystemTiming.total_ms).toBeLessThan(60000); // Still within Windows timeout
-		});
-
-		test("timing progression shows asset check dominates slow startup", () => {
-			// Scenario: slow asset I/O on Windows
-			const slowAssetTiming = {
-				asset_check_ms: 500,
-				database_init_ms: 50,
-				project_count_ms: 30,
-				total_ms: 580,
-			};
-
-			const assetPercentage =
-				(slowAssetTiming.asset_check_ms / slowAssetTiming.total_ms) * 100;
-			expect(assetPercentage).toBeGreaterThan(50);
-		});
+			expect(result.headers?.["x-health-check-time"]).toBe("385");
+			expect(result.headers?.["x-asset-check-time"]).toBe("385");
+			expect(result.headers?.["x-database-init-time"]).toBe("0");
+			expect(result.headers?.["x-project-count-time"]).toBe("0");
+		} finally {
+			server.stop(true);
+		}
 	});
 });

--- a/cli/src/__tests__/daemon/health-check-windows.test.ts
+++ b/cli/src/__tests__/daemon/health-check-windows.test.ts
@@ -1,0 +1,426 @@
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import { mkdtemp, rmdir, writeFile, mkdir } from "node:fs/promises";
+import { tmpdir, platform } from "node:os";
+import { join } from "node:path";
+import type { HealthCheckResult } from "../../../web-ui/src/daemon/ipc.js";
+import { checkHealthWithHeaders } from "../../../web-ui/src/daemon/ipc.js";
+
+/**
+ * Mock DaemonConnection for testing.
+ */
+interface MockDaemonConnection {
+	baseUrl: string;
+}
+
+/**
+ * Helper to create a mock daemon connection.
+ */
+function createMockConnection(port: number): MockDaemonConnection {
+	return {
+		baseUrl: `http://localhost:${port}`,
+	};
+}
+
+/**
+ * Helper to assert header values are valid integers.
+ */
+function assertHeadersAreValidIntegers(
+	headers: Record<string, string | undefined>,
+): void {
+	for (const [key, value] of Object.entries(headers)) {
+		if (value !== undefined) {
+			const num = Number.parseInt(value, 10);
+			expect(Number.isNaN(num)).toBe(false);
+			expect(num).toBeGreaterThanOrEqual(0);
+		}
+	}
+}
+
+describe("health-check-windows", () => {
+	describe("timeout configuration", () => {
+		const originalEnv = { ...process.env };
+
+		beforeEach(() => {
+			// Reset env var
+			delete process.env.RP1_HEALTH_CHECK_TIMEOUT_MS;
+		});
+
+		afterEach(() => {
+			// Restore env
+			process.env = { ...originalEnv };
+		});
+
+		test("returns 60000ms on Windows platform", () => {
+			// This test runs on all platforms and verifies the platform-conditional logic
+			// In actual Windows environment, platform() === "win32"
+			const expectedTimeout =
+				platform() === "win32" ? 60000 : 5000;
+			const isWindows = platform() === "win32";
+			expect(isWindows).toBe(isWindows); // Verify we can detect platform
+		});
+
+		test("respects RP1_HEALTH_CHECK_TIMEOUT_MS env var when set", () => {
+			process.env.RP1_HEALTH_CHECK_TIMEOUT_MS = "30000";
+			const parsed = Number.parseInt(
+				process.env.RP1_HEALTH_CHECK_TIMEOUT_MS,
+				10,
+			);
+			expect(parsed).toBe(30000);
+		});
+
+		test("handles invalid env var gracefully", () => {
+			process.env.RP1_HEALTH_CHECK_TIMEOUT_MS = "invalid";
+			const parsed = Number.parseInt(
+				process.env.RP1_HEALTH_CHECK_TIMEOUT_MS,
+				10,
+			);
+			expect(Number.isNaN(parsed)).toBe(true);
+		});
+
+		test("handles negative env var gracefully", () => {
+			process.env.RP1_HEALTH_CHECK_TIMEOUT_MS = "-5000";
+			const parsed = Number.parseInt(
+				process.env.RP1_HEALTH_CHECK_TIMEOUT_MS,
+				10,
+			);
+			expect(parsed).toBe(-5000);
+		});
+	});
+
+	describe("health check response headers", () => {
+		test("X-Health-Check-Time header is present and valid integer", async () => {
+			// This is a structural test of header format
+			// In real scenario, this would come from handleV2HealthRequest
+			const mockHeaders = {
+				"x-health-check-time": "42",
+				"x-asset-check-time": "10",
+				"x-database-init-time": "20",
+				"x-project-count-time": "12",
+			};
+
+			assertHeadersAreValidIntegers(mockHeaders);
+			expect(mockHeaders["x-health-check-time"]).toBeDefined();
+		});
+
+		test("all timing headers are valid integers", () => {
+			const timingHeaders = {
+				"x-health-check-time": "105",
+				"x-asset-check-time": "15",
+				"x-database-init-time": "35",
+				"x-project-count-time": "55",
+			};
+
+			assertHeadersAreValidIntegers(timingHeaders);
+
+			// Verify each header individually
+			expect(Number.parseInt(timingHeaders["x-health-check-time"], 10)).toBe(
+				105,
+			);
+			expect(Number.parseInt(timingHeaders["x-asset-check-time"], 10)).toBe(
+				15,
+			);
+			expect(
+				Number.parseInt(timingHeaders["x-database-init-time"], 10),
+			).toBe(35);
+			expect(
+				Number.parseInt(timingHeaders["x-project-count-time"], 10),
+			).toBe(55);
+		});
+
+		test("response body includes timing object", () => {
+			// Structural test of expected response body format
+			const mockResponseBody = {
+				status: "ok",
+				uptime: 10,
+				port: 7710,
+				projectCount: 2,
+				isDev: false,
+				version: "0.7.1",
+				timing: {
+					asset_check_ms: 5,
+					database_init_ms: 15,
+					project_count_ms: 8,
+					total_ms: 28,
+				},
+			};
+
+			expect(mockResponseBody.timing).toBeDefined();
+			expect(mockResponseBody.timing.asset_check_ms).toBeGreaterThanOrEqual(0);
+			expect(mockResponseBody.timing.database_init_ms).toBeGreaterThanOrEqual(0);
+			expect(mockResponseBody.timing.project_count_ms).toBeGreaterThanOrEqual(0);
+			expect(mockResponseBody.timing.total_ms).toBeGreaterThanOrEqual(0);
+
+			// Verify total is sum of parts
+			const calculatedTotal =
+				mockResponseBody.timing.asset_check_ms +
+				mockResponseBody.timing.database_init_ms +
+				mockResponseBody.timing.project_count_ms;
+			expect(mockResponseBody.timing.total_ms).toBeGreaterThanOrEqual(
+				calculatedTotal,
+			);
+		});
+
+		test("503 response includes timing for asset failure", () => {
+			// Test 503 response structure when assets not ready
+			const mockResponseBody503 = {
+				status: "starting",
+				reason: "assets not ready",
+				timing: {
+					asset_check_ms: 385,
+					database_init_ms: 0,
+					project_count_ms: 0,
+					total_ms: 385,
+				},
+			};
+
+			expect(mockResponseBody503.status).toBe("starting");
+			expect(mockResponseBody503.timing.asset_check_ms).toBeGreaterThan(0);
+			expect(mockResponseBody503.timing.database_init_ms).toBe(0);
+			expect(mockResponseBody503.timing.project_count_ms).toBe(0);
+		});
+	});
+
+	describe("asset availability retry logic", () => {
+		test("retry backoff delays are [10, 25, 50, 100, 200]ms", () => {
+			// Verify expected backoff sequence
+			const expectedDelays = [10, 25, 50, 100, 200];
+			const sum = expectedDelays.reduce((a, b) => a + b, 0);
+			expect(sum).toBe(385); // Total delay across all retries
+		});
+
+		test("maximum 5 retry attempts before failure", () => {
+			const maxAttempts = 5;
+			expect(maxAttempts).toBe(5);
+		});
+
+		test("total backoff time with all retries is ~385ms", () => {
+			const delays = [10, 25, 50, 100, 200];
+			const total = delays.reduce((a, b) => a + b, 0);
+			expect(total).toBe(385);
+		});
+
+		test("retry timing matches exponential pattern", () => {
+			const delays = [10, 25, 50, 100, 200];
+			// Verify each delay is less than the next
+			for (let i = 0; i < delays.length - 1; i++) {
+				expect(delays[i]).toBeLessThan(delays[i + 1]);
+			}
+		});
+	});
+
+	describe("health check result structure", () => {
+		test("HealthCheckResult with headers has correct interface", () => {
+			const result: HealthCheckResult = {
+				health: {
+					status: "ok",
+					uptime: 5,
+					port: 7710,
+					projectCount: 1,
+					isDev: false,
+				},
+				headers: {
+					"x-health-check-time": "42",
+					"x-asset-check-time": "5",
+					"x-database-init-time": "15",
+					"x-project-count-time": "22",
+				},
+			};
+
+			expect(result.health).toBeDefined();
+			expect(result.headers).toBeDefined();
+			expect(result.headers?.["x-health-check-time"]).toBe("42");
+		});
+
+		test("HealthCheckResult without headers is valid", () => {
+			const result: HealthCheckResult = {
+				health: null,
+			};
+
+			expect(result.health).toBeNull();
+			expect(result.headers).toBeUndefined();
+		});
+	});
+
+	describe("timing instrumentation", () => {
+		test("timing values capture phase durations correctly", () => {
+			// Simulate timing capture as done in handleV2HealthRequest
+			const healthCheckStartTime = Date.now();
+			const assetCheckMs = 10;
+			const databaseInitMs = 25;
+			const projectCountMs = 8;
+			const totalMs = Date.now() - healthCheckStartTime;
+
+			expect(totalMs).toBeGreaterThanOrEqual(0);
+			expect(assetCheckMs).toBeGreaterThanOrEqual(0);
+			expect(databaseInitMs).toBeGreaterThanOrEqual(0);
+			expect(projectCountMs).toBeGreaterThanOrEqual(0);
+		});
+
+		test("timing object sums to total correctly", () => {
+			const timing = {
+				asset_check_ms: 10,
+				database_init_ms: 25,
+				project_count_ms: 8,
+				total_ms: 43,
+			};
+
+			const sum =
+				timing.asset_check_ms +
+				timing.database_init_ms +
+				timing.project_count_ms;
+			expect(timing.total_ms).toBeGreaterThanOrEqual(sum);
+		});
+
+		test("timing is measured in milliseconds with non-negative values", () => {
+			const timings = [0, 1, 10, 100, 1000, 5000, 60000];
+
+			for (const timing of timings) {
+				expect(timing).toBeGreaterThanOrEqual(0);
+				expect(Number.isInteger(timing)).toBe(true);
+			}
+		});
+	});
+
+	describe("diagnostic event logging", () => {
+		test("diagnostic events include attempt count and timing", () => {
+			// Structure test for expected event data
+			const assetCheckAttemptEvent = {
+				event_type: "asset_check_attempt",
+				attempt: 1,
+				result: "success",
+				timingMs: 5,
+				timestamp: Date.now(),
+			};
+
+			expect(assetCheckAttemptEvent.event_type).toBe("asset_check_attempt");
+			expect(assetCheckAttemptEvent.attempt).toBeGreaterThan(0);
+			expect(assetCheckAttemptEvent.timingMs).toBeGreaterThanOrEqual(0);
+		});
+
+		test("health check poll event structure", () => {
+			const pollEvent = {
+				event_type: "health_check_poll",
+				attempt: 2,
+				elapsedMs: 110,
+				result: "no_response",
+				"x-health-check-time": "100",
+				"x-asset-check-time": "25",
+				"x-database-init-time": "50",
+				"x-project-count-time": "25",
+			};
+
+			expect(pollEvent.event_type).toBe("health_check_poll");
+			expect(pollEvent.attempt).toBeGreaterThan(0);
+			expect(pollEvent.elapsedMs).toBeGreaterThanOrEqual(0);
+		});
+
+		test("health check succeeded event includes all timing headers", () => {
+			const successEvent = {
+				event_type: "health_check_succeeded",
+				attemptCount: 3,
+				elapsedMs: 250,
+				projectCount: 2,
+				uptime: 15,
+				"x-health-check-time": "210",
+				"x-asset-check-time": "50",
+				"x-database-init-time": "100",
+				"x-project-count-time": "60",
+			};
+
+			expect(successEvent.event_type).toBe("health_check_succeeded");
+			expect(successEvent["x-health-check-time"]).toBeDefined();
+			expect(successEvent["x-asset-check-time"]).toBeDefined();
+			expect(successEvent["x-database-init-time"]).toBeDefined();
+			expect(successEvent["x-project-count-time"]).toBeDefined();
+		});
+
+		test("health check timeout event documents final state", () => {
+			const timeoutEvent = {
+				event_type: "health_check_timeout",
+				attemptCount: 50,
+				finalElapsedMs: 60000,
+				timeoutMs: 60000,
+			};
+
+			expect(timeoutEvent.event_type).toBe("health_check_timeout");
+			expect(timeoutEvent.attemptCount).toBeGreaterThan(0);
+			expect(timeoutEvent.finalElapsedMs).toBeGreaterThanOrEqual(
+				timeoutEvent.timeoutMs,
+			);
+		});
+	});
+
+	describe("platform-specific timeout behavior", () => {
+		test("Windows timeout (60s) vs Unix timeout (5s) constants", () => {
+			const windowsTimeout = 60000;
+			const unixTimeout = 5000;
+
+			expect(windowsTimeout).toBe(60000);
+			expect(unixTimeout).toBe(5000);
+			expect(windowsTimeout).toBeGreaterThan(unixTimeout);
+		});
+
+		test("polling interval remains constant across platforms", () => {
+			const pollingInterval = 100;
+			expect(pollingInterval).toBe(100);
+		});
+
+		test("health check completion within Windows timeout is acceptable", () => {
+			// If health check completes in <= 60s on Windows, consider success
+			const windowsTimeout = 60000;
+			const healthCheckTime = 15000; // 15 seconds
+
+			expect(healthCheckTime).toBeLessThanOrEqual(windowsTimeout);
+		});
+
+		test("health check completion within Unix timeout is acceptable", () => {
+			// If health check completes in <= 5s on Unix, consider success
+			const unixTimeout = 5000;
+			const healthCheckTime = 2000; // 2 seconds
+
+			expect(healthCheckTime).toBeLessThanOrEqual(unixTimeout);
+		});
+	});
+
+	describe("response timing assertions", () => {
+		test("fast health check on healthy system (<100ms per phase)", () => {
+			const healthySystemTiming = {
+				asset_check_ms: 5,
+				database_init_ms: 20,
+				project_count_ms: 15,
+				total_ms: 40,
+			};
+
+			expect(healthySystemTiming.asset_check_ms).toBeLessThan(100);
+			expect(healthySystemTiming.database_init_ms).toBeLessThan(100);
+			expect(healthySystemTiming.project_count_ms).toBeLessThan(100);
+			expect(healthySystemTiming.total_ms).toBeLessThan(100);
+		});
+
+		test("slow asset check on slow system (>300ms per phase)", () => {
+			const slowSystemTiming = {
+				asset_check_ms: 385, // After 5 retries with backoff
+				database_init_ms: 150,
+				project_count_ms: 100,
+				total_ms: 635,
+			};
+
+			expect(slowSystemTiming.asset_check_ms).toBeGreaterThan(300);
+			expect(slowSystemTiming.total_ms).toBeLessThan(60000); // Still within Windows timeout
+		});
+
+		test("timing progression shows asset check dominates slow startup", () => {
+			// Scenario: slow asset I/O on Windows
+			const slowAssetTiming = {
+				asset_check_ms: 500,
+				database_init_ms: 50,
+				project_count_ms: 30,
+				total_ms: 580,
+			};
+
+			const assetPercentage =
+				(slowAssetTiming.asset_check_ms / slowAssetTiming.total_ms) * 100;
+			expect(assetPercentage).toBeGreaterThan(50);
+		});
+	});
+});

--- a/cli/src/__tests__/migrate/migrate.test.ts
+++ b/cli/src/__tests__/migrate/migrate.test.ts
@@ -1,4 +1,11 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	setDefaultTimeout,
+	test,
+} from "bun:test";
 import { existsSync, readFileSync, realpathSync } from "node:fs";
 import { mkdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -24,6 +31,8 @@ import {
 	expectTaskRight,
 	initTestRepo,
 } from "../helpers/index.js";
+
+setDefaultTimeout(15000);
 
 describe("migrate", () => {
 	let tempDir: string;

--- a/cli/src/__tests__/web-ui/daemon/manager-lifecycle.test.ts
+++ b/cli/src/__tests__/web-ui/daemon/manager-lifecycle.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import * as childProcess from "node:child_process";
 import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -70,18 +71,35 @@ describe("daemon manager lifecycle recovery", () => {
 			},
 		}));
 		mock.module("node:child_process", () => ({
-			execSync: () => {
-				if (portOwnerPid === null) {
-					throw new Error("no owner");
+			...childProcess,
+			execSync: (
+				command: string,
+				options?: childProcess.ExecSyncOptions,
+			): Buffer | string => {
+				if (command.startsWith("lsof -ti:")) {
+					if (portOwnerPid === null) {
+						throw new Error("no owner");
+					}
+					return `${portOwnerPid}\n`;
 				}
-				return `${portOwnerPid}\n`;
+				return childProcess.execSync(command, options);
 			},
-			spawn: (command: string, args: string[]) => {
-				spawned.push({ command, args });
-				return {
-					pid: 4242,
-					unref: () => {},
-				};
+			spawn: (
+				command: string,
+				args?: readonly string[],
+				options?: childProcess.SpawnOptions,
+			) => {
+				const spawnArgs = Array.from(args ?? []);
+				if (spawnArgs[0] === "_daemon-server") {
+					spawned.push({ command, args: spawnArgs });
+					return {
+						pid: 4242,
+						unref: () => {},
+					};
+				}
+				return options === undefined
+					? childProcess.spawn(command, spawnArgs)
+					: childProcess.spawn(command, spawnArgs, options);
 			},
 		}));
 	});

--- a/cli/src/__tests__/web-ui/daemon/manager-lifecycle.test.ts
+++ b/cli/src/__tests__/web-ui/daemon/manager-lifecycle.test.ts
@@ -28,6 +28,8 @@ describe("daemon manager lifecycle recovery", () => {
 	let stoppedPorts: number[];
 	let spawned: Array<{ command: string; args: string[] }>;
 	let portOwnerPid: number | null;
+	const nextHealth = (port: number): Health | null =>
+		healthResponses.length > 0 ? healthResponses.shift()! : healthy(port);
 
 	beforeEach(async () => {
 		tempDir = await mkdtemp(join(tmpdir(), "rp1-daemon-manager-test-"));
@@ -57,10 +59,10 @@ describe("daemon manager lifecycle recovery", () => {
 				port,
 				baseUrl: `http://127.0.0.1:${port}`,
 			}),
-			checkHealth: async (conn: { port: number }) =>
-				healthResponses.length > 0
-					? healthResponses.shift()
-					: healthy(conn.port),
+			checkHealth: async (conn: { port: number }) => nextHealth(conn.port),
+			checkHealthWithHeaders: async (conn: { port: number }) => ({
+				health: nextHealth(conn.port),
+			}),
 			getDaemonStatus: async () => statusResponse,
 			stopDaemon: async (conn: { port: number }) => {
 				stoppedPorts.push(conn.port);

--- a/cli/src/agent-tools/command.ts
+++ b/cli/src/agent-tools/command.ts
@@ -3,7 +3,7 @@
  * Provides Commander.js commands for AI agent tools.
  */
 
-import { isAbsolute } from "node:path";
+import { posix, win32 } from "node:path";
 import { Command } from "commander";
 import * as E from "fp-ts/lib/Either.js";
 import { type CLIError, formatError, usageError } from "../../shared/errors.js";
@@ -74,6 +74,15 @@ import {
 const cleanupAndExit = () => {
 	closeEmitDatabase();
 };
+
+export const isPlatformAbsoluteProjectPath = (
+	projectPath: string,
+	platform: typeof process.platform = process.platform,
+): boolean =>
+	platform === "win32"
+		? win32.isAbsolute(projectPath)
+		: posix.isAbsolute(projectPath);
+
 process.on("exit", cleanupAndExit);
 process.on("SIGTERM", () => {
 	cleanupAndExit();
@@ -1175,10 +1184,7 @@ Examples:
 const emitCommand = agentToolsCommand
 	.command("emit")
 	.description("Record events for the rp1 workflow event system")
-	.option(
-		"--type <type>",
-		`Event type (${VALID_EVENT_TYPES.join(", ")})`,
-	)
+	.option("--type <type>", `Event type (${VALID_EVENT_TYPES.join(", ")})`)
 	.option("--run-id <id>", "Workflow run ID (UUID)")
 	.option("--workflow <name>", "Workflow name (e.g., build, pr-review)")
 	.option(
@@ -1380,7 +1386,7 @@ Examples:
 
 			const projectPath = options.project ?? process.cwd();
 
-			if (!isAbsolute(projectPath)) {
+			if (!isPlatformAbsoluteProjectPath(projectPath)) {
 				console.error(
 					createErrorResponse(
 						toolName,

--- a/cli/src/agent-tools/command.ts
+++ b/cli/src/agent-tools/command.ts
@@ -3,6 +3,7 @@
  * Provides Commander.js commands for AI agent tools.
  */
 
+import { isAbsolute } from "node:path";
 import { Command } from "commander";
 import * as E from "fp-ts/lib/Either.js";
 import { type CLIError, formatError, usageError } from "../../shared/errors.js";
@@ -1174,12 +1175,12 @@ Examples:
 const emitCommand = agentToolsCommand
 	.command("emit")
 	.description("Record events for the rp1 workflow event system")
-	.requiredOption(
+	.option(
 		"--type <type>",
 		`Event type (${VALID_EVENT_TYPES.join(", ")})`,
 	)
-	.requiredOption("--run-id <id>", "Workflow run ID (UUID)")
-	.requiredOption("--workflow <name>", "Workflow name (e.g., build, pr-review)")
+	.option("--run-id <id>", "Workflow run ID (UUID)")
+	.option("--workflow <name>", "Workflow name (e.g., build, pr-review)")
 	.option(
 		"--step <step>",
 		"Workflow step name (required for status_change, subflow_registered)",
@@ -1379,7 +1380,7 @@ Examples:
 
 			const projectPath = options.project ?? process.cwd();
 
-			if (!projectPath.startsWith("/")) {
+			if (!isAbsolute(projectPath)) {
 				console.error(
 					createErrorResponse(
 						toolName,
@@ -1436,7 +1437,6 @@ Examples:
 emitCommand
 	.command("end-run")
 	.description("End a live run as cancelled or abandoned")
-	.requiredOption("--run-id <id>", "Workflow run ID (UUID)")
 	.requiredOption(
 		"--outcome <outcome>",
 		"Terminal outcome (cancelled, abandoned)",
@@ -1463,12 +1463,24 @@ Examples:
 `,
 	)
 	.action(
-		async (options: {
-			runId: string;
-			outcome: string;
-			reason?: string;
-		}): Promise<void> => {
+		async (
+			options: {
+				outcome: string;
+				reason?: string;
+			},
+			command: { optsWithGlobals: () => { runId?: string } },
+		): Promise<void> => {
 			const toolName = "emit";
+			const runId = command.optsWithGlobals().runId;
+			if (!runId || runId.trim() === "") {
+				console.error(
+					createErrorResponse(
+						toolName,
+						formatError(usageError("--run-id is required"), false),
+					),
+				);
+				process.exit(1);
+			}
 			if (options.outcome !== "cancelled" && options.outcome !== "abandoned") {
 				console.error(
 					createErrorResponse(
@@ -1485,7 +1497,7 @@ Examples:
 			}
 
 			const result = await executeEndRun({
-				runId: options.runId,
+				runId,
 				outcome: options.outcome,
 				reason: options.reason,
 			})();

--- a/cli/src/agent-tools/emit/index.ts
+++ b/cli/src/agent-tools/emit/index.ts
@@ -5,7 +5,7 @@
  */
 
 import { createHash } from "node:crypto";
-import { resolve } from "node:path";
+import { isAbsolute, resolve } from "node:path";
 import { pipe } from "fp-ts/lib/function.js";
 import * as TE from "fp-ts/lib/TaskEither.js";
 import { resolveDirectorySet } from "../../../shared/directory-resolution.js";
@@ -360,7 +360,7 @@ const handleArtifactRegistration = (
 	const filePath = input.data.path as string;
 	const storageRoot = input.data.storageRoot as ArtifactStorageRoot;
 	const absolutePath =
-		storageRoot === "absolute" || filePath.startsWith("/")
+		storageRoot === "absolute" || isAbsolute(filePath)
 			? resolve(filePath)
 			: storageRoot === "project"
 				? resolve(run.rp1ProjectRoot, filePath)

--- a/cli/src/build/codex/validator.ts
+++ b/cli/src/build/codex/validator.ts
@@ -23,7 +23,8 @@ const extractFrontmatter = (
 	content: string,
 	file: string,
 ): E.Either<CLIError, Record<string, unknown>> => {
-	const lines = content.split("\n");
+	const normalized = content.replace(/\r\n/g, "\n");
+	const lines = normalized.split("\n");
 
 	// First line must be "---" (trimmed)
 	if (lines.length === 0 || lines[0].trim() !== "---") {

--- a/cli/src/build/parser.ts
+++ b/cli/src/build/parser.ts
@@ -84,17 +84,18 @@ const extractWorkflowMetadata = (
 /**
  * Extract YAML frontmatter and content from markdown.
  */
-const extractFrontmatter = (
+export const extractFrontmatter = (
 	content: string,
 	filePath: string,
 ): E.Either<CLIError, { metadata: Record<string, unknown>; body: string }> => {
-	if (!content.startsWith("---")) {
+	const normalized = content.replace(/\r\n/g, "\n");
+	if (!normalized.startsWith("---")) {
 		return E.left(
 			parseError(filePath, "Missing YAML frontmatter (must start with ---)"),
 		);
 	}
 
-	const parts = content.split("---");
+	const parts = normalized.split("---");
 	if (parts.length < 3) {
 		return E.left(
 			parseError(

--- a/cli/src/build/validator.ts
+++ b/cli/src/build/validator.ts
@@ -237,7 +237,8 @@ const extractFrontmatter = (
 	content: string,
 	file: string,
 ): E.Either<CLIError, { metadata: Record<string, unknown>; body: string }> => {
-	if (!content.startsWith("---")) {
+	const normalized = content.replace(/\r\n/g, "\n");
+	if (!normalized.startsWith("---")) {
 		return E.left(
 			validationError(
 				file,
@@ -247,7 +248,7 @@ const extractFrontmatter = (
 		);
 	}
 
-	const parts = content.split("---");
+	const parts = normalized.split("---");
 	if (parts.length < 3) {
 		return E.left(
 			validationError(

--- a/cli/web-ui/src/daemon/diagnostics.ts
+++ b/cli/web-ui/src/daemon/diagnostics.ts
@@ -2,6 +2,39 @@ import { appendFileSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
 import { getConfigDir } from "./config-dir";
 
+/**
+ * T6: Diagnostic Event Types for daemon health checks and asset availability.
+ * Supported event types:
+ * - asset_check_attempt: Asset availability check attempt with timing and result
+ * - asset_check_complete: Asset check final result after all retries
+ * - database_init_complete: Database initialization completion with timing
+ * - health_check_complete: Health endpoint handler completion with all timings
+ * - health_check_poll: Individual health check polling attempt
+ * - health_check_succeeded: Successful health check during polling
+ * - health_check_timeout: Health check polling timeout reached
+ */
+type DiagnosticEventType =
+	| "asset_check_attempt"
+	| "asset_check_complete"
+	| "database_init_complete"
+	| "health_check_complete"
+	| "health_check_poll"
+	| "health_check_succeeded"
+	| "health_check_timeout"
+	| string;
+
+/**
+ * Structured diagnostic event data for daemon health checks.
+ */
+interface DiagnosticEventData extends Record<string, unknown> {
+	event_type?: DiagnosticEventType;
+	timestamp?: string;
+	attempt_count?: number;
+	timing_ms?: number;
+	correlation_id?: string;
+	[key: string]: unknown;
+}
+
 function getDaemonLogPath(): string {
 	return join(getConfigDir(), "daemon.log");
 }

--- a/cli/web-ui/src/daemon/diagnostics.ts
+++ b/cli/web-ui/src/daemon/diagnostics.ts
@@ -13,7 +13,7 @@ import { getConfigDir } from "./config-dir";
  * - health_check_succeeded: Successful health check during polling
  * - health_check_timeout: Health check polling timeout reached
  */
-type DiagnosticEventType =
+export type DiagnosticEventType =
 	| "asset_check_attempt"
 	| "asset_check_complete"
 	| "database_init_complete"
@@ -26,7 +26,7 @@ type DiagnosticEventType =
 /**
  * Structured diagnostic event data for daemon health checks.
  */
-interface DiagnosticEventData extends Record<string, unknown> {
+export interface DiagnosticEventData extends Record<string, unknown> {
 	event_type?: DiagnosticEventType;
 	timestamp?: string;
 	attempt_count?: number;
@@ -56,8 +56,8 @@ function normalizeError(error: unknown): Record<string, string> {
 }
 
 export function logDaemonEvent(
-	event: string,
-	data: Record<string, unknown> = {},
+	event: DiagnosticEventType,
+	data: DiagnosticEventData = {},
 ): void {
 	try {
 		mkdirSync(getConfigDir(), { recursive: true });

--- a/cli/web-ui/src/daemon/ipc.ts
+++ b/cli/web-ui/src/daemon/ipc.ts
@@ -10,12 +10,19 @@ import type { ProjectEntry } from "../server/registry";
  * Response from daemon health check.
  */
 export interface HealthResponse {
-	readonly status: "ok";
-	readonly uptime: number;
-	readonly port: number;
-	readonly projectCount: number;
+	readonly status: "ok" | "starting";
+	readonly uptime?: number;
+	readonly port?: number;
+	readonly projectCount?: number;
 	readonly isDev?: boolean;
 	readonly version?: string;
+	readonly reason?: string;
+	readonly timing?: {
+		readonly asset_check_ms: number;
+		readonly database_init_ms: number;
+		readonly project_count_ms: number;
+		readonly total_ms: number;
+	};
 }
 
 /**
@@ -52,6 +59,19 @@ export function createConnection(port: number): DaemonConnection {
 }
 
 /**
+ * Health check response with response metadata.
+ */
+export interface HealthCheckResult {
+	readonly health: HealthResponse | null;
+	readonly headers?: {
+		readonly "x-health-check-time"?: string;
+		readonly "x-asset-check-time"?: string;
+		readonly "x-database-init-time"?: string;
+		readonly "x-project-count-time"?: string;
+	};
+}
+
+/**
  * Check if the daemon is healthy.
  */
 export async function checkHealth(
@@ -70,6 +90,45 @@ export async function checkHealth(
 		return (await response.json()) as HealthResponse;
 	} catch {
 		return null;
+	}
+}
+
+/**
+ * Check if the daemon is healthy and capture response headers for diagnostics.
+ * T5: Polling Instrumentation - captures X-* timing headers
+ */
+export async function checkHealthWithHeaders(
+	conn: DaemonConnection,
+): Promise<HealthCheckResult> {
+	try {
+		const response = await fetch(`${conn.baseUrl}/api/v2/health`, {
+			method: "GET",
+			signal: AbortSignal.timeout(2000),
+		});
+
+		if (!response.ok) {
+			return { health: null };
+		}
+
+		const health = (await response.json()) as HealthResponse;
+		return {
+			health,
+			headers: {
+				"x-health-check-time": response.headers.get(
+					"X-Health-Check-Time",
+				) ?? undefined,
+				"x-asset-check-time": response.headers.get("X-Asset-Check-Time") ??
+					undefined,
+				"x-database-init-time": response.headers.get(
+					"X-Database-Init-Time",
+				) ?? undefined,
+				"x-project-count-time": response.headers.get(
+					"X-Project-Count-Time",
+				) ?? undefined,
+			},
+		};
+	} catch {
+		return { health: null };
 	}
 }
 

--- a/cli/web-ui/src/daemon/ipc.ts
+++ b/cli/web-ui/src/daemon/ipc.ts
@@ -71,6 +71,18 @@ export interface HealthCheckResult {
 	};
 }
 
+const readHealthTimingHeaders = (
+	response: Response,
+): NonNullable<HealthCheckResult["headers"]> => ({
+	"x-health-check-time":
+		response.headers.get("X-Health-Check-Time") ?? undefined,
+	"x-asset-check-time": response.headers.get("X-Asset-Check-Time") ?? undefined,
+	"x-database-init-time":
+		response.headers.get("X-Database-Init-Time") ?? undefined,
+	"x-project-count-time":
+		response.headers.get("X-Project-Count-Time") ?? undefined,
+});
+
 /**
  * Check if the daemon is healthy.
  */
@@ -106,27 +118,14 @@ export async function checkHealthWithHeaders(
 			signal: AbortSignal.timeout(2000),
 		});
 
+		const headers = readHealthTimingHeaders(response);
+
 		if (!response.ok) {
-			return { health: null };
+			return { health: null, headers };
 		}
 
 		const health = (await response.json()) as HealthResponse;
-		return {
-			health,
-			headers: {
-				"x-health-check-time": response.headers.get(
-					"X-Health-Check-Time",
-				) ?? undefined,
-				"x-asset-check-time": response.headers.get("X-Asset-Check-Time") ??
-					undefined,
-				"x-database-init-time": response.headers.get(
-					"X-Database-Init-Time",
-				) ?? undefined,
-				"x-project-count-time": response.headers.get(
-					"X-Project-Count-Time",
-				) ?? undefined,
-			},
-		};
+		return { health, headers };
 	} catch {
 		return { health: null };
 	}

--- a/cli/web-ui/src/daemon/manager.ts
+++ b/cli/web-ui/src/daemon/manager.ts
@@ -113,8 +113,10 @@ const DEFAULT_PORT = 7710;
  * macOS and Linux get 5 seconds.
  * Can be overridden via RP1_HEALTH_CHECK_TIMEOUT_MS environment variable.
  */
-function getHealthCheckTimeoutMs(): number {
-	const envTimeout = process.env.RP1_HEALTH_CHECK_TIMEOUT_MS;
+export function getHealthCheckTimeoutMs(
+	platform: typeof process.platform = process.platform,
+	envTimeout: string | undefined = process.env.RP1_HEALTH_CHECK_TIMEOUT_MS,
+): number {
 	if (envTimeout) {
 		const parsed = Number.parseInt(envTimeout, 10);
 		if (!Number.isNaN(parsed) && parsed > 0) {
@@ -122,7 +124,7 @@ function getHealthCheckTimeoutMs(): number {
 		}
 	}
 
-	return process.platform === "win32" ? 60000 : 5000;
+	return platform === "win32" ? 60000 : 5000;
 }
 
 /**

--- a/cli/web-ui/src/daemon/manager.ts
+++ b/cli/web-ui/src/daemon/manager.ts
@@ -11,6 +11,7 @@ import { logDaemonEvent } from "./diagnostics";
 import { resolveDaemonExecutablePath } from "./executable";
 import {
 	checkHealth,
+	checkHealthWithHeaders,
 	createConnection,
 	type DaemonConnection,
 	type DaemonStatus,
@@ -107,9 +108,22 @@ export class DaemonPortConflictError extends Error {
 const DEFAULT_PORT = 7710;
 
 /**
- * Maximum time to wait for daemon to become healthy.
+ * Get the platform-aware timeout for health checks.
+ * Windows gets 60 seconds to accommodate slower I/O and process startup.
+ * macOS and Linux get 5 seconds.
+ * Can be overridden via RP1_HEALTH_CHECK_TIMEOUT_MS environment variable.
  */
-const HEALTH_CHECK_TIMEOUT_MS = 5000;
+function getHealthCheckTimeoutMs(): number {
+	const envTimeout = process.env.RP1_HEALTH_CHECK_TIMEOUT_MS;
+	if (envTimeout) {
+		const parsed = Number.parseInt(envTimeout, 10);
+		if (!Number.isNaN(parsed) && parsed > 0) {
+			return parsed;
+		}
+	}
+
+	return process.platform === "win32" ? 60000 : 5000;
+}
 
 /**
  * Interval between health check polls.
@@ -292,22 +306,74 @@ async function stopUntrackedDaemon(
 
 /**
  * Wait for the daemon to become healthy.
+ * T5: Health Check Polling Instrumentation
+ * - Logs each polling attempt with attempt number and elapsed time
+ * - Captures and logs response headers (X-Health-Check-Time, etc.)
+ * - Logs health_check_succeeded on success with timing and project info
+ * - Logs health_check_timeout on timeout with final metrics
  */
 async function waitForHealth(
 	conn: DaemonConnection,
-	timeoutMs: number = HEALTH_CHECK_TIMEOUT_MS,
+	timeoutMs: number = getHealthCheckTimeoutMs(),
 ): Promise<boolean> {
 	const startTime = Date.now();
+	let attemptCount = 0;
 
 	while (Date.now() - startTime < timeoutMs) {
-		const health = await checkHealth(conn);
-		if (health) {
-			return true;
+		attemptCount++;
+		const elapsedMs = Date.now() - startTime;
+
+		try {
+			const result = await checkHealthWithHeaders(conn);
+			if (result.health) {
+				const successData = {
+					attemptCount,
+					elapsedMs,
+					projectCount: result.health.projectCount,
+					uptime: result.health.uptime,
+				};
+
+				// Include response headers in success log if available
+				if (result.headers) {
+					Object.assign(successData, result.headers);
+				}
+
+				logDaemonEvent("health_check_succeeded", successData);
+				return true;
+			}
+
+			const pollData = {
+				attempt: attemptCount,
+				elapsedMs,
+				result: "no_response",
+			};
+
+			// Include response headers in poll log if available
+			if (result.headers) {
+				Object.assign(pollData, result.headers);
+			}
+
+			logDaemonEvent("health_check_poll", pollData);
+		} catch (error) {
+			logDaemonEvent("health_check_poll", {
+				attempt: attemptCount,
+				elapsedMs,
+				result: "error",
+				error: error instanceof Error ? error.message : String(error),
+			});
 		}
+
 		await new Promise((resolve) =>
 			setTimeout(resolve, HEALTH_CHECK_INTERVAL_MS),
 		);
 	}
+
+	const finalElapsedMs = Date.now() - startTime;
+	logDaemonEvent("health_check_timeout", {
+		attemptCount,
+		finalElapsedMs,
+		timeoutMs,
+	});
 
 	return false;
 }
@@ -417,6 +483,13 @@ export async function ensureDaemon(
 	options?: DaemonEnsureOptions | string,
 ): Promise<DaemonStartResult> {
 	const ensureOptions = normalizeEnsureOptions(options);
+	const healthCheckTimeout = getHealthCheckTimeoutMs();
+	logDaemonEvent("ensure_daemon_start", {
+		port,
+		healthCheckTimeoutMs: healthCheckTimeout,
+		platform: process.platform,
+		cliVersion: ensureOptions.cliVersion,
+	});
 	return withLifecycleLock(
 		{
 			operation: "ensureDaemon",

--- a/cli/web-ui/src/server/routes/content-utils.ts
+++ b/cli/web-ui/src/server/routes/content-utils.ts
@@ -34,10 +34,17 @@ export interface ApiContext {
 	readonly webUIDir?: string;
 }
 
-export function jsonResponse(data: unknown, status = 200): Response {
+export function jsonResponse(
+	data: unknown,
+	status = 200,
+	additionalHeaders: Record<string, string> = {},
+): Response {
 	return new Response(JSON.stringify(data), {
 		status,
-		headers: { "Content-Type": "application/json" },
+		headers: {
+			"Content-Type": "application/json",
+			...additionalHeaders,
+		},
 	});
 }
 

--- a/cli/web-ui/src/server/routes/static.ts
+++ b/cli/web-ui/src/server/routes/static.ts
@@ -1,4 +1,4 @@
-import { extname, join, resolve } from "node:path";
+import { extname, join, resolve, sep } from "node:path";
 import { ARCADE_RUNTIME_MANIFEST_FILENAME } from "../../types/runtime";
 
 const HTML_CACHE_CONTROL = "no-store, no-cache, must-revalidate";
@@ -115,7 +115,7 @@ export async function handleStaticRequest(
 	const filePath = resolve(distDir, pathname.slice(1)); // slice(1) removes leading /
 
 	// Security: Ensure resolved path is within distDir
-	if (!filePath.startsWith(`${resolvedDist}/`) && filePath !== resolvedDist) {
+	if (!filePath.startsWith(`${resolvedDist}${sep}`) && filePath !== resolvedDist) {
 		return new Response("Forbidden", { status: 403 });
 	}
 

--- a/cli/web-ui/src/server/routes/static.ts
+++ b/cli/web-ui/src/server/routes/static.ts
@@ -115,7 +115,10 @@ export async function handleStaticRequest(
 	const filePath = resolve(distDir, pathname.slice(1)); // slice(1) removes leading /
 
 	// Security: Ensure resolved path is within distDir
-	if (!filePath.startsWith(`${resolvedDist}${sep}`) && filePath !== resolvedDist) {
+	if (
+		!filePath.startsWith(`${resolvedDist}${sep}`) &&
+		filePath !== resolvedDist
+	) {
 		return new Response("Forbidden", { status: 403 });
 	}
 

--- a/cli/web-ui/src/server/routes/v2-api.ts
+++ b/cli/web-ui/src/server/routes/v2-api.ts
@@ -2154,7 +2154,7 @@ async function checkAssetAvailability(
 	const backoffDelays = [10, 25, 50, 100, 200];
 	let lastError: unknown;
 
-	for (let attempt = 0; attempt < backoffDelays.length; attempt++) {
+	for (let attempt = 0; attempt <= backoffDelays.length; attempt++) {
 		try {
 			const file = Bun.file(indexPath);
 			if (await file.exists()) {
@@ -2170,7 +2170,7 @@ async function checkAssetAvailability(
 			lastError = error;
 		}
 
-		if (attempt < backoffDelays.length - 1) {
+		if (attempt < backoffDelays.length) {
 			const delay = backoffDelays[attempt];
 			await new Promise((resolve) => setTimeout(resolve, delay));
 		}
@@ -2178,7 +2178,7 @@ async function checkAssetAvailability(
 
 	const timingMs = Date.now() - startTime;
 	logDaemonEvent("asset_check_attempt", {
-		attempt: backoffDelays.length,
+		attempt: backoffDelays.length + 1,
 		result: "exhausted",
 		timingMs,
 		error: lastError instanceof Error ? lastError.message : String(lastError),
@@ -2207,6 +2207,14 @@ export async function handleV2HealthRequest(
 
 		if (!assetsReady) {
 			const totalMs = Date.now() - healthCheckStartTime;
+			logDaemonEvent("health_check_complete", {
+				status: "starting",
+				reason: "assets not ready",
+				assetCheckMs,
+				databaseInitMs: 0,
+				projectCountMs: 0,
+				totalMs,
+			});
 			return jsonResponse(
 				{
 					status: "starting",

--- a/cli/web-ui/src/server/routes/v2-api.ts
+++ b/cli/web-ui/src/server/routes/v2-api.ts
@@ -2143,33 +2143,131 @@ export async function handleV2ProjectContentSaveRequest(
 }
 
 /**
+ * Check if assets are available with exponential backoff retry.
+ * T2: Asset Availability Retry Logic
+ */
+async function checkAssetAvailability(
+	webUIDir: string,
+): Promise<{ available: boolean; timingMs: number }> {
+	const indexPath = join(webUIDir, "client", "index.html");
+	const startTime = Date.now();
+	const backoffDelays = [10, 25, 50, 100, 200];
+	let lastError: unknown;
+
+	for (let attempt = 0; attempt < backoffDelays.length; attempt++) {
+		try {
+			const file = Bun.file(indexPath);
+			if (await file.exists()) {
+				const timingMs = Date.now() - startTime;
+				logDaemonEvent("asset_check_attempt", {
+					attempt: attempt + 1,
+					result: "success",
+					timingMs,
+				});
+				return { available: true, timingMs };
+			}
+		} catch (error) {
+			lastError = error;
+		}
+
+		if (attempt < backoffDelays.length - 1) {
+			const delay = backoffDelays[attempt];
+			await new Promise((resolve) => setTimeout(resolve, delay));
+		}
+	}
+
+	const timingMs = Date.now() - startTime;
+	logDaemonEvent("asset_check_attempt", {
+		attempt: backoffDelays.length,
+		result: "exhausted",
+		timingMs,
+		error: lastError instanceof Error ? lastError.message : String(lastError),
+	});
+	return { available: false, timingMs };
+}
+
+/**
  * GET /api/v2/health - daemon health check.
+ * T3: Health Endpoint Instrumentation
+ * T4: Response Header Injection
  */
 export async function handleV2HealthRequest(
 	ctx: ApiContext,
 ): Promise<Response> {
+	const healthCheckStartTime = Date.now();
+	let assetCheckMs = 0;
+	let databaseInitMs = 0;
+	let projectCountMs = 0;
+	let assetsReady = true;
+
 	if (ctx.webUIDir) {
-		const indexPath = join(ctx.webUIDir, "client", "index.html");
-		const file = Bun.file(indexPath);
-		if (!(await file.exists())) {
+		const assetCheck = await checkAssetAvailability(ctx.webUIDir);
+		assetCheckMs = assetCheck.timingMs;
+		assetsReady = assetCheck.available;
+
+		if (!assetsReady) {
+			const totalMs = Date.now() - healthCheckStartTime;
 			return jsonResponse(
-				{ status: "starting", reason: "assets not ready" },
+				{
+					status: "starting",
+					reason: "assets not ready",
+					timing: {
+						asset_check_ms: assetCheckMs,
+						database_init_ms: 0,
+						project_count_ms: 0,
+						total_ms: totalMs,
+					},
+				},
 				503,
+				{
+					"X-Health-Check-Time": String(totalMs),
+					"X-Asset-Check-Time": String(assetCheckMs),
+					"X-Database-Init-Time": "0",
+					"X-Project-Count-Time": "0",
+				},
 			);
 		}
 	}
 
+	const databaseInitStartTime = Date.now();
 	const db = await getDb();
-	const projectCount = await getProjectCount(db);
-	const uptime = Math.floor((Date.now() - ctx.startTime) / 1000);
+	databaseInitMs = Date.now() - databaseInitStartTime;
 
-	return jsonResponse({
+	const projectCountStartTime = Date.now();
+	const projectCount = await getProjectCount(db);
+	projectCountMs = Date.now() - projectCountStartTime;
+
+	const uptime = Math.floor((Date.now() - ctx.startTime) / 1000);
+	const totalMs = Date.now() - healthCheckStartTime;
+
+	const responseBody = {
 		status: "ok",
 		uptime,
 		port: ctx.port,
 		projectCount,
 		isDev: ctx.isDev ?? false,
 		...(ctx.version && { version: ctx.version }),
+		timing: {
+			asset_check_ms: assetCheckMs,
+			database_init_ms: databaseInitMs,
+			project_count_ms: projectCountMs,
+			total_ms: totalMs,
+		},
+	};
+
+	logDaemonEvent("health_check_complete", {
+		status: "ok",
+		assetCheckMs,
+		databaseInitMs,
+		projectCountMs,
+		totalMs,
+	});
+
+	return jsonResponse(responseBody, 200, {
+		"X-Health-Check-Time": String(totalMs),
+		"X-Asset-Check-Time": String(assetCheckMs),
+		"X-Database-Init-Time": String(databaseInitMs),
+		"X-Project-Count-Time": String(projectCountMs),
 	});
 }
 


### PR DESCRIPTION
  ## Summary

  Cluster of cross-platform bugs in rp1 surfaced while dog-fooding the tool on Windows (Git
  Bash + native Bun-compiled binary). The change set was scoped, planned, implemented, and
  reviewed using rp1's own `/build-fast` and `/code-audit` skills running against rp1's source
   tree — i.e. the project was used to fix the project. The local plan artifact at
  `docs/superpowers/plans/2026-05-13-tier1-windows-platform-hygiene.md` records the
  methodology; it is not part of the PR.

  **Install path on Windows.** `cli/scripts/generate-asset-imports.ts` emitted import paths
  with OS-native backslashes, breaking `bun build --compile`.
  `cli/web-ui/src/server/routes/static.ts` compared `resolve()` output against a hard-coded
  `"${dist}/"`, so every non-root request 403'd. Both now use POSIX-normalized strings and
  `path.sep` respectively.

  **Codex + Copilot platform builds.** Three parallel `extractFrontmatter` implementations
  (`cli/src/build/parser.ts`, `cli/src/build/validator.ts`,
  `cli/src/build/codex/validator.ts`) now normalize CRLF → LF before splitting on `---` or
  feeding text to `parseYaml`. Previously 15 codex and 7 copilot `SKILL.md` files failed with
  `YAMLParseError` whose reported line numbers did not match the content because the parser
  miscounted through `\r\n`.

  **`rp1 agent-tools emit` subcommands.** Parent `emit` declared `--type`, `--run-id`,
  `--workflow` as `requiredOption`, which Commander validates before dispatching to
  subcommands; `emit end-run` and `emit resume-run` could never satisfy the parent's gate.
  Demoted to `.option()`; `end-run` now reads `runId` from `command.optsWithGlobals()` with an
   explicit usage-error guard for the missing case. The bare-emit path is still validated by
  `validateEmitOptions`.

  **Windows absolute-path detection.** Two `startsWith("/")` checks
  (`cli/src/agent-tools/command.ts:1382` resume-run, `cli/src/agent-tools/emit/index.ts:363`
  artifact registration) rejected `C:\…` paths. Replaced with `path.isAbsolute()`.

  **Daemon health-check.** Windows-aware 60 s default timeout (vs 5 s elsewhere), honoring
  `RP1_HEALTH_CHECK_TIMEOUT_MS`. Asset-availability retry with exponential backoff at
  `/api/v2/health`. Per-phase timing captured in both JSON body and `X-Health-Check-Time` /
  `X-Asset-Check-Time` / `X-Database-Init-Time` / `X-Project-Count-Time` response headers.
  Structured `health_check_*` event logging. Regression coverage at
  `cli/src/__tests__/daemon/health-check-{regression,windows}.test.ts`.

  **Build pipeline.** `build-local-dev` now runs `bun install --frozen-lockfile` before the
  platform builds. Previously the recipe assumed the Bun global cache already contained the
  versions pinned in `cli/bun.lock`; on a cold or skewed cache (observed with
  `mermaid-ast@0.6.1` vs `0.8.2`) Bun would silently resolve newer transitive deps and break
  the bundle.

  **Repo hygiene.** New `.gitattributes` enforces LF for text files regardless of contributor
  `core.autocrlf`, with explicit binary entries and `*.bat` / `*.cmd` / `*.ps1` retaining
  CRLF. New `just setup-git` recipe and a "Line Endings" section in `.github/CONTRIBUTING.md`
  help contributors align local git config. `.gitignore` updated for `bin/rp1.exe`,
  `*.stackdump`, and `.claude/settings.local.json`. Skill-awareness catalogs in `AGENTS.md`
  and `CLAUDE.md` refreshed to match the current rp1 surface.

  ## PR Title Format

  `fix(cli): cross-platform install and runtime fixes`

  Patch-version bump under release-please. `cli` is the dominant scope; `web-ui` and repo-root
   changes are ride-alongs that would inflate noise as separate PRs.

  ## Test Plan

  - [x] `cd cli && bun test src/__tests__/build/frontmatter-crlf.test.ts` → 6/6 pass (LF
  baseline, pure CRLF, mixed line endings, body preservation, malformed missing-open,
  malformed missing-close).
  - [x] `cd cli && bun test src/__tests__/agent-tools/command-cli.test.ts` covers four new
  regressions: `emit end-run` with valid args dispatches; `emit resume-run` dispatches and
  accepts Windows paths; `emit end-run` without `--run-id` errors via the action guard with a
  structured JSON payload; bare `emit` without `--run-id` errors via `validateEmitOptions`.
  All four pass at the assertion level. The suite's `afterEach` hits a pre-existing
  Windows-only `EBUSY` flake when deleting the temporary sqlite DB; reproducible on `main`
  against the unrelated `"emit and resume-run operate on an isolated project event store"`
  test, so it is test infrastructure rather than a new regression.
  - [x] `cd cli && RP1_BUILD_INTERNAL=1 bun run scripts/build-codex.ts` → 0 `Invalid YAML in
  frontmatter` errors (previously 15). Same script for copilot → 0 `YAMLParseError` entries
  (previously 7).
  - [x] `cd cli && bun test src/__tests__/daemon/health-check-{regression,windows}.test.ts`
  covers timing-header capture, Windows timeout selection, `RP1_HEALTH_CHECK_TIMEOUT_MS`
  parsing, and asset-retry behavior.
  - [x] `rm -rf ~/.bun/install/cache/mermaid-ast && just build` → green; the new `bun install
  --frozen-lockfile` step re-fetches the locked tree before the compile.
  - [x] Live binary smoke against a freshly built `bin/rp1.exe`:
      - `rp1 agent-tools emit end-run --run-id <uuid> --outcome cancelled --reason demo` →
  reaches the action (was `error: required option '--run-id <id>' not specified`).
      - `rp1 agent-tools emit end-run --outcome cancelled` (no `--run-id`) → structured JSON
  error from the action guard.
      - `rp1 agent-tools emit resume-run --feature demo --flow build --project C:/code/rp1` →
  succeeds (was `Project path must be absolute`).
      - `http://127.0.0.1:7710/projects/<uuid>` against the rebuilt daemon → serves the SPA
  fallback (was `403 Forbidden`).
  - [x] `git check-attr -a plugins/base/skills/artifact-templates/SKILL.md` reports `text:
  auto`, `eol: lf` post-`.gitattributes` commit.

  Cross-platform verification on macOS / Linux is implicit in the shape of each change: every
  fix replaces a Windows-only-broken codepath (`startsWith("/")`, backslash-emitting
  `relative()`, `\r\n` reaching `parseYaml`) with a portable equivalent (`path.isAbsolute()`,
  `.split(sep).join("/")`, `replace(/\r\n/g, "\n")`). The only `process.platform`-conditional
  change is the daemon's 60 s vs 5 s health-check timeout, documented inline and overridable
  via `RP1_HEALTH_CHECK_TIMEOUT_MS`.

  ## Related Issues

  None tracked. All defects surfaced organically during a single dog-fooding session
  attempting a fresh install of rp1 on Windows. Follow-up issues worth filing separately:

  - `EBUSY` `afterEach` flake in `cli/src/__tests__/agent-tools/command-cli.test.ts`
  (pre-existing, surfaced more visibly by the new tests).
  - DRY consolidation of the three parallel `extractFrontmatter` implementations into a shared
   `normalizeLineEndings` helper.
  - Windows CI matrix in GitHub Actions to catch the next regression of this class at PR time
  rather than at install time.