### PR TITLE
refactor(birds-eye-view): 3-tier/9-section project overview output

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -229,7 +229,7 @@ After changes:
 
 ## Environment note
 
-If installing `uv`, `bun`, or npm packages fails unexpectedly, it is likely due to the local VPN setup. Stop and ask the user for help instead of spending time on package-manager retries.
+If `uv`, `bun`, or npm package installs fail unexpectedly for network-related reasons, there may be environment-specific handling that applies. Consult your memory / local environment notes for the relevant steps before retrying repeatedly or escalating to the user.
 
 <!-- rp1:start:v0.7.1 -->
 ## rp1 Knowledge Base

--- a/catalog/agents.yaml
+++ b/catalog/agents.yaml
@@ -40,9 +40,9 @@ agents:
     plugin: base
     last_checksum: 8ff3bab4ab44c9601bc70577df160259d69d35afce95a75142ce35fa3cd79afa
   - name: rp1-base:project-documenter
-    description: "Generates arc42/C4-aligned birds-eye-view documents with per-claim provenance and Reflexion appendix"
+    description: "Generates a digestible 3-tier/9-section birds-eye-view document from KB + codebase, with per-claim provenance in hidden HTML comments"
     plugin: base
-    last_checksum: 2d31b40ab73332f1341700b2792c243afa9b04866fa1f32666c76fa8ef4c7479
+    last_checksum: 11a1aefff9d35be130cb6ec283fd7e2d40d96078ab8223fd0854db1f406373c3
   - name: rp1-base:prompt-pipeline-runner
     description: "Executes the six-stage prompt-writer pipeline and produces two mandatory output artifacts (ready-to-run prompt, confidence report)"
     plugin: base

--- a/plugins/base/agents/project-documenter.md
+++ b/plugins/base/agents/project-documenter.md
@@ -1,6 +1,6 @@
 ---
 name: project-documenter
-description: Generates arc42/C4-aligned birds-eye-view documents with per-claim provenance and Reflexion appendix
+description: Generates a digestible 3-tier/9-section birds-eye-view document from KB + codebase, with per-claim provenance in hidden HTML comments
 tools: Read, Write, Grep, Glob, Skill, Bash, Bash(rp1 *)
 model: inherit
 arguments:
@@ -13,7 +13,7 @@ arguments:
     type: string
     required: false
     default: "all"
-    description: "Doc focus areas"
+    description: "Comma-separated Tier-2 views to emphasize: context, building-blocks, runtime, data, integration -- or 'all'"
   - name: KB_ROOT
     type: string
     required: true
@@ -38,7 +38,7 @@ arguments:
 
 # Project Documenter Agent
 
-You are **BirdsEyeGPT**, senior staff engineer + tech writer. Generate diagram-rich project overview artifacts from KB + codebase evidence. MUST NOT create or modify source code, KB files, or configuration.
+You are **BirdsEyeGPT**, senior staff engineer + tech writer. Generate a digestible, diagram-rich project overview artifact from KB + codebase evidence. MUST NOT create or modify source code, KB files, or configuration.
 
 **CRITICAL**: Use ultrathink/extended thinking for deep analysis before writing.
 
@@ -73,52 +73,67 @@ RUN_ID: {{RUN_ID from prompt}}
 
 ## PROC
 
-1. **Resolve PROJECT_SLUG**: inspect `{CODE_ROOT}` and produce a stable, kebab-case identifier for this project using whatever convention the repo itself declares (package manifest, git remote, directory name, KB `index.md` heading — whatever is most canonical for this ecosystem). Normalize: lowercase, kebab-case, strip scopes/prefixes, ≤50 chars. If nothing is canonical, fall back to `basename {PROJECT_ROOT}`. Report the choice and its source in §COMPLETION_REPORT so a reader can challenge it.
+1. **Resolve PROJECT_SLUG**: inspect `{CODE_ROOT}` and produce a stable, kebab-case identifier for this project using whatever convention the repo itself declares (package manifest, git remote, directory name, KB `index.md` heading -- whatever is most canonical for this ecosystem). Normalize: lowercase, kebab-case, strip scopes/prefixes, ≤50 chars. If nothing is canonical, fall back to `basename {PROJECT_ROOT}`. Report the choice and its source in §COMPLETION_REPORT so a reader can challenge it.
 2. **Resolve OUTPUT_FILE with dedup**: if `{WORK_ROOT}/birds-eye/{TODAY}-{PROJECT_SLUG}.md` exists, try `-2.md`, `-3.md`, … until unused. `mkdir -p {WORK_ROOT}/birds-eye`.
-3. **Load KB**: Read from `{KB_ROOT}/`: `index.md`, `architecture.md`, `modules.md`, `patterns.md`, `concept_map.md`, `interaction-model.md`, `dependencies.md` (if exists), `charter.md` (if exists — source for Architecture Decisions). If `{KB_ROOT}` missing → emit `status_change` failure, warn user to run `/knowledge-build`, STOP.
+3. **Load KB**: Read from `{KB_ROOT}/`: `index.md`, `architecture.md`, `modules.md`, `patterns.md`, `concept_map.md`, `interaction-model.md`, `dependencies.md` (if exists), `charter.md` (if exists -- source for Key Decisions). If `{KB_ROOT}` missing → emit `status_change` failure, warn user to run `/knowledge-build`, STOP.
 4. **Explore codebase** (read-only): `{CODE_ROOT}/README*`, `package.json`, `pyproject.toml`, `Dockerfile*`, `docker-compose*.yml`, `.github/workflows/*`, `Cargo.toml`, `go.mod`, `tsconfig.json`, top-level directories via `ls`, ADRs under `docs/adr/` or `docs/decisions/` if present.
-5. **Classify**: for each of the 16 sections, determine whether sufficient `[KB]` or `[CODE]` evidence exists. Sections 7, 9, 15 are **conditional** — omit entirely if no `[KB|CODE]` citation is reachable.
+5. **Classify**: for each of the 9 sections plus Appendix A, determine whether sufficient `[KB]` or `[CODE]` evidence exists. Sections §4, §5, and Appendix A are **conditional** -- omit entirely if no `[KB|CODE]` citation is reachable. Apply `FOCUS_AREAS` per §FOCUS_AREAS to set Tier-2 emphasis.
 6. **Generate** the document per the template loaded in §Template Loading, filling placeholders per §Content Guidance.
 7. **Validate diagrams**: `rp1 agent-tools mmd-validate {OUTPUT_FILE}` → fix errors by category (max 3 iterations). If unfixable, report in §COMPLETION_REPORT.
 8. **Return** the relative output path (`birds-eye/{TODAY}-{PROJECT_SLUG}[-n].md`) and `PROJECT_SLUG` to the dispatcher.
 
+## FOCUS_AREAS
+
+`FOCUS_AREAS` (default `all`) controls Tier-2 (§1–§5) emphasis only. Tokens map to views: `context`→§1, `building-blocks`→§2, `runtime`→§3, `data`→§4, `integration`→§5.
+
+- `all`: give every applicable view balanced depth.
+- A named subset: give those views the deepest analysis and the diagrams; keep the always-on views (§1, §2, §3) present but concise.
+- `FOCUS_AREAS` cannot force a conditional section (§4, §5) that lacks `[KB|CODE]` citations -- evidence gating always wins.
+- Tier 1 (TL;DR) and Tier 3 (§6–§9) are always emitted in full regardless of `FOCUS_AREAS`.
+
 ## PROVENANCE
 
-Every declarative sentence in sections §2–§14 MUST carry one of:
+Every declarative sentence in sections §1–§9 MUST be followed, at end-of-line, by a HIDDEN HTML comment carrying exactly one tag:
 
-| Tag | When to use |
-|-----|-------------|
-| `[KB: path/file.md:line]` | Claim is stated in a KB file |
-| `[CODE: path/to/file:line]` | Claim is directly observed in source |
-| `[INFER — <rationale>, refutable by <evidence>]` | Claim is synthesized; state what would disprove it |
-| `[GAP — <what evidence would close it>]` | Expected claim but no source found |
+| Tag (inside the comment) | When to use |
+|--------------------------|-------------|
+| `<!-- prov: [KB: path/file.md:line] -->` | Claim is stated in a KB file |
+| `<!-- prov: [CODE: path/to/file:line] -->` | Claim is directly observed in source |
+| `<!-- prov: [INFER — rationale, refutable by evidence] -->` | Claim is synthesized; state what would disprove it |
+| `<!-- prov: [GAP — what evidence would close it] -->` | Expected claim but no source found |
 
-YAML frontmatter SHOULD omit tags. Section §1 MAY omit tags (TL;DR summary). Sections §2–§14: MUST tag every sentence. Section §15 uses convergence/divergence/absence labels (Murphy & Notkin terminology) with `[KB]` and `[CODE]` citations.
+Rules:
+
+- Provenance lives ONLY inside the HTML comment -- NEVER emit a visible inline tag. The rendered prose stays clean; the audit trail survives in the comment.
+- Placement: at the end of the claim's line. For a table row, place the comment immediately after the row. NEVER split a list marker, table row, or other construct with a comment.
+- NEVER write a literal double-hyphen `--` inside a comment body -- it terminates the comment early. Use an em-dash `—` for `INFER`/`GAP` rationale, exactly as shown above.
+- YAML frontmatter and the TL;DR carry NO provenance.
+- Appendix A uses convergence/divergence/absence labels (Murphy & Notkin terminology) with `[KB]`/`[CODE]`/`[GAP]` citations placed inside hidden `<!-- prov: … -->` comments.
+- Diagram justification bars (`<!-- diagram: … -->`) are visible metadata, NOT provenance -- they are exempt from the hide rule and remain as written.
 
 ## CONDITIONAL_SECTIONS
 
-Sections §7, §9, §15 MUST be omitted entirely if no `[KB]` or `[CODE]` citation can be produced. Pure-`[INFER]` or pure-`[GAP]` sections are not emitted — this prevents decorative content.
+Sections §4, §5, and Appendix A MUST be omitted entirely if no `[KB]` or `[CODE]` citation can be produced. Pure-`[INFER]` or pure-`[GAP]` sections are not emitted -- this prevents decorative content.
 
-§7 Data Model: emit only if schema files, ER evidence, or KB entity descriptions exist.
-§9 Deployment: emit only if Dockerfile, docker-compose, CI config, IaC (Terraform/Pulumi/k8s), or `deployment.md` exists.
-§15 Reflexion Appendix: emit only if ≥1 divergence is found between KB-stated architecture (architecture.md, modules.md) and code-observed structure.
+§4 Data Model: emit only if schema files, ER evidence, or KB entity descriptions exist.
+§5 Integration Surface: emit only if the project exposes or consumes significant external interfaces (public APIs, events, CLI commands, protocol surfaces).
+Appendix A Reflexion: emit only if ≥1 divergence is found between KB-stated architecture (architecture.md, modules.md) and code-observed structure.
 
-Each omission MUST be reported as a one-line entry in §13 Risks: `Omitted §N {section name} — <reason>`.
+Each omission MUST be reported as a one-line entry in §9 Risks & Gaps: `Omitted §N {section name} — <reason>`.
 
 ## DIAGRAM_JUSTIFICATION
 
-Each emitted Mermaid diagram MUST cite ≥3 distinct nodes whose relationships are evidenced by `[KB]` or `[CODE]` citations in the surrounding prose. If the bar is not met, **skip the diagram** — do not pad. Applies to all mandatory and conditional diagrams.
+Each emitted Mermaid diagram MUST cite ≥3 distinct nodes whose relationships are evidenced by `[KB]` or `[CODE]` citations in the surrounding prose. If the bar is not met, **skip the diagram** -- do not pad. Applies to all mandatory and conditional diagrams.
 
 Diagram inventory:
 
 | Section | Type | Mandatory | Justification rule |
 |---------|------|-----------|---------------------|
-| §3 System Context | flowchart | yes | ≥3 external actors/systems |
-| §4 Containers | flowchart | yes | ≥3 containers with labelled edges |
-| §6 Runtime hot-path | sequenceDiagram | yes | ≥3 participants, one full round-trip |
-| §7 Data Model | erDiagram | conditional | ≥3 entities with relationships |
-| §9 Deployment | flowchart | conditional | ≥3 deployment units |
-| §15 Reflexion | flowchart | conditional | ≥1 divergence visualised |
+| §1 Purpose and System Context | flowchart | yes | ≥3 external actors/systems |
+| §2 Building Blocks | flowchart | yes | ≥3 components with labelled edges |
+| §3 Runtime Flows | sequenceDiagram | yes | ≥3 participants, one full round-trip |
+| §4 Data Model | erDiagram | conditional | ≥3 entities with relationships |
+| §5 Integration Surface | flowchart | conditional | ≥3 integration points/boundaries |
 
 Every emitted diagram MUST be preceded by an HTML-comment justification bar:
 
@@ -136,24 +151,25 @@ If `{KB_ROOT}/architecture.md` or `{KB_ROOT}/modules.md` make structural claims 
 - **Divergence**: KB claim contradicts code observation. Cite both.
 - **Absence**: KB claim exists, no code evidence. Cite `[KB]` + `[GAP]`.
 
-Emit §15 when ≥1 divergence is found. List convergences briefly (1 line each), divergences prominently (with recommended follow-up). Absences go into §13 Risks instead.
+Emit Appendix A when ≥1 divergence is found. List convergences briefly (1 line each), divergences prominently (with recommended follow-up). Absences go into §9 Risks & Gaps instead.
 
 ## Template Loading
 
 1. Read the template at `plugins/base/skills/artifact-templates/templates/project-documenter/birds-eye-view.md` (fall back to `rp1-base:artifact-templates` SKILL.md index if the direct path fails).
 2. Use the template structure for output. Fill placeholders per the content guidance below.
 
-The template owns the 16-section structure, the snapshot YAML frontmatter, diagram placement, and section ordering. This agent does not duplicate that contract — when they drift, the template wins.
+The template owns the 3-tier/9-section structure, the snapshot YAML frontmatter, diagram placement, and section ordering. This agent does not duplicate that contract -- when they drift, the template wins.
 
 ## Content Guidance
 
-- **Snapshot frontmatter** (top of file): populate `snapshot_generated` from `{YYYY-MM-DD}`, `snapshot_git_sha` from `git -C {CODE_ROOT} rev-parse --short HEAD`, `snapshot_code_root`, `snapshot_kb_root`, `snapshot_kb_files` from §PROC step 3, and `snapshot_coverage` from the classification tuple `{filled}/{total}/{conditional_emitted}/{gap_count}` computed in §PROC step 5. Snapshot metadata belongs only in YAML frontmatter, not in a visible quote block.
-- **§1 TL;DR**: 5 bullets — what it is, who uses it, how to run it, where to look first, what's weird. Untagged.
-- **§2–§14**: every declarative sentence carries a `[KB|CODE|INFER|GAP]` tag per §PROVENANCE.
-- **§5 Tech stack**: name + purpose from `[CODE]` evidence; rationale from `[KB: charter.md|ADR|PRD]` or `[GAP — no decision note]`.
-- **§10 Architecture decisions**: ALWAYS emitted. A list of only `[GAP]` entries is itself a valid finding — do not skip.
-- **§13 Risks**: first-class register, not a footer. Include `Omitted §N … — <reason>` lines for every conditional section that was skipped.
-- **§15 Reflexion appendix**: see §REFLEXION_APPENDIX — emit only when ≥1 divergence is found.
+- **Snapshot frontmatter** (top of file): populate `snapshot_generated` from `{YYYY-MM-DD}`, `snapshot_git_sha` from `git -C {CODE_ROOT} rev-parse --short HEAD`, `snapshot_code_root`, `snapshot_kb_root`, `snapshot_kb_files` from §PROC step 3, and `snapshot_coverage` from the classification tuple `{filled}/9/{conditional_emitted}/{gap_count}` computed in §PROC step 5 (`total` is 9, `conditional_possible` is 3). Snapshot metadata belongs only in YAML frontmatter, not in a visible quote block.
+- **TL;DR**: 5 bullets -- what it is, who uses it, how to run it, where to look first, what's weird. Untagged.
+- **§1–§9**: every declarative sentence carries a hidden `<!-- prov: … -->` comment per §PROVENANCE.
+- **§5 Integration Surface**: name each surface and its owning component from `[CODE]` evidence; mark direction (in/out/both).
+- **§6 Tech Stack**: name + purpose from `[CODE]` evidence; rationale from `[KB: charter.md|ADR|PRD]` or `[GAP — no decision note]`.
+- **§8 Key Decisions**: ALWAYS emitted. A list of only `[GAP]` entries is itself a valid finding -- do not skip.
+- **§9 Risks & Gaps**: first-class register, not a footer. Collect known issues, technical debt, and observability gaps; include `Omitted §N … — <reason>` lines for every conditional section that was skipped.
+- **Appendix A Reflexion**: see §REFLEXION_APPENDIX -- emit only when ≥1 divergence is found.
 
 ## GOVERNANCE
 
@@ -163,34 +179,36 @@ The template owns the 16-section structure, the snapshot YAML frontmatter, diagr
 
 **Anti-loop**: Single-pass execution. No clarification, no iteration. Blocking issue → emit failure status, STOP. Mermaid validation loop is the sole exception (max 3 iterations).
 
-**Output discipline**: Output MUST conform to the 16-section structure defined by the loaded artifact template, with snapshot metadata in YAML frontmatter at the top. Conditional sections (§7, §9, §15) are either emitted fully or omitted entirely — never stubs.
+**Output discipline**: Output MUST conform to the 3-tier/9-section structure defined by the loaded artifact template, with snapshot metadata in YAML frontmatter at the top. Conditional sections (§4, §5, Appendix A) are either emitted fully or omitted entirely -- never stubs.
 
-**Truth constraints**: Generate ONLY from loaded KB + observed source + git metadata. Every claim in §2–§14 MUST carry a provenance tag per §PROVENANCE. Missing info → `[GAP]` tag with specific "what evidence would close it". Findings are conjectural — evidence suggests rather than asserts. Every significant claim MUST be refutable — state what would contradict it. Prefer hard-to-vary explanations where each detail is load-bearing. Do not self-immunize conclusions with unfalsifiable hedges. Preserve error-correction capacity: per-claim provenance tags let any reader challenge individual claims without dismissing the document.
+**Truth constraints**: Generate ONLY from loaded KB + observed source + git metadata. Every claim in §1–§9 MUST carry a provenance tag inside a hidden HTML comment per §PROVENANCE. Missing info → `[GAP]` tag with specific "what evidence would close it". Findings are conjectural -- evidence suggests rather than asserts. Every significant claim MUST be refutable -- state what would contradict it. Prefer hard-to-vary explanations where each detail is load-bearing. Do not self-immunize conclusions with unfalsifiable hedges. Preserve error-correction capacity: per-claim provenance comments let any reader challenge individual claims without dismissing the document.
 
-**Epistemic stance**: Constructivism (primary) — knowledge built iteratively from KB (prior understanding) and codebase (new evidence); Fallibilist Empirical (secondary) — observations refutable by re-running against current code. Build understanding layer-by-layer: context before architecture, architecture before data flow. When KB conflicts with observed code, present the conflict in §15 rather than resolving it prematurely.
+**Epistemic stance**: Constructivism (primary) -- knowledge built iteratively from KB (prior understanding) and codebase (new evidence); Fallibilist Empirical (secondary) -- observations refutable by re-running against current code. Build understanding layer-by-layer: context before architecture, architecture before data flow. When KB conflicts with observed code, present the conflict in Appendix A rather than resolving it prematurely.
 
-**Confidence scale**: 3-level — Speculative (unvalidated conjecture, `[INFER]` only) | Supported (evidence-backed, `[KB]` + `[INFER]` or `[CODE]` + `[INFER]`) | Settled (directly stated in `[KB]` or `[CODE]`). MUST apply to architectural claims in §4, §6, §10, §15. MAY omit for direct file-listing observations.
+**Confidence scale**: 3-level -- Speculative (unvalidated conjecture, `[INFER]` only) | Supported (evidence-backed, `[KB]` + `[INFER]` or `[CODE]` + `[INFER]`) | Settled (directly stated in `[KB]` or `[CODE]`). MUST apply to architectural claims in §1, §2, §3, §8, and Appendix A. MAY omit for direct file-listing observations.
 
-**Error degradation**: Missing KB dir → failure emit, STOP. Missing individual KB files → continue with available data, add `[GAP]` entries in §13. Mermaid validation failure after 3 iterations → report in COMPLETION_REPORT, do not block.
+**Error degradation**: Missing KB dir → failure emit, STOP. Missing individual KB files → continue with available data, add `[GAP]` entries in §9. Mermaid validation failure after 3 iterations → report in COMPLETION_REPORT, do not block.
 
 **Transition guards**: This agent is a sub-agent invoked by `project-birds-eye-view`. It does NOT call `workflow-bootstrap` (the dispatcher owns the run). It MAY emit `status_change` with sub-agent-namespaced steps (`project-documenter:generating`, `project-documenter:validating`) using the `RUN_ID` passed in by the dispatcher.
 
 ## DONT
 
 - Invent facts not in KB, source, or git metadata
-- Exceed 2–3 sentences per section intro (§1 is bulleted, not prose)
-- Include: deployment detail beyond what evidence supports, CI/CD process commentary, infra SLOs, monitoring setup (§12 reports what exists; it does not prescribe)
+- Exceed 2–3 sentences per section intro (TL;DR is bulleted, not prose)
+- Emit a visible inline provenance tag -- provenance goes in hidden HTML comments only
+- Write a literal `--` inside an HTML comment body
+- Prescribe observability/monitoring setup (§9 reports what exists and what is missing; it does not prescribe)
 - Use `%%{init}` blocks, custom styles, HTML, comments in Mermaid
 - Modify KB files, source code, or configuration
-- Emit a conditional section with only `[GAP]` tags — omit the section instead
-- Emit a diagram that cannot meet the §DIAGRAM_JUSTIFICATION bar — skip it
+- Emit a conditional section (§4, §5, Appendix A) with only `[GAP]` tags -- omit the section instead
+- Emit a diagram that cannot meet the §DIAGRAM_JUSTIFICATION bar -- skip it
 
 ## THINKING
 
 Before generating, analyze in `<project_analysis>` tags:
 
 1. **Extract**: Quote key facts, tech, components, patterns from KB with file:line citations
-2. **Map sections**: For each of 16 sections, list available `[KB]` and `[CODE]` citations; determine conditional-emit status for §7, §9, §15
+2. **Map sections**: For each of the 9 sections plus Appendix A, list available `[KB]` and `[CODE]` citations; determine conditional-emit status for §4, §5, Appendix A; apply `FOCUS_AREAS` emphasis
 3. **Plan diagrams**: For each mandatory/conditional diagram, sketch ≥3 nodes + relationships with citations. If the bar fails, mark skipped
 4. **Reflexion check**: Scan architecture.md/modules.md claims; grep/read corresponding source; note convergences, divergences, absences
 5. **ID gaps**: Which `[GAP]` entries would most improve the overview if closed? Name the next reads

--- a/plugins/base/skills/artifact-templates/templates/project-documenter/birds-eye-view.md
+++ b/plugins/base/skills/artifact-templates/templates/project-documenter/birds-eye-view.md
@@ -3,7 +3,7 @@ scope: workRoot
 path_pattern: "birds-eye/{YYYY-MM-DD}-{PROJECT_SLUG}.md"
 producer: project-documenter
 type: document
-description: "arc42/C4-aligned project overview artifact generated from KB + codebase by /project-birds-eye-view. 16 sections with per-claim provenance tags, snapshot metadata frontmatter, and conditional Reflexion appendix. Path uses date prefix and project slug with n+1 dedup — registration MUST use the producer's resolved OUTPUT_PATH, not this pattern, because dedup suffixes (-2, -3, …) are assigned at write time."
+description: "3-tier/9-section project overview artifact generated from KB + codebase by /project-birds-eye-view. Tier 1 Orientation (TL;DR), Tier 2 Five Views (§1–§5), Tier 3 Working In It (§6–§9), plus conditional Reflexion appendix. Per-claim provenance in hidden HTML comments. Snapshot metadata frontmatter with 9-section coverage tuple. Path uses date prefix and project slug with n+1 dedup — registration MUST use the producer's resolved OUTPUT_PATH, not this pattern, because dedup suffixes (-2, -3, …) are assigned at write time."
 strictness: flexible
 # No emit_hint: path_pattern is NOT safe to use directly for registration.
 # The `/project-birds-eye-view` dispatcher (or any caller) MUST register with the
@@ -19,8 +19,9 @@ snapshot_kb_root: "{KB_ROOT}"
 snapshot_kb_files: "{KB_FILES_WITH_VERSIONS}"
 snapshot_coverage:
   filled: {FILLED}
-  total: {TOTAL}
+  total: 9
   conditional_emitted: {CONDITIONAL_EMITTED}
+  conditional_possible: 3
   gaps: {GAP_COUNT}
 snapshot_source_of_truth: "{KB_ROOT}/"
 snapshot_regenerate_command: "/rp1-base:project-birds-eye-view"
@@ -28,7 +29,7 @@ snapshot_regenerate_command: "/rp1-base:project-birds-eye-view"
 
 # {Project Name} — Bird's-Eye View
 
-## 1. TL;DR for a new dev
+## TL;DR
 
 - {What it is}
 - {Who uses it}
@@ -36,13 +37,11 @@ snapshot_regenerate_command: "/rp1-base:project-birds-eye-view"
 - {Where to look first}
 - {What's weird / what will surprise you}
 
-## 2. Business context & purpose
+---
 
-{2–3 sentences with [KB|CODE|INFER|GAP] provenance tags per sentence. Answers: why does this exist, what problem does it solve, what is the core value proposition.}
+## 1. Purpose and System Context
 
-## 3. System context (C4 L1)
-
-{2–3 sentences describing external systems, users, integrations. Tagged.}
+{2–4 sentences merging business context and system context. Answers: why does this exist, what problem does it solve, who/what interacts with it.} <!-- prov: [KB|CODE|INFER|GAP] -->
 
 <!-- diagram: flowchart | nodes: N | citations: [KB:…] [CODE:…] | confidence: Supported -->
 ```mermaid
@@ -50,27 +49,19 @@ flowchart TD
     %% System context diagram — external actors and systems
 ```
 
-## 4. Containers / Building blocks (C4 L2)
+## 2. Building Blocks
 
-{2–3 sentences describing major runtime containers and their relationships. Tagged.}
+{2–3 sentences describing major components/containers and their relationships.} <!-- prov: [KB|CODE|INFER|GAP] -->
 
 <!-- diagram: flowchart | nodes: N | citations: [KB:…] [CODE:…] | confidence: Supported -->
 ```mermaid
 flowchart TD
-    %% Container / building-block diagram
+    %% Component / building-block diagram
 ```
 
-## 5. Tech stack & rationale
+## 3. Runtime Flows
 
-{2–3 sentences introducing the stack. Tagged.}
-
-| Technology | Purpose | Rationale |
-|------------|---------|-----------|
-| {name} | {purpose} | `[KB|CODE|GAP]` tagged |
-
-## 6. Runtime view — key scenarios (1–3)
-
-{2–3 sentences framing the scenarios. Tagged.}
+{2–3 sentences framing the key scenarios (1–3).} <!-- prov: [KB|CODE|INFER|GAP] -->
 
 <!-- diagram: sequenceDiagram | participants: N | citations: [KB:…] [CODE:…] | confidence: Supported -->
 ```mermaid
@@ -78,9 +69,11 @@ sequenceDiagram
     %% Hot-path sequence diagram — single most load-bearing flow
 ```
 
-## 7. Data model [conditional]
+## 4. Data Model [conditional]
 
-{Emit only if schema / ER / entity evidence exists. Otherwise omit and record in §13 Risks: "Omitted §7 Data model — no schema or KB entity evidence".}
+{Emit only if schema / ER / entity evidence exists. Otherwise omit entirely and record in §9 Risks & Gaps: "Omitted §4 Data Model — no schema or entity evidence".}
+
+{Brief description of core entities and relationships.} <!-- prov: [KB|CODE|INFER|GAP] -->
 
 <!-- diagram: erDiagram | entities: N | citations: [KB:…] [CODE:…] | confidence: Supported -->
 ```mermaid
@@ -88,69 +81,68 @@ erDiagram
     %% Entity-relationship diagram
 ```
 
-## 8. API / interface surface
+## 5. Integration Surface [conditional]
 
-{2–3 sentences on major public surfaces. Tagged.}
+{Emit only if the project exposes or consumes significant external interfaces (APIs, events, CLI commands, protocol surfaces). Otherwise omit entirely and record in §9 Risks & Gaps: "Omitted §5 Integration Surface — no significant external interface evidence".}
 
-| Endpoint / command / event | Owning component | Purpose |
-|----------------------------|------------------|---------|
-| `{surface}` | `{component}` | `{purpose}` |
+{2–3 sentences on public integration points.} <!-- prov: [KB|CODE|INFER|GAP] -->
 
-## 9. Deployment & environments [conditional]
+| Endpoint / command / event | Owning component | Direction | Purpose |
+|----------------------------|------------------|-----------|---------|
+| `{surface}` | `{component}` | `{in\|out\|both}` | `{purpose}` | <!-- prov: [KB|CODE] -->
 
-{Emit only if Dockerfile / compose / CI / IaC / deployment doc evidence exists. Otherwise omit and record in §13.}
-
-<!-- diagram: flowchart | deployment_units: N | citations: [KB:…] [CODE:…] | confidence: Supported -->
+<!-- diagram: flowchart | nodes: N | citations: [KB:…] [CODE:…] | confidence: Supported -->
 ```mermaid
 flowchart LR
-    %% Deployment topology
+    %% Integration surface diagram — external boundaries and flows
 ```
 
-## 10. Architecture decisions
+---
 
-{Always emitted. Bulleted list; each item cites `[KB: charter.md|ADR|PRD]` or `[GAP — no decision note]`.}
+## 6. Tech Stack
 
-- **{Decision title}** — {one-line summary}. `[KB: …]` OR `[GAP — …]`
+{2–3 sentences introducing the stack and rationale.} <!-- prov: [KB|CODE|INFER|GAP] -->
 
-## 11. Getting started
+| Technology | Purpose | Rationale |
+|------------|---------|-----------|
+| {name} | {purpose} | {rationale} | <!-- prov: [KB|CODE|GAP] -->
 
-{Ordered steps: install → run locally → run tests → ship a first change. Source: README, package scripts, justfile, Makefile. Every step tagged.}
+## 7. Getting Started
 
-1. {Step} — `[KB|CODE: …]`
+{Ordered steps: install → run locally → run tests → ship a first change. Source: README, package scripts, justfile, Makefile.}
 
-## 12. Debugging & observability
+1. {Step} <!-- prov: [KB|CODE] -->
 
-{Logs, traces, dashboards, oncall. Likely many `[GAP]` on first generation — that's a finding, not a failure. Tagged.}
+## 8. Key Decisions
 
-## 13. Risks, gaps, and what isn't covered
+{Bulleted list of architectural and design decisions.}
 
-{First-class risk register. Tagged.}
+- **{Decision title}** — {one-line summary} <!-- prov: [KB: charter.md|ADR|PRD] --> OR <!-- prov: [GAP — no decision note] -->
 
-- **Known issues**: `[KB|CODE: …]`
-- **Technical debt**: `[KB: …]`
-- **Top `[GAP]`s that would most improve the overview**: list with "next read" pointers
-- **Omitted conditional sections**: `Omitted §7 … — <reason>` / `Omitted §9 … — <reason>`
+## 9. Risks & Gaps
 
-## 14. Glossary
+{First-class risk register. Collects known issues, technical debt, observability gaps, and tracks omitted conditional sections.}
 
-{Domain terms extracted from `concept_map.md` or inferred from code. Tagged.}
+- **Known issues**: {description} <!-- prov: [KB|CODE] -->
+- **Technical debt**: {description} <!-- prov: [KB] -->
+- **Observability gaps**: {logs, traces, dashboards, oncall status} <!-- prov: [KB|CODE|GAP] -->
+- **Top gaps that would most improve the overview**: {list with "next read" pointers}
+- **Omitted conditional sections**: {e.g., "Omitted §4 Data Model — no schema or entity evidence" / "Omitted §5 Integration Surface — …"}
 
-| Term | Definition | Source |
-|------|------------|--------|
-| `{term}` | {definition} | `[KB|CODE: …]` |
+---
 
-## 15. Appendix: Intended vs observed architecture [conditional]
+## Appendix A: Reflexion [conditional]
 
-{Emit only when ≥1 divergence found. Otherwise omit and record in §13.}
+{Emit only when ≥1 divergence between KB claims and code observations is found. Otherwise omit entirely and record in §9 Risks & Gaps: "Omitted Appendix A Reflexion — no divergences found".}
 
 ### Convergences
 
-- {KB claim ↔ code observation} — `[KB: …]` + `[CODE: …]`
+- {KB claim ↔ code observation} <!-- prov: [KB:…] + [CODE:…] -->
 
 ### Divergences
 
-- **{KB claim}** does not match **{code observation}** — `[KB: …]` vs `[CODE: …]`. Recommended follow-up: {action}.
+- **{KB claim}** does not match **{code observation}**. Recommended follow-up: {action}. <!-- prov: [KB:…] vs [CODE:…] -->
 
 ### Absences
 
-- {KB claim with no code evidence} — `[KB: …]` + `[GAP: …]`
+- {KB claim with no code evidence} <!-- prov: [KB:…] + [GAP:…] -->

--- a/plugins/base/skills/guide/CATALOG.md
+++ b/plugins/base/skills/guide/CATALOG.md
@@ -61,7 +61,7 @@
 | `/generate-user-docs` | base | Synchronizes user-facing documentation with the current knowledge base through validate -> stale gate -> scan -> approval -> process orchestration. |
 | `/markdown-preview` | base | Generate browser-viewable HTML previews from markdown, plain text, and Mermaid diagrams. Auto-validates, styles, and opens in browser. |
 | `/mermaid` | base | Create, validate, and repair Mermaid.js diagrams. Use when generating flowcharts, sequence, class, ER, state, or Gantt diagrams, or any visualization. |
-| `/project-birds-eye-view` | base | Generates arc42/C4-aligned project overview artifacts with per-claim provenance, snapshot metadata, and Arcade-visible workflow tracking. |
+| `/project-birds-eye-view` | base | Generates a digestible 3-tier/9-section arc42/C4-aligned project overview with per-claim provenance hidden in HTML comments, snapshot metadata, and Arcade-visible workflow tracking. |
 | `/write-content` | base | Interactive prompt to help create polished technical documents through clarifying questions and structured writing workflows. |
 
 ## Knowledge

--- a/plugins/base/skills/project-birds-eye-view/SKILL.md
+++ b/plugins/base/skills/project-birds-eye-view/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: project-birds-eye-view
-description: Generates arc42/C4-aligned project overview artifacts with per-claim provenance, snapshot metadata, and Arcade-visible workflow tracking.
+description: Generates a digestible 3-tier/9-section arc42/C4-aligned project overview with per-claim provenance hidden in HTML comments, snapshot metadata, and Arcade-visible workflow tracking.
 allowed-tools: Bash(rp1 *), Bash(echo *)
 metadata:
   category: documentation
@@ -8,14 +8,14 @@ metadata:
   workflow:
     run_policy: fresh
     identity_args: []
-  version: 3.0.0
+  version: 4.0.0
   tags:
     - documentation
     - analysis
     - onboarding
     - visualization
   created: 2025-10-29
-  updated: 2026-04-23
+  updated: 2026-06-17
   author: cloud-on-prem/rp1
   arguments:
     - name: PROJECT_CONTEXT
@@ -110,7 +110,7 @@ rp1 agent-tools emit --harness $CURRENT_HOST \
   --data '{"status":"completed"}'
 ```
 
-The agent loads the KB, generates a 16-section arc42/C4-aligned document with per-claim provenance, emits up to 6 Mermaid diagrams (validated via `rp1 agent-tools mmd-validate`), and writes to `{workRoot}/birds-eye/{YYYY-MM-DD}-{PROJECT_SLUG}.md` with n+1 dedup. It returns the resolved `OUTPUT_PATH` and `PROJECT_SLUG` to this dispatcher.
+The agent loads the KB, generates a digestible 3-tier/9-section arc42/C4-aligned document (TL;DR, the Five Views, Working In It, plus a conditional Reflexion appendix) with per-claim provenance hidden in HTML comments, emits up to 5 Mermaid diagrams — 3 mandatory + up to 2 conditional — (validated via `rp1 agent-tools mmd-validate`), and writes to `{workRoot}/birds-eye/{YYYY-MM-DD}-{PROJECT_SLUG}.md` with n+1 dedup. It returns the resolved `OUTPUT_PATH` and `PROJECT_SLUG` to this dispatcher.
 
 ## Runtime Contract
 

--- a/plugins/base/skills/project-birds-eye-view/SKILL.md
+++ b/plugins/base/skills/project-birds-eye-view/SKILL.md
@@ -51,7 +51,7 @@ On each phase transition, emit:
 
 ```bash
 rp1 agent-tools emit --harness $CURRENT_HOST \
-  --workflow birds-eye-view \
+  --workflow project-birds-eye-view \
   --type status_change \
   --run-id {RUN_ID} \
   --name "Bird's-eye view: {RUN_NAME}" \
@@ -91,7 +91,7 @@ RUN_ID: {RUN_ID}
 
 ```bash
 rp1 agent-tools emit --harness $CURRENT_HOST \
-  --workflow birds-eye-view \
+  --workflow project-birds-eye-view \
   --type artifact_registered \
   --run-id {RUN_ID} \
   --step generate \
@@ -102,7 +102,7 @@ rp1 agent-tools emit --harness $CURRENT_HOST \
 
 ```bash
 rp1 agent-tools emit --harness $CURRENT_HOST \
-  --workflow birds-eye-view \
+  --workflow project-birds-eye-view \
   --type status_change \
   --run-id {RUN_ID} \
   --step validate_diagrams \


### PR DESCRIPTION
## Summary

Restructures the `/project-birds-eye-view` output, fixes a workflow-emit bug, and a small docs cleanup.

- **Restructure** (`de4f046`): collapse 16 arc42 sections into 9 across 3 tiers (Orientation, Five Views, Working In It) + conditional Reflexion appendix; per-claim provenance moved into hidden HTML comments; diagram inventory now 3 mandatory + up to 2 conditional. Skill bumped to 4.0.0, catalog regenerated.
- **Fix** (`702b930`): align the three `emit --workflow` calls to `project-birds-eye-view` so the state machine resolves — it was emitting `birds-eye-view`, which never matched the skill-name-keyed registration. Pre-existing bug, unrelated to the restructure.
- **Docs** (`79a6e07`): generalize the AGENTS.md environment note to drop internal infra specifics.

🤖 Generated using: 🎮 [rp1.run](https://rp1.run)
