### PR TITLE
ci(attestation): pin Node 24 so better-sqlite3 builds in the release job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,10 +144,15 @@ jobs:
       - uses: actions/checkout@v4
         if: ${{ github.event_name == 'pull_request' && github.head_ref == 'release-please--branches--main' }}
 
+      # Pin Node 24 rather than .tool-versions (node 26): the `cd cli && bun install`
+      # step below builds web-ui's promptfoo -> better-sqlite3, which ships no prebuilt
+      # binary for Node 26 and fails to compile from source. Node 24 has prebuilts.
+      # Follow-up: migrate web-ui's promptfoo to the libsql build (as evals already did)
+      # to drop better-sqlite3, then this can return to node-version-file: .tool-versions.
       - uses: actions/setup-node@v4
         if: ${{ github.event_name == 'pull_request' && github.head_ref == 'release-please--branches--main' }}
         with:
-          node-version-file: .tool-versions
+          node-version: "24"
 
       - uses: oven-sh/setup-bun@v2
         if: ${{ github.event_name == 'pull_request' && github.head_ref == 'release-please--branches--main' }}


### PR DESCRIPTION
## Problem

The **Verify Attestations** check fails on the release-please PR (#401, `chore(main): release 0.7.11`), blocking the release — even though `just eval-verify` passes locally.

## Root cause

The failure is in dependency install, **before** `just eval-verify` ever runs:

```
prebuild-install warn install No prebuilt binaries found (target=26.3.0 runtime=node arch=x64 ... platform=linux)
error: install script from "better-sqlite3" exited with 1
```

- The `attestation` job is the **only** CI job that runs `actions/setup-node` from `.tool-versions` (`node 26`, resolved to 26.3.0) before installing.
- Its `cd cli && bun install` step triggers a postinstall that installs `cli/web-ui` deps, which pull **promptfoo `0.120.25` → `better-sqlite3@12.6.2`** (a native module).
- `better-sqlite3@12.6.2` ships **no prebuilt binary for Node 26**, and the from-source build fails → the job dies during install.
- `test` / `check` / `plugins` jobs run the same install but on the runner's **default Node** (which has prebuilts), so they pass.
- Locally, `just eval-verify` only runs `bun run evals/src/attestation/cli.ts verify` against `evals/` deps — and `evals/` already moved to promptfoo `0.121.15` (**libsql**, no better-sqlite3). So the native build is never triggered and it passes. The attestations themselves are current.

The trigger was #402, which added both `.tool-versions` (`node 26`) and the `setup-node` step to this job. Since the job only runs on the release PR, the breakage stayed latent until this release cycle.

## Fix

Pin the attestation job to **Node 24** (has better-sqlite3 prebuilts). No `engines.node` requires 26, and `eval-verify` uses `evals'` libsql promptfoo, which is unaffected.

## Follow-up (separate PR)

Migrate `cli/web-ui`'s promptfoo to the **libsql** build (as `evals/` already did) to drop `better-sqlite3` entirely — then this job can return to `node-version-file: .tool-versions`.

Once merged, release-please rebases #401 and the check re-runs green.

🤖 Generated using: 🎮 [rp1.run](https://rp1.run)
