### PR TITLE
ci(release): tolerate transient Cloudflare Pages deploy flake in lighthouse

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -143,6 +143,11 @@ jobs:
       - name: Wait for Cloudflare Pages deploy
         uses: WalshyDev/cf-pages-await@3abae9f62a7672a1701300702ce42908e16cb88a  # v1
         id: cf-pages
+        # A transient Cloudflare Pages build flake must not fail the release
+        # workflow: the release is already created, and docs content is verified
+        # separately by the Docs Link Check (mkdocs build --strict). Tolerate the
+        # failure here and gate the audit below on the deploy actually succeeding.
+        continue-on-error: true
         with:
           accountId: ${{ secrets.CF_ACCOUNT_ID }}
           apiToken: ${{ secrets.CF_API_TOKEN }}
@@ -150,6 +155,7 @@ jobs:
           commitHash: ${{ github.sha }}
 
       - name: Run Lighthouse CI
+        if: steps.cf-pages.outcome == 'success'
         env:
           LHCI_GITHUB_APP_TOKEN: ${{ secrets.LHCI_GITHUB_APP_TOKEN }}
         run: |


### PR DESCRIPTION
## Problem

The Release Please run for [release 0.7.11](https://github.com/rp1-run/rp1/actions/runs/27889139158) failed. `release-please`, `deploy-docs`, and `build-opencode-artifacts` all succeeded — only **`lighthouse`** failed, at the **"Wait for Cloudflare Pages deploy"** step:

> `##[error]Deployment failed on step: build!`

The post-release `lighthouse` job uses `cf-pages-await` to wait for the Cloudflare Pages build, then audits the deployed docs. When Cloudflare's build flakes, that wait step fails and takes the whole Release Please workflow down with it — even though:

- the release was already created (`release-please` succeeded), and
- the docs content is verified independently by **Docs Link Check** (`mkdocs build --strict`), which passes.

This was a **transient Cloudflare-side flake**: the release commit `0068bdc1` changed only version/CHANGELOG files, and the immediately-preceding run (the #397 merge `9b51a5ce`, identical docs, ~5 min earlier) deployed and audited cleanly.

## Fix

- `continue-on-error: true` on the `cf-pages-await` step — a Cloudflare deploy/build hiccup no longer fails the release workflow.
- `if: steps.cf-pages.outcome == 'success'` on **Run Lighthouse CI** — the audit still runs (and its assertions still fail the job) when the deploy succeeds, and is skipped rather than failed when the deploy didn't.

Net: Lighthouse keeps catching real perf regressions on healthy deploys; transient Cloudflare deploy failures stop blocking releases.

## Note

If the Cloudflare Pages build turns out to be *persistently* failing (not transient), this keeps the release workflow green while the docs site may be stale — that needs a separate look at the Cloudflare Pages build logs / dashboard config (Python version, `pip install`), which aren't visible from GitHub. This is the right resilience fix regardless; deploy-health monitoring is a separate concern from the Lighthouse audit.

🤖 Generated using: 🎮 [rp1.run](https://rp1.run)
