### PR TITLE
feat(build): per-step model + reasoning-effort tiering for agents

### DIFF
--- a/.rp1/context/architecture.md
+++ b/.rp1/context/architecture.md
@@ -2,102 +2,72 @@
 
 **Project**: rp1
 **Architecture Pattern**: Plugin-based CLI with tracked workflow state, artifact-backed handoffs, and multi-platform prompt compilation
-**Last Updated**: 2026-04-12
+**Last Updated**: 2026-06-30
 
-## System Layers
+rp1 is a Bun/TypeScript CLI + plugin monorepo that compiles markdown-defined skills and agents into host-specific artifacts, tracks workflow runtime state as events, and serves a live Arcade dashboard.
 
-```text
-Interaction          CLI commands (cli/src/commands/)
-Workflow Definition  Plugin skills & agents (plugins/*)
-Runtime Services     Agent tools, emit, bootstrap (cli/src/agent-tools/)
-Build & Distribution Build pipeline, catalog (cli/src/build/, cli/src/catalog/)
-Presentation         Arcade SPA + HTTP/WS server (cli/web-ui/)
-Persistence          SQLite (~/.rp1/rp1.db), KB files (.rp1/context/), work artifacts (.rp1/work/)
-Evaluation           Dockerized eval execution (evals/)
-Quality Gates        Lefthook, Biome, catalog checks
-```
-
-## Architecture Diagram
+## High-Level Architecture
 
 ```mermaid
 flowchart TB
-    Host["Host Tools\nClaude Code / OpenCode / Codex"] --> CLI["rp1 CLI\ncli/src/main.ts"]
-    CLI --> Skills["Plugin Skills & Agents\nplugins/base, dev, utils"]
-    CLI --> AgentTools["Agent Tools\nemit, workflow-bootstrap,\nresolve-args, rp1-root-dir"]
-    CLI --> Build["Build Command"]
-    CLI --> Catalog["Catalog Registry\ncli/src/catalog/"]
+    Host["Host Tools<br/>Claude Code / OpenCode / Codex"] --> CLI["rp1 CLI<br/>cli/src/main.ts"]
+    CLI --> Skills["Plugin Skills & Agents<br/>plugins/base, dev, utils"]
+    CLI --> AgentTools["Agent Tools<br/>emit, workflow-bootstrap, resolve-args"]
+    CLI --> Build["Build Pipeline"]
+    CLI --> Catalog["Catalog Registry"]
     AgentTools --> EventDB[("~/.rp1/rp1.db")]
-    AgentTools --> Daemon["Arcade Daemon\nHTTP + WS"]
+    AgentTools --> Daemon["Arcade Daemon<br/>HTTP + WS"]
     Daemon --> Browser["Web Browser"]
-    Daemon --> Registry["Project Registry\nprojects.json + async mutex"]
-    Daemon --> Diagnostics["Diagnostics\ndaemon.log"]
-    Skills --> KB["Knowledge Base\n.rp1/context/*.md"]
-    Skills --> Work[".rp1/work/\nbrief.md + scan_results.json"]
-    Build --> Pipeline["LiquidJS build pipeline"]
-    Pipeline --> Artifacts["Platform artifacts + compiled binary"]
-    Catalog --> Guide["/guide meta-skill\nCATALOG.md + WORKFLOWS.md"]
+    Daemon --> Registry["Project Registry<br/>async mutex"]
+    Skills --> KB[".rp1/context KB"]
+    Skills --> Work[".rp1/work artifacts"]
+    Build --> Parse["parser"]
+    Parse --> Validate["validator<br/>tier + effort"]
+    Validate --> TierRes["tier-resolution<br/>resolveTier / resolveEffort"]
+    TierRes --> Render["LiquidJS templates"]
+    Render --> Artifacts["dist platform artifacts"]
 ```
 
 ## Architectural Patterns
 
-| Pattern | Description |
-|---------|-------------|
-| Plugin Architecture | Three plugin packs (base, dev, utils) with scoped capabilities and enforced dependency direction |
-| Event-Sourced Runtime State | Workflow progress tracked as events via `rp1 agent-tools emit` with status_change, waiting_for_user, artifact_registered, subflow_registered |
-| Cross-Platform Build Pipeline | Markdown specs compile into host-specific artifacts through shared LiquidJS pipeline. All 3 platform templates emit `arcade_tracked` field |
-| State-Machine-Driven Workflows | Skills declare `stateDiagram-v2` phases with explicit step transitions and validation |
-| Map-Reduce Agent Orchestration | Heavy analysis fans out to narrow workers and rejoins through parent orchestrator |
-| Artifact-Backed Workflow Handoffs | Multi-phase workflows bridge context through durable files in `.rp1/work/` |
-| Deterministic Workflow Bootstrap | `workflow-bootstrap` resolves directories, arguments, and run identity atomically. Skills declare `runPolicy` and `identityArgs` |
-| Catalog-as-Code | TypeScript catalog registry parses frontmatter, groups by category, renders CATALOG.md and init skill-awareness blocks |
-| Session Hooks | Host-specific hooks start services at session boundary using `--format hook-json` for structured output |
-| Cross-Process Registry Serialization | `withRegistryLock` async mutex serializes all registry mutations preventing race conditions |
-| Daemon Diagnostics Logging | Structured NDJSON log entries to `daemon.log` for post-mortem debugging |
-| Git Worktree-Aware Project Resolution | Project resolution derives paths from repo identity; guards against home-directory adoption |
-| Worktree-Aware Code Editing (CODE_ROOT) | Code-writing agents receive an explicit `codeRoot` directory for source-file reads and writes. In worktree contexts `codeRoot` equals the worktree path; in standard repos it equals `projectRoot`. Work artifacts continue to use `workRoot` (canonical `.rp1/work/`) and KB reads use `kbRoot`, keeping Arcade visibility intact while edits land in the user's active worktree |
-| Versioned Stanza Markers | Instruction-file stanzas carry version stamps for staleness detection and `rp1 migrate` upgrades |
-| Dockerized Eval Execution | Prompt evals run inside Docker containers isolating harness CLIs and dependencies |
+- **Cross-Platform Build Pipeline** — single-source agent/skill markdown compiles to 6 targets (Claude Code, OpenCode, Codex, Copilot, Antigravity, Gemini) via data-driven `PlatformDefinition` configs + LiquidJS templates.
+- **Additive-Field Tier Resolution** — agent `model` tier (deep/standard/fast/inherit) and `effort` (low–max) are resolved at build time from abstract aliases to platform-specific model IDs and effort field names, propagated as additive fields through the template context so templates stay format-only. (New in tiered-models-effort.)
+- **Event-Sourced Runtime State** — all workflow state changes are `rp1 agent-tools emit` events persisted to SQLite and broadcast over WebSocket.
+- **State-Machine-Driven Workflows** — skills declare `stateDiagram-v2` phases; steps are validated against the graph at emit time.
+- **Map-Reduce Agent Orchestration** — heavy analysis fans out to narrow workers and rejoins through a parent orchestrator (KB build, PR review).
+- **Deterministic Workflow Bootstrap** — `workflow-bootstrap` resolves directories, arguments, and run identity atomically; skills declare `runPolicy` + `identityArgs`.
+- **Artifact-Backed Handoffs** — inter-phase state persists as markdown/JSON under `.rp1/work/`.
+- **Catalog-as-Code** — the skill/agent catalog is derived from source frontmatter at build time.
+- **Worktree-Aware Code Editing** — agents distinguish `codeRoot` (edit target, worktree-aware) from `workRoot`/`kbRoot` (canonical `.rp1/`).
 
-## Key Data Flows
+## Layers
 
-### Event Pipeline
-Skill/agent emits workflow event -> State machine validation -> SQLite persistence -> HTTP notify daemon -> WebSocket broadcast to Arcade
+| Layer | Purpose | Components |
+|-------|---------|-----------|
+| Interaction | User-facing CLI commands, host tool integration | `cli/src/commands/` |
+| Workflow Definition | Plugin skills + agents | `plugins/{base,dev,utils}/` |
+| Runtime Services | Agent tools, emit, bootstrap, resolve-args | `cli/src/agent-tools/` |
+| Build & Distribution | Multi-platform compile with tier resolution, validation, rendering | `cli/src/build/`, `cli/src/catalog/` |
+| Presentation | Arcade SPA with real-time WS | `cli/web-ui/` |
+| Persistence | SQLite event store, KB, work artifacts | `~/.rp1/rp1.db`, `.rp1/context/`, `.rp1/work/` |
+| Evaluation | Dockerized prompt evals | `evals/` |
 
-### Workflow Bootstrap
-Tracked skill invokes `workflow-bootstrap` -> Resolves canonical directories -> Validates workflow contract -> Creates/resumes run -> Returns runId + directories + arguments
+## Data Flows
 
-### KB Generation
-Orchestrator selects mode (FULL/INCREMENTAL/FEATURE_LEARNING) -> Spatial analysis -> Parallel specialist agents -> Reconcile each section -> Write `.rp1/context/*.md` + `state.json`
+- **Build Pipeline (per-agent artifact)**: parse frontmatter (model tier + effort) → validate tier/effort/protected for all platforms → preprocess includes/conditionals → `resolveTier` → concrete model ID → `resolveEffort` → provider-specific `{fieldName, value}` → build `AgentArtifactData` → render platform Liquid template (conditional emit) → lint → write platform artifacts.
+- **Event Pipeline**: skill/agent emits event → state-machine validation → SQLite persist → HTTP daemon notify → WebSocket broadcast to Arcade.
+- **KB Generation**: orchestrator selects mode (FULL/INCREMENTAL/FEATURE_LEARNING) → spatial analysis → parallel specialist agents → reconcile → write `.rp1/context/*.md` + `state.json`.
 
-### Startup Recovery
-Server reads `daemon-state.json` high-water mark -> Queries SQLite for missed events -> Replays via WebSocket hub -> Prunes stale projects from registry
+## Integration Points
 
-### Project Registry
-Registration/access from CLI/hooks -> Worktree normalization -> UUID-keyed entry -> Async-mutex-serialized read-modify-write -> Atomic temp-file + rename
-
-## Integrations
-
-| Service | Purpose | Type |
-|---------|---------|------|
-| Bun | CLI runtime, HTTP/WS server, binary compilation, tests | Runtime |
-| bun:sqlite | Persist events, runs, artifacts, annotations, notifications | Embedded DB |
-| Git CLI | KB staleness, diffs, repo context, worktree resolution | Version control |
-| GitHub API | PR review, comments, reactions | REST API |
-| React + Vite | Arcade dashboard SPA | Frontend |
-| LiquidJS | Multi-platform prompt artifact rendering | Build |
-| chokidar | Watch `.rp1/work` and `.rp1/context` for live updates | Runtime |
-| promptfoo | Prompt quality evaluations | Testing |
-| Release Please | Semver and release automation | CI/CD |
-| GitHub Actions | CI, release, and automation jobs | CI/CD |
-| Lefthook | Local quality gates (lint, format, catalog check) | Dev tooling |
-| Biome | Linting and formatting for TS/TSX | Dev tooling |
-| MkDocs Material | Publish docs at `rp1.run` | Documentation |
-| Docker | Cross-platform testing and eval execution | Dev tooling |
+- **Runtime/build**: Bun (runtime, HTTP/WS server, binary compile, tests), `bun:sqlite` (event store), LiquidJS (template engine, `greedy:true` whitespace control).
+- **VCS/CI**: Git CLI (KB staleness, diffs, worktree resolution), GitHub API via `gh` (PR review), Release Please + GitHub Actions, Lefthook + Biome (local quality gates).
+- **Frontend**: React + Vite (Arcade SPA), chokidar (file watching), promptfoo + Docker (evals).
 
 ## Deployment
 
-- **Distribution**: Single-executable CLI with embedded assets plus background daemon
-- **Targets**: darwin-arm64, darwin-x64, linux-arm64, linux-x64, windows-x64
-- **Daemon**: Background Bun HTTP+WS server on port 7710 with PID-file lifecycle, version-aware restart, SIGTERM->SIGKILL escalation, diagnostic logging
-- **Config directory**: macOS `~/Library/Application Support/rp1/`, Linux `$XDG_CONFIG_HOME/rp1/`, Windows `%APPDATA%\rp1\`
-- **Docker**: Multi-stage Dockerfile (base -> target-repo -> stable | dev) for isolated testing and eval execution
+Single-executable CLI per platform (darwin/linux/windows) via GitHub releases, plus a background Bun HTTP+WS daemon on port 7710 with PID-file lifecycle, version-aware restart, and NDJSON diagnostics. Config dir is OS-specific.
+
+## Related KB
+
+- Component detail: `modules.md` · Concepts: `concept_map.md` · Conventions: `patterns.md` · Surfaces: `interaction-model.md`

--- a/.rp1/context/concept_map.md
+++ b/.rp1/context/concept_map.md
@@ -26,6 +26,10 @@
 | Arcade Tracked | mechanism | Optional `metadata.arcade_tracked` boolean controlling Activity feed visibility without disabling workflow mechanics |
 | Platform Definition | entity | Data-driven build configuration capturing platform-varying behavior: registry, templates, naming, lifecycle hooks |
 | Subflow | entity | Nested workflow registered within a parent run via `subflow_registered` event type |
+| ModelTier | entity | Abstract model alias (`deep`, `standard`, `fast`, `inherit`) declared in agent frontmatter, decoupling agent definitions from vendor-specific model identifiers. Resolved to platform-specific concrete model IDs at build time via `TIER_MODEL_MAP` |
+| EffortLevel | entity | Reasoning-depth control (`low`, `medium`, `high`, `xhigh`, `max`) declared independently of model tier in agent frontmatter. Resolved to platform-specific field names and values at build time; incompatible with the fast tier |
+| TIER_MODEL_MAP | mechanism | Centralized resolution dictionary mapping each abstract tier to concrete platform model IDs for Claude Code, Codex, OpenCode, Antigravity, and Gemini. Single-update-propagates-to-all-agents design |
+| Protected Agents | mechanism | Set of 14 reasoning-critical agents (feature-architect, phase-planner, security-validator, pr-sub-reviewer, etc.) that must remain on the deep tier. Build emits a warning (not error) when downgraded, allowing intentional experiments |
 
 ## Key Terminology
 
@@ -51,6 +55,12 @@
 | Document Kind | Requested or inferred document shape selecting default structure (auto, blog-post, technical-proposal, feedback) |
 | Section Scenario | Doc-sync classification for a section: `verify`, `add`, or `fix` |
 | Logical Step Key | Collapsed step identifier for dashboard grouping: non-namespaced steps keep their ID; namespaced lifecycle steps collapse to namespace prefix |
+| Model Tier | Abstract alias (`deep`, `standard`, `fast`, `inherit`) for agent model selection. `deep` = frontier reasoning model, `standard` = capable general-purpose model, `fast` = cheapest single-pass model, `inherit` = session model (backward-compatible default) |
+| Effort Level | Reasoning-depth control independent of model tier: `low`, `medium`, `high`, `xhigh`, `max`. Omitted for fast-tier agents. Platform-specific field names: `effort` (Claude Code), `model_reasoning_effort` (Codex), `reasoningEffort` (OpenCode/OpenAI provider) |
+| Tier Resolution | Build-time process that maps an abstract ModelTier + platform to a concrete vendor model ID via `TIER_MODEL_MAP`, and maps EffortLevel + platform to a provider-specific field name and value via `resolveEffort()` |
+| Protected Agent | One of 14 reasoning-critical agents that must remain on the deep tier; build emits a warning (not error) on downgrade attempt |
+| Effort Clamping | Mapping `xhigh` and `max` effort levels to `high` for platforms supporting only three-level effort vocabulary (OpenAI/Codex) |
+| Provider-Aware Effort | OpenCode effort resolution that derives the model provider (Anthropic vs OpenAI) from the resolved model ID to select the correct pass-through field name |
 
 ## Relationships
 
@@ -72,6 +82,10 @@ Platform Definition ──configures──> Build Template Context
 Discovery Registry ──generates──> Guide, Init Wizard
 Arcade Tracked ──filters──> Run (Activity feed visibility)
 Attestation ──validates──> Skill
+ModelTier ──classifies──> Agent (14 deep, 33 standard, 5 fast)
+TIER_MODEL_MAP ──resolves──> ModelTier (abstract tier → platform model ID)
+EffortLevel ──tunes──> Agent (optional reasoning-depth control)
+Protected Agents ──constrains──> ModelTier (build warning on non-deep downgrade)
 ```
 
 ## Agent Patterns
@@ -85,6 +99,8 @@ Attestation ──validates──> Skill
 | Stateless Agent | Blueprint charter creation | State persisted in visible file-based scratch pad for session-independent resumability |
 | Data-Driven Platform Build | Multi-platform artifacts | PlatformDefinition entries capture all platform-varying behavior |
 | Notification Auto-Generation | Emit pipeline | Status changes and waiting_for_user events auto-generate deduplicated notifications |
+| Build-Time Tier Resolution | Agent build pipeline | Agent frontmatter declares abstract tier + effort; `resolveTier()` and `resolveEffort()` map to platform-specific model IDs and effort field names before template rendering. Templates remain format-only |
+| Generator-Verifier Asymmetry | Agent classification | Generator agents (e.g., task-builder) run at standard tier because deep-tier verifier agents (e.g., task-reviewer) validate their output, preserving quality while reducing cost |
 
 ## Bounded Contexts
 
@@ -96,7 +112,7 @@ Attestation ──validates──> Skill
 | Feature Delivery | rp1-dev | PR Review, Task Queue, Builder-Reviewer |
 | Runtime Services | cli/src | Project, Run, Event, Workflow Bootstrap, Notification |
 | Dashboard | cli/web-ui | Arcade, Artifact, Annotation, Run Invocation Context |
-| Platform Abstraction | build pipeline | Platform Tag, CanonicalName, Platform Definition |
+| Platform Abstraction | build pipeline | Platform Tag, CanonicalName, Platform Definition, ModelTier, EffortLevel, Tier Resolution |
 | Discovery | cli/catalog | Discovery Registry, Guide, Skill Category, Arcade Tracked |
 | Project Lifecycle | cli/init, cli/migrate | Fence Versioning, Init Wizard, Project Migration |
 | Quality Assurance | evals/ | Attestation |
@@ -108,6 +124,6 @@ Attestation ──validates──> Skill
 - **Traceable state**: Intermediates (`brief.md`, `scan_results.json`) persist under `.rp1/work/`
 - **State discipline**: Mermaid states, emitted steps, namespaced sub-agent steps, and logical step keys stay aligned
 - **Configuration resolution**: `resolve-args` + `workflow-bootstrap` unify argument, directory, and run creation
-- **Platform portability**: Semantic tags and data-driven definitions let one prompt target multiple hosts
+- **Platform portability**: Semantic tags, data-driven definitions, and tier resolution let one prompt target multiple hosts with appropriate model and effort settings
 - **Single-source discovery**: Frontmatter metadata drives all catalog views, avoiding drift
 - **Standard tool envelope**: All agent-tools return `ToolResult<T>` JSON for predictable AI-agent parsing

--- a/.rp1/context/index.md
+++ b/.rp1/context/index.md
@@ -3,11 +3,11 @@
 **Type**: Monorepo
 **Languages**: TypeScript, TSX, Markdown, JSON, YAML, TOML, Shell, CSS, HTML
 **Version**: 0.7.1-dev
-**Updated**: 2026-04-12
+**Updated**: 2026-06-30
 
 ## Project Summary
 
-rp1 is a Bun/TypeScript CLI and plugin monorepo for authoring, building, and running AI agent workflows across Claude Code, OpenCode, and Codex. It combines markdown-defined skills and agents, tracked runtime state with deterministic workflow bootstrap, the Arcade dashboard with notifications and contextual commands, a multi-platform build pipeline with arcade tracking controls, catalog-driven skill discovery, and a progressively loaded knowledge base.
+rp1 is a Bun/TypeScript CLI and plugin monorepo for authoring, building, and running AI agent workflows across Claude Code, OpenCode, Codex, Antigravity, and Gemini. It combines markdown-defined skills and agents, tracked runtime state with deterministic workflow bootstrap, the Arcade dashboard with notifications and contextual commands, a multi-platform build pipeline with per-agent model/effort tiering and arcade tracking controls, catalog-driven skill discovery, and a progressively loaded knowledge base.
 
 ## Quick Reference
 
@@ -23,11 +23,11 @@ rp1 is a Bun/TypeScript CLI and plugin monorepo for authoring, building, and run
 
 | File | Lines | Load For |
 |------|-------|----------|
-| architecture.md | 102 | System design, layers, data flow, integrations |
-| interaction-model.md | 89 | Cross-surface semantics, workflow states, notifications, accessibility |
-| modules.md | 87 | Module boundaries, responsibilities, dependency highlights |
-| patterns.md | 81 | Code conventions, workflow idioms, extension patterns |
-| concept_map.md | 113 | Domain concepts, terminology, bounded contexts |
+| architecture.md | 73 | System design, layers, data flow, integrations |
+| interaction-model.md | 61 | Cross-surface semantics, workflow states, notifications, accessibility |
+| modules.md | 71 | Module boundaries, responsibilities, dependency highlights |
+| patterns.md | 63 | Code conventions, workflow idioms, extension patterns |
+| concept_map.md | 129 | Domain concepts, terminology, bounded contexts |
 
 ## Task-Based Loading
 
@@ -52,7 +52,7 @@ cli/
 ├── src/               # CLI commands, agent-tools, build pipeline, init/install flows
 │   ├── commands/      # User-facing CLI commands including build, migrate, and arcade
 │   ├── agent-tools/   # Workflow protocol tools (emit, workflow-bootstrap, resolve-args, feedback, root-dir, etc.)
-│   ├── build/         # Multi-platform artifact build pipeline with arcade tracking
+│   ├── build/         # Multi-platform artifact build pipeline with model/effort tiering + arcade tracking
 │   ├── catalog/       # Skill/agent catalog registry with distribution scoping
 │   ├── install/       # Host-tool installation and verification
 │   ├── migrate/       # Project migration with stanza upgrades and DB backfill

--- a/.rp1/context/interaction-model.md
+++ b/.rp1/context/interaction-model.md
@@ -1,109 +1,61 @@
 # rp1 - Interaction Model
 
 **Project**: rp1
-**Analysis Date**: 2026-04-14
-**Surfaces**: CLI, Host Tool Integration, Arcade Web UI, Agent Tools CLI, Reference Docs, Init Wizard
+**Analysis Date**: 2026-06-30
+**Surfaces**: CLI, Host Tool Integration, Arcade Web UI, Agent Tools CLI, Agent .md frontmatter, Reference Docs, Init Wizard
 
 ## Experience Principles
 
-| Principle | Description |
-|-----------|-------------|
-| Keyboard-first monitoring | Arcade is keyboard-first and mouse-optional for run navigation, dialogs, command palette, and notification management |
-| Observable workflows | Long-running skills expose named runs, explicit phase transitions, gate pauses, and registered artifacts |
-| Evidence before questions | Interactive workflows read repo or KB material first and ask only for material-changing facts or decisions |
-| Durable handoffs | Intermediate artifacts are source-of-truth handoffs preserved across review, block, and cancel paths |
-| Contract-gated artifact views | Specialized artifact readers appear only after artifact contracts validate; markdown remains the source-of-truth fallback |
-| Automation-aware CLI | CLI commands expose machine-friendly modes: JSON output, lint-only checks, hook-json format, daemon-only startup |
-| Attention-proportional notification | Notifications categorized by attention level (action_required, attention, info). Bulk dismiss via "Read all" enables efficient triage |
-| Exclusive overlay model | Only one overlay active at a time. Side panels (ToC, annotations) are mutually exclusive within artifact viewer |
-| Progressive detail disclosure | Secondary metadata (frontmatter, run invocation context) hidden by default, surfaced via contextual commands. State persists in sessionStorage |
+- **Observable workflows** — long-running skills expose named runs, explicit phase transitions, gate pauses, and registered artifacts.
+- **Evidence before questions** — interactive workflows read repo/KB material first and ask only for material-changing decisions.
+- **Durable handoffs** — intermediate artifacts are source-of-truth handoffs preserved across review/block/cancel paths.
+- **Automation-aware CLI** — machine-friendly modes (`--json`, `--lint`, `hook-json`, `--daemon-only`); build validates agent frontmatter and emits structured errors/warnings without blocking on human input.
+- **Fail-fast with actionable diagnostics** — build-time validation surfaces the file, the invalid value, and the allowed set so the agent author can fix without guesswork.
+- **Attention-proportional notification** — notifications categorized by attention level with bulk dismiss.
+- **Progressive detail disclosure** — secondary metadata (frontmatter, run invocation context) hidden by default, toggled via contextual commands, persisted in sessionStorage.
 
-## Surfaces
+## Actors & Surfaces
 
-| Surface | Role | Key Entry Points |
-|---------|------|------------------|
-| CLI | Project setup, maintenance, artifact build, daemon launch | `rp1 init`, `rp1 install`, `rp1 arcade`, `rp1 arcade --daemon-only`, `rp1 arcade --format hook-json`, `rp1 build` |
-| Host Tool Integration | Conversational execution for slash-command workflows | `/write-content`, `/generate-user-docs`, `/build`, `/knowledge-build` |
-| Arcade Web UI | Live observability, artifact review, walkthrough slide reading, notification, file browsing, feedback | `/`, `/projects`, `/runs/:runId`, `/runs/:runId/artifacts/:path`, `/projects/:projectId/files/:path` |
-| Agent Tools CLI | Protocol surface for workflow state, path resolution, artifact registration | `rp1 agent-tools emit`, `resolve-args`, `rp1-root-dir`, `feedback` |
-| Reference Docs | Preflight discovery for harness-specific invocation and parameters | `docs/reference/`, `docs/arcade/` |
-| Init Wizard | Interactive terminal UI for project initialization | `rp1 init` |
+| Actor | Goals | Surfaces |
+|-------|-------|----------|
+| End user | Execute workflows, monitor runs, review artifacts, give feedback | CLI, Host Tool, Arcade |
+| **Agent author** | Set model tier + effort in agent frontmatter; get build-time validation feedback | Agent `.md` frontmatter, `rp1 build`, Agent Tools CLI |
+| CI system | Validate/lint, produce JSON build output | `rp1 build --json --lint` |
+
+**Agent `.md` frontmatter** is a declarative configuration surface: authors set `model: deep|standard|fast|inherit` and optional `effort: low|medium|high|xhigh|max`, plus tools/arguments. `rp1 build` resolves and validates these.
 
 ## User-Visible States
 
 | State | Meaning | Surfaces |
 |-------|---------|----------|
-| running | A workflow phase is actively executing | Arcade, Agent Tools |
-| waiting_for_user | Workflow paused for user decision | Arcade, Host Tool, Agent Tools |
-| completed | Workflow finished with final outputs | Arcade, Host Tool, Agent Tools |
-| failed | Phase or run terminated with error | Arcade, Agent Tools |
-| blocked | Required facts or decisions unresolved | Host Tool |
-| cancelled | User chose to stop; work products preserved | Host Tool |
-| kb_stale | KB behind HEAD but still readable; continue/rebuild/cancel gate | Host Tool |
-| connection_status | Live-update health vs reconnecting/fallback | Arcade |
-| annotation_status | Artifact feedback open or resolved | Arcade |
-| artifact_view_mode | Supported walkthrough artifacts can render as slides or markdown; unsupported or failed slide rendering uses markdown | Arcade |
-| notification_attention | Per-notification attention level (action_required, attention, info) | Arcade |
-| frontmatter_visibility | Artifact/file frontmatter shown/hidden per view (sessionStorage) | Arcade |
-| run_metadata_visibility | Run invocation metadata shown/hidden (sessionStorage) | Arcade |
+| running / waiting_for_user / completed / failed | Workflow phase lifecycle | Arcade, Host Tool, Agent Tools |
+| blocked / cancelled | Unresolved facts; user-stopped (work preserved) | Host Tool |
+| kb_stale | KB behind HEAD; continue/rebuild/cancel gate | Host Tool |
+| **build_validation_error** | Unknown model tier/effort; build halts that agent, exits 1, lists allowed values | CLI (`rp1 build`) |
+| **build_validation_warning** | Valid but sub-optimal (fast+effort, protected-agent downgrade); build continues | CLI (`rp1 build`) |
+| connection_status / annotation_status / notification_attention | Arcade live-update + feedback + triage signals | Arcade |
 
 ## Feedback Loops
 
-| Loop | Trigger | Behavior |
-|------|---------|----------|
-| Workflow gate | Phase needs user choice | Emit waiting_for_user -> Arcade shows pause -> Host tool asks -> Answer resumes/revises/cancels |
-| Artifact registration | Workflow creates durable output | Emit artifact_registered with storageRoot -> Arcade resolves and shows file |
-| Annotation feedback | User comments/edits artifact in Arcade | Runtime persists change -> Agents read via feedback read -> Replies update UI via WebSocket |
-| Notification lifecycle | Events produce notifications | Emitted workflow events and notifications arrive over the project WebSocket -> Toast auto-dismiss (6s) with dedup guard -> Sidebar grouped by attention -> Individual dismiss via X, bulk via "Read all" |
-| Contextual command registration | View mounts with commands | ShortcutRegistryProvider stores view commands -> Command palette shows view-labeled group -> User executes -> Cleanup on unmount |
-| Emit-driven run projection | `event:notification` or `event:replay` arrives for a project | Browser stores `lastEventId`, reduces the event through `LiveRunIndex`, and patches only the affected run detail, feed rows, attention groups, and project summaries |
-| Snapshot reconciliation | Reconnect gap is too large for replay | Browser reconnects with the saved project cursor -> Server sends `state:snapshot` -> Client replaces the project's active-run subset and only refetches visible collections whose membership may now be stale |
-| Recovery fallback | Live socket is disconnected or replay was missed entirely | Persisted REST state plus disconnected-only polling restore the latest run truth without treating broad refresh as the normal workflow-status path |
-| Artifact viewing mode | Supported PR walkthrough artifact content loads in Arcade | Browser parses the fetched markdown contract -> valid decks default to Slides mode -> user can switch to Markdown -> unsupported, malformed, or failed slide rendering shows markdown with a fallback notice |
+- **Workflow gate** — emit `waiting_for_user` → Arcade pause + host-tool prompt → answer resumes/revises/cancels.
+- **Artifact registration** — emit `artifact_registered` with `storageRoot` → Arcade resolves and shows the file.
+- **Annotation feedback** — user annotates/edits in Arcade → runtime persists → agents read via `feedback read` → replies update UI over WS.
+- **Notification lifecycle** — events produce deduplicated notifications; toasts auto-dismiss (6s); sidebar groups by attention.
+- **Build-time tier & effort validation** — `rp1 build` parses frontmatter → `validateAgentTierAndEffort` (errors halt with file+allowed values; warnings print to stderr and continue) → `resolveTier`/`resolveEffort` → platform-native config emitted.
+- **Emit-driven run projection / snapshot reconciliation / recovery fallback** — Arcade reduces events into `LiveRunIndex`, reconnects with saved cursor, and falls back to REST when replay is impossible.
 
-## Artifact Surface Behavior
+## Cross-Surface Deltas
 
-| Behavior | Contract |
-|----------|----------|
-| Walkthrough slide reader | File-backed markdown artifacts that declare `rp1_contract: pr-walkthrough-slide-source` and contain valid line-alone slide markers open in Slides mode from the existing artifact surface |
-| Markdown fallback | The original markdown content stays available in Markdown mode and is shown for unsupported artifacts, invalid contracts, parser failures, or Reveal.js render failures |
-| Reader navigation | Slides mode owns horizontal and vertical navigation, active-slide position, current-slide announcements, and Reveal speaker-view notes while evidence IDs stay in slide and markdown content |
-| Artifact context | Run artifact selection, content fetching, cache behavior, and path reconciliation stay on the existing artifact surface; no server API or artifact schema change is required |
-| Annotation behavior | Inline annotations remain on the markdown path; slide mode disables transformed-DOM annotation anchoring for this phase |
+- **Model tier resolution** — same abstract tier resolves to different vendor IDs per platform (CC: opus/sonnet/haiku; Codex: o3/o4-mini/gpt-4.1-nano; OpenCode/Antigravity: Anthropic names; Gemini: gemini-2.5-pro/flash; Copilot: tiering omitted). `inherit` emits no model field anywhere (backward compatible).
+- **Effort field resolution** — CC emits `effort` (5 levels); Codex emits `model_reasoning_effort` (clamped to 3); OpenCode emits `reasoningEffort` for OpenAI-provider models (clamped), omits for Anthropic/unknown; Antigravity/Gemini/Copilot omit; fast tier always omits.
+- **Agent template output format** — CC/OpenCode emit YAML frontmatter; Codex emits TOML; all three conditionally omit model (inherit) and effort (undefined/unsupported).
+- **Plugin install** — CC uses MCP registration; OpenCode copies filesystem artifacts; Codex uses its own path.
+- **Execution vs observability** — host tools do the work; Agent Tools carry protocol; Arcade shows passive status.
 
-## Keyboard & Command System
+## Accessibility & Discoverability
 
-- **Global shortcuts**: `g h` (home), `g p` (projects), `Cmd+K` (command palette), `n` (notifications)
-- **Navigation shortcuts**: Arrow keys with roving tabindex, `Enter` to open, `Escape` to close
-- **Contextual shortcuts**: Views register `ShortcutDefinition[]` and `CommandDefinition[]` via `useContextualShortcuts`
-- **Command palette**: Navigation, actions, theme toggle, and per-view contextual commands with keyword search
-- **Chord timeout**: 500ms with visual `data-chordPending` indicator
-- **Text input guard**: Single-key shortcuts suppressed during text entry
+Keyboard-first Arcade (roving tabindex, single-key suppression during text entry, reduced-motion fallback, ARIA labels + live regions); named emits + state-machine-aligned steps give meaningful dashboard labels; namespaced sub-agent steps avoid timeline collisions.
 
-## Cross-Surface Behavior
+## Related KB
 
-| Behavior | Delta |
-|----------|-------|
-| Plugin installation | Claude Code uses MCP registration with scope; OpenCode copies filesystem artifacts; Codex uses its own path |
-| Skill invocation syntax | Claude Code uses short slash commands; OpenCode uses rp1-prefixed names |
-| Execution vs observability | Host tools do the work; Agent Tools carry protocol; Arcade shows passive status |
-| Responsive layout | Desktop: icon-rail sidebar + resizable panels. Mobile: bottom tab bar + drawers |
-| Workflow freshness source | Arcade: emitted workflow events hydrate `LiveRunIndex`, run detail, and attention/project surfaces via scope-aware global/project `lastEventId` cursors. Host tools: inline gates still come from the emitting workflow |
-| Artifact reader source | Host tools produce and register markdown artifacts; Arcade may add a contract-gated slide reader for supported PR walkthrough artifacts while retaining markdown fallback |
-| Browser/native runtime contract | Browser launch defaults to `hostMode=browser`; native launch appends `hostMode=native` and `cacheBust` while loading the same loopback Arcade SPA. Both host modes validate the no-store `/api/v2/runtime` contract before route-level WebSocket consumers mount |
-| Notification delivery | Arcade: real-time toasts with dedup + dismissible sidebar driven by the same emit stream. Host tools: inline gates |
-| Recovery semantics | Arcade reconnects with its saved cursor, replays missed events when possible, and falls back to bounded snapshot reconciliation or persisted REST recovery only when needed |
-| Run invocation context | Hidden by default, toggled via contextual command; shows workflow, run policy, worktree state |
-| Daemon lifecycle modes | Full mode (register + browser), daemon-only (start without project), hook-json (structured output for hooks) |
-
-## Accessibility
-
-- Roving tabindex for dense lists without trapping tab order
-- Single-key shortcut suppression during text entry
-- Reduced-motion fallback for all animations
-- Screen-reader aria-labels on status dots, notification triggers, commands
-- Live region announcements for ToC navigation and notifications
-- Walkthrough slide reader controls have accessible names, disabled boundary states, keyboard navigation, active-slide announcements, Reveal speaker-view notes, and a markdown fallback for source-order reading
-- Named emits and state-machine-aligned steps for meaningful dashboard labels
-- Namespaced sub-agent steps prevent timeline collisions
-- Notification items use attention-level-differentiated backgrounds for visual triage
+- Surfaces map to `architecture.md` layers · build internals in `modules.md` · conventions in `patterns.md`

--- a/.rp1/context/modules.md
+++ b/.rp1/context/modules.md
@@ -1,94 +1,71 @@
 # Module & Component Breakdown
 
 **Project**: rp1
-**Analysis Date**: 2026-04-12
+**Analysis Date**: 2026-06-30
 **Modules Analyzed**: 22
 
-## Module Map
+## Core Modules
 
-| Module | Purpose | Files |
-|--------|---------|-------|
-| cli/commands | User-facing CLI commands including build, migrate, and arcade | 27 |
-| cli/agent-tools | Agent-tools CLI with emit, workflow-bootstrap, resolve-args, state-machine, task, feedback | 59 |
-| cli/build | Multi-platform artifact build pipeline for Claude Code, OpenCode, Codex | 50 |
-| cli/catalog | Skill/agent catalog registry with distribution scoping and arcade tracking | 3 |
-| cli/install | Install plugin artifacts into host tools with staging, backup/rollback, verification | 22 |
-| cli/init | Project initialization with context detection, fence markers, and Ink UI | 23 |
-| cli/shared | Cross-cutting library: errors, fp-ts helpers, events, logging, directory resolution | 15 |
-| cli/lib | Utility: cache, colors, package-manager detection, fence version tracking | 6 |
-| cli/settings | Settings file loading and validation | 2 |
-| cli/migrate | Migration system for project structure upgrades | 5 |
-| cli/pr-review | PR review config and CI environment detection | 4 |
-| web-ui/server | Bun HTTP/WS server with REST APIs, file watching, event broadcast, notifications | 16 |
-| web-ui/daemon | Daemon lifecycle manager with diagnostic logging and IPC | 4 |
-| web-ui/frontend | React SPA dashboard: pages, components, hooks, providers, motion, artifact viewers, walkthrough slide reader | 190 |
-| plugins/base | KB, docs sync, writing, research, strategy, security, prompt authoring pipeline, guide meta-skill | 98 |
-| plugins/dev | Build workflows, blueprinting, PR review and walkthrough, feature delivery | 58 |
-| plugins/utils | Prompt tersification, eval helpers | 14 |
-| docs/reference | User-facing reference docs for CLI, plugins, web UI, platform tags | 36 |
-| evals | Prompt attestation with content-addressable hashing and dockerized execution | 26 |
+| Module | Purpose | Files | Key Files |
+|--------|---------|-------|-----------|
+| `cli/commands` | User-facing CLI commands (build, arcade, migrate, init) | 27 | build.ts, arcade.ts |
+| `cli/agent-tools` | emit, workflow-bootstrap, resolve-args, state-machine, task, feedback | 59 | emit/index.ts, workflow-bootstrap.ts |
+| `cli/build` | Multi-platform artifact pipeline with per-agent model tiering + effort resolution | 51 | command.ts, models.ts, parser.ts, validator.ts, **tier-resolution.ts**, template-context.ts, template-engine.ts |
+| `cli/catalog` | Skill/agent catalog registry (distribution scope, arcadeTracked) | 3 | catalog-generator.ts |
+| `cli/install` | Install artifacts into host tools (staging, backup/rollback, verify) | 22 | verifier.ts |
+| `cli/init` | Project init with context detection, fence markers, Ink UI | 23 | — |
+| `cli/shared` | Errors, fp-ts helpers, events, logging, directory resolution | 15 | errors.ts, logger.ts |
+| `web-ui/server` | Bun HTTP/WS server, REST APIs, file watching, notifications | 16 | registry.ts |
+| `web-ui/daemon` | Daemon lifecycle + diagnostic logging | 4 | — |
+| `web-ui/frontend` | React SPA: pages, hooks, providers, artifact viewers | 190 | — |
+| `plugins/base` | KB, docs, writing, research, strategy, security, prompt pipeline | 98 | — |
+| `plugins/dev` | Build workflows, blueprint, PR review/walkthrough, feature delivery | 58 | — |
+| `plugins/utils` | Prompt tersification, eval helpers | 14 | — |
+| `evals` | Prompt attestation, content-addressable hashing, dockerized exec | 26 | — |
 
-## Key Components
+## Key Components (build pipeline)
 
-| Component | Module | Purpose |
-|-----------|--------|---------|
-| workflow-bootstrap | agent-tools | Deterministic run creation/resumption with run_policy, identity_args, and 5-layer argument merge |
-| emit pipeline | agent-tools/emit | Records all 6 event types with status derivation, step validation, skipped-step detection, and notification generation |
-| notification system | agent-tools/emit | Auto-generates notifications for terminal run states and waiting_for_user events with deduplication |
-| state-machine | agent-tools | Parses Mermaid stateDiagram-v2, validates step transitions, provides graph queries |
-| resolve-args | agent-tools | 5-layer argument merge (user > project settings > user settings > ENV > schema default) with directory resolution |
-| build parser | build | Frontmatter parsing for skills/agents including arcadeTracked extraction and workflow metadata |
-| build validator | build | L1 (syntax) + L2 (schema) validation including arcade_tracked field |
-| catalog registry | catalog | Centralized skill catalog with distribution scoping, category ordering, and arcadeTracked propagation |
-| server registry | web-ui/server | Multi-project registry with async mutex (`withRegistryLock`), atomic file persistence, worktree normalization |
-| daemon diagnostics | web-ui/daemon | Structured NDJSON logging for daemon lifecycle events to daemon.log |
-| arcade command | commands | CLI entry point with start/stop/status/restart, --daemon-only, --format hook-json modes |
-| install verifier | install | Cross-platform installation health check and skill discovery with arcade_tracked metadata |
-| pr-walkthrough | plugins/dev | Review workflow skill that resolves PR or branch targets, collects direct `gh`/`git` evidence, dispatches markdown synthesis, and registers a work artifact |
-| pr-walkthrough-reporter | plugins/dev | Agent that turns direct PR evidence into a plain markdown walkthrough with Evidence Index citations under `.rp1/work/pr-walkthroughs/` |
-| walkthrough-slide-source | web-ui/frontend | Client-side parser that validates the `pr-walkthrough-slide-source` markdown contract, extracts horizontal and vertical slides, notes, evidence IDs, and fallback reasons |
-| WalkthroughRevealReader | web-ui/frontend | Reveal.js-backed artifact reader for supported PR walkthroughs with slide/depth controls, hidden Reveal speaker notes, source-order evidence preservation, and markdown fallback hooks |
-| build-prompt orchestrator | plugins/utils | Workflow skill that walks the six-stage prompt-writer pipeline via prompt-pipeline-runner agent with budgeted governance |
-| prompt-pipeline-runner | plugins/base | Agent executing constitutional-checklist, fallibilist-overlay, epistemic-stance, popper-patterns, confidence-schema, prompt-validation stages |
+### tier-resolution (`cli/src/build/tier-resolution.ts`) — new
+Centralized tier-to-model and effort-to-field resolution dictionary. Pure functions, no side effects, called per-agent per-platform during the build loop.
+- `resolveTier(tier, platform) → modelId | null` — maps abstract tier to platform-specific model ID via `TIER_MODEL_MAP` (3 tiers × 5 platforms); returns `null` for `inherit`, unmapped platforms (copilot), so the template omits the field.
+- `resolveEffort(effort, tier, platform, resolvedModel) → {fieldName, value} | null` — platform/provider-specific effort field; derives provider (anthropic/openai) from the resolved model ID for OpenCode; clamps 5-level effort to 3-level for OpenAI/Codex; returns `null` for fast tier and unsupported platforms.
+- Depends on `models` (ModelTier/EffortLevel) and `template-context` (BuildPlatform).
 
-## Dependency Highlights
+### build models (`cli/src/build/models.ts`)
+Defines `ModelTier`/`EffortLevel` unions + parallel `VALID_MODEL_TIERS`/`VALID_EFFORT_LEVELS` arrays, the `PROTECTED_AGENTS` set (14 frontier-critical agents), and `ClaudeCodeAgent.effort?`. Also `BuildConfig`, `ArtifactResult`, `BundleManifest`, and platform artifact interfaces.
 
-```text
-cli/commands --> cli/shared, cli/init, cli/install, cli/build, web-ui/daemon (lazy)
-cli/build --> cli/shared, cli/agent-tools/state-machine, cli/catalog
-cli/agent-tools/emit --> cli/agent-tools/state-machine, web-ui/daemon (lazy)
-cli/agent-tools/resolve-args --> cli/settings, cli/shared
-cli/catalog --> cli/build/parser, cli/shared/canonical-name
-cli/install/verifier --> cli/build/parser, cli/assets
-web-ui/server/registry --> web-ui/daemon/config-dir
-web-ui/daemon --> web-ui/daemon/diagnostics
-web-ui/frontend --> web-ui/server (REST + WebSocket)
-plugins/dev --> plugins/base (runtime)
-plugins/* --> cli/agent-tools (runtime conventions)
-```
+### build validator (`cli/src/build/validator.ts`)
+L1 (syntax) + L2 (schema) validation plus `validateAgentTierAndEffort(agent, model, effort, file) → {errors, warnings}` for **all** platforms: errors on unknown tier/effort (blocking); warnings on fast+effort and protected-agent downgrade (advisory).
+
+### build command (`cli/src/build/command.ts`)
+Orchestrates multi-platform builds. Integrates the validation gate then `resolveTier`/`resolveEffort` into the agent build loop before constructing template context. Uses `fp-ts` `pipe(... TE.chain ...)`.
+
+### template-context (`cli/src/build/template-context.ts`) / codex/models.ts
+`AgentArtifactData` and `CodexAgent` gain optional `effortFieldName`/`effortValue`, consumed by Liquid templates at render time.
+
+### agent Liquid templates (`cli/src/build/templates/`)
+Per-platform conditional emission: Claude Code (YAML `model` + `effort`), Codex (TOML `model` + `model_reasoning_effort`), OpenCode (YAML `model` + provider-keyed effort pass-through). Inherit/undefined/unsupported → field omitted (byte-identical opt-out).
+
+## Module Dependencies (highlights)
+
+- `cli/build/command` → `cli/build/tier-resolution` (resolveTier/resolveEffort per agent/platform).
+- `cli/build/tier-resolution` → `cli/build/models`, `cli/build/template-context`.
+- `cli/build/validator` → `cli/build/models` (VALID_* arrays, PROTECTED_AGENTS).
+- `cli/build/templates` → `cli/build/template-context` (consume effortFieldName/effortValue at render).
+- `cli/agent-tools/emit` → `state-machine`, `web-ui/daemon` (lazy).
+- `plugins/*` → `cli/agent-tools` (emit, resolve-args, bootstrap conventions); `plugins/dev` → `plugins/base` (runtime).
+- External: fp-ts, liquidjs, commander, yaml, bun:sqlite.
+
+## Module Metrics
+
+| Module | Files | LOC (approx) | Components |
+|--------|-------|--------------|------------|
+| `cli/build` | 51 | ~15,159 | 12 |
 
 ## Cross-Module Patterns
 
-| Pattern | Modules | Benefit |
-|---------|---------|---------|
-| Skill-Agent Delegation | plugins/*, cli/agent-tools | Separation: skills orchestrate, agents do bounded work |
-| Tracked Workflow Bootstrap | workflow-bootstrap, emit, resolve-args | Atomic run creation with identity-based deduplication |
-| State-Machine + Emit Discipline | state-machine, emit, plugins/* | Dashboard-visible progress through validated step emissions |
-| Arcade Tracked Visibility | parser, validator, catalog, verifier | Skills opt out of Activity feed via arcadeTracked without losing workflow mechanics |
-| Async Mutex Registry | web-ui/server/registry | Serializes concurrent registry mutations preventing race conditions |
-| Notification Auto-Generation | emit, daemon, frontend | Terminal events auto-create deduplicated notifications relayed via WebSocket |
-| Contract-Gated Artifact Reader | web-ui/frontend, plugins/dev | PR walkthrough artifacts can open as slides only when the markdown contract validates; unsupported or failed render paths keep the normal markdown viewer |
-| Catalog Registry | catalog, build, base/guide | Single-source catalog drives CATALOG.md, init blocks, and /guide |
-| Versioned Fence Markers | init, lib, migrate | Instruction stanzas carry version stamps for staleness detection and auto-upgrade |
-| Thin Command Adapter | commands, build, install, init | CLI commands translate flags and delegate to deeper modules |
-| Multi-Platform Build | build | Single markdown sources transform into 3 platform artifacts via shared pipeline |
+Skill-Agent Delegation · Tracked Workflow Bootstrap · State-Machine + Emit Discipline · Async-Mutex Registry · Notification Auto-Generation · Catalog Registry · Multi-Platform Build · **Abstract Tier Resolution** (one `TIER_MODEL_MAP` update propagates to all agents at that tier on next build).
 
-## External Dependencies
+## Related KB
 
-| Package | Purpose |
-|---------|---------|
-| fp-ts | Functional programming: Either, TaskEither, Option |
-| liquidjs | Template engine for multi-platform build pipeline |
-| commander | CLI command framework |
-| yaml | YAML parsing for frontmatter and settings |
-| bun:sqlite | SQLite for emit events, notifications, tasks |
+- System design: `architecture.md` · Conventions: `patterns.md` · Concepts: `concept_map.md`

--- a/.rp1/context/patterns.md
+++ b/.rp1/context/patterns.md
@@ -1,109 +1,63 @@
 # Implementation Patterns
 
 **Project**: rp1
-**Last Updated**: 2026-04-29
+**Last Updated**: 2026-06-30
 
-## Naming Conventions
+## Naming & Organization
 
-- **Files**: Feature-scoped directories (`cli/src/commands/`, `cli/src/build/`); prompt assets use kebab-case skill folders with `SKILL.md`; React: PascalCase components, camelCase hooks
-- **Functions**: CLI camelCase verbs; React hooks prefix `use`; error factories match their `_tag` (usageError, runtimeError)
-- **Parameters**: UPPER_SNAKE_CASE enforced by `/^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$/`
-- **Imports**: Relative TS imports keep `.js` suffixes; web-ui uses `@/` path alias; CSS classes use `rp1-` prefix to avoid Tailwind collisions
+- Feature-scoped directories (`cli/src/commands/`, `cli/src/build/`); prompt assets use kebab-case skill folders with `SKILL.md`.
+- CLI camelCase verbs; React hooks prefix `use`; error factories match their `_tag` (`usageError`, `runtimeError`).
+- Parameters UPPER_SNAKE_CASE (`/^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$/`); relative TS imports keep `.js` suffixes; web-ui uses `@/`; CSS classes use `rp1-` prefix to avoid Tailwind collisions.
 
-## Type Patterns
+## Type & Data Modeling
 
-- **Discriminated unions**: `_tag` field on CLIError, `type` field on EventPayload
-- **Enum tables**: SkillCategory, WorkflowRunPolicy, Status, EventType as string literal unions with parallel `VALID_*` arrays
-- **Immutability**: `readonly` properties and `as const` assertions throughout; persisted artifacts as source-of-truth snapshots
-- **Template strictness**: LiquidJS uses `strictVariables` and `strictFilters`
+- **Enum tables**: string-literal unions with parallel `VALID_*` arrays for build-time validation — `ModelTier`/`VALID_MODEL_TIERS`, `EffortLevel`/`VALID_EFFORT_LEVELS`, `SkillCategory`, `WorkflowRunPolicy`, `Status`, `EventType`.
+- Discriminated unions: `_tag` on `CLIError`, `type` on `EventPayload`.
+- `readonly` + `as const` throughout; persisted artifacts are source-of-truth snapshots.
+- **Tier abstraction**: abstract tier aliases (deep/standard/fast/inherit) decoupled from vendor model IDs via the centralized `TIER_MODEL_MAP` — single update point on vendor model releases. `PROTECTED_AGENTS` guards frontier-critical agents from accidental downgrade.
 
 ## Error Handling
 
-- **Strategy**: Returns `Either` or `TaskEither<CLIError, A>`; formats errors once at CLI boundary via `formatError`; `tryCatchTE` wraps async
-- **Propagation**: Parent skills gate on hard failures; batch workflows tolerate partial success
-- **Validation staging**: L1 (syntax) then L2 (schema) in build pipeline
-- **Error discrimination**: `isValidProject` distinguishes ENOENT from transient I/O errors instead of swallowing all
-- **Common types**: UsageError, NotFoundError, ConfigError, RuntimeError, PrerequisiteError, ParseError, ValidationError, GenerationError, TransformError, PortInUseError
+- Returns `Either`/`TaskEither<CLIError, A>`; formatted once at the CLI boundary via `formatError`; `tryCatchTE` wraps async.
+- Parent skills gate on hard failures; batch workflows tolerate partial success. L1 (syntax) then L2 (schema) validation staging.
+- **Warnings vs errors**: `validateAgentTierAndEffort` returns `{errors[], warnings[]}` — errors halt agent processing, warnings emit advisories (fast-tier effort, protected-agent downgrade).
 
-## Validation
+## Validation & Boundaries
 
-- **Location**: Workflow intake and command boundaries
-- **Method**: Explicit enum/default tables, existence checks, compatibility aliases
-- **Additive-field propagation**: New fields (e.g., `arcadeTracked`) flow parser -> models -> validator -> template -> registry without breaking existing paths
-- **Argument validation**: Each definition validated field-by-field with early return on first error
+- **Additive-field propagation**: a new frontmatter field flows `parser → model interface → validator → tier-resolution → template context → Liquid templates` without breaking existing paths. Established for `arcadeTracked`; extended identically for `model` (ModelTier) and `effort` (EffortLevel).
+- Each definition validated field-by-field with early return on first error.
 
-## fp-ts Pipeline Pattern
+## Build Pipeline
 
-- Arcade command uses `pipe(loadConfig, TE.fromEither, TE.chain(...))` for all operation modes
-- `tryCatchTE` wraps async operations with error factories
-- `map`, `flatMap`, `isLeft` preferred over overengineered abstractions
-
-## Concurrency Patterns
-
-- **Async mutex**: `withRegistryLock` in server/registry.ts serializes read-modify-write cycles via promise-chain mutex
-- **Toast dedup guard**: `NotificationContainer` uses functional state updater (`setToasts(prev => ...)`) to prevent duplicate toasts from concurrent WebSocket messages
-- **Request identity tracking**: Web-UI hooks use `useCallback`/`useRef` to handle stale async responses
-- **Lazy loading**: Heavy subsystems (daemon, emit relay) loaded via dynamic `import()` at runtime
-
-## I/O Patterns
-
-- **Database**: SQLite via `bun:sqlite` for runs, events, artifacts, annotations, notifications. Upsert semantics; dedup via `hasNotificationForSource`
-- **File I/O**: Atomic writes via temp-file + rename (registry `saveRegistry`); PID file with mode 0o600; diagnostic log uses `appendFileSync`
-- **Workflow event transport**: `rp1 agent-tools emit` persists canonical workflow events, then the daemon relays typed project-scoped WebSocket envelopes for status-bearing and attention-bearing live updates
-- **Run artifact locations**: File artifacts keep the `path` plus `storageRoot` contract. Curated external links register as URL artifacts with `locationKind: "url"`, `type: "link"`, `url`, `label`, and `relationship`; optional `sourceContext` and `sourceArtifactPath` tie the link back to a report. URL artifact identity is deterministic per run, relationship, and canonical URL so completion retries update one artifact instead of creating duplicates
-- **Link artifact scope**: Workflows should register only curated external links that represent run outputs, not every URL found in generated markdown. PR review is the first concrete workflow and registers only the reviewed PR URL as a `Reviewed PR` link artifact when available
-- **HTTP clients**: Web-UI SPA seeds surfaces from `/api/v2/` and uses targeted hydration such as `GET /api/v2/runs/:id/summary`; reconnect polling stays limited to disconnected recovery instead of routine freshness
-- **Freshness split**: Workflow status and attention come from emitted event delivery plus replay/snapshot recovery; file watching remains responsible only for artifact and file-content freshness
-- **Directory-scoped agent I/O**: Code-writing agents resolve source-file paths against `codeRoot` (the worktree path when in a worktree, `projectRoot` otherwise). Work-artifact reads and writes use `workRoot` and KB reads use `kbRoot`, both of which always point to the canonical `.rp1/` tree. This separation ensures edits land in the user's active working tree while Arcade-visible artifacts remain at the shared canonical location
-
-## PR/Review Workflow Patterns
-
-- **Direct evidence source**: Review-orientation workflows should gather PR metadata, changed files, diffs, stats, and commits directly through `gh` and `git`; generated review artifacts are outputs, not source material for later synthesis
-- **Evidence IDs**: Walkthrough-style artifacts assign stable IDs such as `E-PR-###`, `E-FILE-###`, `E-DIFF-###`, and `E-COMMIT-###`, then cite those IDs inline for major purpose, change, reviewer-focus, and risk claims
-- **Markdown artifact registration**: Plain markdown review artifacts live under purpose-specific workRoot directories, such as `pr-walkthroughs/{REVIEW_ID}-walkthrough-{NNN}.md`, and register with `artifact_registered` using a relative path plus explicit `storageRoot: "work_dir"`
-- **Workflow separation**: `/pr-walkthrough` orients reviewers without posting comments or verdicts; `/pr-review` remains the verdict/finding workflow and `/pr-visual` remains the diagram generator
-
-## UI Patterns
-
-- **Contextual commands**: Views register `CommandDefinition[]` via `useContextualShortcuts` hook, surfaced in command palette alongside navigation/action commands
-- **SessionStorage persistence**: `showFrontmatter`/`showMetadata` use `useState` + `sessionStorage` for per-tab, per-view toggle persistence; WebSocket cursors follow the same pattern with `rp1:last-event-id:global` and `rp1:last-event-id:{projectId}`
-- **Notification lifecycle**: Toasts auto-dismiss 6s with dedup guard; sidebar groups by attention level; "Read all" bulk dismiss
-- **Attention-level styling**: `itemClassForLevel` maps attention levels to differentiated background colors for visual triage
-- **Runtime contract boundary**: `RuntimeProvider` loads the no-store `/api/v2/runtime` contract before WebSocket consumers mount, validates browser/native host mode, exposes reconnect policy, and performs one cache-busted reload before controlled runtime-load failure
-- **LiveRunIndex projection**: Feed, runs, attention, project summaries, and run detail seed from REST, then scope-aware emitted workflow activity flows through a shared `LiveRunIndex` keyed by `runId` to patch only affected surfaces
-- **Scope-aware Activity replay**: Global Activity stores `rp1:last-event-id:global`, project Activity stores `rp1:last-event-id:{projectId}`, and global live events advance both the global cursor and the event project's cursor when project identity is available
-- **Server-side Activity search projection**: Search feed requests refresh compact `activity_search_runs` rows, match normalized tokens against Activity-visible fields before pagination, then apply runtime visibility and reuse `runRecordToListRun` so search and browse keep the same feed item contract
-- **Snapshot reconciliation**: Project `state:snapshot` replaces the project's active-run subset; global snapshots upsert/hydrate without pruning unrelated project runs. Both paths trigger bounded refetch only for currently visible collections whose membership may have changed
-- **Targeted hydration**: Unknown run events hydrate a single run summary before reducers apply queued updates, avoiding collection-wide invalidation for routine workflow activity
-- **Policy-driven Activity recovery**: `useReconnectRecovery`, `useFeed`, and `useRuns` read reconnect timing and `activityRecoveryLimit` from the runtime contract, reconcile in the background after reconnect, and merge replay/REST overlap through stable run identity
+- **Tier resolution**: `resolveTier` maps tier→platform model ID via `TIER_MODEL_MAP` (null for `inherit`/unmapped). `resolveEffort` derives provider from the resolved model ID (closed-world assumption) and returns a platform/provider `{fieldName, value}` — `effort` (Claude Code), `model_reasoning_effort` (Codex), `reasoningEffort` (OpenAI-on-OpenCode); omits for fast tier, unknown provider, or null platform config.
+- **LiquidJS whitespace control (CRITICAL)**: production engine (`template-engine.ts`) uses `greedy:true`. Golden-file tests MUST replicate the identical config (`greedy:true`, `strictVariables`, `strictFilters`, `lenientIf`) — config drift lets whitespace bugs ship undetected. Use `{%- endif %}` (no trailing dash) when a newline separator must survive after an `endif`; a trailing `{%- endif -%}` under `greedy:true` strips the separator and concatenates adjacent fields (this caused invalid Codex TOML). Gate optional fields on `model != "inherit"` / `effortValue` so opt-out output is byte-identical to legacy.
+- **fp-ts pipeline**: `pipe(loadConfig, TE.fromEither, TE.chain(...))`; prefer clear `map`/`flatMap`/`isLeft` over abstractions.
 
 ## Observability
 
-- **CLI logging**: consola-based logger with `--verbose`/`--trace` mapping to numeric levels
-- **Daemon diagnostics**: Append-only NDJSON to `daemon.log` via `logDaemonEvent` with structured event/data fields; failures silently swallowed
-- **Correlation**: `runId`, `projectId`, and source IDs in notification and event records
+- consola logger with `--verbose`/`--trace` levels; daemon appends structured NDJSON to `daemon.log`; `runId`/`projectId`/source IDs correlate events and notifications.
 
-## Progressive-Disclosure Pipeline
+## Testing Idioms
 
-- Skills with large instruction sets split content into subdirectories (`references/`, `pipeline/`) loaded on demand
-- Entry-point SKILL.md contains a manifest table mapping companion files to load conditions
-- Pipeline stages are standalone `.md` files with consistent structure (Purpose, Input, Process, Output)
-- Agents execute stages sequentially, accumulating context across stages in conversation state
-- Exemplar: `prompt-writer` with three reference layers (`references/`) and six pipeline stages (`pipeline/`)
+- Tests under `cli/src/__tests__/` mirror feature areas with shared helpers (temp dirs, env save/restore, Either/TaskEither unwrap).
+- **Golden-file tests** validate rendered template output; the test Liquid engine config MUST match production (`greedy:true`) or whitespace bugs ship undetected.
+- Evals share assertions under `evals/suites/shared/`.
 
-## Extension Points
+## I/O & Integration
 
-- Commands registered centrally via `program.addCommand` in `main.ts`
-- Agent tools register via `registerTool()`
-- Build pipeline uses LiquidJS templates with registered lint rules and filters
-- State machines declared in `stateDiagram-v2` blocks with auto-skip and auto-complete
-- Views register contextual commands via `useContextualShortcuts` hook for command palette integration
-- Prompt pipeline stages loaded progressively via companion reference files in skill subdirectories (`prompt-writer` as first exemplar)
+- SQLite via `bun:sqlite` (runs, events, artifacts, annotations, notifications); upsert + source dedup.
+- Atomic writes via temp-file + rename (registry); PID file mode `0o600`.
+- `rp1 agent-tools emit` persists canonical events; daemon relays project-scoped WS envelopes. File artifacts keep `path`+`storageRoot`; URL artifacts register as `type: link` with deterministic identity (only curated run-output links).
+- **Directory-scoped I/O**: code edits resolve against `codeRoot` (worktree-aware); work/KB reads use `workRoot`/`kbRoot` (canonical `.rp1/`).
 
-## Testing
+## Concurrency & Async
 
-- Tests under `cli/src/__tests__/` mirror feature areas with shared helpers
-- Common patterns: temp directories, explicit env save/restore, Either/TaskEither unwrap helpers
-- Unit-heavy with integration-style setup for CLI, filesystem, config, and build pipeline
-- Golden-file tests validate rendered template output
-- Evals share assertions under `evals/suites/shared/`
+- `withRegistryLock` async mutex serializes registry read-modify-write; functional state updaters dedup concurrent WS toasts; heavy subsystems (daemon, LiquidJS) loaded via dynamic `import()` and excluded from the compiled binary.
+
+## Extension Mechanisms
+
+- Commands via `program.addCommand` in `main.ts`; agent tools via `registerTool()`; build templates per-platform under `templates/<platform>/` with registered lint rules + filters; state machines via `stateDiagram-v2` with auto-skip/auto-complete.
+
+## Related KB
+
+- Components: `modules.md` · System design: `architecture.md` · Concepts: `concept_map.md`

--- a/.rp1/context/state.json
+++ b/.rp1/context/state.json
@@ -10,8 +10,8 @@
     "evals/",
     "docs/"
   ],
-  "generated_at": "2026-04-12T00:00:00Z",
-  "git_commit": "c0e31eb1b9bcebe4720181365667bf38fa435ea6",
+  "generated_at": "2026-06-30T04:51:23Z",
+  "git_commit": "fbd06f6c797d9327e3e65d5573d8cab9ff88c3c6",
   "files_analyzed": 919,
   "languages": [
     "TypeScript",
@@ -26,7 +26,7 @@
   ],
   "metrics": {
     "modules": 22,
-    "components": 12,
-    "concepts": 36
+    "components": 13,
+    "concepts": 40
   }
 }

--- a/catalog/agents.yaml
+++ b/catalog/agents.yaml
@@ -10,204 +10,204 @@ agents:
   - name: rp1-base:kb-architecture-mapper
     description: "Maps system architecture patterns, layers, and integrations for architecture.md from pre-filtered files"
     plugin: base
-    last_checksum: da1ad68e6904eb65d6541d2fe1c46d36129aa9d318a53490adce40ca00d6e808
+    last_checksum: 0cb8aa34654c64e8e7a305372f1214afab4afbba28ddc356506ab3d7f9a31d3a
   - name: rp1-base:kb-concept-extractor
     description: "Extracts domain concepts and terminology for concept_map.md from pre-filtered files"
     plugin: base
-    last_checksum: 577d091e7a9deab2f07639de3e1c534965dc83807b1f51158793c12dc9f7f2c3
+    last_checksum: d710d7e5d5d63777b41de5f4c64fda577994f9a4a18a88d13c3f9379c98a7f06
   - name: rp1-base:kb-index-builder
     description: "[DEPRECATED] Generates project overview data for index.md from pre-filtered files"
     plugin: base
-    last_checksum: 3af1eaf3ce78dcb61930e92e4f0d16077ad09a882ea45a54da0004064142ea4e
+    last_checksum: 3998ad02e71360ec8c9375a7101e9fe2096c5712cb9d922bc67273f69d6f92bd
   - name: rp1-base:kb-interaction-mapper
     description: "Maps cross-surface interaction semantics for interaction-model.md from pre-filtered files"
     plugin: base
-    last_checksum: 5c643f07f71d6d460dc8ddde55dffe569a4a4d68fddb8448a5d9339653dd10f4
+    last_checksum: 0ed07df012ddba810d45fde3cf7c16037e277e5d2f3fc801e11a09791174a51f
   - name: rp1-base:kb-module-analyzer
     description: "Analyzes modules, components, and dependencies for modules.md from pre-filtered files"
     plugin: base
-    last_checksum: 6530cecb5ac4210b39d47f8042b2ec291f536abecbb4c25a98b2db6aa0868cf5
+    last_checksum: d0664b4910ba52562813ef48b8e623fd5a2d1d2729d7493be02d05e8c24a4129
   - name: rp1-base:kb-pattern-extractor
     description: "Extracts implementation patterns and idioms for patterns.md from pre-filtered source files"
     plugin: base
-    last_checksum: 5dacf041f8944184c5a0c21f5d72c8c6f8c4f589b9c5e18af706c30df004e6a4
+    last_checksum: b3b38c9d17e1f7ee2c8f07cc2ad2e1764590856ed0878ffe51b31fb49f7ffe89
   - name: rp1-base:kb-spatial-analyzer
     description: "Scans repository files, ranks by importance (0-5), and categorizes them by KB section for parallel analysis"
     plugin: base
-    last_checksum: 6a82d0ac72419509edd4883de21cf0bdbf3fc10cb759ecf7e83cb9e940dffda4
+    last_checksum: ef1e6d7f770f4d441277a26f189c1993c6a58d459708a235d239a6529d362682
   - name: rp1-base:mermaid-fixer
     description: "Validates and repairs mermaid diagrams in markdown files. Scans for mermaid blocks, validates each diagram, attempts automatic repair (up to 3 iterations), and inserts placeholders for unfixable diagrams."
     plugin: base
-    last_checksum: 8ff3bab4ab44c9601bc70577df160259d69d35afce95a75142ce35fa3cd79afa
+    last_checksum: 5a592e65f9af3e25525e79ce31b97090b6589371a355f9a8612e2fa21e80543b
   - name: rp1-base:project-documenter
     description: "Generates a digestible 3-tier/9-section birds-eye-view document from KB + codebase, with per-claim provenance in hidden HTML comments"
     plugin: base
-    last_checksum: 11a1aefff9d35be130cb6ec283fd7e2d40d96078ab8223fd0854db1f406373c3
+    last_checksum: 57e663472cab105d80ce513eb8af7a2745af3003ac0f1cb880b116d7472dd0bf
   - name: rp1-base:prompt-pipeline-runner
     description: "Executes the six-stage prompt-writer pipeline and produces two mandatory output artifacts (ready-to-run prompt, confidence report)"
     plugin: base
-    last_checksum: 85ebd9f3e197d8281c6697b45f1643fb08548e0612a3ddaf23c4397692495d60
+    last_checksum: 605f47f09e034d7f5a250a5c0de95446fb95c63d768686d8f0484120f0428e6a
   - name: rp1-base:research-explorer
     description: "Deep exploration of codebases or web resources, returning structured JSON findings with evidence"
     plugin: base
-    last_checksum: e8900faad05e4696457428b81f90c28187449da79cfdf92e0fffc7e55368cec4
+    last_checksum: e56f673713ba6aadc6c09928d5887251d878f643add02fb9638991af06d1b4df
   - name: rp1-base:research-reporter
     description: "Generates structured research reports with validated Mermaid diagrams from synthesis data"
     plugin: base
-    last_checksum: 040c7ee7e9740ba072c59c05eeb9c75aecec521c8e563a2bff0105a11817ce10
+    last_checksum: 0651848e62cbc3c312252405d11da1fefad8b0a9de67a8615a331ec2feb2148b
   - name: rp1-base:scribe
     description: "Dual-mode doc worker for scan/process batches. Returns JSON only."
     plugin: base
-    last_checksum: 008217154322a692c3662ea60a33c2b0f92a5dd565026cf1afb0cdec7352b0c2
+    last_checksum: 856a779694035edec613a7b159c0c700a3095216afdd60c03e359357b4c5e483
   - name: rp1-base:security-validator
     description: "Performs evidence-bounded, standards-mapped security posture assessment for a project, sub-directory, module, concept, or feature topic"
     plugin: base
-    last_checksum: 7308d8a8d2cab5e1066efbdd58216d9187995cda94271e9a8e83c7d65c5e4453
+    last_checksum: 433ccf11f18d7dc8158c122745fc6034b6990d3e394c15a9e105ea23abd759ec
   - name: rp1-base:socratic-duel-participant
     description: "Participates in a Socratic Duel run using pre-resolved launcher context and participant-owned artifact writes."
     plugin: base
-    last_checksum: 23f8013b39083b1b229948a6c5099870837b253ec3a2bc3b2fc1e4a9ebdf43ec
+    last_checksum: 4260cbc7c74ac0aca78463d957f5d99b9ed5c13705f7886c1924404f5ce8f7b1
   - name: rp1-base:strategic-advisor
     description: "Analyzes systems holistically to provide strategic recommendations balancing cost, quality, performance, complexity, and business objectives with quantified trade-offs"
     plugin: base
-    last_checksum: 68538e3755c49b13be3b82a6b240133617ac9b05481a234e6e591523139f5f51
+    last_checksum: 23d3514b788f7910bec9b8a1095a5e175bafb9a5c6c96c1437ac7b7d2c5da7d6
   - name: rp1-dev:blueprint-auditor
     description: "Audits PRD documents against implementation status and executes disposition actions"
     plugin: dev
-    last_checksum: ff32057e796afeeb6caac8071bc29d600ae8a48e7ffa8b17a03f1c3ba1ea2a93
+    last_checksum: b9fa265ccc043134173d3befa9f670da952cb6d8248d1e34324a43e763e10697
   - name: rp1-dev:blueprint-wizard
     description: "Stateless PRD wizard that analyzes interview state and returns structured JSON responses for PRD creation"
     plugin: dev
-    last_checksum: 65c0dae963cc4fe91b47858fa0f272934acc751dd9e48b8716acaca8cc81bd31
+    last_checksum: 2e9cb6150c9970b8b17bcfcc6b00e9dd3c654df3d4dbd23842553b553b02fc40
   - name: rp1-dev:bootstrap-scaffolder
     description: "Stateless scaffolder that analyzes interview state and returns structured JSON responses for tech stack selection and project scaffolding"
     plugin: dev
-    last_checksum: 82658b068bb9a78b2aa063355dbbeb52e1b0eb467ffa73d7b2030f18b11d5ecd
+    last_checksum: f27998505c7a1302dde800ddf83ddc999a2ea71025035be0d93167286b207389
   - name: rp1-dev:bug-investigator
     description: "Systematic investigation of bugs and issues to identify root causes through evidence-based analysis, hypothesis testing, and comprehensive documentation without permanent code changes"
     plugin: dev
-    last_checksum: 9224f4929f0c8617f18c8845c5fb75c0c0ff85452f26d6b2f3ce26e13fe92ed8
+    last_checksum: 8895b0926e49fbc2c66d6067fc6a5b781e7c6286815cc68eeb9cffa30152221c
   - name: rp1-dev:build-artifact-detector
     description: "Determines workflow start_step by checking existing feature artifacts using bootstrap-provided run context"
     plugin: dev
-    last_checksum: 79cebe3897d75aaa61435ac8987c0a6f3b83225307060e6b7f7564e80c0d3879
+    last_checksum: 78cc1c42e80de7c27d81abb15c18a21b5f7444e22dd2fccc0be9b3811b7a5eb3
   - name: rp1-dev:build-fast-planner
     description: "Quick-iteration workflow planner. Loads KB, assesses scope, generates task breakdown, writes combined artifact, outputs plan for confirmation or large scope redirect."
     plugin: dev
-    last_checksum: 3d2f457a4815d14b28c3ee5434d8149db2011a606b0268a7e418e419a1101f90
+    last_checksum: d2a86433b74fdede0fe235dfe8e28dad5c75a257eb35b5e39a6a0ad21c00d8d0
   - name: rp1-dev:build-task-grouper
     description: "Batches parsed tasks into execution units based on complexity rules"
     plugin: dev
-    last_checksum: b9be10c0ba36aede4fed7c86e0ff8a5cf5df91d7147257b5e91a4a9f5969a352
+    last_checksum: 2fcedc2dda433bc5e9f748f8552b1113008e71962fa95e6935e31a054b96ecfa
   - name: rp1-dev:build-task-parser
     description: "Extracts structured task information from tasks.md files"
     plugin: dev
-    last_checksum: ba7fb12df3d274160a027a111c05742e74e1cb7c310eaea2c77ebfc1f2dabb73
+    last_checksum: aa6e1a48c7f356e42f5cf71a784820f961992162c9a35e6493676f42c76ff172
   - name: rp1-dev:build-verify-aggregator
     description: "Combines validation envelopes into final build readiness status and artifact"
     plugin: dev
-    last_checksum: 05dcaa97d373ba47141d83992d1bc07782dbe795558d82c88cfe075c511c870e
+    last_checksum: ae940bac221e1bdd49c0027d7155c0d7d9f8e5b0e8fe97b6c584ca7ddd3dc454
   - name: rp1-dev:charter-interviewer
     description: "Stateless interview agent that analyzes charter state and returns structured JSON responses for greenfield project vision capture"
     plugin: dev
-    last_checksum: adbdeed987b804e5364ae8f461228046757de95ee9098494bc8d61403e4c56f2
+    last_checksum: ea9eb5a37fd7e77c3cfea9985ffcd8ad2d15dedcd80294b4830496f219d20812
   - name: rp1-dev:code-auditor
     description: "Analyzes implemented code for pattern consistency, maintainability, code duplication, comment quality, and documentation drift"
     plugin: dev
-    last_checksum: aa25da4d6f900c6300a72d1e6003e869a41f16027e8de4254da7df9ff46b287d
+    last_checksum: 51974522df4de596ea392a109090c24bc544c2a03e56a5a428cc8b646398238e
   - name: rp1-dev:code-checker
     description: "Fast code hygiene validation (linters, formatters, tests, coverage) for quick dev loop feedback"
     plugin: dev
-    last_checksum: 7aa3090816f66a490e09f9ae672bb77fe59b91d5d51e0e49e80208f1130be709
+    last_checksum: 31975a88a21fbf64e0fb99f0c2365d296c784ff4329738f17d4c50f6f49f1abe
   - name: rp1-dev:comment-cleaner
     description: "Systematically removes unnecessary comments from manifest-owned code lines while preserving docstrings, critical logic explanations, and type directives"
     plugin: dev
-    last_checksum: b9d0afe4c8f4de9f7d6ead2372367190a16e4eb7e7b87c46fb1e36756d1d2161
+    last_checksum: c92138f701e57951c1b1f0ab9a23fb29f33ecc83ac8ae73c0a5020afcc49748f
   - name: rp1-dev:feature-architect
     description: "Transforms requirements into technical design specifications. Invoked by /build workflow. Does NOT spawn hypothesis-tester."
     plugin: dev
-    last_checksum: 35743bb7e093c86f8fc7cace4a67d5cd6523777327e7ef2d11c11854311f5a9d
+    last_checksum: 5eaaf42ec03ab67de97b14a32e5c2802e8ab921c36e57843cab438dee83f2aae
   - name: rp1-dev:feature-archiver
     description: "Archives completed features to .rp1/work/archives/features/ or restores archived features back to active features directory"
     plugin: dev
-    last_checksum: 92e06bbca75a64c23df02b1d70478e40fe5205eca637517b306de4db8ce83189
+    last_checksum: 6488ca4f0f7751df50338503f228eaa13a5571a3afcaa1817a9ac231297c11e0
   - name: rp1-dev:feature-editor
     description: "Analyzes mid-stream edits for validity, detects conflicts, and propagates approved changes across feature documentation"
     plugin: dev
-    last_checksum: bdf279df9f0adf5915d02e91492a48d915337a472d5485d4cc938d5320688b97
+    last_checksum: 1a8ecc51d058ff57ee684b6c1c6daca3a2e2e9ee96446ded42d099a43767c7d9
   - name: rp1-dev:feature-requirement-gatherer
     description: "Transforms high-level feature concepts into structured requirements specifications. Invoked by /build workflow."
     plugin: dev
-    last_checksum: 632f70b1b972c1d9e9595178f5a27b9c2a48ac6d22c0b916b20668c0eb0ab4ea
+    last_checksum: cfb2b16497a5643c7c56f908f4c7be62c8774705b4ab97d813323bbec2a59230
   - name: rp1-dev:feature-tasker
     description: "Generates development tasks from design specifications with support for incremental updates that preserve completed work"
     plugin: dev
-    last_checksum: 86ea3138b5e5bdac2f2798d32d5ba720c5e0dbea5205dd12f4e3a9ba11a2a852
+    last_checksum: 9d0a61367cb422986ff27db320ce6fabfd1ba090f5af4d9c8cdca2c209c48f24
   - name: rp1-dev:feature-verifier
     description: "Verifies feature acceptance criteria and requirements mapping with full KB context awareness for comprehensive feature validation before merge"
     plugin: dev
-    last_checksum: 8e10231da20d0a6837041dde657890a5979c4c2e8d511ec5266c1cfd02b7500f
+    last_checksum: 1eff89e6b8511d4f23a175abe6106ce287e3f70d3799a6ead7fd0508117a49fa
   - name: rp1-dev:hypothesis-tester
     description: "Validates design hypotheses through code experiments, codebase analysis, and external research"
     plugin: dev
-    last_checksum: a28027850e007d57843778d28c5b8ee5b75e5e4bc5b5743e9aa7d607508d5cf3
+    last_checksum: f2197ee767b985cbb4ac6462492d6d3d57459fe218006e6d054bbc4f93622375
   - name: rp1-dev:phase-planner
     description: "Decomposes a planning source into a source-adjacent phase-plan artifact and refreshes source backlinks."
     plugin: dev
-    last_checksum: 179a848ffa5ad417e55a352b00d8f5d3873d51bb2f2630b15b519d3d5400c2ae
+    last_checksum: 5d5cb8a37ea5ec50fd40874195f3d036d7d4f8fdbdf2b2a8ea3515dbb0c6fced
   - name: rp1-dev:pr-comment-deduplicator
     description: "Deduplicates PR review comments against existing bot and human comments"
     plugin: dev
-    last_checksum: 0c6383836decc8544be38821497e75d2b030dae96d3271147ea7ea2d9239805b
+    last_checksum: 9186cec9f1b7d7312451c1a88d31142559fe247340d471e9a8ca10c0e4fcb046
   - name: rp1-dev:pr-comment-poster
     description: "Posts PR review comments via github-pr agent-tools"
     plugin: dev
-    last_checksum: 73ee88b9301e11576c2bc3013d2c04ecb932482fae5f8ba68952ce2a9773b1b8
+    last_checksum: 45b6913c5970806028cc5e263b1e47f22c4ab538f85e84727eb49b8e680364ed
   - name: rp1-dev:pr-feedback-collector
     description: "Automatically gathers pull request review comments from GitHub, classifies them by priority and type, extracts actionable tasks, and generates structured feedback documents for systematic resolution"
     plugin: dev
-    last_checksum: f0337fd639c506c88d8265349da8bc7d9153b07c4b9af864dc29dfe61fa95854
+    last_checksum: 2e994a28783e6b51f51fe20e11052a4881bcf2a94a28116d8ac888604e14675d
   - name: rp1-dev:pr-review-reporter
     description: "Formats findings into markdown report and writes to file"
     plugin: dev
-    last_checksum: 63e802e96eabbe916fb00dedf2000efcaa6234575a19602b117953bfbbd3995f
+    last_checksum: e8e79e7d532aa18150925a92a7dc0d8c4478a85accdf928dcb408c44f845cce0
   - name: rp1-dev:pr-review-splitter
     description: "Splits PR diff into reviewable units, filtering out generated/low-value files"
     plugin: dev
-    last_checksum: 1b3ed7fca8c2c8ad45218b7967b8ccb9d1152c187f4db866d1456b4422bfbe58
+    last_checksum: 7de5b99e57defaa8770465378ac26ee7a87c0714fb8a345daaaed1b4575d3095
   - name: rp1-dev:pr-review-synthesizer
     description: "Holistic cross-file verification using compressed summaries"
     plugin: dev
-    last_checksum: 43fb00dbefe6f63d46b44e8c8b5ae76510cb16c48cb6ab585d9b5bf1de1033a4
+    last_checksum: 13d1a930c76747e1a5dc57aaf20401c4fd79d22b74f9defbcad92781361aed5d
   - name: rp1-dev:pr-sub-reviewer
     description: "Analyzes one review unit across 5 dimensions with confidence gating"
     plugin: dev
-    last_checksum: e11e95c29212eb85ec06fdd53693f87335a11085e56c58365e1115ab02b09a3c
+    last_checksum: f07584319aa00ad1a48b8b09287e92a20daae5947583811c7fa5731763432c07
   - name: rp1-dev:pr-visualizer
     description: "Transform PR diffs into Mermaid diagrams for visual code review"
     plugin: dev
-    last_checksum: f86ce7f37ad094d098ff1238ce56a01682cec96a53bf92218d1288e08ffba161
+    last_checksum: df4a4a325fc95b033f40e85f9cecb99fe286b759f6fde628b981bc847d19f76e
   - name: rp1-dev:pr-walkthrough-reporter
     description: "Generate an evidence-grounded slide-ready markdown walkthrough for a pull request"
     plugin: dev
-    last_checksum: 18bed696e5740277e74bc6690b0ef1a6d29aae467a4f6229154c666c07bbba31
+    last_checksum: 6feabfb683117308accf7a322876cc8203c6b2c06dd07faf0e26d1c606062759
   - name: rp1-dev:prd-archiver
     description: "Archives completed PRDs to .rp1/work/archives/prds/, archives associated completed features, checks KB staleness, and generates closure summaries"
     plugin: dev
-    last_checksum: e8666b82d61fd6a811d36f90eaa12c1401dfe1b3f80d4f5485a3de6607e1b6ec
+    last_checksum: d4e6f8897b4c4548d2730bef820ece2b4db2308fea18cc05778326902b228e3b
   - name: rp1-dev:speedrun-builder
     description: "Implements a single focused code change from a speedrun request"
     plugin: dev
-    last_checksum: 3f791efe3a9238e1cb7a15b26b655af51617565ed39a9a5cd555d0644e30fc19
+    last_checksum: b9a57e3448993006712cedede15014b3e726e250f779cff1130c3a87b4d7a295
   - name: rp1-dev:task-builder
     description: "Implements assigned task(s) w/ full context, writes summaries to the resolved task file. Uses extended thinking (or ultrathink)."
     plugin: dev
-    last_checksum: 7b586d5d8c87c5a63ba8e241a7bf4e621b11b5d2a9abe5429f0dea9fbdb2011d
+    last_checksum: 0e5027e8f818ad9152ce9346c7f075c2146903797bf4f0a62962e069d82ed3f5
   - name: rp1-dev:task-reviewer
     description: "Verifies builder's work for discipline, accuracy, completeness, and commit quality. Returns SUCCESS or FAILURE with actionable feedback. Uses extended thinking for careful verification."
     plugin: dev
-    last_checksum: f1897df0e9373a23535e9098457b8ba6143dfcf68c92ce4346bfb554c0ea258f
+    last_checksum: 127b1f730e6983fbaf645d5b8a086e9af8b9e662c0ab64874320be2d597f9be1
   - name: rp1-dev:test-runner
     description: "Executes comprehensive functional testing of implemented features including automated tests, coverage measurement, acceptance criteria verification, and detailed test reporting"
     plugin: dev
-    last_checksum: 3fc05bbc1e5e7ea5d6ac4fb147dd4c5e0043e9f1fa488b5136a881b8bb0fa5e8
+    last_checksum: ea72d209649b38f39a6c707e7973664f84344d7fc05de9aab2f2bb038a0cb6ed

--- a/cli/src/__tests__/build/command.test.ts
+++ b/cli/src/__tests__/build/command.test.ts
@@ -943,6 +943,118 @@ Research explorer content.
 	});
 });
 
+describe("buildPlatformPlugin (tier resolution)", () => {
+	let tempDir: string;
+	let outputDir: string;
+
+	beforeAll(async () => {
+		tempDir = await createTempDir("tier-resolution");
+		outputDir = join(tempDir, "output");
+	});
+
+	afterAll(async () => {
+		await cleanupTempDir(tempDir);
+	});
+
+	test("resolves abstract model tier to platform-specific ID and maps effort fields on AgentArtifactData", async () => {
+		const projectRoot = join(tempDir, "project-tier-resolution");
+		await writeFixture(
+			projectRoot,
+			"plugins/base/skills/sample/SKILL.md",
+			`---
+name: sample
+description: "Sample skill with enough text to pass build validation"
+---
+
+Sample skill content.
+`,
+		);
+		await writeFixture(
+			projectRoot,
+			"plugins/base/agents/deep-agent.md",
+			`---
+name: deep-agent
+description: "Agent with deep tier and high effort for resolution testing"
+tools: Read
+model: deep
+effort: high
+---
+
+Deep agent content for tier resolution.
+`,
+		);
+
+		const out = join(outputDir, "tier-opencode");
+		const result = await buildPlatformPlugin(
+			"base",
+			projectRoot,
+			out,
+			opencodeDef,
+			noopLogger,
+			true,
+			false,
+		);
+
+		expect(result.summary.errors).toEqual([]);
+		expect(result.summary.agents).toBe(1);
+
+		const agentPath = join(out, "base", "agents", "rp1-base-deep-agent.md");
+		const agentContent = await readFile(agentPath, "utf-8");
+
+		// Model tier "deep" should be resolved to "opus" for OpenCode
+		expect(agentContent).toContain("model: opus");
+		expect(agentContent).not.toContain("model: deep");
+	});
+
+	test("preserves inherit model as-is and omits effort when resolveEffort returns null", async () => {
+		const projectRoot = join(tempDir, "project-tier-inherit");
+		await writeFixture(
+			projectRoot,
+			"plugins/base/skills/sample/SKILL.md",
+			`---
+name: sample
+description: "Sample skill with enough text to pass build validation"
+---
+
+Sample skill content.
+`,
+		);
+		await writeFixture(
+			projectRoot,
+			"plugins/base/agents/inherit-agent.md",
+			`---
+name: inherit-agent
+description: "Agent with inherit model for backward compatibility testing"
+tools: Read
+model: inherit
+---
+
+Inherit agent content.
+`,
+		);
+
+		const out = join(outputDir, "tier-inherit");
+		const result = await buildPlatformPlugin(
+			"base",
+			projectRoot,
+			out,
+			opencodeDef,
+			noopLogger,
+			true,
+			false,
+		);
+
+		expect(result.summary.errors).toEqual([]);
+		expect(result.summary.agents).toBe(1);
+
+		const agentPath = join(out, "base", "agents", "rp1-base-inherit-agent.md");
+		const agentContent = await readFile(agentPath, "utf-8");
+
+		// Inherit model should NOT emit model field at all (backward compatible)
+		expect(agentContent).not.toContain("model:");
+	});
+});
+
 describe("ParseCache", () => {
 	let tempDir: string;
 	let outputDir: string;

--- a/cli/src/__tests__/build/command.test.ts
+++ b/cli/src/__tests__/build/command.test.ts
@@ -1053,6 +1053,187 @@ Inherit agent content.
 		// Inherit model should NOT emit model field at all (backward compatible)
 		expect(agentContent).not.toContain("model:");
 	});
+
+	test("Claude Code agent with deep tier emits YAML frontmatter with model and effort", async () => {
+		const projectRoot = join(tempDir, "project-tier-cc");
+		await writeFixture(
+			projectRoot,
+			"plugins/base/skills/sample/SKILL.md",
+			`---
+name: sample
+description: "Sample skill with enough text to pass build validation"
+metadata:
+  category: development
+  is_workflow: false
+---
+
+Sample skill content.
+`,
+		);
+		await writeFixture(
+			projectRoot,
+			"plugins/base/agents/deep-agent.md",
+			`---
+name: deep-agent
+description: "Agent with deep tier for Claude Code pipeline test"
+tools: Read
+model: deep
+effort: high
+---
+
+Deep agent content for CC pipeline test.
+`,
+		);
+
+		const out = join(outputDir, "tier-cc");
+		const result = await buildPlatformPlugin(
+			"base",
+			projectRoot,
+			out,
+			claudeCodeDef,
+			noopLogger,
+			true,
+			false,
+		);
+
+		expect(result.summary.errors).toEqual([]);
+		expect(result.summary.agents).toBe(1);
+
+		const agentPath = join(out, "base", "agents", "deep-agent.md");
+		const agentContent = await readFile(agentPath, "utf-8");
+
+		// Deep tier resolves to "opus" for Claude Code
+		expect(agentContent).toContain("model: opus");
+		expect(agentContent).not.toContain("model: deep");
+		// Effort emitted as "effort" field for Claude Code
+		expect(agentContent).toContain("effort: high");
+		// Frontmatter markers present
+		expect(agentContent).toContain("---");
+	});
+
+	test("Codex agent with deep tier emits model and model_reasoning_effort TOML fields", async () => {
+		const projectRoot = join(tempDir, "project-tier-codex");
+		await writeFixture(
+			projectRoot,
+			"plugins/base/skills/sample/SKILL.md",
+			`---
+name: sample
+description: "Sample skill with enough text to pass build validation"
+metadata:
+  category: development
+  is_workflow: false
+---
+
+Sample skill content.
+`,
+		);
+		await writeFixture(
+			projectRoot,
+			"plugins/base/agents/deep-agent.md",
+			`---
+name: deep-agent
+description: "Agent with deep tier for Codex pipeline test"
+tools: Read
+model: deep
+effort: high
+---
+
+Deep agent content for Codex pipeline test.
+`,
+		);
+
+		const out = join(outputDir, "tier-codex");
+		const result = await buildPlatformPlugin(
+			"base",
+			projectRoot,
+			out,
+			codexDef,
+			noopLogger,
+			true,
+			false,
+		);
+
+		expect(result.summary.errors).toEqual([]);
+		expect(result.summary.agents).toBe(1);
+
+		const agentPath = join(out, "base", "agents", "rp1-base-deep-agent.toml");
+		const agentContent = await readFile(agentPath, "utf-8");
+
+		// Deep tier resolves to "o3" for Codex
+		expect(agentContent).toContain('model = "o3"');
+		expect(agentContent).not.toContain('model = "deep"');
+		// Effort emitted as "model_reasoning_effort" for Codex
+		expect(agentContent).toContain('model_reasoning_effort = "high"');
+	});
+
+	test("fast tier agent omits effort across all platforms", async () => {
+		const projectRoot = join(tempDir, "project-tier-fast");
+		await writeFixture(
+			projectRoot,
+			"plugins/base/skills/sample/SKILL.md",
+			`---
+name: sample
+description: "Sample skill with enough text to pass build validation"
+metadata:
+  category: development
+  is_workflow: false
+---
+
+Sample skill content.
+`,
+		);
+		await writeFixture(
+			projectRoot,
+			"plugins/base/agents/fast-agent.md",
+			`---
+name: fast-agent
+description: "Agent with fast tier for omission testing"
+tools: Read
+model: fast
+---
+
+Fast agent content.
+`,
+		);
+
+		// Claude Code
+		const outCC = join(outputDir, "tier-fast-cc");
+		const ccResult = await buildPlatformPlugin(
+			"base",
+			projectRoot,
+			outCC,
+			claudeCodeDef,
+			noopLogger,
+			true,
+			false,
+		);
+		expect(ccResult.summary.errors).toEqual([]);
+		const ccContent = await readFile(
+			join(outCC, "base", "agents", "fast-agent.md"),
+			"utf-8",
+		);
+		expect(ccContent).toContain("model: haiku");
+		expect(ccContent).not.toContain("effort:");
+
+		// Codex
+		const outCdx = join(outputDir, "tier-fast-codex");
+		const cdxResult = await buildPlatformPlugin(
+			"base",
+			projectRoot,
+			outCdx,
+			codexDef,
+			noopLogger,
+			true,
+			false,
+		);
+		expect(cdxResult.summary.errors).toEqual([]);
+		const cdxContent = await readFile(
+			join(outCdx, "base", "agents", "rp1-base-fast-agent.toml"),
+			"utf-8",
+		);
+		expect(cdxContent).toContain('model = "gpt-4.1-nano"');
+		expect(cdxContent).not.toContain("model_reasoning_effort");
+	});
 });
 
 describe("ParseCache", () => {

--- a/cli/src/__tests__/build/parser.test.ts
+++ b/cli/src/__tests__/build/parser.test.ts
@@ -245,6 +245,57 @@ Content.`;
 				await cleanupTempDir(tempDir);
 			}
 		});
+
+		test("extracts effort from agent frontmatter", async () => {
+			const tempDir = await createTempDir("parser-agent-effort");
+			try {
+				const content = `---
+name: effort-agent
+description: Agent with effort level
+tools: Read
+model: deep
+effort: high
+---
+Content.`;
+
+				const filePath = await writeFixture(
+					tempDir,
+					"effort-agent.md",
+					content,
+				);
+				const result = await expectTaskRight(parseAgent(filePath));
+
+				expect(result.effort).toBe("high");
+				expect(result.model).toBe("deep");
+			} finally {
+				await cleanupTempDir(tempDir);
+			}
+		});
+
+		test("defaults effort to undefined when not specified", async () => {
+			const tempDir = await createTempDir("parser-agent-no-effort");
+			try {
+				const content = `---
+name: no-effort-agent
+description: Agent without effort
+tools: Read
+model: standard
+---
+Content.`;
+
+				const filePath = await writeFixture(
+					tempDir,
+					"no-effort-agent.md",
+					content,
+				);
+				const result = await expectTaskRight(parseAgent(filePath));
+
+				expect(result.effort).toBeUndefined();
+				expect(result.model).toBe("standard");
+			} finally {
+				await cleanupTempDir(tempDir);
+			}
+		});
 	});
 
 	describe("parseSkill", () => {

--- a/cli/src/__tests__/build/templates/golden/antigravity-agent-model.md
+++ b/cli/src/__tests__/build/templates/golden/antigravity-agent-model.md
@@ -2,18 +2,10 @@
 name: rp1-base-deep-agent
 description: Agent with deep tier for Antigravity
 kind: local
-
-
 tools:
-
   - read_file
-
   - run_shell_command
-
-
-
 model: opus
-
 max_turns: 30
 metadata:
   rp1:

--- a/cli/src/__tests__/build/templates/golden/antigravity-agent-model.md
+++ b/cli/src/__tests__/build/templates/golden/antigravity-agent-model.md
@@ -1,0 +1,30 @@
+---
+name: rp1-base-deep-agent
+description: Agent with deep tier for Antigravity
+kind: local
+
+
+tools:
+
+  - read_file
+
+  - run_shell_command
+
+
+
+model: opus
+
+max_turns: 30
+metadata:
+  rp1:
+    runtime_delegation: dynamic_define_subagent
+    static_agents_discovery: non_contract
+---
+
+## Host Context
+
+Identify the active AI coding harness as `antigravity`. Antigravity generated workflows export `CURRENT_HOST=antigravity` before bootstrap and keep that value for later emitted workflow events.
+
+Pass `--harness` only to `rp1 agent-tools emit`, the generated workflow bootstrap command, or another `rp1 agent-tools` command whose help explicitly documents `--harness`. Do not add it to `resolve-args`, `rp1-root-dir`, or other commands.
+
+Agent content for Antigravity tier test.

--- a/cli/src/__tests__/build/templates/golden/cc-agent-inherit.md
+++ b/cli/src/__tests__/build/templates/golden/cc-agent-inherit.md
@@ -1,0 +1,7 @@
+## Host Context
+
+Identify which AI coding harness is executing this prompt and assign `CURRENT_HOST` from: `claude-code`, `codex`, `antigravity`, `gemini-cli`, `gh-copilot`, `opencode`, `amp`, `unknown`. Default: `claude-code`.
+
+Use `CURRENT_HOST` for host-specific decisions. Pass `--harness $CURRENT_HOST` only to `rp1 agent-tools emit`, the generated workflow bootstrap command, or another `rp1 agent-tools` command whose help explicitly documents `--harness`; do not add it to `resolve-args`, `rp1-root-dir`, or other commands.
+
+Agent content with inherited model.

--- a/cli/src/__tests__/build/templates/golden/cc-agent-model-effort.md
+++ b/cli/src/__tests__/build/templates/golden/cc-agent-model-effort.md
@@ -1,10 +1,6 @@
 ---
-
 model: opus
-
-
 effort: high
-
 ---
 
 ## Host Context

--- a/cli/src/__tests__/build/templates/golden/cc-agent-model-effort.md
+++ b/cli/src/__tests__/build/templates/golden/cc-agent-model-effort.md
@@ -1,0 +1,16 @@
+---
+
+model: opus
+
+
+effort: high
+
+---
+
+## Host Context
+
+Identify which AI coding harness is executing this prompt and assign `CURRENT_HOST` from: `claude-code`, `codex`, `antigravity`, `gemini-cli`, `gh-copilot`, `opencode`, `amp`, `unknown`. Default: `claude-code`.
+
+Use `CURRENT_HOST` for host-specific decisions. Pass `--harness $CURRENT_HOST` only to `rp1 agent-tools emit`, the generated workflow bootstrap command, or another `rp1 agent-tools` command whose help explicitly documents `--harness`; do not add it to `resolve-args`, `rp1-root-dir`, or other commands.
+
+Agent content for deep tier with effort.

--- a/cli/src/__tests__/build/templates/golden/cc-agent-model-only.md
+++ b/cli/src/__tests__/build/templates/golden/cc-agent-model-only.md
@@ -1,8 +1,5 @@
 ---
-
 model: haiku
-
-
 ---
 
 ## Host Context

--- a/cli/src/__tests__/build/templates/golden/cc-agent-model-only.md
+++ b/cli/src/__tests__/build/templates/golden/cc-agent-model-only.md
@@ -1,0 +1,14 @@
+---
+
+model: haiku
+
+
+---
+
+## Host Context
+
+Identify which AI coding harness is executing this prompt and assign `CURRENT_HOST` from: `claude-code`, `codex`, `antigravity`, `gemini-cli`, `gh-copilot`, `opencode`, `amp`, `unknown`. Default: `claude-code`.
+
+Use `CURRENT_HOST` for host-specific decisions. Pass `--harness $CURRENT_HOST` only to `rp1 agent-tools emit`, the generated workflow bootstrap command, or another `rp1 agent-tools` command whose help explicitly documents `--harness`; do not add it to `resolve-args`, `rp1-root-dir`, or other commands.
+
+Agent content for fast tier without effort.

--- a/cli/src/__tests__/build/templates/golden/codex-agent-toml-model-effort.toml
+++ b/cli/src/__tests__/build/templates/golden/codex-agent-toml-model-effort.toml
@@ -1,0 +1,18 @@
+name = "rp1-dev-task-builder"
+description = "Implements feature tasks"
+
+model = "o3"
+
+model_reasoning_effort = "high"
+
+developer_instructions = '''
+You are running in Codex with shared rp1 prompt content.
+- If shared instructions mention `Read`, `Write`, `Grep`, or `Glob`, use `functions.exec_command` shell equivalents instead.
+- Prefer `rg --files` for file inventory, `rg -n` for search, and `sed -n` or `cat` for targeted reads.
+- Prefer bounded, path-first exploration over open-ended repository scanning.
+- When a parent/orchestrator already scoped the task inputs, trust that scope and do not re-derive it unless explicitly required.
+- Favor best-effort completion quickly over prolonged exploration.
+- Identify which AI coding harness is executing this prompt and assign `CURRENT_HOST` from: `claude-code`, `codex`, `antigravity`, `gemini-cli`, `gh-copilot`, `opencode`, `amp`, `unknown`. Default: `codex`. Use `CURRENT_HOST` for host-specific decisions. Pass `--harness $CURRENT_HOST` only to `rp1 agent-tools emit`, the generated workflow bootstrap command, or another `rp1 agent-tools` command whose help explicitly documents `--harness`; do not add it to `resolve-args`, `rp1-root-dir`, or other commands.
+
+Agent instructions for deep tier with effort.
+'''

--- a/cli/src/__tests__/build/templates/golden/codex-agent-toml-model-effort.toml
+++ b/cli/src/__tests__/build/templates/golden/codex-agent-toml-model-effort.toml
@@ -1,8 +1,6 @@
 name = "rp1-dev-task-builder"
 description = "Implements feature tasks"
-
 model = "o3"
-
 model_reasoning_effort = "high"
 
 developer_instructions = '''
@@ -13,6 +11,5 @@ You are running in Codex with shared rp1 prompt content.
 - When a parent/orchestrator already scoped the task inputs, trust that scope and do not re-derive it unless explicitly required.
 - Favor best-effort completion quickly over prolonged exploration.
 - Identify which AI coding harness is executing this prompt and assign `CURRENT_HOST` from: `claude-code`, `codex`, `antigravity`, `gemini-cli`, `gh-copilot`, `opencode`, `amp`, `unknown`. Default: `codex`. Use `CURRENT_HOST` for host-specific decisions. Pass `--harness $CURRENT_HOST` only to `rp1 agent-tools emit`, the generated workflow bootstrap command, or another `rp1 agent-tools` command whose help explicitly documents `--harness`; do not add it to `resolve-args`, `rp1-root-dir`, or other commands.
-
 Agent instructions for deep tier with effort.
 '''

--- a/cli/src/__tests__/build/templates/golden/codex-agent-toml.toml
+++ b/cli/src/__tests__/build/templates/golden/codex-agent-toml.toml
@@ -9,6 +9,5 @@ You are running in Codex with shared rp1 prompt content.
 - When a parent/orchestrator already scoped the task inputs, trust that scope and do not re-derive it unless explicitly required.
 - Favor best-effort completion quickly over prolonged exploration.
 - Identify which AI coding harness is executing this prompt and assign `CURRENT_HOST` from: `claude-code`, `codex`, `antigravity`, `gemini-cli`, `gh-copilot`, `opencode`, `amp`, `unknown`. Default: `codex`. Use `CURRENT_HOST` for host-specific decisions. Pass `--harness $CURRENT_HOST` only to `rp1 agent-tools emit`, the generated workflow bootstrap command, or another `rp1 agent-tools` command whose help explicitly documents `--harness`; do not add it to `resolve-args`, `rp1-root-dir`, or other commands.
-
 Agent instructions with $rp1-base-knowledge-build reference.
 '''

--- a/cli/src/__tests__/build/templates/golden/codex-agents-md.md
+++ b/cli/src/__tests__/build/templates/golden/codex-agents-md.md
@@ -2,8 +2,5 @@
 
 | Agent | Role | Description |
 |-------|------|-------------|
-
 | task-builder | worker | Implements feature tasks |
-
 | pr-reviewer | reviewer | Reviews pull requests |
-

--- a/cli/src/__tests__/build/templates/golden/codex-skill.md
+++ b/cli/src/__tests__/build/templates/golden/codex-skill.md
@@ -1,28 +1,21 @@
 ---
 name: rp1-dev-build
 description: Build plugin artifacts
-
 allowed-tools: "functions.exec_command(echo *)"
-
 metadata:
   rp1:
     plugin: dev
     name: build
-
-
   version: 1.0.0
 
   tags:
-
     - workflow
-
 
   created: 2026-01-01
 
   author: cloud-on-prem/rp1
 
   argument-hint: "<feature-id>"
-
 
 ---
 

--- a/cli/src/__tests__/build/templates/golden/gemini-agent-model.md
+++ b/cli/src/__tests__/build/templates/golden/gemini-agent-model.md
@@ -1,0 +1,26 @@
+---
+name: rp1-base-deep-agent
+description: Agent with deep tier for Gemini
+kind: local
+
+
+tools:
+
+  - read_file
+
+  - run_shell_command
+
+
+
+model: gemini-2.5-pro
+
+max_turns: 30
+---
+
+## Host Context
+
+Identify which AI coding harness is executing this prompt and assign `CURRENT_HOST` from: `claude-code`, `codex`, `antigravity`, `gemini-cli`, `gh-copilot`, `opencode`, `amp`, `unknown`. Default: `gemini-cli`.
+
+Use `CURRENT_HOST` for host-specific decisions. Pass `--harness $CURRENT_HOST` only to `rp1 agent-tools emit`, the generated workflow bootstrap command, or another `rp1 agent-tools` command whose help explicitly documents `--harness`; do not add it to `resolve-args`, `rp1-root-dir`, or other commands.
+
+Agent content for Gemini tier test.

--- a/cli/src/__tests__/build/templates/golden/gemini-agent-model.md
+++ b/cli/src/__tests__/build/templates/golden/gemini-agent-model.md
@@ -2,18 +2,10 @@
 name: rp1-base-deep-agent
 description: Agent with deep tier for Gemini
 kind: local
-
-
 tools:
-
   - read_file
-
   - run_shell_command
-
-
-
 model: gemini-2.5-pro
-
 max_turns: 30
 ---
 

--- a/cli/src/__tests__/build/templates/golden/opencode-agent-effort.md
+++ b/cli/src/__tests__/build/templates/golden/opencode-agent-effort.md
@@ -1,0 +1,21 @@
+---
+description: Agent with deep tier and effort
+mode: subagent
+
+model: o3
+
+reasoningEffort: high
+
+tools:
+  bash: true
+  write: false
+  edit: false
+---
+
+## Host Context
+
+Identify which AI coding harness is executing this prompt and assign `CURRENT_HOST` from: `claude-code`, `codex`, `antigravity`, `gemini-cli`, `gh-copilot`, `opencode`, `amp`, `unknown`. Default: `opencode`.
+
+Use `CURRENT_HOST` for host-specific decisions. Pass `--harness $CURRENT_HOST` only to `rp1 agent-tools emit`, the generated workflow bootstrap command, or another `rp1 agent-tools` command whose help explicitly documents `--harness`; do not add it to `resolve-args`, `rp1-root-dir`, or other commands.
+
+Agent content for effort pass-through test.

--- a/cli/src/__tests__/build/templates/golden/opencode-agent-effort.md
+++ b/cli/src/__tests__/build/templates/golden/opencode-agent-effort.md
@@ -1,11 +1,8 @@
 ---
 description: Agent with deep tier and effort
 mode: subagent
-
 model: o3
-
 reasoningEffort: high
-
 tools:
   bash: true
   write: false

--- a/cli/src/__tests__/build/templates/golden/opencode-agent-inherit.md
+++ b/cli/src/__tests__/build/templates/golden/opencode-agent-inherit.md
@@ -1,7 +1,6 @@
 ---
 description: Agent with inherited model
 mode: subagent
-
 tools:
   bash: false
   write: false

--- a/cli/src/__tests__/build/templates/golden/opencode-agent.md
+++ b/cli/src/__tests__/build/templates/golden/opencode-agent.md
@@ -1,9 +1,7 @@
 ---
 description: A test agent for building
 mode: subagent
-
 model: claude-sonnet-4-20250514
-
 tools:
   bash: true
   write: true

--- a/cli/src/__tests__/build/templates/golden/opencode-skill-no-tools.md
+++ b/cli/src/__tests__/build/templates/golden/opencode-skill-no-tools.md
@@ -1,7 +1,6 @@
 ---
 name: rp1-base-simple-skill
 description: A simple skill without tools
-
 metadata:
   rp1:
     plugin: base

--- a/cli/src/__tests__/build/templates/golden/opencode-skill.md
+++ b/cli/src/__tests__/build/templates/golden/opencode-skill.md
@@ -1,15 +1,9 @@
 ---
 name: rp1-base-knowledge-build
 description: Build knowledge base artifacts
-
-
 allowed-tools:
-
   - Bash
-
   - Read
-
-
 metadata:
   rp1:
     plugin: base

--- a/cli/src/__tests__/build/templates/template-rendering.test.ts
+++ b/cli/src/__tests__/build/templates/template-rendering.test.ts
@@ -461,6 +461,43 @@ describeWithLiquid("template rendering", () => {
 				readGolden("opencode-agent-inherit.md").trim(),
 			);
 		});
+
+		test("emits provider-keyed effort pass-through field when present", async () => {
+			const engine = createTestEngine();
+			const result = await engine.renderFile("opencode/agent", {
+				platform: "opencode",
+				artifact: {
+					type: "agent",
+					name: "test-agent",
+					description: "Agent with effort",
+					model: "o3",
+					effortFieldName: "reasoningEffort",
+					effortValue: "high",
+					tools: ["Bash", "Read"],
+					content: "Agent content.",
+				},
+			});
+			expect(result).toContain("model: o3");
+			expect(result).toContain("reasoningEffort: high");
+		});
+
+		test("omits effort field when effortValue is absent", async () => {
+			const engine = createTestEngine();
+			const result = await engine.renderFile("opencode/agent", {
+				platform: "opencode",
+				artifact: {
+					type: "agent",
+					name: "test-agent",
+					description: "Agent without effort",
+					model: "sonnet",
+					tools: ["Bash"],
+					content: "Agent content.",
+				},
+			});
+			expect(result).toContain("model: sonnet");
+			expect(result).not.toContain("reasoningEffort:");
+			expect(result).not.toContain("effort:");
+		});
 	});
 
 	describe("codex/skill.liquid", () => {
@@ -615,6 +652,46 @@ describeWithLiquid("template rendering", () => {
 				},
 			});
 			expect(result.trim()).toBe(readGolden("codex-agent-toml.toml").trim());
+		});
+
+		test("emits model and model_reasoning_effort TOML fields when present", async () => {
+			const engine = createTestEngine();
+			const result = await engine.renderFile("codex/agent-toml", {
+				platform: "codex",
+				pluginName: "dev",
+				namespacedPluginName: "rp1-dev",
+				artifact: {
+					type: "agent",
+					name: "task-builder",
+					description: "Implements feature tasks",
+					model: "o3",
+					effortFieldName: "model_reasoning_effort",
+					effortValue: "high",
+					tools: ["Bash", "Edit"],
+					content: "Agent instructions.",
+				},
+			});
+			expect(result).toContain('model = "o3"');
+			expect(result).toContain('model_reasoning_effort = "high"');
+		});
+
+		test("omits model and effort TOML fields when model is inherit", async () => {
+			const engine = createTestEngine();
+			const result = await engine.renderFile("codex/agent-toml", {
+				platform: "codex",
+				pluginName: "dev",
+				namespacedPluginName: "rp1-dev",
+				artifact: {
+					type: "agent",
+					name: "task-builder",
+					description: "Implements feature tasks",
+					model: "inherit",
+					tools: ["Bash", "Edit"],
+					content: "Agent instructions.",
+				},
+			});
+			expect(result).not.toContain("model =");
+			expect(result).not.toContain("model_reasoning_effort");
 		});
 	});
 
@@ -1226,6 +1303,61 @@ describeWithLiquid("template rendering", () => {
 			});
 			expect(result).toContain("Default: `claude-code`");
 			expect(result).toContain("Agent content with rp1-base:agent reference.");
+		});
+
+		test("emits YAML frontmatter with model and effort when both present", async () => {
+			const engine = createTestEngine();
+			const result = await engine.renderFile("claude-code/agent", {
+				platform: "claude-code",
+				artifact: {
+					type: "agent",
+					name: "test-agent",
+					description: "Test agent",
+					model: "opus",
+					effortFieldName: "effort",
+					effortValue: "high",
+					tools: ["Bash", "Read"],
+					content: "Agent content.",
+				},
+			});
+			expect(result).toContain("---");
+			expect(result).toContain("model: opus");
+			expect(result).toContain("effort: high");
+		});
+
+		test("emits frontmatter with model only when effort is absent", async () => {
+			const engine = createTestEngine();
+			const result = await engine.renderFile("claude-code/agent", {
+				platform: "claude-code",
+				artifact: {
+					type: "agent",
+					name: "test-agent",
+					description: "Test agent",
+					model: "haiku",
+					tools: ["Bash"],
+					content: "Agent content.",
+				},
+			});
+			expect(result).toContain("---");
+			expect(result).toContain("model: haiku");
+			expect(result).not.toContain("effort:");
+		});
+
+		test("omits frontmatter entirely when model is inherit and no effort", async () => {
+			const engine = createTestEngine();
+			const result = await engine.renderFile("claude-code/agent", {
+				platform: "claude-code",
+				artifact: {
+					type: "agent",
+					name: "test-agent",
+					description: "Test agent",
+					model: "inherit",
+					tools: [],
+					content: "Agent content.",
+				},
+			});
+			expect(result).not.toContain("---");
+			expect(result).not.toContain("model:");
 		});
 	});
 

--- a/cli/src/__tests__/build/templates/template-rendering.test.ts
+++ b/cli/src/__tests__/build/templates/template-rendering.test.ts
@@ -49,7 +49,7 @@ const createTestEngine = () => {
 		extname: ".liquid",
 		strictVariables: true,
 		strictFilters: true,
-		greedy: false,
+		greedy: true,
 		lenientIf: true,
 	});
 

--- a/cli/src/__tests__/build/templates/template-rendering.test.ts
+++ b/cli/src/__tests__/build/templates/template-rendering.test.ts
@@ -498,6 +498,42 @@ describeWithLiquid("template rendering", () => {
 			expect(result).not.toContain("reasoningEffort:");
 			expect(result).not.toContain("effort:");
 		});
+
+		test("golden: effort pass-through produces provider-keyed field", async () => {
+			const engine = createTestEngine();
+			const result = await engine.renderFile("opencode/agent", {
+				platform: "opencode",
+				artifact: {
+					type: "agent",
+					name: "test-agent",
+					description: "Agent with deep tier and effort",
+					model: "o3",
+					effortFieldName: "reasoningEffort",
+					effortValue: "high",
+					tools: ["Bash"],
+					content: "Agent content for effort pass-through test.",
+				},
+			});
+			expect(result.trim()).toBe(readGolden("opencode-agent-effort.md").trim());
+		});
+
+		test("golden: inherit model produces unchanged output (backward compat)", async () => {
+			const engine = createTestEngine();
+			const result = await engine.renderFile("opencode/agent", {
+				platform: "opencode",
+				artifact: {
+					type: "agent",
+					name: "inherit-agent",
+					description: "Agent with inherited model",
+					model: "inherit",
+					tools: [],
+					content: "Agent content with no tools.",
+				},
+			});
+			expect(result.trim()).toBe(
+				readGolden("opencode-agent-inherit.md").trim(),
+			);
+		});
 	});
 
 	describe("codex/skill.liquid", () => {
@@ -692,6 +728,47 @@ describeWithLiquid("template rendering", () => {
 			});
 			expect(result).not.toContain("model =");
 			expect(result).not.toContain("model_reasoning_effort");
+		});
+
+		test("golden: model + effort produces TOML with both fields", async () => {
+			const engine = createTestEngine();
+			const result = await engine.renderFile("codex/agent-toml", {
+				platform: "codex",
+				pluginName: "dev",
+				namespacedPluginName: "rp1-dev",
+				artifact: {
+					type: "agent",
+					name: "task-builder",
+					description: "Implements feature tasks",
+					model: "o3",
+					effortFieldName: "model_reasoning_effort",
+					effortValue: "high",
+					tools: ["Bash", "Edit"],
+					content: "Agent instructions for deep tier with effort.",
+				},
+			});
+			expect(result.trim()).toBe(
+				readGolden("codex-agent-toml-model-effort.toml").trim(),
+			);
+		});
+
+		test("golden: inherit model produces TOML identical to pre-tiering", async () => {
+			const engine = createTestEngine();
+			const result = await engine.renderFile("codex/agent-toml", {
+				platform: "codex",
+				pluginName: "dev",
+				namespacedPluginName: "rp1-dev",
+				artifact: {
+					type: "agent",
+					name: "task-builder",
+					description: "Implements feature tasks",
+					model: "inherit",
+					tools: ["Bash", "Edit"],
+					content:
+						"Agent instructions with /rp1-base:knowledge-build reference.",
+				},
+			});
+			expect(result.trim()).toBe(readGolden("codex-agent-toml.toml").trim());
 		});
 	});
 
@@ -1036,6 +1113,50 @@ describeWithLiquid("template rendering", () => {
 		});
 	});
 
+	describe("antigravity/agent.liquid", () => {
+		test("golden: model emitted, effort omitted for Antigravity agent", async () => {
+			const engine = createTestEngine();
+			const result = await engine.renderFile("antigravity/agent", {
+				platform: "antigravity",
+				pluginName: "base",
+				namespacedPluginName: "rp1-base",
+				artifact: {
+					type: "agent",
+					name: "deep-agent",
+					description: "Agent with deep tier for Antigravity",
+					model: "opus",
+					tools: ["Read", "Bash"],
+					content: "Agent content for Antigravity tier test.",
+				},
+			});
+			expect(result.trim()).toBe(
+				readGolden("antigravity-agent-model.md").trim(),
+			);
+			expect(result).toContain("model: opus");
+			expect(result).not.toContain("effort:");
+			expect(result).not.toContain("reasoningEffort:");
+		});
+
+		test("inherit model omits model field for Antigravity agent", async () => {
+			const engine = createTestEngine();
+			const result = await engine.renderFile("antigravity/agent", {
+				platform: "antigravity",
+				pluginName: "base",
+				namespacedPluginName: "rp1-base",
+				artifact: {
+					type: "agent",
+					name: "inherit-agent",
+					description: "Agent with inherited model",
+					model: "inherit",
+					tools: ["Read"],
+					content: "Agent content.",
+				},
+			});
+			expect(result).not.toContain("model:");
+			expect(result).not.toContain("effort:");
+		});
+	});
+
 	describe("gemini templates", () => {
 		test("renders Gemini skill with workflow bootstrap and Gemini tool names", async () => {
 			const engine = createTestEngine();
@@ -1107,6 +1228,27 @@ describeWithLiquid("template rendering", () => {
 			expect(result).toContain("- run_shell_command");
 			expect(result).toContain("max_turns: 30");
 			expect(result).toContain("Default: `gemini-cli`");
+		});
+
+		test("golden: model emitted, effort omitted for Gemini agent", async () => {
+			const engine = createTestEngine();
+			const result = await engine.renderFile("gemini/agent", {
+				platform: "gemini",
+				pluginName: "base",
+				namespacedPluginName: "rp1-base",
+				artifact: {
+					type: "agent",
+					name: "deep-agent",
+					description: "Agent with deep tier for Gemini",
+					model: "gemini-2.5-pro",
+					tools: ["Read", "Bash"],
+					content: "Agent content for Gemini tier test.",
+				},
+			});
+			expect(result.trim()).toBe(readGolden("gemini-agent-model.md").trim());
+			expect(result).toContain("model: gemini-2.5-pro");
+			expect(result).not.toContain("effort:");
+			expect(result).not.toContain("reasoningEffort:");
 		});
 
 		test("renders Gemini command TOML with argument placeholder intact", async () => {
@@ -1358,6 +1500,56 @@ describeWithLiquid("template rendering", () => {
 			});
 			expect(result).not.toContain("---");
 			expect(result).not.toContain("model:");
+		});
+
+		test("golden: model + effort produces frontmatter with both fields", async () => {
+			const engine = createTestEngine();
+			const result = await engine.renderFile("claude-code/agent", {
+				platform: "claude-code",
+				artifact: {
+					type: "agent",
+					name: "test-agent",
+					description: "Test agent",
+					model: "opus",
+					effortFieldName: "effort",
+					effortValue: "high",
+					tools: ["Bash", "Read"],
+					content: "Agent content for deep tier with effort.",
+				},
+			});
+			expect(result.trim()).toBe(readGolden("cc-agent-model-effort.md").trim());
+		});
+
+		test("golden: model only produces frontmatter without effort", async () => {
+			const engine = createTestEngine();
+			const result = await engine.renderFile("claude-code/agent", {
+				platform: "claude-code",
+				artifact: {
+					type: "agent",
+					name: "test-agent",
+					description: "Test agent",
+					model: "haiku",
+					tools: ["Bash"],
+					content: "Agent content for fast tier without effort.",
+				},
+			});
+			expect(result.trim()).toBe(readGolden("cc-agent-model-only.md").trim());
+		});
+
+		test("golden: inherit model produces no frontmatter", async () => {
+			const engine = createTestEngine();
+			const result = await engine.renderFile("claude-code/agent", {
+				platform: "claude-code",
+				artifact: {
+					type: "agent",
+					name: "test-agent",
+					description: "Test agent",
+					model: "inherit",
+					tools: [],
+					content: "Agent content with inherited model.",
+				},
+			});
+			expect(result.trim()).toBe(readGolden("cc-agent-inherit.md").trim());
 		});
 	});
 

--- a/cli/src/__tests__/build/tier-resolution.test.ts
+++ b/cli/src/__tests__/build/tier-resolution.test.ts
@@ -14,6 +14,26 @@ import { resolveEffort, resolveTier } from "../../build/tier-resolution.js";
 // ---------------------------------------------------------------------------
 
 describe("resolveTier", () => {
+	test("frontier tier returns fable for claude-code", () => {
+		expect(resolveTier("frontier", "claude-code")).toBe("fable");
+	});
+
+	test("frontier tier returns o3 for codex", () => {
+		expect(resolveTier("frontier", "codex")).toBe("o3");
+	});
+
+	test("frontier tier returns fable for opencode", () => {
+		expect(resolveTier("frontier", "opencode")).toBe("fable");
+	});
+
+	test("frontier tier returns fable for antigravity", () => {
+		expect(resolveTier("frontier", "antigravity")).toBe("fable");
+	});
+
+	test("frontier tier returns gemini-2.5-pro for gemini", () => {
+		expect(resolveTier("frontier", "gemini")).toBe("gemini-2.5-pro");
+	});
+
 	test("deep tier returns frontier model for claude-code", () => {
 		const result = resolveTier("deep", "claude-code");
 		expect(result).toBe("opus");
@@ -191,5 +211,23 @@ describe("resolveEffort", () => {
 		// (though this combination may be caught by validation separately)
 		const result = resolveEffort("high", "inherit", "claude-code", null);
 		expect(result).toEqual({ fieldName: "effort", value: "high" });
+	});
+
+	// --- Frontier tier ---
+
+	test("frontier tier on claude-code returns effort field with value", () => {
+		const result = resolveEffort("high", "frontier", "claude-code", "fable");
+		expect(result).toEqual({ fieldName: "effort", value: "high" });
+	});
+
+	test("frontier tier on opencode with fable (Anthropic) returns null", () => {
+		const result = resolveEffort("high", "frontier", "opencode", "fable");
+		expect(result).toBeNull();
+	});
+
+	test("provider registry classifies fable as anthropic (verified via opencode null)", () => {
+		// fable is Anthropic, so OpenCode effort pass-through is null
+		const result = resolveEffort("max", "frontier", "opencode", "fable");
+		expect(result).toBeNull();
 	});
 });

--- a/cli/src/__tests__/build/tier-resolution.test.ts
+++ b/cli/src/__tests__/build/tier-resolution.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Unit tests for the tier resolution dictionary.
+ * Validates abstract tier → platform model ID mapping and
+ * effort → platform-specific field name + value mapping.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { EffortLevel, ModelTier } from "../../build/models.js";
+import type { BuildPlatform } from "../../build/template-context.js";
+import { resolveEffort, resolveTier } from "../../build/tier-resolution.js";
+
+// ---------------------------------------------------------------------------
+// resolveTier
+// ---------------------------------------------------------------------------
+
+describe("resolveTier", () => {
+	test("deep tier returns frontier model for claude-code", () => {
+		const result = resolveTier("deep", "claude-code");
+		expect(result).toBe("opus");
+	});
+
+	test("deep tier returns frontier model for codex", () => {
+		const result = resolveTier("deep", "codex");
+		expect(result).toBe("o3");
+	});
+
+	test("deep tier returns frontier model for opencode", () => {
+		const result = resolveTier("deep", "opencode");
+		expect(result).toBe("opus");
+	});
+
+	test("deep tier returns frontier model for antigravity", () => {
+		const result = resolveTier("deep", "antigravity");
+		expect(result).toBe("opus");
+	});
+
+	test("deep tier returns frontier model for gemini", () => {
+		const result = resolveTier("deep", "gemini");
+		expect(result).toBe("gemini-2.5-pro");
+	});
+
+	test("standard tier returns balanced model for each platform", () => {
+		expect(resolveTier("standard", "claude-code")).toBe("sonnet");
+		expect(resolveTier("standard", "codex")).toBe("o4-mini");
+		expect(resolveTier("standard", "opencode")).toBe("sonnet");
+		expect(resolveTier("standard", "antigravity")).toBe("sonnet");
+		expect(resolveTier("standard", "gemini")).toBe("gemini-2.5-flash");
+	});
+
+	test("fast tier returns cheapest model for each platform", () => {
+		expect(resolveTier("fast", "claude-code")).toBe("haiku");
+		expect(resolveTier("fast", "codex")).toBe("gpt-4.1-nano");
+		expect(resolveTier("fast", "opencode")).toBe("haiku");
+		expect(resolveTier("fast", "antigravity")).toBe("haiku");
+		expect(resolveTier("fast", "gemini")).toBe("gemini-2.5-flash");
+	});
+
+	test("inherit returns null for every platform", () => {
+		const platforms: BuildPlatform[] = [
+			"claude-code",
+			"codex",
+			"opencode",
+			"antigravity",
+			"gemini",
+			"copilot",
+		];
+		for (const p of platforms) {
+			expect(resolveTier("inherit", p)).toBeNull();
+		}
+	});
+
+	test("copilot returns null for any tier (not supported)", () => {
+		const tiers: ModelTier[] = ["deep", "standard", "fast"];
+		for (const t of tiers) {
+			expect(resolveTier(t, "copilot")).toBeNull();
+		}
+	});
+});
+
+// ---------------------------------------------------------------------------
+// resolveEffort
+// ---------------------------------------------------------------------------
+
+describe("resolveEffort", () => {
+	// --- Claude Code ---
+
+	test("claude-code returns effort field with pass-through value", () => {
+		const result = resolveEffort("high", "deep", "claude-code", "opus");
+		expect(result).toEqual({ fieldName: "effort", value: "high" });
+	});
+
+	test("claude-code passes through all effort levels", () => {
+		const levels: EffortLevel[] = ["low", "medium", "high", "xhigh", "max"];
+		for (const level of levels) {
+			const result = resolveEffort(level, "deep", "claude-code", "opus");
+			expect(result).not.toBeNull();
+			expect(result!.fieldName).toBe("effort");
+			expect(result!.value).toBe(level);
+		}
+	});
+
+	// --- Codex ---
+
+	test("codex returns model_reasoning_effort field", () => {
+		const result = resolveEffort("high", "deep", "codex", "o3");
+		expect(result).toEqual({
+			fieldName: "model_reasoning_effort",
+			value: "high",
+		});
+	});
+
+	test("codex clamps xhigh and max to high", () => {
+		expect(resolveEffort("xhigh", "deep", "codex", "o3")).toEqual({
+			fieldName: "model_reasoning_effort",
+			value: "high",
+		});
+		expect(resolveEffort("max", "deep", "codex", "o3")).toEqual({
+			fieldName: "model_reasoning_effort",
+			value: "high",
+		});
+	});
+
+	// --- OpenCode (provider-aware) ---
+
+	test("opencode with OpenAI model returns reasoningEffort field", () => {
+		const result = resolveEffort("high", "deep", "opencode", "o3");
+		expect(result).toEqual({ fieldName: "reasoningEffort", value: "high" });
+	});
+
+	test("opencode with OpenAI model clamps xhigh/max to high", () => {
+		expect(resolveEffort("xhigh", "standard", "opencode", "o4-mini")).toEqual({
+			fieldName: "reasoningEffort",
+			value: "high",
+		});
+	});
+
+	test("opencode with Anthropic model returns null", () => {
+		const result = resolveEffort("high", "deep", "opencode", "opus");
+		expect(result).toBeNull();
+	});
+
+	test("opencode with Anthropic model (sonnet) returns null", () => {
+		const result = resolveEffort("medium", "standard", "opencode", "sonnet");
+		expect(result).toBeNull();
+	});
+
+	// --- Antigravity / Gemini ---
+
+	test("antigravity returns null (effort not supported per-agent)", () => {
+		const result = resolveEffort("high", "deep", "antigravity", "opus");
+		expect(result).toBeNull();
+	});
+
+	test("gemini returns null (effort not supported per-agent)", () => {
+		const result = resolveEffort("high", "deep", "gemini", "gemini-2.5-pro");
+		expect(result).toBeNull();
+	});
+
+	// --- Copilot ---
+
+	test("copilot returns null (not supported)", () => {
+		const result = resolveEffort("high", "deep", "copilot", null);
+		expect(result).toBeNull();
+	});
+
+	// --- Fast tier ---
+
+	test("fast tier returns null regardless of platform", () => {
+		const platforms: BuildPlatform[] = [
+			"claude-code",
+			"codex",
+			"opencode",
+			"antigravity",
+			"gemini",
+		];
+		for (const p of platforms) {
+			expect(resolveEffort("high", "fast", p, "haiku")).toBeNull();
+		}
+	});
+
+	// --- Undefined effort ---
+
+	test("undefined effort returns null", () => {
+		expect(resolveEffort(undefined, "deep", "claude-code", "opus")).toBeNull();
+	});
+
+	// --- Inherit tier with effort ---
+
+	test("inherit tier with effort still resolves effort (tier gating is fast-only)", () => {
+		// inherit just means no model override; effort can still be set
+		// (though this combination may be caught by validation separately)
+		const result = resolveEffort("high", "inherit", "claude-code", null);
+		expect(result).toEqual({ fieldName: "effort", value: "high" });
+	});
+});

--- a/cli/src/__tests__/build/validator.test.ts
+++ b/cli/src/__tests__/build/validator.test.ts
@@ -378,6 +378,17 @@ Content.`;
 	});
 
 	describe("validateAgentTierAndEffort", () => {
+		test("accepts frontier as a valid model tier", () => {
+			const result = validateAgentTierAndEffort(
+				"test-agent",
+				"frontier",
+				"high",
+				"test-agent.md",
+			);
+			expect(result.errors.length).toBe(0);
+			expect(result.warnings.length).toBe(0);
+		});
+
 		test("rejects unknown model tier with allowed values listed", () => {
 			const result = validateAgentTierAndEffort(
 				"test-agent",
@@ -387,6 +398,7 @@ Content.`;
 			);
 			expect(result.errors.length).toBe(1);
 			expect(result.errors[0]).toContain("turbo");
+			expect(result.errors[0]).toContain("frontier");
 			expect(result.errors[0]).toContain("deep");
 			expect(result.errors[0]).toContain("standard");
 			expect(result.errors[0]).toContain("fast");
@@ -431,7 +443,7 @@ Content.`;
 			expect(result.errors.length).toBe(0);
 			expect(result.warnings.length).toBe(1);
 			expect(result.warnings[0]).toContain("feature-architect");
-			expect(result.warnings[0]).toContain("protected");
+			expect(result.warnings[0]).toContain("downgraded below deep");
 		});
 
 		test("warns on protected agent downgrade to fast", () => {
@@ -442,10 +454,9 @@ Content.`;
 				"task-reviewer.md",
 			);
 			expect(result.errors.length).toBe(0);
-			// fast + protected = 2 warnings (fast+no-effort is fine since effort is undefined, but protected downgrade)
-			// Actually: fast with no effort => no fast+effort warning. Protected downgrade => 1 warning.
+			// fast with no effort => no fast+effort warning. Protected downgrade => 1 warning.
 			expect(result.warnings.length).toBe(1);
-			expect(result.warnings[0]).toContain("protected");
+			expect(result.warnings[0]).toContain("downgraded below deep");
 		});
 
 		test("accepts valid tier and effort combination", () => {
@@ -474,6 +485,17 @@ Content.`;
 			const result = validateAgentTierAndEffort(
 				"feature-architect",
 				"deep",
+				"high",
+				"feature-architect.md",
+			);
+			expect(result.errors.length).toBe(0);
+			expect(result.warnings.length).toBe(0);
+		});
+
+		test("does not warn on protected agent assigned frontier (upgrade, not downgrade)", () => {
+			const result = validateAgentTierAndEffort(
+				"feature-architect",
+				"frontier",
 				"high",
 				"feature-architect.md",
 			);

--- a/cli/src/__tests__/build/validator.test.ts
+++ b/cli/src/__tests__/build/validator.test.ts
@@ -8,6 +8,7 @@ import * as E from "fp-ts/lib/Either.js";
 import {
 	validateAgent,
 	validateAgentSchema,
+	validateAgentTierAndEffort,
 	validateCommand,
 	validateCommandSchema,
 	validateCommandSyntax,
@@ -373,6 +374,137 @@ Content.`;
 			const result = validateSkillSchema(content, "test.md");
 
 			expect(E.isRight(result)).toBe(true);
+		});
+	});
+
+	describe("validateAgentTierAndEffort", () => {
+		test("rejects unknown model tier with allowed values listed", () => {
+			const result = validateAgentTierAndEffort(
+				"test-agent",
+				"turbo",
+				undefined,
+				"test-agent.md",
+			);
+			expect(result.errors.length).toBe(1);
+			expect(result.errors[0]).toContain("turbo");
+			expect(result.errors[0]).toContain("deep");
+			expect(result.errors[0]).toContain("standard");
+			expect(result.errors[0]).toContain("fast");
+			expect(result.errors[0]).toContain("inherit");
+			expect(result.warnings.length).toBe(0);
+		});
+
+		test("rejects unknown effort level with allowed values listed", () => {
+			const result = validateAgentTierAndEffort(
+				"test-agent",
+				"standard",
+				"extreme",
+				"test-agent.md",
+			);
+			expect(result.errors.length).toBe(1);
+			expect(result.errors[0]).toContain("extreme");
+			expect(result.errors[0]).toContain("low");
+			expect(result.errors[0]).toContain("high");
+			expect(result.warnings.length).toBe(0);
+		});
+
+		test("warns on fast tier with effort set", () => {
+			const result = validateAgentTierAndEffort(
+				"test-agent",
+				"fast",
+				"high",
+				"test-agent.md",
+			);
+			expect(result.errors.length).toBe(0);
+			expect(result.warnings.length).toBe(1);
+			expect(result.warnings[0]).toContain("fast");
+			expect(result.warnings[0]).toContain("effort");
+		});
+
+		test("warns on protected agent downgrade to standard", () => {
+			const result = validateAgentTierAndEffort(
+				"feature-architect",
+				"standard",
+				"high",
+				"feature-architect.md",
+			);
+			expect(result.errors.length).toBe(0);
+			expect(result.warnings.length).toBe(1);
+			expect(result.warnings[0]).toContain("feature-architect");
+			expect(result.warnings[0]).toContain("protected");
+		});
+
+		test("warns on protected agent downgrade to fast", () => {
+			const result = validateAgentTierAndEffort(
+				"task-reviewer",
+				"fast",
+				undefined,
+				"task-reviewer.md",
+			);
+			expect(result.errors.length).toBe(0);
+			// fast + protected = 2 warnings (fast+no-effort is fine since effort is undefined, but protected downgrade)
+			// Actually: fast with no effort => no fast+effort warning. Protected downgrade => 1 warning.
+			expect(result.warnings.length).toBe(1);
+			expect(result.warnings[0]).toContain("protected");
+		});
+
+		test("accepts valid tier and effort combination", () => {
+			const result = validateAgentTierAndEffort(
+				"speedrun-builder",
+				"standard",
+				"medium",
+				"speedrun-builder.md",
+			);
+			expect(result.errors.length).toBe(0);
+			expect(result.warnings.length).toBe(0);
+		});
+
+		test("accepts inherit tier with no effort", () => {
+			const result = validateAgentTierAndEffort(
+				"test-agent",
+				"inherit",
+				undefined,
+				"test-agent.md",
+			);
+			expect(result.errors.length).toBe(0);
+			expect(result.warnings.length).toBe(0);
+		});
+
+		test("accepts deep tier on protected agent", () => {
+			const result = validateAgentTierAndEffort(
+				"feature-architect",
+				"deep",
+				"high",
+				"feature-architect.md",
+			);
+			expect(result.errors.length).toBe(0);
+			expect(result.warnings.length).toBe(0);
+		});
+
+		test("does not warn on protected agent with inherit tier", () => {
+			const result = validateAgentTierAndEffort(
+				"security-validator",
+				"inherit",
+				undefined,
+				"security-validator.md",
+			);
+			expect(result.errors.length).toBe(0);
+			expect(result.warnings.length).toBe(0);
+		});
+
+		test("collects both error and warning when both conditions apply", () => {
+			const result = validateAgentTierAndEffort(
+				"feature-architect",
+				"fast",
+				"extreme",
+				"feature-architect.md",
+			);
+			// error: unknown effort "extreme"
+			// warning: fast+effort (even though effort is invalid, the combo check still warns)
+			// warning: protected agent downgrade
+			expect(result.errors.length).toBe(1);
+			expect(result.errors[0]).toContain("extreme");
+			expect(result.warnings.length).toBe(2);
 		});
 	});
 

--- a/cli/src/build/codex/models.ts
+++ b/cli/src/build/codex/models.ts
@@ -20,6 +20,8 @@ export interface CodexAgent {
 	readonly description: string;
 	readonly model: string;
 	readonly roleType: CodexRoleType;
+	readonly effortFieldName?: string;
+	readonly effortValue?: string;
 	readonly developerInstructions: string;
 }
 

--- a/cli/src/build/command.ts
+++ b/cli/src/build/command.ts
@@ -67,7 +67,11 @@ import {
 } from "./template-context.js";
 import { createTemplateEngine } from "./template-engine.js";
 import { injectEmitHarness } from "./transforms.js";
-import { validateAgent, validateSkill } from "./validator.js";
+import {
+	validateAgent,
+	validateAgentTierAndEffort,
+	validateSkill,
+} from "./validator.js";
 
 const VALID_PLATFORMS = [
 	"opencode",
@@ -817,6 +821,22 @@ export const buildPlatformPlugin = async (
 		if (agentArgErrors.length > 0) {
 			for (const d of agentArgErrors) {
 				errors.push(formatLintDiagnostic(d));
+			}
+			continue;
+		}
+
+		const tierValidation = validateAgentTierAndEffort(
+			ccAgent.name,
+			ccAgent.model,
+			ccAgent.effort,
+			agentFile,
+		);
+		for (const warning of tierValidation.warnings) {
+			emitWarn(warning);
+		}
+		if (tierValidation.errors.length > 0) {
+			for (const err of tierValidation.errors) {
+				errors.push(err);
 			}
 			continue;
 		}

--- a/cli/src/build/command.ts
+++ b/cli/src/build/command.ts
@@ -43,6 +43,8 @@ import type {
 	BuildSummary,
 	BundleAssetEntry,
 	BundlePluginAssets,
+	EffortLevel,
+	ModelTier,
 	OpenCodePluginAsset,
 	SkillCategory,
 	SkillMetadata,
@@ -861,12 +863,15 @@ export const buildPlatformPlugin = async (
 		}
 		const processedContent = preprocessResult.right;
 
+		// resolveTier returns null for unmapped platforms (e.g. copilot) and
+		// "inherit" tier. Falling back to ccAgent.model preserves the original
+		// value ("inherit" or raw tier alias). This is safe because unmapped
+		// platforms' templates (copilot) never emit a model field.
 		const resolvedModel =
-			resolveTier(ccAgent.model as import("./models.js").ModelTier, platform) ??
-			ccAgent.model;
+			resolveTier(ccAgent.model as ModelTier, platform) ?? ccAgent.model;
 		const effortResolution = resolveEffort(
-			ccAgent.effort as import("./models.js").EffortLevel | undefined,
-			ccAgent.model as import("./models.js").ModelTier,
+			ccAgent.effort as EffortLevel | undefined,
+			ccAgent.model as ModelTier,
 			platform,
 			resolvedModel !== ccAgent.model ? resolvedModel : null,
 		);

--- a/cli/src/build/command.ts
+++ b/cli/src/build/command.ts
@@ -66,6 +66,7 @@ import {
 	withDerivedArgumentHint,
 } from "./template-context.js";
 import { createTemplateEngine } from "./template-engine.js";
+import { resolveEffort, resolveTier } from "./tier-resolution.js";
 import { injectEmitHarness } from "./transforms.js";
 import {
 	validateAgent,
@@ -860,6 +861,16 @@ export const buildPlatformPlugin = async (
 		}
 		const processedContent = preprocessResult.right;
 
+		const resolvedModel =
+			resolveTier(ccAgent.model as import("./models.js").ModelTier, platform) ??
+			ccAgent.model;
+		const effortResolution = resolveEffort(
+			ccAgent.effort as import("./models.js").EffortLevel | undefined,
+			ccAgent.model as import("./models.js").ModelTier,
+			platform,
+			resolvedModel !== ccAgent.model ? resolvedModel : null,
+		);
+
 		let ctx: Record<string, unknown> = buildTemplateContext(
 			platform,
 			pluginName,
@@ -868,9 +879,13 @@ export const buildPlatformPlugin = async (
 				type: "agent",
 				name: ccAgent.name,
 				description: ccAgent.description,
-				model: ccAgent.model,
+				model: resolvedModel,
 				tools: ccAgent.tools,
 				content: processedContent,
+				...(effortResolution && {
+					effortFieldName: effortResolution.fieldName,
+					effortValue: effortResolution.value,
+				}),
 				...(ccAgent.arguments && { arguments: ccAgent.arguments }),
 				...(ccAgent.environment && { environment: ccAgent.environment }),
 			},

--- a/cli/src/build/models.ts
+++ b/cli/src/build/models.ts
@@ -43,6 +43,50 @@ export interface ClaudeCodeCommand {
 	readonly content: string;
 }
 
+/** Abstract model tier aliases decoupling agent definitions from vendor model identifiers. */
+export type ModelTier = "deep" | "standard" | "fast" | "inherit";
+
+/** Valid model tier values for runtime validation. */
+export const VALID_MODEL_TIERS: readonly ModelTier[] = [
+	"deep",
+	"standard",
+	"fast",
+	"inherit",
+] as const;
+
+/** Reasoning effort levels controlling depth independently of model tier. */
+export type EffortLevel = "low" | "medium" | "high" | "xhigh" | "max";
+
+/** Valid effort level values for runtime validation. */
+export const VALID_EFFORT_LEVELS: readonly EffortLevel[] = [
+	"low",
+	"medium",
+	"high",
+	"xhigh",
+	"max",
+] as const;
+
+/**
+ * Agents that must remain on the deep/frontier tier.
+ * Build emits a warning when any of these agents is assigned a non-deep tier.
+ */
+export const PROTECTED_AGENTS: ReadonlySet<string> = new Set([
+	"feature-architect",
+	"phase-planner",
+	"research-explorer",
+	"strategic-advisor",
+	"security-validator",
+	"socratic-duel-participant",
+	"bug-investigator",
+	"hypothesis-tester",
+	"code-auditor",
+	"blueprint-auditor",
+	"pr-review-synthesizer",
+	"pr-sub-reviewer",
+	"task-reviewer",
+	"feature-verifier",
+]);
+
 /**
  * Parsed Claude Code agent with frontmatter.
  * Represents an agent from Claude Code's .claude-plugin/agents/ directory
@@ -53,6 +97,7 @@ export interface ClaudeCodeAgent {
 	readonly description: string;
 	readonly tools: readonly string[];
 	readonly model: string;
+	readonly effort?: string;
 	readonly content: string;
 	readonly arguments?: readonly ArgumentDefinition[];
 	readonly environment?: readonly EnvironmentDefinition[];

--- a/cli/src/build/models.ts
+++ b/cli/src/build/models.ts
@@ -43,16 +43,42 @@ export interface ClaudeCodeCommand {
 	readonly content: string;
 }
 
-/** Abstract model tier aliases decoupling agent definitions from vendor model identifiers. */
-export type ModelTier = "deep" | "standard" | "fast" | "inherit";
+/**
+ * Abstract model tier aliases decoupling agent definitions from vendor model identifiers.
+ *
+ * **How to add a new model tier/class:**
+ * 1. Add the new tier to the `ModelTier` union AND `VALID_MODEL_TIERS` here.
+ * 2. Add a numeric rank entry in `TIER_RANK` here.
+ * 3. Add a row in `TIER_MODEL_MAP` (one concrete model per platform) in `tier-resolution.ts`.
+ * 4. Register any new concrete model IDs in `MODEL_PROVIDER` in `tier-resolution.ts`.
+ * 5. Optionally add agents to `PROTECTED_AGENTS` that must stay at or above a tier.
+ *
+ * The TS types (`Exclude<ModelTier, "inherit">` keys on `TIER_MODEL_MAP` and `TIER_RANK`)
+ * force a compile error if a tier is added without its mappings.
+ */
+export type ModelTier = "frontier" | "deep" | "standard" | "fast" | "inherit";
 
 /** Valid model tier values for runtime validation. */
 export const VALID_MODEL_TIERS: readonly ModelTier[] = [
+	"frontier",
 	"deep",
 	"standard",
 	"fast",
 	"inherit",
 ] as const;
+
+/**
+ * Ordered rank map for tier comparison. Higher = more capable.
+ * `inherit` is intentionally excluded — it means "use session model", not a rank.
+ */
+export const TIER_RANK: Readonly<
+	Record<Exclude<ModelTier, "inherit">, number>
+> = {
+	frontier: 3,
+	deep: 2,
+	standard: 1,
+	fast: 0,
+} as const;
 
 /** Reasoning effort levels controlling depth independently of model tier. */
 export type EffortLevel = "low" | "medium" | "high" | "xhigh" | "max";

--- a/cli/src/build/parser.ts
+++ b/cli/src/build/parser.ts
@@ -193,6 +193,7 @@ export const parseAgent = (
 			const name = metadata.name;
 			const description = metadata.description;
 			const model = metadata.model;
+			const effort = metadata.effort;
 
 			if (!name || !description) {
 				const missing = [!name && "name", !description && "description"].filter(
@@ -234,6 +235,8 @@ export const parseAgent = (
 				description: String(description),
 				tools,
 				model: model ? String(model) : "inherit",
+				...(effort !== undefined &&
+					effort !== null && { effort: String(effort) }),
 				content: body,
 				...(parsedArgs.length > 0 && { arguments: parsedArgs }),
 				...(parsedEnv.length > 0 && { environment: parsedEnv }),

--- a/cli/src/build/template-context.ts
+++ b/cli/src/build/template-context.ts
@@ -69,6 +69,8 @@ export interface AgentArtifactData {
 	readonly tools: readonly string[];
 	readonly content: string; // post-conditional-processing
 	readonly roleType?: CodexRoleType; // computed for Codex
+	readonly effortFieldName?: string; // platform/provider-specific effort field name
+	readonly effortValue?: string; // resolved effort value for the platform
 	readonly arguments?: readonly ArgumentDefinition[];
 	readonly environment?: readonly EnvironmentDefinition[];
 }

--- a/cli/src/build/templates/claude-code/agent.liquid
+++ b/cli/src/build/templates/claude-code/agent.liquid
@@ -1,2 +1,13 @@
+{%- if artifact.model != "inherit" or artifact.effortValue -%}
+---
+{%- if artifact.model != "inherit" %}
+model: {{ artifact.model }}
+{%- endif %}
+{%- if artifact.effortValue %}
+{{ artifact.effortFieldName }}: {{ artifact.effortValue }}
+{%- endif %}
+---
+
+{% endif -%}
 {% render "shared/host-context", platform: platform %}
 {{ artifact.content | namespace_ref: platform | slash_commands: platform }}

--- a/cli/src/build/templates/codex/agent-toml.liquid
+++ b/cli/src/build/templates/codex/agent-toml.liquid
@@ -5,7 +5,7 @@ model = "{{ artifact.model }}"
 {%- endif -%}
 {%- if artifact.effortValue %}
 {{ artifact.effortFieldName }} = "{{ artifact.effortValue }}"
-{%- endif -%}
+{%- endif %}
 
 developer_instructions = '''
 You are running in Codex with shared rp1 prompt content.

--- a/cli/src/build/templates/codex/agent-toml.liquid
+++ b/cli/src/build/templates/codex/agent-toml.liquid
@@ -1,5 +1,11 @@
 name = "{{ namespacedPluginName }}-{{ artifact.name }}"
 description = "{{ artifact.description | escape_toml }}"
+{%- if artifact.model != "inherit" %}
+model = "{{ artifact.model }}"
+{%- endif -%}
+{%- if artifact.effortValue %}
+{{ artifact.effortFieldName }} = "{{ artifact.effortValue }}"
+{%- endif -%}
 
 developer_instructions = '''
 You are running in Codex with shared rp1 prompt content.

--- a/cli/src/build/templates/opencode/agent.liquid
+++ b/cli/src/build/templates/opencode/agent.liquid
@@ -3,6 +3,9 @@ description: {{ artifact.description | escape_yaml }}
 mode: subagent
 {%- if artifact.model != "inherit" %}
 model: {{ artifact.model }}
+{%- endif -%}
+{%- if artifact.effortValue %}
+{{ artifact.effortFieldName }}: {{ artifact.effortValue }}
 {%- endif %}
 tools:
   bash: {% if artifact.tools contains "Bash" or artifact.tools contains "Bash(rp1 *)" %}true{% else %}false{% endif %}

--- a/cli/src/build/tier-resolution.ts
+++ b/cli/src/build/tier-resolution.ts
@@ -1,0 +1,189 @@
+/**
+ * Tier resolution dictionary for per-agent model and effort tiering.
+ *
+ * Maps abstract tier aliases (deep, standard, fast) to platform-specific
+ * model identifiers, and effort levels to platform-specific field names
+ * and values. Centralizes all vendor model mappings so a single update
+ * propagates to every agent at that tier.
+ */
+
+import type { EffortLevel, ModelTier } from "./models.js";
+import type { BuildPlatform } from "./template-context.js";
+
+// ---------------------------------------------------------------------------
+// Tier → Platform → Model ID
+// ---------------------------------------------------------------------------
+
+/**
+ * Centralized mapping from abstract tiers to concrete platform model IDs.
+ * Updating an entry here propagates to all agents of that tier on next build.
+ *
+ * Copilot is intentionally omitted (no tiering mechanism); resolveTier
+ * returns null for unmapped platforms.
+ */
+const TIER_MODEL_MAP: Readonly<
+	Record<Exclude<ModelTier, "inherit">, Partial<Record<BuildPlatform, string>>>
+> = {
+	deep: {
+		"claude-code": "opus",
+		codex: "o3",
+		opencode: "opus",
+		antigravity: "opus",
+		gemini: "gemini-2.5-pro",
+	},
+	standard: {
+		"claude-code": "sonnet",
+		codex: "o4-mini",
+		opencode: "sonnet",
+		antigravity: "sonnet",
+		gemini: "gemini-2.5-flash",
+	},
+	fast: {
+		"claude-code": "haiku",
+		codex: "gpt-4.1-nano",
+		opencode: "haiku",
+		antigravity: "haiku",
+		gemini: "gemini-2.5-flash",
+	},
+} as const;
+
+// ---------------------------------------------------------------------------
+// Effort resolution
+// ---------------------------------------------------------------------------
+
+/** Resolved effort output with the platform/provider-specific field name and mapped value. */
+interface EffortResolution {
+	readonly fieldName: string;
+	readonly value: string;
+}
+
+/** Per-platform effort field configuration. */
+interface EffortFieldConfig {
+	readonly fieldName: string;
+	readonly mapValue: (effort: EffortLevel) => string;
+}
+
+/**
+ * Clamp effort levels to the three-level vocabulary (low/medium/high)
+ * supported by OpenAI and Codex platforms. xhigh and max map to high.
+ */
+function clampToThreeLevels(effort: EffortLevel): string {
+	if (effort === "xhigh" || effort === "max") return "high";
+	return effort;
+}
+
+/**
+ * Derive the model provider from a resolved model identifier.
+ * Used by OpenCode to select the correct effort pass-through field name.
+ */
+function deriveProvider(
+	resolvedModel: string,
+): "anthropic" | "openai" | "unknown" {
+	const lower = resolvedModel.toLowerCase();
+
+	// Anthropic models: opus, sonnet, haiku, claude-*
+	if (
+		lower.includes("opus") ||
+		lower.includes("sonnet") ||
+		lower.includes("haiku") ||
+		lower.includes("claude")
+	) {
+		return "anthropic";
+	}
+
+	// OpenAI models: o3, o4, o1, gpt-*
+	if (
+		lower.startsWith("o3") ||
+		lower.startsWith("o4") ||
+		lower.startsWith("o1") ||
+		lower.includes("gpt")
+	) {
+		return "openai";
+	}
+
+	return "unknown";
+}
+
+/**
+ * OpenCode effort field configs keyed by derived provider.
+ * Anthropic models on OpenCode do not support per-agent effort pass-through.
+ */
+const OPENCODE_PROVIDER_EFFORT: Readonly<
+	Record<string, EffortFieldConfig | null>
+> = {
+	openai: { fieldName: "reasoningEffort", mapValue: clampToThreeLevels },
+	anthropic: null,
+	unknown: null,
+};
+
+/**
+ * Direct platform effort configurations (non-provider-dependent).
+ * Platforms not listed (copilot) or with null values do not support
+ * per-agent effort control.
+ */
+const PLATFORM_EFFORT: Readonly<
+	Partial<Record<BuildPlatform, EffortFieldConfig | null>>
+> = {
+	"claude-code": { fieldName: "effort", mapValue: (e) => e },
+	codex: {
+		fieldName: "model_reasoning_effort",
+		mapValue: clampToThreeLevels,
+	},
+	antigravity: null,
+	gemini: null,
+	copilot: null,
+};
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve an abstract model tier to the platform-specific model identifier.
+ *
+ * @returns The concrete model ID for the platform, or null when:
+ *   - tier is "inherit" (agent inherits session model)
+ *   - the platform has no tiering support (e.g., copilot)
+ */
+export function resolveTier(
+	tier: ModelTier,
+	platform: BuildPlatform,
+): string | null {
+	if (tier === "inherit") return null;
+	return TIER_MODEL_MAP[tier]?.[platform] ?? null;
+}
+
+/**
+ * Resolve an effort level to the platform/provider-specific field name and value.
+ *
+ * For OpenCode, the provider is derived from the resolved model ID to select
+ * the correct pass-through field name (e.g., `reasoningEffort` for OpenAI).
+ *
+ * @returns `{ fieldName, value }` for platforms that support per-agent effort,
+ *   or null when:
+ *   - effort is undefined (not declared)
+ *   - tier is "fast" (fast-tier models do not support effort control)
+ *   - the platform/provider does not support per-agent effort
+ */
+export function resolveEffort(
+	effort: EffortLevel | undefined,
+	tier: ModelTier,
+	platform: BuildPlatform,
+	resolvedModel: string | null,
+): EffortResolution | null {
+	if (effort === undefined) return null;
+	if (tier === "fast") return null;
+
+	// OpenCode: provider-dependent effort field
+	if (platform === "opencode") {
+		const provider = resolvedModel ? deriveProvider(resolvedModel) : "unknown";
+		const config = OPENCODE_PROVIDER_EFFORT[provider];
+		if (!config) return null;
+		return { fieldName: config.fieldName, value: config.mapValue(effort) };
+	}
+
+	// Other platforms: direct lookup
+	const config = PLATFORM_EFFORT[platform];
+	if (!config) return null;
+	return { fieldName: config.fieldName, value: config.mapValue(effort) };
+}

--- a/cli/src/build/tier-resolution.ts
+++ b/cli/src/build/tier-resolution.ts
@@ -24,6 +24,19 @@ import type { BuildPlatform } from "./template-context.js";
 const TIER_MODEL_MAP: Readonly<
 	Record<Exclude<ModelTier, "inherit">, Partial<Record<BuildPlatform, string>>>
 > = {
+	// frontier: most-capable model per platform.
+	// claude-code/opencode/antigravity are Anthropic-backed and share the same
+	// alias vocabulary (they already map deep→opus identically), so frontier→fable
+	// on all three. codex (OpenAI) and gemini (Google) have no class above their
+	// current deep model yet, so frontier currently coincides with their deep model
+	// (o3 / gemini-2.5-pro) and should be bumped when a higher class ships.
+	frontier: {
+		"claude-code": "fable",
+		codex: "o3",
+		opencode: "fable",
+		antigravity: "fable",
+		gemini: "gemini-2.5-pro",
+	},
 	deep: {
 		"claude-code": "opus",
 		codex: "o3",
@@ -72,40 +85,36 @@ function clampToThreeLevels(effort: EffortLevel): string {
 	return effort;
 }
 
+// Every model produced by TIER_MODEL_MAP MUST have an entry here;
+// add new model classes in one place.
+const MODEL_PROVIDER: Readonly<
+	Record<string, "anthropic" | "openai" | "google">
+> = {
+	fable: "anthropic",
+	opus: "anthropic",
+	sonnet: "anthropic",
+	haiku: "anthropic",
+	o3: "openai",
+	"o4-mini": "openai",
+	"gpt-4.1-nano": "openai",
+	"gemini-2.5-pro": "google",
+	"gemini-2.5-flash": "google",
+};
+
 /**
  * Derive the model provider from a resolved model identifier.
  * Used by OpenCode to select the correct effort pass-through field name.
  *
- * Closed-world assumption: only model IDs produced by TIER_MODEL_MAP reach
- * this function (e.g. "opus", "sonnet", "haiku", "o3", "o4-mini",
- * "gpt-4.1-nano"). If TIER_MODEL_MAP is extended with models from a new
- * provider, add a matching branch here.
+ * Looks up the explicit MODEL_PROVIDER registry (case-insensitive fallback).
+ * Returns "unknown" for unrecognized models.
  */
 function deriveProvider(
 	resolvedModel: string,
-): "anthropic" | "openai" | "unknown" {
-	const lower = resolvedModel.toLowerCase();
-
-	// Anthropic models: opus, sonnet, haiku, claude-*
-	if (
-		lower.includes("opus") ||
-		lower.includes("sonnet") ||
-		lower.includes("haiku") ||
-		lower.includes("claude")
-	) {
-		return "anthropic";
-	}
-
-	// OpenAI models: o3, o4, o1, gpt-*
-	if (
-		lower.startsWith("o3") ||
-		lower.startsWith("o4") ||
-		lower.startsWith("o1") ||
-		lower.includes("gpt")
-	) {
-		return "openai";
-	}
-
+): "anthropic" | "openai" | "google" | "unknown" {
+	const direct = MODEL_PROVIDER[resolvedModel];
+	if (direct) return direct;
+	const lower = MODEL_PROVIDER[resolvedModel.toLowerCase()];
+	if (lower) return lower;
 	return "unknown";
 }
 
@@ -118,6 +127,7 @@ const OPENCODE_PROVIDER_EFFORT: Readonly<
 > = {
 	openai: { fieldName: "reasoningEffort", mapValue: clampToThreeLevels },
 	anthropic: null,
+	google: null,
 	unknown: null,
 };
 

--- a/cli/src/build/tier-resolution.ts
+++ b/cli/src/build/tier-resolution.ts
@@ -75,6 +75,11 @@ function clampToThreeLevels(effort: EffortLevel): string {
 /**
  * Derive the model provider from a resolved model identifier.
  * Used by OpenCode to select the correct effort pass-through field name.
+ *
+ * Closed-world assumption: only model IDs produced by TIER_MODEL_MAP reach
+ * this function (e.g. "opus", "sonnet", "haiku", "o3", "o4-mini",
+ * "gpt-4.1-nano"). If TIER_MODEL_MAP is extended with models from a new
+ * provider, add a matching branch here.
  */
 function deriveProvider(
 	resolvedModel: string,
@@ -174,7 +179,10 @@ export function resolveEffort(
 	if (effort === undefined) return null;
 	if (tier === "fast") return null;
 
-	// OpenCode: provider-dependent effort field
+	// OpenCode: provider-dependent effort field.
+	// When tier is "inherit", resolvedModel is null (the session model is
+	// unknown at build time), so provider resolves to "unknown" and effort
+	// is correctly omitted — the runtime session model determines behavior.
 	if (platform === "opencode") {
 		const provider = resolvedModel ? deriveProvider(resolvedModel) : "unknown";
 		const config = OPENCODE_PROVIDER_EFFORT[provider];

--- a/cli/src/build/validator.ts
+++ b/cli/src/build/validator.ts
@@ -15,6 +15,7 @@ import type {
 } from "./models.js";
 import {
 	PROTECTED_AGENTS,
+	TIER_RANK,
 	VALID_EFFORT_LEVELS,
 	VALID_MODEL_TIERS,
 } from "./models.js";
@@ -587,11 +588,12 @@ export const validateAgentTierAndEffort = (
 
 	if (
 		PROTECTED_AGENTS.has(agentName) &&
-		model !== "deep" &&
-		model !== "inherit"
+		model !== "inherit" &&
+		model in TIER_RANK &&
+		TIER_RANK[model as keyof typeof TIER_RANK] < TIER_RANK.deep
 	) {
 		warnings.push(
-			`${file}: protected agent '${agentName}' downgraded from deep to '${model}'`,
+			`${file}: protected agent '${agentName}' downgraded below deep to '${model}'`,
 		);
 	}
 

--- a/cli/src/build/validator.ts
+++ b/cli/src/build/validator.ts
@@ -7,7 +7,17 @@ import * as E from "fp-ts/lib/Either.js";
 import { parse as parseYaml } from "yaml";
 import type { CLIError } from "../../shared/errors.js";
 import { validationError } from "../../shared/errors.js";
-import type { SkillCategory, WorkflowRunPolicy } from "./models.js";
+import type {
+	EffortLevel,
+	ModelTier,
+	SkillCategory,
+	WorkflowRunPolicy,
+} from "./models.js";
+import {
+	PROTECTED_AGENTS,
+	VALID_EFFORT_LEVELS,
+	VALID_MODEL_TIERS,
+} from "./models.js";
 
 const VALID_SKILL_CATEGORIES: readonly SkillCategory[] = [
 	"development",
@@ -524,4 +534,66 @@ export const validateSkill = (
 		return syntaxResult;
 	}
 	return validateSkillSchema(content, file);
+};
+
+// ============================================================================
+// Agent Tier and Effort Validation
+// ============================================================================
+
+/** Validation result containing both hard errors and advisory warnings. */
+export interface AgentTierValidationResult {
+	readonly errors: readonly string[];
+	readonly warnings: readonly string[];
+}
+
+/**
+ * Validate an agent's model tier and effort level declarations.
+ *
+ * Checks:
+ * - model must be a known tier alias from VALID_MODEL_TIERS
+ * - effort (when present) must be a known level from VALID_EFFORT_LEVELS
+ * - fast tier with effort set produces a warning (fast models lack effort control)
+ * - protected agents assigned non-deep, non-inherit tiers produce a downgrade warning
+ */
+export const validateAgentTierAndEffort = (
+	agentName: string,
+	model: string,
+	effort: string | undefined,
+	file: string,
+): AgentTierValidationResult => {
+	const errors: string[] = [];
+	const warnings: string[] = [];
+
+	if (!VALID_MODEL_TIERS.includes(model as ModelTier)) {
+		errors.push(
+			`${file}: unknown model tier '${model}'. Allowed values: ${VALID_MODEL_TIERS.join(", ")}`,
+		);
+	}
+
+	if (
+		effort !== undefined &&
+		!VALID_EFFORT_LEVELS.includes(effort as EffortLevel)
+	) {
+		errors.push(
+			`${file}: unknown effort level '${effort}'. Allowed values: ${VALID_EFFORT_LEVELS.join(", ")}`,
+		);
+	}
+
+	if (model === "fast" && effort !== undefined) {
+		warnings.push(
+			`${file}: effort '${effort}' set on fast-tier agent '${agentName}'; fast models do not support effort control`,
+		);
+	}
+
+	if (
+		PROTECTED_AGENTS.has(agentName) &&
+		model !== "deep" &&
+		model !== "inherit"
+	) {
+		warnings.push(
+			`${file}: protected agent '${agentName}' downgraded from deep to '${model}'`,
+		);
+	}
+
+	return { errors, warnings };
 };

--- a/plugins/base/agents/kb-architecture-mapper.md
+++ b/plugins/base/agents/kb-architecture-mapper.md
@@ -2,7 +2,8 @@
 name: kb-architecture-mapper
 description: Maps system architecture patterns, layers, and integrations for architecture.md from pre-filtered files
 tools: Read, Grep, Glob, Bash
-model: inherit
+model: standard
+effort: medium
 arguments:
   - name: CODEBASE_ROOT
     type: string

--- a/plugins/base/agents/kb-concept-extractor.md
+++ b/plugins/base/agents/kb-concept-extractor.md
@@ -2,7 +2,8 @@
 name: kb-concept-extractor
 description: Extracts domain concepts and terminology for concept_map.md from pre-filtered files
 tools: Read, Grep, Glob
-model: inherit
+model: standard
+effort: medium
 arguments:
   - name: CODEBASE_ROOT
     type: string

--- a/plugins/base/agents/kb-index-builder.md
+++ b/plugins/base/agents/kb-index-builder.md
@@ -2,7 +2,8 @@
 name: kb-index-builder
 description: "[DEPRECATED] Generates project overview data for index.md from pre-filtered files"
 tools: Read, Grep, Glob, Bash
-model: inherit
+model: standard
+effort: low
 deprecated: true
 arguments:
   - name: CODEBASE_ROOT

--- a/plugins/base/agents/kb-interaction-mapper.md
+++ b/plugins/base/agents/kb-interaction-mapper.md
@@ -2,7 +2,8 @@
 name: kb-interaction-mapper
 description: Maps cross-surface interaction semantics for interaction-model.md from pre-filtered files
 tools: Read, Grep, Glob, Bash
-model: inherit
+model: standard
+effort: medium
 arguments:
   - name: CODEBASE_ROOT
     type: string

--- a/plugins/base/agents/kb-module-analyzer.md
+++ b/plugins/base/agents/kb-module-analyzer.md
@@ -2,7 +2,8 @@
 name: kb-module-analyzer
 description: Analyzes modules, components, and dependencies for modules.md from pre-filtered files
 tools: Read, Grep, Glob, Bash
-model: inherit
+model: standard
+effort: medium
 arguments:
   - name: CODEBASE_ROOT
     type: string

--- a/plugins/base/agents/kb-pattern-extractor.md
+++ b/plugins/base/agents/kb-pattern-extractor.md
@@ -2,7 +2,8 @@
 name: kb-pattern-extractor
 description: Extracts implementation patterns and idioms for patterns.md from pre-filtered source files
 tools: Read, Grep, Glob
-model: inherit
+model: standard
+effort: medium
 arguments:
   - name: CODEBASE_ROOT
     type: string

--- a/plugins/base/agents/kb-spatial-analyzer.md
+++ b/plugins/base/agents/kb-spatial-analyzer.md
@@ -2,7 +2,8 @@
 name: kb-spatial-analyzer
 description: Scans repository files, ranks by importance (0-5), and categorizes them by KB section for parallel analysis
 tools: Read, Grep, Glob, Bash
-model: inherit
+model: standard
+effort: medium
 arguments:
   - name: CODEBASE_ROOT
     type: string

--- a/plugins/base/agents/mermaid-fixer.md
+++ b/plugins/base/agents/mermaid-fixer.md
@@ -2,7 +2,8 @@
 name: mermaid-fixer
 description: Validates and repairs mermaid diagrams in markdown files. Scans for mermaid blocks, validates each diagram, attempts automatic repair (up to 3 iterations), and inserts placeholders for unfixable diagrams.
 tools: Read, Write, Edit, Bash, Bash(rp1 *)
-model: inherit
+model: standard
+effort: low
 arguments:
   - name: INPUT_PATH
     type: string

--- a/plugins/base/agents/project-documenter.md
+++ b/plugins/base/agents/project-documenter.md
@@ -2,7 +2,8 @@
 name: project-documenter
 description: Generates a digestible 3-tier/9-section birds-eye-view document from KB + codebase, with per-claim provenance in hidden HTML comments
 tools: Read, Write, Grep, Glob, Skill, Bash, Bash(rp1 *)
-model: inherit
+model: standard
+effort: high
 arguments:
   - name: PROJECT_CONTEXT
     type: string

--- a/plugins/base/agents/prompt-pipeline-runner.md
+++ b/plugins/base/agents/prompt-pipeline-runner.md
@@ -2,7 +2,8 @@
 name: prompt-pipeline-runner
 description: Executes the six-stage prompt-writer pipeline and produces two mandatory output artifacts (ready-to-run prompt, confidence report)
 tools: Skill, Read, Bash
-model: inherit
+model: standard
+effort: high
 arguments:
   - name: PROMPT_NAME
     type: string

--- a/plugins/base/agents/research-explorer.md
+++ b/plugins/base/agents/research-explorer.md
@@ -2,7 +2,8 @@
 name: research-explorer
 description: Deep exploration of codebases or web resources, returning structured JSON findings with evidence
 tools: Read, Grep, Glob, WebSearch
-model: inherit
+model: deep
+effort: high
 arguments:
   - name: EXPLORATION_TARGET
     type: string

--- a/plugins/base/agents/research-reporter.md
+++ b/plugins/base/agents/research-reporter.md
@@ -2,7 +2,8 @@
 name: research-reporter
 description: Generates structured research reports with validated Mermaid diagrams from synthesis data
 tools: Write, Skill, Bash
-model: inherit
+model: standard
+effort: high
 arguments:
   - name: SYNTHESIS_DATA
     type: string

--- a/plugins/base/agents/scribe.md
+++ b/plugins/base/agents/scribe.md
@@ -2,7 +2,8 @@
 name: scribe
 description: Dual-mode doc worker for scan/process batches. Returns JSON only.
 tools: Read, Edit, Glob, Grep
-model: inherit
+model: standard
+effort: low
 arguments:
   - name: MODE
     type: enum

--- a/plugins/base/agents/security-validator.md
+++ b/plugins/base/agents/security-validator.md
@@ -2,7 +2,8 @@
 name: security-validator
 description: Performs evidence-bounded, standards-mapped security posture assessment for a project, sub-directory, module, concept, or feature topic
 tools: Read, Write, Grep, Glob, Bash
-model: inherit
+model: deep
+effort: high
 arguments:
   - name: TOPIC
     type: string

--- a/plugins/base/agents/socratic-duel-participant.md
+++ b/plugins/base/agents/socratic-duel-participant.md
@@ -2,7 +2,8 @@
 name: socratic-duel-participant
 description: Participates in a Socratic Duel run using pre-resolved launcher context and participant-owned artifact writes.
 tools: Read, Write, Edit, Bash(rp1 *)
-model: inherit
+model: deep
+effort: high
 arguments:
   - name: RUN_ID
     type: string

--- a/plugins/base/agents/strategic-advisor.md
+++ b/plugins/base/agents/strategic-advisor.md
@@ -2,7 +2,8 @@
 name: strategic-advisor
 description: Analyzes systems holistically to provide strategic recommendations balancing cost, quality, performance, complexity, and business objectives with quantified trade-offs
 tools: Read, Grep, Glob, Bash, WebFetch
-model: inherit
+model: deep
+effort: high
 arguments:
   - name: PROBLEM_STATEMENT
     type: string

--- a/plugins/dev/agents/blueprint-auditor.md
+++ b/plugins/dev/agents/blueprint-auditor.md
@@ -2,7 +2,8 @@
 name: blueprint-auditor
 description: Audits PRD documents against implementation status and executes disposition actions
 tools: Read, Glob, Bash, Grep, Write, Task
-model: inherit
+model: deep
+effort: high
 author: cloud-on-prem/rp1
 arguments:
   - name: MODE

--- a/plugins/dev/agents/blueprint-wizard.md
+++ b/plugins/dev/agents/blueprint-wizard.md
@@ -2,7 +2,8 @@
 name: blueprint-wizard
 description: Stateless PRD wizard that analyzes interview state and returns structured JSON responses for PRD creation
 tools: Read, Write, Glob, Bash
-model: inherit
+model: standard
+effort: high
 author: cloud-on-prem/rp1
 arguments:
   - name: PRD_NAME

--- a/plugins/dev/agents/bootstrap-scaffolder.md
+++ b/plugins/dev/agents/bootstrap-scaffolder.md
@@ -2,7 +2,8 @@
 name: bootstrap-scaffolder
 description: Stateless scaffolder that analyzes interview state and returns structured JSON responses for tech stack selection and project scaffolding
 tools: Read, Write, Bash
-model: inherit
+model: standard
+effort: medium
 author: cloud-on-prem/rp1
 arguments:
   - name: PROJECT_NAME

--- a/plugins/dev/agents/bug-investigator.md
+++ b/plugins/dev/agents/bug-investigator.md
@@ -2,7 +2,8 @@
 name: bug-investigator
 description: Systematic investigation of bugs and issues to identify root causes through evidence-based analysis, hypothesis testing, and comprehensive documentation without permanent code changes
 tools: Read, Write, Edit, Grep, Glob, Bash
-model: inherit
+model: deep
+effort: high
 author: cloud-on-prem/rp1
 arguments:
   - name: PROBLEM_STATEMENT

--- a/plugins/dev/agents/build-artifact-detector.md
+++ b/plugins/dev/agents/build-artifact-detector.md
@@ -2,7 +2,7 @@
 name: build-artifact-detector
 description: Determines workflow start_step by checking existing feature artifacts using bootstrap-provided run context
 tools: Read, Bash(rp1 *)
-model: inherit
+model: fast
 arguments:
   - name: FEATURE_ID
     type: string

--- a/plugins/dev/agents/build-fast-planner.md
+++ b/plugins/dev/agents/build-fast-planner.md
@@ -2,6 +2,8 @@
 name: build-fast-planner
 description: Quick-iteration workflow planner. Loads KB, assesses scope, generates task breakdown, writes combined artifact, outputs plan for confirmation or large scope redirect.
 tools: Read, Write, Glob, Grep, Bash, Bash(rp1 *)
+model: standard
+effort: high
 arguments:
   - name: REQUEST
     type: string

--- a/plugins/dev/agents/build-task-grouper.md
+++ b/plugins/dev/agents/build-task-grouper.md
@@ -2,7 +2,7 @@
 name: build-task-grouper
 description: Batches parsed tasks into execution units based on complexity rules
 tools: []
-model: inherit
+model: fast
 arguments:
   - name: TASKS
     type: string

--- a/plugins/dev/agents/build-task-parser.md
+++ b/plugins/dev/agents/build-task-parser.md
@@ -2,7 +2,7 @@
 name: build-task-parser
 description: Extracts structured task information from tasks.md files
 tools: Read
-model: inherit
+model: fast
 arguments:
   - name: TASKS_PATH
     type: string

--- a/plugins/dev/agents/build-verify-aggregator.md
+++ b/plugins/dev/agents/build-verify-aggregator.md
@@ -2,7 +2,8 @@
 name: build-verify-aggregator
 description: Combines validation envelopes into final build readiness status and artifact
 tools: Read, Write, Bash
-model: inherit
+model: standard
+effort: low
 arguments:
   - name: PHASE_RESULTS
     type: string

--- a/plugins/dev/agents/charter-interviewer.md
+++ b/plugins/dev/agents/charter-interviewer.md
@@ -2,7 +2,8 @@
 name: charter-interviewer
 description: Stateless interview agent that analyzes charter state and returns structured JSON responses for greenfield project vision capture
 tools: Read
-model: inherit
+model: standard
+effort: medium
 author: cloud-on-prem/rp1
 arguments:
   - name: CHARTER_PATH

--- a/plugins/dev/agents/code-auditor.md
+++ b/plugins/dev/agents/code-auditor.md
@@ -2,7 +2,8 @@
 name: code-auditor
 description: Analyzes implemented code for pattern consistency, maintainability, code duplication, comment quality, and documentation drift
 tools: Read, Write, Grep, Glob, Bash
-model: inherit
+model: deep
+effort: high
 arguments:
   - name: FEATURE_ID
     type: string

--- a/plugins/dev/agents/code-checker.md
+++ b/plugins/dev/agents/code-checker.md
@@ -2,7 +2,8 @@
 name: code-checker
 description: Fast code hygiene validation (linters, formatters, tests, coverage) for quick dev loop feedback
 tools: Read, Write, Bash
-model: inherit
+model: standard
+effort: medium
 arguments:
   - name: FEATURE_ID
     type: string

--- a/plugins/dev/agents/comment-cleaner.md
+++ b/plugins/dev/agents/comment-cleaner.md
@@ -2,7 +2,8 @@
 name: comment-cleaner
 description: Systematically removes unnecessary comments from manifest-owned code lines while preserving docstrings, critical logic explanations, and type directives
 tools: Read, Edit, Grep, Bash, Skill
-model: inherit
+model: standard
+effort: medium
 arguments:
   - name: CHANGE_MANIFEST
     type: string

--- a/plugins/dev/agents/feature-architect.md
+++ b/plugins/dev/agents/feature-architect.md
@@ -2,7 +2,8 @@
 name: feature-architect
 description: Transforms requirements into technical design specifications. Invoked by /build workflow. Does NOT spawn hypothesis-tester.
 tools: Read, Write, Glob, Bash(rp1 *)
-model: inherit
+model: deep
+effort: xhigh
 skills: rp1-base:mermaid
 arguments:
   - name: FEATURE_ID

--- a/plugins/dev/agents/feature-archiver.md
+++ b/plugins/dev/agents/feature-archiver.md
@@ -2,7 +2,8 @@
 name: feature-archiver
 description: Archives completed features to .rp1/work/archives/features/ or restores archived features back to active features directory
 tools: Read, Glob, Bash, Edit
-model: inherit
+model: standard
+effort: low
 author: cloud-on-prem/rp1
 arguments:
   - name: MODE

--- a/plugins/dev/agents/feature-editor.md
+++ b/plugins/dev/agents/feature-editor.md
@@ -2,7 +2,8 @@
 name: feature-editor
 description: Analyzes mid-stream edits for validity, detects conflicts, and propagates approved changes across feature documentation
 tools: Read, Edit, Glob, Bash
-model: inherit
+model: standard
+effort: high
 author: cloud-on-prem/rp1
 arguments:
   - name: FEATURE_ID

--- a/plugins/dev/agents/feature-requirement-gatherer.md
+++ b/plugins/dev/agents/feature-requirement-gatherer.md
@@ -2,7 +2,8 @@
 name: feature-requirement-gatherer
 description: Transforms high-level feature concepts into structured requirements specifications. Invoked by /build workflow.
 tools: Read, Write, Glob, Bash(rp1 *)
-model: inherit
+model: standard
+effort: high
 arguments:
   - name: FEATURE_ID
     type: string

--- a/plugins/dev/agents/feature-tasker.md
+++ b/plugins/dev/agents/feature-tasker.md
@@ -2,7 +2,8 @@
 name: feature-tasker
 description: Generates development tasks from design specifications with support for incremental updates that preserve completed work
 tools: Read, Write, Glob, Bash(rp1 *)
-model: inherit
+model: standard
+effort: high
 arguments:
   - name: FEATURE_ID
     type: string

--- a/plugins/dev/agents/feature-verifier.md
+++ b/plugins/dev/agents/feature-verifier.md
@@ -2,7 +2,8 @@
 name: feature-verifier
 description: Verifies feature acceptance criteria and requirements mapping with full KB context awareness for comprehensive feature validation before merge
 tools: Read, Write, Bash, Bash(rp1 *)
-model: inherit
+model: deep
+effort: high
 arguments:
   - name: FEATURE_ID
     type: string

--- a/plugins/dev/agents/hypothesis-tester.md
+++ b/plugins/dev/agents/hypothesis-tester.md
@@ -2,7 +2,8 @@
 name: hypothesis-tester
 description: Validates design hypotheses through code experiments, codebase analysis, and external research
 tools: Read, Write, Edit, Grep, Glob, Bash, Bash(rp1 *)
-model: inherit
+model: deep
+effort: high
 author: cloud-on-prem/rp1
 arguments:
   - name: FEATURE_ID

--- a/plugins/dev/agents/phase-planner.md
+++ b/plugins/dev/agents/phase-planner.md
@@ -2,7 +2,8 @@
 name: phase-planner
 description: Decomposes a planning source into a source-adjacent phase-plan artifact and refreshes source backlinks.
 tools: Read, Write, Edit, Glob, Grep
-model: inherit
+model: deep
+effort: high
 author: cloud-on-prem/rp1
 arguments:
   - name: SOURCE

--- a/plugins/dev/agents/pr-comment-deduplicator.md
+++ b/plugins/dev/agents/pr-comment-deduplicator.md
@@ -2,7 +2,7 @@
 name: pr-comment-deduplicator
 description: Deduplicates PR review comments against existing bot and human comments
 tools: []
-model: inherit
+model: fast
 arguments:
   - name: NEW_COMMENTS
     type: string

--- a/plugins/dev/agents/pr-comment-poster.md
+++ b/plugins/dev/agents/pr-comment-poster.md
@@ -2,7 +2,7 @@
 name: pr-comment-poster
 description: Posts PR review comments via github-pr agent-tools
 tools: Read, Bash, Bash(rp1 *)
-model: inherit
+model: fast
 arguments:
   - name: OWNER
     type: string

--- a/plugins/dev/agents/pr-feedback-collector.md
+++ b/plugins/dev/agents/pr-feedback-collector.md
@@ -2,7 +2,8 @@
 name: pr-feedback-collector
 description: Automatically gathers pull request review comments from GitHub, classifies them by priority and type, extracts actionable tasks, and generates structured feedback documents for systematic resolution
 tools: Read, Write, Bash
-model: inherit
+model: standard
+effort: medium
 arguments:
   - name: FEATURE_ID
     type: string

--- a/plugins/dev/agents/pr-review-reporter.md
+++ b/plugins/dev/agents/pr-review-reporter.md
@@ -2,7 +2,8 @@
 name: pr-review-reporter
 description: Formats findings into markdown report and writes to file
 tools: Read, Write, Glob, Bash
-model: inherit
+model: standard
+effort: low
 arguments:
   - name: PR_INFO
     type: string

--- a/plugins/dev/agents/pr-review-splitter.md
+++ b/plugins/dev/agents/pr-review-splitter.md
@@ -2,7 +2,8 @@
 name: pr-review-splitter
 description: Splits PR diff into reviewable units, filtering out generated/low-value files
 tools: Read, Grep, Glob, Bash
-model: inherit
+model: standard
+effort: low
 arguments:
   - name: PR_BRANCH
     type: string

--- a/plugins/dev/agents/pr-review-synthesizer.md
+++ b/plugins/dev/agents/pr-review-synthesizer.md
@@ -2,7 +2,8 @@
 name: pr-review-synthesizer
 description: Holistic cross-file verification using compressed summaries
 tools: Read, Grep, Glob, Bash
-model: inherit
+model: deep
+effort: high
 arguments:
   - name: INTENT_JSON
     type: string

--- a/plugins/dev/agents/pr-sub-reviewer.md
+++ b/plugins/dev/agents/pr-sub-reviewer.md
@@ -2,7 +2,8 @@
 name: pr-sub-reviewer
 description: Analyzes one review unit across 5 dimensions with confidence gating
 tools: Read, Grep, Glob, Bash
-model: inherit
+model: deep
+effort: high
 arguments:
   - name: UNIT_JSON
     type: string

--- a/plugins/dev/agents/pr-visualizer.md
+++ b/plugins/dev/agents/pr-visualizer.md
@@ -2,7 +2,8 @@
 name: pr-visualizer
 description: Transform PR diffs into Mermaid diagrams for visual code review
 tools: Read, Write, Bash, Glob
-model: inherit
+model: standard
+effort: medium
 arguments:
   - name: PR_BRANCH
     type: string

--- a/plugins/dev/agents/pr-walkthrough-reporter.md
+++ b/plugins/dev/agents/pr-walkthrough-reporter.md
@@ -2,7 +2,8 @@
 name: pr-walkthrough-reporter
 description: Generate an evidence-grounded slide-ready markdown walkthrough for a pull request
 tools: Read, Write, Glob, Bash
-model: inherit
+model: standard
+effort: high
 arguments:
   - name: EVIDENCE_JSON
     type: string

--- a/plugins/dev/agents/prd-archiver.md
+++ b/plugins/dev/agents/prd-archiver.md
@@ -2,7 +2,8 @@
 name: prd-archiver
 description: Archives completed PRDs to .rp1/work/archives/prds/, archives associated completed features, checks KB staleness, and generates closure summaries
 tools: Read, Glob, Bash, Grep, Write
-model: inherit
+model: standard
+effort: low
 author: cloud-on-prem/rp1
 arguments:
   - name: MODE

--- a/plugins/dev/agents/speedrun-builder.md
+++ b/plugins/dev/agents/speedrun-builder.md
@@ -2,7 +2,8 @@
 name: speedrun-builder
 description: Implements a single focused code change from a speedrun request
 tools: Read, Write, Edit, Bash, Glob, Grep
-model: inherit
+model: standard
+effort: medium
 ---
 
 # Speedrun Builder Agent

--- a/plugins/dev/agents/task-builder.md
+++ b/plugins/dev/agents/task-builder.md
@@ -2,7 +2,8 @@
 name: task-builder
 description: Implements assigned task(s) w/ full context, writes summaries to the resolved task file. Uses extended thinking (or ultrathink).
 tools: Read, Write, Edit, Bash, Glob, Grep, Bash(rp1 *)
-model: inherit
+model: standard
+effort: high
 arguments:
   - name: FEATURE_ID
     type: string

--- a/plugins/dev/agents/task-reviewer.md
+++ b/plugins/dev/agents/task-reviewer.md
@@ -2,7 +2,8 @@
 name: task-reviewer
 description: Verifies builder's work for discipline, accuracy, completeness, and commit quality. Returns SUCCESS or FAILURE with actionable feedback. Uses extended thinking for careful verification.
 tools: Read, Grep, Glob, Edit, Bash, Bash(rp1 *)
-model: inherit
+model: deep
+effort: high
 arguments:
   - name: FEATURE_ID
     type: string

--- a/plugins/dev/agents/test-runner.md
+++ b/plugins/dev/agents/test-runner.md
@@ -2,7 +2,8 @@
 name: test-runner
 description: Executes comprehensive functional testing of implemented features including automated tests, coverage measurement, acceptance criteria verification, and detailed test reporting
 tools: Read, Write, Bash
-model: inherit
+model: standard
+effort: medium
 arguments:
   - name: FEATURE_ID
     type: string

--- a/plugins/utils/agents/prompt-tersifier.md
+++ b/plugins/utils/agents/prompt-tersifier.md
@@ -2,7 +2,8 @@
 name: prompt-tersifier
 description: Transforms agent-instruction prompts into maximally terse versions while preserving full intent
 tools: Read, Write, Bash, Skill
-model: inherit
+model: standard
+effort: high
 arguments:
   - name: INPUT_PROMPT
     type: string


### PR DESCRIPTION
## Summary

Introduces **per-step model + reasoning-effort tiering** so each rp1 agent runs on an appropriately-sized model and reasoning budget, instead of every agent inheriting one global model. The goal is faster, more cost-efficient workflows (cheaper tiers on mechanical steps) with no quality regression on reasoning-critical steps.

Built via `/build` (feature `tiered-models-effort`); design + decisions in `.rp1/work/features/tiered-models-effort/`.

## How it works

- **Internal dictionary** — `cli/src/build/tier-resolution.ts` centralizes a single `TIER_MODEL_MAP` plus provider-aware `resolveTier()` / `resolveEffort()`. Updating one entry propagates to every agent on that tier.
- **Abstract tiers** — agents declare a `model` tier (`deep` / `standard` / `fast` / `inherit`) and optional `effort`, validated at build time against `VALID_MODEL_TIERS` / `VALID_EFFORT_LEVELS`.
- **Per-harness templates, compiled correctly** — each harness template emits the resolved values in its own recognized format:

  | Harness | model | effort |
  |---|---|---|
  | Claude Code | `model` frontmatter | `effort` |
  | Codex | `model` (TOML) | `model_reasoning_effort` |
  | OpenCode | `model` | provider-keyed effort pass-through (e.g. `reasoningEffort`) |
  | Antigravity | `model` | *omitted* (no per-agent effort support) |
  | Gemini CLI | `model` | *omitted* (no per-agent effort support) |

  OpenCode support is via its documented provider pass-through (`opencode.ai/docs/agents` → Additional); Antigravity/Gemini gracefully omit effort.
- **52 agents classified** — 14 deep / 33 standard / 5 fast. The 14 deep-tier agents match the `PROTECTED_AGENTS` set; downgrading a protected agent emits a build warning. The 5 fast-tier agents are single-pass schema-bound agents and carry no effort.
- **Backward compatible** — `inherit` produces byte-identical output (no model/effort frontmatter), so untiered agents are unaffected.

## Validation

- All acceptance criteria (REQ-001 … REQ-010) verified by `feature-verifier`.
- Lint, format, and typecheck clean; build test suite green (golden files + end-to-end coverage added). The only failing tests in the repo are pre-existing, unrelated `teach-me` test-harness issues with zero file overlap with this change.

## Pending before merge (why this is a draft)

**REQ-008 manual spot-checks** (chosen over automated eval suites):
- [ ] Wave 1 — 5 fast-tier agents: JSON output correctness
- [ ] Wave 2 — task-builder & speedrun-builder at standard tier: /build output quality + perceived latency
- [ ] Wave 3 — deep-agent effort tuning (security-validator, task-reviewer): false-negative / rejection-rate check

## Non-blocking follow-ups

KB/doc updates deferred (no acceptance criteria): `patterns.md`, `modules.md`, `AGENTS.md`, `docs/reference` agent-authoring notes.

🤖 Generated using: 🎮 [rp1.run](https://rp1.run)
