### PR TITLE
fix(build): correct codex/antigravity model mappings and make opencode inherit

### DIFF
--- a/cli/src/__tests__/build/command.test.ts
+++ b/cli/src/__tests__/build/command.test.ts
@@ -956,7 +956,7 @@ describe("buildPlatformPlugin (tier resolution)", () => {
 		await cleanupTempDir(tempDir);
 	});
 
-	test("resolves abstract model tier to platform-specific ID and maps effort fields on AgentArtifactData", async () => {
+	test("opencode agent with real tier omits model field (inherit)", async () => {
 		const projectRoot = join(tempDir, "project-tier-resolution");
 		await writeFixture(
 			projectRoot,
@@ -1001,8 +1001,8 @@ Deep agent content for tier resolution.
 		const agentPath = join(out, "base", "agents", "rp1-base-deep-agent.md");
 		const agentContent = await readFile(agentPath, "utf-8");
 
-		// Model tier "deep" should be resolved to "opus" for OpenCode
-		expect(agentContent).toContain("model: opus");
+		// OpenCode is now unmapped — model field should be omitted (inherit)
+		expect(agentContent).not.toContain("model:");
 		expect(agentContent).not.toContain("model: deep");
 	});
 
@@ -1159,8 +1159,8 @@ Deep agent content for Codex pipeline test.
 		const agentPath = join(out, "base", "agents", "rp1-base-deep-agent.toml");
 		const agentContent = await readFile(agentPath, "utf-8");
 
-		// Deep tier resolves to "o3" for Codex
-		expect(agentContent).toContain('model = "o3"');
+		// Deep tier resolves to "gpt-5.5" for Codex
+		expect(agentContent).toContain('model = "gpt-5.5"');
 		expect(agentContent).not.toContain('model = "deep"');
 		// Effort emitted as "model_reasoning_effort" for Codex
 		expect(agentContent).toContain('model_reasoning_effort = "high"');
@@ -1231,7 +1231,7 @@ Fast agent content.
 			join(outCdx, "base", "agents", "rp1-base-fast-agent.toml"),
 			"utf-8",
 		);
-		expect(cdxContent).toContain('model = "gpt-4.1-nano"');
+		expect(cdxContent).toContain('model = "gpt-5.4-mini"');
 		expect(cdxContent).not.toContain("model_reasoning_effort");
 	});
 });

--- a/cli/src/__tests__/build/templates/golden/antigravity-agent-model.md
+++ b/cli/src/__tests__/build/templates/golden/antigravity-agent-model.md
@@ -5,7 +5,7 @@ kind: local
 tools:
   - read_file
   - run_shell_command
-model: opus
+model: gemini-3.1-pro
 max_turns: 30
 metadata:
   rp1:

--- a/cli/src/__tests__/build/templates/golden/codex-agent-toml-model-effort.toml
+++ b/cli/src/__tests__/build/templates/golden/codex-agent-toml-model-effort.toml
@@ -1,6 +1,6 @@
 name = "rp1-dev-task-builder"
 description = "Implements feature tasks"
-model = "o3"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 
 developer_instructions = '''

--- a/cli/src/__tests__/build/templates/golden/opencode-agent-effort.md
+++ b/cli/src/__tests__/build/templates/golden/opencode-agent-effort.md
@@ -1,8 +1,6 @@
 ---
 description: Agent with deep tier and effort
 mode: subagent
-model: o3
-reasoningEffort: high
 tools:
   bash: true
   write: false

--- a/cli/src/__tests__/build/templates/template-rendering.test.ts
+++ b/cli/src/__tests__/build/templates/template-rendering.test.ts
@@ -499,7 +499,7 @@ describeWithLiquid("template rendering", () => {
 			expect(result).not.toContain("effort:");
 		});
 
-		test("golden: effort pass-through produces provider-keyed field", async () => {
+		test("golden: opencode agent with tier inherits (model + effort omitted)", async () => {
 			const engine = createTestEngine();
 			const result = await engine.renderFile("opencode/agent", {
 				platform: "opencode",
@@ -507,9 +507,7 @@ describeWithLiquid("template rendering", () => {
 					type: "agent",
 					name: "test-agent",
 					description: "Agent with deep tier and effort",
-					model: "o3",
-					effortFieldName: "reasoningEffort",
-					effortValue: "high",
+					model: "inherit",
 					tools: ["Bash"],
 					content: "Agent content for effort pass-through test.",
 				},
@@ -700,14 +698,14 @@ describeWithLiquid("template rendering", () => {
 					type: "agent",
 					name: "task-builder",
 					description: "Implements feature tasks",
-					model: "o3",
+					model: "gpt-5.5",
 					effortFieldName: "model_reasoning_effort",
 					effortValue: "high",
 					tools: ["Bash", "Edit"],
 					content: "Agent instructions.",
 				},
 			});
-			expect(result).toContain('model = "o3"');
+			expect(result).toContain('model = "gpt-5.5"');
 			expect(result).toContain('model_reasoning_effort = "high"');
 		});
 
@@ -740,7 +738,7 @@ describeWithLiquid("template rendering", () => {
 					type: "agent",
 					name: "task-builder",
 					description: "Implements feature tasks",
-					model: "o3",
+					model: "gpt-5.5",
 					effortFieldName: "model_reasoning_effort",
 					effortValue: "high",
 					tools: ["Bash", "Edit"],
@@ -1124,7 +1122,7 @@ describeWithLiquid("template rendering", () => {
 					type: "agent",
 					name: "deep-agent",
 					description: "Agent with deep tier for Antigravity",
-					model: "opus",
+					model: "gemini-3.1-pro",
 					tools: ["Read", "Bash"],
 					content: "Agent content for Antigravity tier test.",
 				},
@@ -1132,7 +1130,7 @@ describeWithLiquid("template rendering", () => {
 			expect(result.trim()).toBe(
 				readGolden("antigravity-agent-model.md").trim(),
 			);
-			expect(result).toContain("model: opus");
+			expect(result).toContain("model: gemini-3.1-pro");
 			expect(result).not.toContain("effort:");
 			expect(result).not.toContain("reasoningEffort:");
 		});

--- a/cli/src/__tests__/build/tier-resolution.test.ts
+++ b/cli/src/__tests__/build/tier-resolution.test.ts
@@ -18,60 +18,60 @@ describe("resolveTier", () => {
 		expect(resolveTier("frontier", "claude-code")).toBe("fable");
 	});
 
-	test("frontier tier returns o3 for codex", () => {
-		expect(resolveTier("frontier", "codex")).toBe("o3");
+	test("frontier tier returns gpt-5.5 for codex", () => {
+		expect(resolveTier("frontier", "codex")).toBe("gpt-5.5");
 	});
 
-	test("frontier tier returns fable for opencode", () => {
-		expect(resolveTier("frontier", "opencode")).toBe("fable");
+	test("frontier tier returns null for opencode (inherit)", () => {
+		expect(resolveTier("frontier", "opencode")).toBeNull();
 	});
 
-	test("frontier tier returns fable for antigravity", () => {
-		expect(resolveTier("frontier", "antigravity")).toBe("fable");
+	test("frontier tier returns gemini-3.1-pro for antigravity", () => {
+		expect(resolveTier("frontier", "antigravity")).toBe("gemini-3.1-pro");
 	});
 
 	test("frontier tier returns gemini-2.5-pro for gemini", () => {
 		expect(resolveTier("frontier", "gemini")).toBe("gemini-2.5-pro");
 	});
 
-	test("deep tier returns frontier model for claude-code", () => {
+	test("deep tier returns opus for claude-code", () => {
 		const result = resolveTier("deep", "claude-code");
 		expect(result).toBe("opus");
 	});
 
-	test("deep tier returns frontier model for codex", () => {
+	test("deep tier returns gpt-5.5 for codex", () => {
 		const result = resolveTier("deep", "codex");
-		expect(result).toBe("o3");
+		expect(result).toBe("gpt-5.5");
 	});
 
-	test("deep tier returns frontier model for opencode", () => {
+	test("deep tier returns null for opencode (inherit)", () => {
 		const result = resolveTier("deep", "opencode");
-		expect(result).toBe("opus");
+		expect(result).toBeNull();
 	});
 
-	test("deep tier returns frontier model for antigravity", () => {
+	test("deep tier returns gemini-3.1-pro for antigravity", () => {
 		const result = resolveTier("deep", "antigravity");
-		expect(result).toBe("opus");
+		expect(result).toBe("gemini-3.1-pro");
 	});
 
-	test("deep tier returns frontier model for gemini", () => {
+	test("deep tier returns gemini-2.5-pro for gemini", () => {
 		const result = resolveTier("deep", "gemini");
 		expect(result).toBe("gemini-2.5-pro");
 	});
 
 	test("standard tier returns balanced model for each platform", () => {
 		expect(resolveTier("standard", "claude-code")).toBe("sonnet");
-		expect(resolveTier("standard", "codex")).toBe("o4-mini");
-		expect(resolveTier("standard", "opencode")).toBe("sonnet");
-		expect(resolveTier("standard", "antigravity")).toBe("sonnet");
+		expect(resolveTier("standard", "codex")).toBe("gpt-5.4");
+		expect(resolveTier("standard", "opencode")).toBeNull();
+		expect(resolveTier("standard", "antigravity")).toBe("gemini-3.5-flash");
 		expect(resolveTier("standard", "gemini")).toBe("gemini-2.5-flash");
 	});
 
 	test("fast tier returns cheapest model for each platform", () => {
 		expect(resolveTier("fast", "claude-code")).toBe("haiku");
-		expect(resolveTier("fast", "codex")).toBe("gpt-4.1-nano");
-		expect(resolveTier("fast", "opencode")).toBe("haiku");
-		expect(resolveTier("fast", "antigravity")).toBe("haiku");
+		expect(resolveTier("fast", "codex")).toBe("gpt-5.4-mini");
+		expect(resolveTier("fast", "opencode")).toBeNull();
+		expect(resolveTier("fast", "antigravity")).toBe("gemini-3.5-flash");
 		expect(resolveTier("fast", "gemini")).toBe("gemini-2.5-flash");
 	});
 
@@ -86,6 +86,13 @@ describe("resolveTier", () => {
 		];
 		for (const p of platforms) {
 			expect(resolveTier("inherit", p)).toBeNull();
+		}
+	});
+
+	test("opencode returns null for any tier (inherits session model)", () => {
+		const tiers: ModelTier[] = ["frontier", "deep", "standard", "fast"];
+		for (const t of tiers) {
+			expect(resolveTier(t, "opencode")).toBeNull();
 		}
 	});
 
@@ -105,14 +112,14 @@ describe("resolveEffort", () => {
 	// --- Claude Code ---
 
 	test("claude-code returns effort field with pass-through value", () => {
-		const result = resolveEffort("high", "deep", "claude-code", "opus");
+		const result = resolveEffort("high", "deep", "claude-code");
 		expect(result).toEqual({ fieldName: "effort", value: "high" });
 	});
 
-	test("claude-code passes through all effort levels", () => {
+	test("claude-code passes through all effort levels including max", () => {
 		const levels: EffortLevel[] = ["low", "medium", "high", "xhigh", "max"];
 		for (const level of levels) {
-			const result = resolveEffort(level, "deep", "claude-code", "opus");
+			const result = resolveEffort(level, "deep", "claude-code");
 			expect(result).not.toBeNull();
 			expect(result!.fieldName).toBe("effort");
 			expect(result!.value).toBe(level);
@@ -122,64 +129,60 @@ describe("resolveEffort", () => {
 	// --- Codex ---
 
 	test("codex returns model_reasoning_effort field", () => {
-		const result = resolveEffort("high", "deep", "codex", "o3");
+		const result = resolveEffort("high", "deep", "codex");
 		expect(result).toEqual({
 			fieldName: "model_reasoning_effort",
 			value: "high",
 		});
 	});
 
-	test("codex clamps xhigh and max to high", () => {
-		expect(resolveEffort("xhigh", "deep", "codex", "o3")).toEqual({
+	test("codex passes through xhigh unchanged", () => {
+		expect(resolveEffort("xhigh", "deep", "codex")).toEqual({
 			fieldName: "model_reasoning_effort",
-			value: "high",
+			value: "xhigh",
 		});
-		expect(resolveEffort("max", "deep", "codex", "o3")).toEqual({
+	});
+
+	test("codex clamps max to xhigh", () => {
+		expect(resolveEffort("max", "deep", "codex")).toEqual({
 			fieldName: "model_reasoning_effort",
-			value: "high",
+			value: "xhigh",
 		});
 	});
 
-	// --- OpenCode (provider-aware) ---
-
-	test("opencode with OpenAI model returns reasoningEffort field", () => {
-		const result = resolveEffort("high", "deep", "opencode", "o3");
-		expect(result).toEqual({ fieldName: "reasoningEffort", value: "high" });
+	test("codex passes through low/medium/high unchanged", () => {
+		for (const level of ["low", "medium", "high"] as EffortLevel[]) {
+			const result = resolveEffort(level, "deep", "codex");
+			expect(result).toEqual({
+				fieldName: "model_reasoning_effort",
+				value: level,
+			});
+		}
 	});
 
-	test("opencode with OpenAI model clamps xhigh/max to high", () => {
-		expect(resolveEffort("xhigh", "standard", "opencode", "o4-mini")).toEqual({
-			fieldName: "reasoningEffort",
-			value: "high",
-		});
-	});
+	// --- OpenCode ---
 
-	test("opencode with Anthropic model returns null", () => {
-		const result = resolveEffort("high", "deep", "opencode", "opus");
-		expect(result).toBeNull();
-	});
-
-	test("opencode with Anthropic model (sonnet) returns null", () => {
-		const result = resolveEffort("medium", "standard", "opencode", "sonnet");
+	test("opencode returns null (effort not supported per-agent)", () => {
+		const result = resolveEffort("high", "deep", "opencode");
 		expect(result).toBeNull();
 	});
 
 	// --- Antigravity / Gemini ---
 
 	test("antigravity returns null (effort not supported per-agent)", () => {
-		const result = resolveEffort("high", "deep", "antigravity", "opus");
+		const result = resolveEffort("high", "deep", "antigravity");
 		expect(result).toBeNull();
 	});
 
 	test("gemini returns null (effort not supported per-agent)", () => {
-		const result = resolveEffort("high", "deep", "gemini", "gemini-2.5-pro");
+		const result = resolveEffort("high", "deep", "gemini");
 		expect(result).toBeNull();
 	});
 
 	// --- Copilot ---
 
 	test("copilot returns null (not supported)", () => {
-		const result = resolveEffort("high", "deep", "copilot", null);
+		const result = resolveEffort("high", "deep", "copilot");
 		expect(result).toBeNull();
 	});
 
@@ -194,14 +197,14 @@ describe("resolveEffort", () => {
 			"gemini",
 		];
 		for (const p of platforms) {
-			expect(resolveEffort("high", "fast", p, "haiku")).toBeNull();
+			expect(resolveEffort("high", "fast", p)).toBeNull();
 		}
 	});
 
 	// --- Undefined effort ---
 
 	test("undefined effort returns null", () => {
-		expect(resolveEffort(undefined, "deep", "claude-code", "opus")).toBeNull();
+		expect(resolveEffort(undefined, "deep", "claude-code")).toBeNull();
 	});
 
 	// --- Inherit tier with effort ---
@@ -209,25 +212,14 @@ describe("resolveEffort", () => {
 	test("inherit tier with effort still resolves effort (tier gating is fast-only)", () => {
 		// inherit just means no model override; effort can still be set
 		// (though this combination may be caught by validation separately)
-		const result = resolveEffort("high", "inherit", "claude-code", null);
+		const result = resolveEffort("high", "inherit", "claude-code");
 		expect(result).toEqual({ fieldName: "effort", value: "high" });
 	});
 
 	// --- Frontier tier ---
 
 	test("frontier tier on claude-code returns effort field with value", () => {
-		const result = resolveEffort("high", "frontier", "claude-code", "fable");
+		const result = resolveEffort("high", "frontier", "claude-code");
 		expect(result).toEqual({ fieldName: "effort", value: "high" });
-	});
-
-	test("frontier tier on opencode with fable (Anthropic) returns null", () => {
-		const result = resolveEffort("high", "frontier", "opencode", "fable");
-		expect(result).toBeNull();
-	});
-
-	test("provider registry classifies fable as anthropic (verified via opencode null)", () => {
-		// fable is Anthropic, so OpenCode effort pass-through is null
-		const result = resolveEffort("max", "frontier", "opencode", "fable");
-		expect(result).toBeNull();
 	});
 });

--- a/cli/src/build/command.ts
+++ b/cli/src/build/command.ts
@@ -863,17 +863,15 @@ export const buildPlatformPlugin = async (
 		}
 		const processedContent = preprocessResult.right;
 
-		// resolveTier returns null for unmapped platforms (e.g. copilot) and
-		// "inherit" tier. Falling back to ccAgent.model preserves the original
-		// value ("inherit" or raw tier alias). This is safe because unmapped
-		// platforms' templates (copilot) never emit a model field.
+		// resolveTier returns null for unmapped platforms (opencode, copilot) and
+		// "inherit" tier. Falling back to "inherit" ensures templates omit the
+		// model field rather than emitting a raw tier alias like "deep".
 		const resolvedModel =
-			resolveTier(ccAgent.model as ModelTier, platform) ?? ccAgent.model;
+			resolveTier(ccAgent.model as ModelTier, platform) ?? "inherit";
 		const effortResolution = resolveEffort(
 			ccAgent.effort as EffortLevel | undefined,
 			ccAgent.model as ModelTier,
 			platform,
-			resolvedModel !== ccAgent.model ? resolvedModel : null,
 		);
 
 		let ctx: Record<string, unknown> = buildTemplateContext(

--- a/cli/src/build/models.ts
+++ b/cli/src/build/models.ts
@@ -50,7 +50,7 @@ export interface ClaudeCodeCommand {
  * 1. Add the new tier to the `ModelTier` union AND `VALID_MODEL_TIERS` here.
  * 2. Add a numeric rank entry in `TIER_RANK` here.
  * 3. Add a row in `TIER_MODEL_MAP` (one concrete model per platform) in `tier-resolution.ts`.
- * 4. Register any new concrete model IDs in `MODEL_PROVIDER` in `tier-resolution.ts`.
+ * 4. Add per-platform effort configs in `PLATFORM_EFFORT` in `tier-resolution.ts` if needed.
  * 5. Optionally add agents to `PROTECTED_AGENTS` that must stay at or above a tier.
  *
  * The TS types (`Exclude<ModelTier, "inherit">` keys on `TIER_MODEL_MAP` and `TIER_RANK`)

--- a/cli/src/build/tier-resolution.ts
+++ b/cli/src/build/tier-resolution.ts
@@ -18,44 +18,41 @@ import type { BuildPlatform } from "./template-context.js";
  * Centralized mapping from abstract tiers to concrete platform model IDs.
  * Updating an entry here propagates to all agents of that tier on next build.
  *
- * Copilot is intentionally omitted (no tiering mechanism); resolveTier
- * returns null for unmapped platforms.
+ * Intentionally omitted platforms (resolveTier returns null → inherit):
+ * - copilot: no per-agent model tiering mechanism.
+ * - opencode: no per-agent model tiering — inherits the session model, like copilot.
+ *
+ * Codex: deep and frontier both map to gpt-5.5 (its most capable model);
+ * standard = gpt-5.4; fast = gpt-5.4-mini.
+ *
+ * Antigravity: uses Gemini models (gemini-3.1-pro for deep/frontier,
+ * gemini-3.5-flash for standard/fast).
  */
 const TIER_MODEL_MAP: Readonly<
 	Record<Exclude<ModelTier, "inherit">, Partial<Record<BuildPlatform, string>>>
 > = {
-	// frontier: most-capable model per platform.
-	// claude-code/opencode/antigravity are Anthropic-backed and share the same
-	// alias vocabulary (they already map deep→opus identically), so frontier→fable
-	// on all three. codex (OpenAI) and gemini (Google) have no class above their
-	// current deep model yet, so frontier currently coincides with their deep model
-	// (o3 / gemini-2.5-pro) and should be bumped when a higher class ships.
 	frontier: {
 		"claude-code": "fable",
-		codex: "o3",
-		opencode: "fable",
-		antigravity: "fable",
+		codex: "gpt-5.5",
+		antigravity: "gemini-3.1-pro",
 		gemini: "gemini-2.5-pro",
 	},
 	deep: {
 		"claude-code": "opus",
-		codex: "o3",
-		opencode: "opus",
-		antigravity: "opus",
+		codex: "gpt-5.5",
+		antigravity: "gemini-3.1-pro",
 		gemini: "gemini-2.5-pro",
 	},
 	standard: {
 		"claude-code": "sonnet",
-		codex: "o4-mini",
-		opencode: "sonnet",
-		antigravity: "sonnet",
+		codex: "gpt-5.4",
+		antigravity: "gemini-3.5-flash",
 		gemini: "gemini-2.5-flash",
 	},
 	fast: {
 		"claude-code": "haiku",
-		codex: "gpt-4.1-nano",
-		opencode: "haiku",
-		antigravity: "haiku",
+		codex: "gpt-5.4-mini",
+		antigravity: "gemini-3.5-flash",
 		gemini: "gemini-2.5-flash",
 	},
 } as const;
@@ -77,75 +74,28 @@ interface EffortFieldConfig {
 }
 
 /**
- * Clamp effort levels to the three-level vocabulary (low/medium/high)
- * supported by OpenAI and Codex platforms. xhigh and max map to high.
+ * Clamp effort to Codex's vocabulary: Codex reasoning effort tops out at
+ * xhigh, so max → xhigh; all other levels pass through unchanged.
  */
-function clampToThreeLevels(effort: EffortLevel): string {
-	if (effort === "xhigh" || effort === "max") return "high";
-	return effort;
-}
-
-// Every model produced by TIER_MODEL_MAP MUST have an entry here;
-// add new model classes in one place.
-const MODEL_PROVIDER: Readonly<
-	Record<string, "anthropic" | "openai" | "google">
-> = {
-	fable: "anthropic",
-	opus: "anthropic",
-	sonnet: "anthropic",
-	haiku: "anthropic",
-	o3: "openai",
-	"o4-mini": "openai",
-	"gpt-4.1-nano": "openai",
-	"gemini-2.5-pro": "google",
-	"gemini-2.5-flash": "google",
-};
-
-/**
- * Derive the model provider from a resolved model identifier.
- * Used by OpenCode to select the correct effort pass-through field name.
- *
- * Looks up the explicit MODEL_PROVIDER registry (case-insensitive fallback).
- * Returns "unknown" for unrecognized models.
- */
-function deriveProvider(
-	resolvedModel: string,
-): "anthropic" | "openai" | "google" | "unknown" {
-	const direct = MODEL_PROVIDER[resolvedModel];
-	if (direct) return direct;
-	const lower = MODEL_PROVIDER[resolvedModel.toLowerCase()];
-	if (lower) return lower;
-	return "unknown";
+function clampToCodexEffort(effort: EffortLevel): string {
+	return effort === "max" ? "xhigh" : effort;
 }
 
 /**
- * OpenCode effort field configs keyed by derived provider.
- * Anthropic models on OpenCode do not support per-agent effort pass-through.
- */
-const OPENCODE_PROVIDER_EFFORT: Readonly<
-	Record<string, EffortFieldConfig | null>
-> = {
-	openai: { fieldName: "reasoningEffort", mapValue: clampToThreeLevels },
-	anthropic: null,
-	google: null,
-	unknown: null,
-};
-
-/**
- * Direct platform effort configurations (non-provider-dependent).
- * Platforms not listed (copilot) or with null values do not support
- * per-agent effort control.
+ * Per-platform effort configurations.
+ * Platforms with null or not listed do not support per-agent effort control.
  */
 const PLATFORM_EFFORT: Readonly<
 	Partial<Record<BuildPlatform, EffortFieldConfig | null>>
 > = {
-	"claude-code": { fieldName: "effort", mapValue: (e) => e },
+	"claude-code": { fieldName: "effort", mapValue: (e) => e }, // supports all 5 levels incl max
 	codex: {
 		fieldName: "model_reasoning_effort",
-		mapValue: clampToThreeLevels,
+		mapValue: clampToCodexEffort,
 	},
 	antigravity: null,
 	gemini: null,
+	opencode: null,
 	copilot: null,
 };
 
@@ -169,38 +119,22 @@ export function resolveTier(
 }
 
 /**
- * Resolve an effort level to the platform/provider-specific field name and value.
- *
- * For OpenCode, the provider is derived from the resolved model ID to select
- * the correct pass-through field name (e.g., `reasoningEffort` for OpenAI).
+ * Resolve an effort level to the platform-specific field name and value.
  *
  * @returns `{ fieldName, value }` for platforms that support per-agent effort,
  *   or null when:
  *   - effort is undefined (not declared)
  *   - tier is "fast" (fast-tier models do not support effort control)
- *   - the platform/provider does not support per-agent effort
+ *   - the platform does not support per-agent effort
  */
 export function resolveEffort(
 	effort: EffortLevel | undefined,
 	tier: ModelTier,
 	platform: BuildPlatform,
-	resolvedModel: string | null,
 ): EffortResolution | null {
 	if (effort === undefined) return null;
 	if (tier === "fast") return null;
 
-	// OpenCode: provider-dependent effort field.
-	// When tier is "inherit", resolvedModel is null (the session model is
-	// unknown at build time), so provider resolves to "unknown" and effort
-	// is correctly omitted — the runtime session model determines behavior.
-	if (platform === "opencode") {
-		const provider = resolvedModel ? deriveProvider(resolvedModel) : "unknown";
-		const config = OPENCODE_PROVIDER_EFFORT[provider];
-		if (!config) return null;
-		return { fieldName: config.fieldName, value: config.mapValue(effort) };
-	}
-
-	// Other platforms: direct lookup
 	const config = PLATFORM_EFFORT[platform];
 	if (!config) return null;
 	return { fieldName: config.fieldName, value: config.mapValue(effort) };


### PR DESCRIPTION
## Summary

Patch to the per-step model tiering shipped in #409. The per-harness model mappings were outdated for **Codex** and **Antigravity**, **OpenCode** shouldn't be tiered, and **Codex** effort handling incorrectly clamped away `xhigh`.

## Corrected model mappings (`cli/src/build/tier-resolution.ts`)

| rp1 tier | claude-code | codex | antigravity | gemini¹ |
|----------|-------------|-------|-------------|---------|
| frontier | `fable` | `gpt-5.5` | `gemini-3.1-pro` | `gemini-2.5-pro` |
| deep | `opus` | `gpt-5.5` | `gemini-3.1-pro` | `gemini-2.5-pro` |
| standard | `sonnet` | `gpt-5.4` | `gemini-3.5-flash` | `gemini-2.5-flash` |
| fast | `haiku` | `gpt-5.4-mini` | `gemini-3.5-flash` | `gemini-2.5-flash` |
| **opencode** | — inherits session model (removed from the map, like copilot) — |

¹ Gemini CLI left on `2.5` — out of scope for this patch; bump separately if needed.

## Also fixed

- **Codex effort supports `xhigh`.** Replaced the 3-level clamp with a Codex mapper that passes `xhigh` through and maps `max → xhigh` (Codex reasoning effort tops out at `xhigh`; `gpt-5.4-mini` caps at `high`).
- **OpenCode inherits cleanly.** `command.ts` unmapped-platform fallback changed from the raw tier alias to `"inherit"`, so no harness can emit an invalid literal like `model: deep` (fixes a latent alias-leak that would have surfaced once OpenCode was unmapped).
- **Dead code stripped.** Removed `deriveProvider` / `MODEL_PROVIDER` / `OPENCODE_PROVIDER_EFFORT` / `clampToThreeLevels`; `resolveEffort` drops its now-unused `resolvedModel` parameter.

## Validation

- `tsc --noEmit` clean; **829/829** build tests pass.
- Golden files regenerated under production `greedy:true`; Codex TOML re-validated as parseable.
- End-to-end: building the dev plugin for OpenCode emits **0** `model:` fields (all inherit).
- Scope: code + tests only — no agent frontmatter or catalog changes.

## Notes

Model IDs remain hardcoded defaults. A follow-up could make them overridable via `.rp1/config/` (deep-merged over defaults) so future model-class churn is a config edit rather than a code change — deferred by choice to keep this patch minimal.

🤖 Generated using: 🎮 [rp1.run](https://rp1.run)
