### PR TITLE
fix(build): dispatch ready task waves in parallel

### DIFF
--- a/catalog/agents.yaml
+++ b/catalog/agents.yaml
@@ -202,7 +202,7 @@ agents:
   - name: rp1-dev:task-builder
     description: "Implements assigned task(s) w/ full context, writes summaries to the resolved task file. Uses extended thinking (or ultrathink)."
     plugin: dev
-    last_checksum: 0e5027e8f818ad9152ce9346c7f075c2146903797bf4f0a62962e069d82ed3f5
+    last_checksum: af9935b641aa18addcaa5125ab269946dc37bffb3ba3f3e510cddb7816aa43f0
   - name: rp1-dev:task-reviewer
     description: "Verifies builder's work for discipline, accuracy, completeness, and commit quality. Returns SUCCESS or FAILURE with actionable feedback. Uses extended thinking for careful verification."
     plugin: dev

--- a/cli/src/__tests__/build/build-v2-contracts.test.ts
+++ b/cli/src/__tests__/build/build-v2-contracts.test.ts
@@ -231,6 +231,56 @@ describe("Build v2 static contracts", () => {
 		expect(content).not.toContain("build-task-grouper");
 	});
 
+	test("implementation checks the ready wave before falling back to serial dispatch", async () => {
+		const content = await readProjectFile("plugins/dev/skills/build/SKILL.md");
+
+		const readySetIndex = content.indexOf("#### Ready-Set Derivation");
+		const pipelinedIndex = content.indexOf("#### Pipelined Dispatch");
+		const parallelWaveIndex = content.indexOf("#### Parallel-Wave Mode");
+
+		expect(readySetIndex).toBeGreaterThan(-1);
+		expect(pipelinedIndex).toBeGreaterThan(readySetIndex);
+		expect(parallelWaveIndex).toBeGreaterThan(pipelinedIndex);
+		expect(content).toContain(
+			"Before every dispatch cycle, recalculate `READY_UNITS`",
+		);
+		expect(content).toContain(
+			"Do not require one builder to finish before checking for a ready wave.",
+		);
+		expect(content).toContain(
+			"If `READY_UNITS` has 2+ entries and all Parallel-Wave Mode preconditions pass, use Parallel-Wave Mode immediately.",
+		);
+		expect(content).toContain(
+			"At the start of each dispatch cycle, before selecting a serial unit",
+		);
+		expect(content).toContain("Default no-commit builds are serial.");
+	});
+
+	test("parallel builder reference integrates secondary work only after primary review succeeds", async () => {
+		const build = await readProjectFile("plugins/dev/skills/build/SKILL.md");
+		const reference = await readProjectFile(
+			"plugins/dev/skills/build/references/parallel-builders.md",
+		);
+		const builder = await readProjectFile("plugins/dev/agents/task-builder.md");
+
+		expect(build).toContain(
+			"Dispatch reviewer(k) on the primary `codeRoot` before integrating the secondary worktree.",
+		);
+		expect(build).toContain(
+			"If reviewer(k) fails or is malformed, abandon the secondary worktree",
+		);
+		expect(reference).toContain(
+			"After both builders complete and reviewer(k) succeeds on the primary branch",
+		);
+		expect(reference).toContain(
+			"If reviewer(k) fails after both builders succeeded:",
+		);
+		expect(builder).toContain(".task-file.lock");
+		expect(builder).toContain(
+			"Run Sections 4.1 through 4.3 while holding the lock.",
+		);
+	});
+
 	test("task plan machine schema includes targets for code and docs parity", async () => {
 		const tasker = await readProjectFile(
 			"plugins/dev/agents/feature-tasker.md",

--- a/plugins/dev/agents/task-builder.md
+++ b/plugins/dev/agents/task-builder.md
@@ -277,7 +277,7 @@ After implementing all assigned tasks, embed a `stateDiagram-v2` fenced mermaid 
 
 1. Generate the diagram content using actual task IDs as state names and task descriptions as labels. For single tasks, produce a simple `[*] --> TaskState --> [*]` diagram.
 
-2. **Feature mode**: Embed the diagram in the resolved task file (`tasks.md` or legacy `milestone-{N}.md`) as an `**Execution Flow**` block after the implementation summary for the last task in the batch (see Section 4.2 for placement).
+2. **Feature mode**: Generate the diagram content now. Write it to the resolved task file (`tasks.md` or legacy `milestone-{N}.md`) during Section 4, under the task-file lock, as an `**Execution Flow**` block after the implementation summary for the last task in the batch (see Section 4.2 for placement).
 
    **Quick-build mode**: Embed the diagram in the quick-build artifact after the Implementation Summary table.
 
@@ -334,6 +334,21 @@ This is the default. Most runs skip this section entirely.
 Commit rules: only source code files you modified, no `.rp1/` work files, no unrelated files, one commit per task. Amend is only permitted when `REWRITE_COMMITS=true`.
 
 ## 4. Task File Update
+
+Feature mode updates the shared task markdown file, so protect this read-modify-write sequence with a lock:
+
+```bash
+LOCK_DIR="{WORK_ROOT}/features/{FEATURE_ID}/.task-file.lock"
+while ! mkdir "$LOCK_DIR" 2>/dev/null; do sleep 2; done
+```
+
+Run Sections 4.1 through 4.3 while holding the lock. Always release it after the task file has been written:
+
+```bash
+rmdir "$LOCK_DIR"
+```
+
+If the process fails after acquiring the lock, remove the lock before returning failure. In quick-build mode, use the same lock pattern next to `{QUICK_BUILD_PATH}` when updating the quick-build artifact.
 
 ### 4.1 Mark Complete (MUST DO IF IMPLEMENTED)
 

--- a/plugins/dev/skills/build/SKILL.md
+++ b/plugins/dev/skills/build/SKILL.md
@@ -378,11 +378,15 @@ Initialize before the first dispatch:
 - `COMPLETED_UNIT_TASK_IDS` = `{}` (set of task IDs from units whose reviewer returned SUCCESS).
 - `UNIT_LOOKUP` = map from each task ID to its parent `task_unit.unit_id`, built once from all `task_units`.
 
-A unit is **ready** when every task ID in its `depends_on` is in `COMPLETED_UNIT_TASK_IDS`. Units with empty `depends_on` are ready immediately. Pick the next ready unit by lowest `unit_id`. If no unit is ready and uncompleted units remain, emit `implementation` waiting with `reason: "dependency_deadlock"` and STOP.
+A unit is **ready** when every task ID in its `depends_on` is in `COMPLETED_UNIT_TASK_IDS`. Units with empty `depends_on` are ready immediately.
+
+Before every dispatch cycle, recalculate `READY_UNITS` from unbuilt units, sorted by lowest `unit_id`. Do not require one builder to finish before checking for a ready wave. If no unit is ready and uncompleted units remain, emit `implementation` waiting with `reason: "dependency_deadlock"` and STOP.
+
+If `READY_UNITS` has 2+ entries and all Parallel-Wave Mode preconditions pass, use Parallel-Wave Mode immediately. Otherwise pick the first ready unit by lowest `unit_id` and use the serial-pipelined dispatch below.
 
 #### Pipelined Dispatch
 
-For each ready unit **k**, dispatch the builder:
+For each selected ready unit **k**, dispatch the builder:
 
 {% dispatch_agent "rp1-dev:task-builder" %}
 FEATURE_ID={FEATURE_ID}, KB_ROOT={kbRoot}, WORK_ROOT={workRoot}, CODE_ROOT={codeRoot}, TASK_IDS={TASK_UNIT_IDS}, GIT_COMMIT={GIT_COMMIT}, WORKFLOW=build, RUN_ID={RUN_ID}
@@ -455,6 +459,7 @@ Escalate without marking parent `implementation` failed while recovery remains.
 7. **Overlapping file lists never concurrent.** If two units' task file lists share any source file path, they MUST NOT be in flight together — this applies to pipelined reviewer(k) ∥ builder(k+1) dispatch as well as parallel-wave builders. Fall back to strictly serial dispatch for those units.
 8. **Serial fallback.** When in doubt about preconditions, file overlap, or worktree health, fall back to the serial pipelined path. Parallel-wave is an optimization, not a requirement.
 9. **Emit namespacing unchanged.** Both primary and secondary builders emit with the same `task-builder:` step prefix. The `--unit` parameter distinguishes their events.
+10. **Default no-commit builds are serial.** When `GIT_COMMIT=false`, parallel groups in `tasks.md` describe dependency windows, but builder execution stays serial-pipelined because there is no atomic commit to replay from a worktree.
 
 #### Parallel-Wave Mode
 
@@ -465,27 +470,23 @@ When ALL of the following preconditions are met, dispatch two builders concurren
 3. The ready set contains 2+ units with no mutual dependency (neither unit's `depends_on` includes the other's task IDs).
 4. The two candidate units' task file lists have no overlapping source file paths.
 
-**Trigger**: After builder(k) completes and the next ready unit k+1 is pipeline-eligible, check whether a second ready unit k+2 also exists and is pipeline-eligible (no dependency on k or k+1, no file overlap with k+1). If so, dispatch reviewer(k) on the primary `codeRoot`, builder(k+1) on the primary `codeRoot`, and builder(k+2) on a worktree `codeRoot` -- all three as parallel agents in a single message.
+**Trigger**: At the start of each dispatch cycle, before selecting a serial unit, compute the current ready wave. If at least two ready units are mutually independent and file-disjoint, dispatch the first unit as primary builder(k) on `codeRoot` and the second unit as secondary builder(k+1) on a worktree `codeRoot` in a single message.
 
-If only one additional ready unit exists, use the standard pipelined dispatch (reviewer(k) + builder(k+1)).
+If fewer than two ready units qualify, use the standard serial-pipelined dispatch.
 
 **Dispatch**:
 
-{% dispatch_agent "rp1-dev:task-reviewer", background %}
+{% dispatch_agent "rp1-dev:task-builder", background %}
 FEATURE_ID={FEATURE_ID}, KB_ROOT={kbRoot}, WORK_ROOT={workRoot}, CODE_ROOT={codeRoot}, TASK_IDS={TASK_UNIT_IDS_K}, GIT_COMMIT={GIT_COMMIT}, WORKFLOW=build, RUN_ID={RUN_ID}
 {% enddispatch_agent %}
 
 {% dispatch_agent "rp1-dev:task-builder", background %}
-FEATURE_ID={FEATURE_ID}, KB_ROOT={kbRoot}, WORK_ROOT={workRoot}, CODE_ROOT={codeRoot}, TASK_IDS={TASK_UNIT_IDS_K1}, GIT_COMMIT={GIT_COMMIT}, WORKFLOW=build, RUN_ID={RUN_ID}
+FEATURE_ID={FEATURE_ID}, KB_ROOT={kbRoot}, WORK_ROOT={workRoot}, CODE_ROOT={worktreePath}, TASK_IDS={TASK_UNIT_IDS_K1}, GIT_COMMIT={GIT_COMMIT}, WORKFLOW=build, RUN_ID={RUN_ID}
 {% enddispatch_agent %}
 
-{% dispatch_agent "rp1-dev:task-builder", background %}
-FEATURE_ID={FEATURE_ID}, KB_ROOT={kbRoot}, WORK_ROOT={workRoot}, CODE_ROOT={worktreePath}, TASK_IDS={TASK_UNIT_IDS_K2}, GIT_COMMIT={GIT_COMMIT}, WORKFLOW=build, RUN_ID={RUN_ID}
-{% enddispatch_agent %}
+Wait for both builders to complete. Dispatch reviewer(k) on the primary `codeRoot` before integrating the secondary worktree. If reviewer(k) fails or is malformed, abandon the secondary worktree, retry or escalate k per the Reviewer Failure sections, and rebuild k+1 later from the serial path after k passes. If reviewer(k) succeeds, add k's task IDs to `COMPLETED_UNIT_TASK_IDS`, then integrate the secondary worktree per `references/parallel-builders.md` and dispatch reviewer(k+1) on the primary `codeRoot`.
 
-Wait for all three to complete. Process reviewer(k) result first. Then integrate the worktree per `references/parallel-builders.md` before dispatching any reviewer for k+1 or k+2.
-
-**Integration order**: After both builders finish, integrate the worktree branch (k+2) onto the primary branch per the Integration section in `references/parallel-builders.md`. If integration fails, apply the Conflict Fallback procedure (discard worktree, rebuild k+2 serially). Then dispatch reviewers for k+1 and k+2 using the standard serial or pipelined path.
+**Integration order**: After both builders finish and reviewer(k) succeeds, integrate the worktree branch (k+1) onto the primary branch per the Integration section in `references/parallel-builders.md`. If integration fails, apply the Conflict Fallback procedure (discard worktree, rebuild k+1 serially). Then dispatch reviewer(k+1) using the standard serial or pipelined path.
 
 See `references/parallel-builders.md` for the full worktree lifecycle protocol: creation, CODE_ROOT routing, integration, conflict fallback, cleanup, and failure handling.
 

--- a/plugins/dev/skills/build/references/parallel-builders.md
+++ b/plugins/dev/skills/build/references/parallel-builders.md
@@ -32,7 +32,7 @@ The two builders receive different `CODE_ROOT` values; work artifacts stay canon
 
 ## Integration
 
-After both builders complete and before dispatching any reviewer, integrate the secondary builder's worktree commits onto the primary branch:
+After both builders complete and reviewer(k) succeeds on the primary branch, integrate the secondary builder's worktree commits onto the primary branch:
 
 1. Verify the worktree branch carries exactly one commit beyond its **fork point** -- the commit `HEAD` pointed at when the worktree was created (`git rev-list --count {forkPoint}..build-wt/{FEATURE_ID}/{unit_id}` = 1). Do not count against the current primary `HEAD`: the primary builder may have added one or more commits since the fork, and that is expected -- the rebase below replays the worktree's single commit onto whatever the primary `HEAD` is now.
 2. From the primary `codeRoot`, rebase the worktree branch:
@@ -47,7 +47,7 @@ git -C "{codeRoot}" rebase HEAD "build-wt/{FEATURE_ID}/{unit_id}"
 git -C "{codeRoot}" merge --ff-only "build-wt/{FEATURE_ID}/{unit_id}"
 ```
 
-4. If both rebase and fast-forward succeed, proceed to dispatch reviewer(k) and reviewer(k+1) sequentially, or pipeline reviewer(k) with the next ready builder if one exists.
+4. If both rebase and fast-forward succeed, proceed to dispatch reviewer(k+1), or pipeline reviewer(k+1) with the next ready builder if one exists.
 
 ## Conflict Fallback
 
@@ -75,8 +75,15 @@ If the primary builder failed while the secondary succeeded:
 1. Do not integrate the secondary's worktree yet.
 2. Clean up the primary builder's failed state.
 3. Retry the primary builder on `codeRoot` per the normal retry path.
-4. Only after the primary unit succeeds, attempt integration of the secondary worktree.
+4. Only after the primary unit succeeds and reviewer(k) passes, attempt integration of the secondary worktree.
 5. If the retry window is exhausted for the primary, escalate per section 4.3.7. The secondary worktree is abandoned alongside the primary.
+
+If reviewer(k) fails after both builders succeeded:
+
+1. Do not integrate the secondary worktree.
+2. Clean up the worktree and branch per the Cleanup section.
+3. Retry or escalate unit k per the parent build prompt.
+4. Re-dispatch unit k+1's builder serially after unit k passes review.
 
 ## Cleanup
 


### PR DESCRIPTION
## Summary

- Recomputes build ready units before selecting a serial task so eligible ready waves can use parallel-wave builders immediately.
- Updates the parallel builder worktree flow so secondary work is integrated only after the primary unit passes review.
- Adds a task-file lock around task-builder updates to shared task markdown, plus static contract coverage and the generated task-builder catalog checksum.

## Root Cause

The build prompt documented parallel task groups, but the orchestration path only considered parallel-wave mode after one builder had already completed. That meant an initially ready group could be serialized before the workflow ever checked for concurrent builders. Default no-commit builds also remain serial because there is no atomic commit to replay from a worktree.

## Validation

- `bun test src/__tests__/build/build-v2-contracts.test.ts src/__tests__/agent-tools/build-task-plan/build-task-plan.test.ts`
- `just check-cli`
- `just build-plugins-check`
- `just catalog-generate`

## Notes

- Prompt attestations were not refreshed for this PR. The Docker eval run attempted during publish failed while installing dependencies with `SELF_SIGNED_CERT_IN_CHAIN`, and the attestation refresh was explicitly waived for this draft.
