### PR TITLE
feat(settings): user-controllable model & effort tier remapping via late-bound resolution

### DIFF
--- a/.rp1/context/architecture.md
+++ b/.rp1/context/architecture.md
@@ -2,19 +2,20 @@
 
 **Project**: rp1
 **Architecture Pattern**: Plugin-based CLI with tracked workflow state, artifact-backed handoffs, and multi-platform prompt compilation
-**Last Updated**: 2026-06-30
+**Last Updated**: 2026-07-03
 
-rp1 is a Bun/TypeScript CLI + plugin monorepo that compiles markdown-defined skills and agents into host-specific artifacts, tracks workflow runtime state as events, and serves a live Arcade dashboard.
+rp1 is a Bun/TypeScript CLI + plugin monorepo that compiles markdown-defined skills and agents into host-specific artifacts, tracks workflow runtime state as events, serves a live Arcade dashboard, and lets users remap agent model tiers on their own machines at install time.
 
 ## High-Level Architecture
 
 ```mermaid
 flowchart TB
-    Host["Host Tools<br/>Claude Code / OpenCode / Codex"] --> CLI["rp1 CLI<br/>cli/src/main.ts"]
+    Host["Host Tools<br/>Claude Code / OpenCode / Codex / Copilot / Antigravity"] --> CLI["rp1 CLI<br/>cli/src/main.ts"]
     CLI --> Skills["Plugin Skills & Agents<br/>plugins/base, dev, utils"]
     CLI --> AgentTools["Agent Tools<br/>emit, workflow-bootstrap, resolve-args"]
     CLI --> Build["Build Pipeline"]
     CLI --> Catalog["Catalog Registry"]
+    CLI --> Settings["Settings<br/>apply, presets, rewriter"]
     AgentTools --> EventDB[("~/.rp1/rp1.db")]
     AgentTools --> Daemon["Arcade Daemon<br/>HTTP + WS"]
     Daemon --> Browser["Web Browser"]
@@ -22,16 +23,22 @@ flowchart TB
     Skills --> KB[".rp1/context KB"]
     Skills --> Work[".rp1/work artifacts"]
     Build --> Parse["parser"]
-    Parse --> Validate["validator<br/>tier + effort"]
-    Validate --> TierRes["tier-resolution<br/>resolveTier / resolveEffort"]
+    Parse --> Validate["validator<br/>tier + effort + protected"]
+    Validate --> TierRes["tier-resolution<br/>frontier/deep/standard/fast"]
     TierRes --> Render["LiquidJS templates"]
-    Render --> Artifacts["dist platform artifacts"]
+    Render --> Artifacts["dist platform artifacts<br/>+ BundleAgentEntry metadata"]
+    Settings --> Presets["budget / standard / premium"]
+    Settings --> Rewriter["artifact rewriter<br/>.md frontmatter / .toml"]
+    Settings --> TierRes
+    Rewriter --> Artifacts
 ```
 
 ## Architectural Patterns
 
-- **Cross-Platform Build Pipeline** — single-source agent/skill markdown compiles to 6 targets (Claude Code, OpenCode, Codex, Copilot, Antigravity, Gemini) via data-driven `PlatformDefinition` configs + LiquidJS templates.
-- **Additive-Field Tier Resolution** — agent `model` tier (deep/standard/fast/inherit) and `effort` (low–max) are resolved at build time from abstract aliases to platform-specific model IDs and effort field names, propagated as additive fields through the template context so templates stay format-only. (New in tiered-models-effort.)
+- **Cross-Platform Build Pipeline** — single-source agent/skill markdown compiles to 5 targets (Claude Code, OpenCode, Codex, Copilot, Antigravity) via data-driven `PlatformDefinition` configs + LiquidJS templates. (Gemini platform removed.)
+- **Additive-Field Tier Resolution with Frontier Tier** — agent `model` tier (frontier/deep/standard/fast/inherit) and `effort` (low–max) are resolved at build time from abstract aliases to platform-specific model IDs. Frontier maps to fable (CC), gpt-5.5 (Codex), gemini-3.1-pro (Antigravity); Codex clamps effort `max`→`xhigh`; OpenCode provider-dependent effort logic removed.
+- **Install-Time Tier Remapping** — user-controlled post-install model remapping via `settings.toml` `[models.<platform>]` sections or presets (budget/standard/premium): load → validate against `TIER_MODEL_MAP` → discover agents from bundle metadata → rewrite CC (.md frontmatter) and Codex (.toml) artifacts in place → strip effort on fast-class remaps → warn on protected-agent downgrades. `rp1 update` re-applies automatically (try/catch isolated).
+- **Protected Agent Downgrade Guards** — 14 reasoning-critical agents flagged in `PROTECTED_AGENTS`; build and remapping emit warnings via `TIER_RANK` comparison when they would drop below deep.
 - **Event-Sourced Runtime State** — all workflow state changes are `rp1 agent-tools emit` events persisted to SQLite and broadcast over WebSocket.
 - **State-Machine-Driven Workflows** — skills declare `stateDiagram-v2` phases; steps are validated against the graph at emit time.
 - **Map-Reduce Agent Orchestration** — heavy analysis fans out to narrow workers and rejoins through a parent orchestrator (KB build, PR review).
@@ -47,14 +54,15 @@ flowchart TB
 | Interaction | User-facing CLI commands, host tool integration | `cli/src/commands/` |
 | Workflow Definition | Plugin skills + agents | `plugins/{base,dev,utils}/` |
 | Runtime Services | Agent tools, emit, bootstrap, resolve-args | `cli/src/agent-tools/` |
-| Build & Distribution | Multi-platform compile with tier resolution, validation, rendering | `cli/src/build/`, `cli/src/catalog/` |
+| Build & Distribution | Multi-platform compile with tier resolution, validation, rendering, and install-time remapping | `cli/src/build/`, `cli/src/catalog/`, `cli/src/settings/` |
 | Presentation | Arcade SPA with real-time WS | `cli/web-ui/` |
-| Persistence | SQLite event store, KB, work artifacts | `~/.rp1/rp1.db`, `.rp1/context/`, `.rp1/work/` |
+| Persistence | SQLite event store, KB, work artifacts, settings | `~/.rp1/rp1.db`, `.rp1/context/`, `.rp1/work/`, `settings.toml` |
 | Evaluation | Dockerized prompt evals | `evals/` |
 
 ## Data Flows
 
-- **Build Pipeline (per-agent artifact)**: parse frontmatter (model tier + effort) → validate tier/effort/protected for all platforms → preprocess includes/conditionals → `resolveTier` → concrete model ID → `resolveEffort` → provider-specific `{fieldName, value}` → build `AgentArtifactData` → render platform Liquid template (conditional emit) → lint → write platform artifacts.
+- **Build Pipeline (per-agent artifact)**: parse frontmatter (model tier + effort) → validate tier/effort/protected → preprocess → `resolveTier` → concrete model ID → `resolveEffort` → `{fieldName, value}` → build `AgentArtifactData` + `BundleAgentEntry` (tier/effort metadata) → render platform Liquid template → lint → write platform artifacts.
+- **Install-Time Tier Remapping**: load `[models]` from project+user settings.toml (project wins) → resolve preset if any → validate (platforms, model IDs, effort compatibility) → discover installed agents via `BundleAgentEntry` metadata in the embedded manifest → rewrite artifacts → report modified / already-current / effort adjustments / protected warnings. Dry-run previews without writing.
 - **Event Pipeline**: skill/agent emits event → state-machine validation → SQLite persist → HTTP daemon notify → WebSocket broadcast to Arcade.
 - **KB Generation**: orchestrator selects mode (FULL/INCREMENTAL/FEATURE_LEARNING) → spatial analysis → parallel specialist agents → reconcile → write `.rp1/context/*.md` + `state.json`.
 
@@ -66,7 +74,7 @@ flowchart TB
 
 ## Deployment
 
-Single-executable CLI per platform (darwin/linux/windows) via GitHub releases, plus a background Bun HTTP+WS daemon on port 7710 with PID-file lifecycle, version-aware restart, and NDJSON diagnostics. Config dir is OS-specific.
+Single-executable CLI per platform (darwin/linux/windows) via GitHub releases, plus a background Bun HTTP+WS daemon on port 7710 with PID-file lifecycle, version-aware restart, and NDJSON diagnostics. Config dir is OS-specific. Agent tier metadata ships inside the binary's embedded manifest, enabling settings-driven remapping without source access.
 
 ## Related KB
 

--- a/.rp1/context/concept_map.md
+++ b/.rp1/context/concept_map.md
@@ -24,12 +24,18 @@
 | Workflow Bootstrap | entity | Auto-injected initialization step resolving arguments, directories, and run identity in one atomic call |
 | Discovery Registry | entity | Canonical skill catalog built from frontmatter at build time. Drives CATALOG.md, init awareness blocks, `rp1 list --json`, and ambient suggestions |
 | Arcade Tracked | mechanism | Optional `metadata.arcade_tracked` boolean controlling Activity feed visibility without disabling workflow mechanics |
-| Platform Definition | entity | Data-driven build configuration capturing platform-varying behavior: registry, templates, naming, lifecycle hooks |
+| Platform Definition | entity | Data-driven build configuration capturing platform-varying behavior. Supported platforms: claude-code, opencode, codex, copilot, antigravity |
 | Subflow | entity | Nested workflow registered within a parent run via `subflow_registered` event type |
-| ModelTier | entity | Abstract model alias (`deep`, `standard`, `fast`, `inherit`) declared in agent frontmatter, decoupling agent definitions from vendor-specific model identifiers. Resolved to platform-specific concrete model IDs at build time via `TIER_MODEL_MAP` |
-| EffortLevel | entity | Reasoning-depth control (`low`, `medium`, `high`, `xhigh`, `max`) declared independently of model tier in agent frontmatter. Resolved to platform-specific field names and values at build time; incompatible with the fast tier |
-| TIER_MODEL_MAP | mechanism | Centralized resolution dictionary mapping each abstract tier to concrete platform model IDs for Claude Code, Codex, OpenCode, Antigravity, and Gemini. Single-update-propagates-to-all-agents design |
-| Protected Agents | mechanism | Set of 14 reasoning-critical agents (feature-architect, phase-planner, security-validator, pr-sub-reviewer, etc.) that must remain on the deep tier. Build emits a warning (not error) when downgraded, allowing intentional experiments |
+| ModelTier | entity | Abstract model alias (`frontier`, `deep`, `standard`, `fast`, `inherit`) declared in agent frontmatter, decoupling agents from vendor model IDs. Ordered by `TIER_RANK` (frontier=3, deep=2, standard=1, fast=0); `inherit` unranked (session model). Resolved at build time via `TIER_MODEL_MAP` |
+| EffortLevel | entity | Reasoning-depth control (`low`, `medium`, `high`, `xhigh`, `max`) declared independently of tier. Resolved to platform-specific field names at build time; incompatible with the fast tier |
+| TIER_MODEL_MAP | mechanism | Exported resolution dictionary mapping each tier (frontier/deep/standard/fast) to concrete model IDs for Claude Code, Codex, and Antigravity (OpenCode/Copilot omitted — no per-agent tiering). Single source of truth for build AND install-time remapping |
+| TIER_RANK | mechanism | Ordered numeric rank for tier comparison. Used by protected-agent downgrade checks at build and remap time — compares capability level, not name equality |
+| Protected Agents | mechanism | Set of 14 reasoning-critical agents (feature-architect, phase-planner, security-validator, pr-sub-reviewer, task-reviewer, …) that must stay at or above deep. Build and remapping warn (never block) on downgrade |
+| BundleAgentEntry | entity | Bundle asset entry extended with optional tier/effort metadata, carried through manifests and the embedded manifest so install-time remapping needs no source frontmatter |
+| TierRemappingConfig | entity | User-declared remapping from `settings.toml` `[models]`: optional preset name + per-platform `[models.<platform>]` tier overrides (explicit entries beat preset values) |
+| Preset | entity | Blessed tier-to-model profile (`budget`, `standard`, `premium`) for CC + Codex. Budget = fast-class everywhere; standard = deep collapses to sonnet-class; premium = build defaults |
+| Artifact Rewriter | mechanism | Pure-function module rewriting installed agent artifacts per remapping: CC YAML frontmatter, Codex TOML line replacement; strips effort on fast-class remaps; warns on protected downgrades |
+| Task File Lock | mechanism | Directory-based lock (`mkdir .task-file.lock`) serializing concurrent task-file updates during parallel builder execution |
 
 ## Key Terminology
 
@@ -55,12 +61,13 @@
 | Document Kind | Requested or inferred document shape selecting default structure (auto, blog-post, technical-proposal, feedback) |
 | Section Scenario | Doc-sync classification for a section: `verify`, `add`, or `fix` |
 | Logical Step Key | Collapsed step identifier for dashboard grouping: non-namespaced steps keep their ID; namespaced lifecycle steps collapse to namespace prefix |
-| Model Tier | Abstract alias (`deep`, `standard`, `fast`, `inherit`) for agent model selection. `deep` = frontier reasoning model, `standard` = capable general-purpose model, `fast` = cheapest single-pass model, `inherit` = session model (backward-compatible default) |
-| Effort Level | Reasoning-depth control independent of model tier: `low`, `medium`, `high`, `xhigh`, `max`. Omitted for fast-tier agents. Platform-specific field names: `effort` (Claude Code), `model_reasoning_effort` (Codex), `reasoningEffort` (OpenCode/OpenAI provider) |
-| Tier Resolution | Build-time process that maps an abstract ModelTier + platform to a concrete vendor model ID via `TIER_MODEL_MAP`, and maps EffortLevel + platform to a provider-specific field name and value via `resolveEffort()` |
-| Protected Agent | One of 14 reasoning-critical agents that must remain on the deep tier; build emits a warning (not error) on downgrade attempt |
-| Effort Clamping | Mapping `xhigh` and `max` effort levels to `high` for platforms supporting only three-level effort vocabulary (OpenAI/Codex) |
-| Provider-Aware Effort | OpenCode effort resolution that derives the model provider (Anthropic vs OpenAI) from the resolved model ID to select the correct pass-through field name |
+| Model Tier | Abstract alias for agent model selection. `frontier` = maximum-capability (fable on CC), `deep` = frontier reasoning (opus), `standard` = capable general-purpose (sonnet), `fast` = cheapest single-pass (haiku), `inherit` = session model (default) |
+| Effort Level | Reasoning-depth control independent of tier: `low`–`max`. Omitted for fast tier. Field names: `effort` (CC, all 5 levels), `model_reasoning_effort` (Codex, `max` clamps to `xhigh`) |
+| Tier Resolution | Build-time mapping of ModelTier + platform → concrete model ID via `TIER_MODEL_MAP`, and EffortLevel + platform → field name/value via `resolveEffort()` |
+| Tier Remapping | Install-time process applying `[models]` settings to rewrite installed agent artifacts without rebuilding: load → validate → discover via bundle metadata → rewrite → report. Idempotent (re-runs report "already up to date") |
+| RemappableTier | Preset-exposed tier subset: `deep`, `standard`, `fast` (`frontier` and `inherit` excluded from presets) |
+| Effort Clamping | Codex-specific `max` → `xhigh` mapping (Codex supports four levels); CC supports all five natively |
+| Hermetic Settings Seam | Optional `globalSettingsPath` parameter on settings loaders/resolvers isolating tests from real `~/.config/rp1/settings.toml` |
 
 ## Relationships
 
@@ -69,23 +76,25 @@ Plugin ──contains──> Skill, Agent
 Skill ──delegates to──> Agent
 Skill ──embeds──> State Machine
 Skill ──enrolls in──> Discovery Registry
-Skill ──declares──> Arcade Tracked
 State Machine ──governs──> Run
 Run ──contains──> Event
 Run ──produces──> Artifact
 Run ──triggers──> Notification
 Artifact ──anchors──> Annotation
 Knowledge Base ──grounds──> Documentation Synchronization
-Knowledge Base ──informs──> Content Workflow
 Workflow Bootstrap ──initializes──> Run
 Platform Definition ──configures──> Build Template Context
 Discovery Registry ──generates──> Guide, Init Wizard
-Arcade Tracked ──filters──> Run (Activity feed visibility)
 Attestation ──validates──> Skill
-ModelTier ──classifies──> Agent (14 deep, 33 standard, 5 fast)
+ModelTier ──classifies──> Agent (14 deep, 33 standard, 5 fast; frontier unused by default)
 TIER_MODEL_MAP ──resolves──> ModelTier (abstract tier → platform model ID)
+TIER_RANK ──orders──> ModelTier (frontier > deep > standard > fast)
 EffortLevel ──tunes──> Agent (optional reasoning-depth control)
-Protected Agents ──constrains──> ModelTier (build warning on non-deep downgrade)
+Protected Agents ──constrains──> ModelTier (rank-based warning on downgrade below deep)
+BundleAgentEntry ──feeds──> Artifact Rewriter (build-time metadata → install-time rewriting)
+TierRemappingConfig ──configures──> Artifact Rewriter (user settings drive substitutions)
+Preset ──provides defaults for──> TierRemappingConfig (explicit overrides supersede)
+Task File Lock ──protects──> Task Queue (serializes concurrent task-file writes)
 ```
 
 ## Agent Patterns
@@ -99,8 +108,10 @@ Protected Agents ──constrains──> ModelTier (build warning on non-deep do
 | Stateless Agent | Blueprint charter creation | State persisted in visible file-based scratch pad for session-independent resumability |
 | Data-Driven Platform Build | Multi-platform artifacts | PlatformDefinition entries capture all platform-varying behavior |
 | Notification Auto-Generation | Emit pipeline | Status changes and waiting_for_user events auto-generate deduplicated notifications |
-| Build-Time Tier Resolution | Agent build pipeline | Agent frontmatter declares abstract tier + effort; `resolveTier()` and `resolveEffort()` map to platform-specific model IDs and effort field names before template rendering. Templates remain format-only |
-| Generator-Verifier Asymmetry | Agent classification | Generator agents (e.g., task-builder) run at standard tier because deep-tier verifier agents (e.g., task-reviewer) validate their output, preserving quality while reducing cost |
+| Build-Time Tier Resolution | Agent build pipeline | Frontmatter declares abstract tier + effort; `resolveTier()`/`resolveEffort()` map to platform specifics before rendering. Templates stay format-only |
+| Install-Time Tier Remapping | User model settings | Build embeds tier metadata in `BundleAgentEntry`; settings.toml overrides rewrite installed artifacts without rebuilding. Preset → validate → discover → rewrite → report |
+| Generator-Verifier Asymmetry | Agent classification | Generator agents (task-builder) run at standard tier because deep-tier verifiers (task-reviewer) validate their output — quality preserved, cost reduced |
+| Directory-Based File Lock | Parallel task-builder execution | `mkdir` atomicity serializes concurrent read-modify-write on shared task files; sleep-poll on contention; always release |
 
 ## Bounded Contexts
 
@@ -109,10 +120,11 @@ Protected Agents ──constrains──> ModelTier (build warning on non-deep do
 | Knowledge Management | rp1-base | Knowledge Base, Spatial Analyzer, Progressive Disclosure |
 | Documentation Production | rp1-base | Content Workflow, Documentation Synchronization, Scribe |
 | Prompt Tooling | rp1-utils | Prompt Authoring Workflow, Shell-Safe Formatting |
-| Feature Delivery | rp1-dev | PR Review, Task Queue, Builder-Reviewer |
+| Feature Delivery | rp1-dev | PR Review, Task Queue, Builder-Reviewer, Task File Lock |
 | Runtime Services | cli/src | Project, Run, Event, Workflow Bootstrap, Notification |
 | Dashboard | cli/web-ui | Arcade, Artifact, Annotation, Run Invocation Context |
-| Platform Abstraction | build pipeline | Platform Tag, CanonicalName, Platform Definition, ModelTier, EffortLevel, Tier Resolution |
+| Platform Abstraction | build pipeline | Platform Tag, CanonicalName, Platform Definition, ModelTier, EffortLevel, Tier Resolution, TIER_RANK |
+| Model Settings | cli/src/settings | TierRemappingConfig, Preset, Artifact Rewriter, BundleAgentEntry, Install-Time Tier Remapping |
 | Discovery | cli/catalog | Discovery Registry, Guide, Skill Category, Arcade Tracked |
 | Project Lifecycle | cli/init, cli/migrate | Fence Versioning, Init Wizard, Project Migration |
 | Quality Assurance | evals/ | Attestation |
@@ -123,7 +135,8 @@ Protected Agents ──constrains──> ModelTier (build warning on non-deep do
 - **Human gates**: `waiting_for_user` emitted before prompts, visible in host tool and Arcade
 - **Traceable state**: Intermediates (`brief.md`, `scan_results.json`) persist under `.rp1/work/`
 - **State discipline**: Mermaid states, emitted steps, namespaced sub-agent steps, and logical step keys stay aligned
-- **Configuration resolution**: `resolve-args` + `workflow-bootstrap` unify argument, directory, and run creation
-- **Platform portability**: Semantic tags, data-driven definitions, and tier resolution let one prompt target multiple hosts with appropriate model and effort settings
+- **Configuration resolution**: `resolve-args` + `workflow-bootstrap` unify argument, directory, and run creation; `settings.toml` layers (global, project) with preset and per-platform overrides for model tier remapping
+- **Platform portability**: Semantic tags, data-driven definitions, and tier resolution let one prompt target 5 hosts with appropriate model and effort settings
 - **Single-source discovery**: Frontmatter metadata drives all catalog views, avoiding drift
 - **Standard tool envelope**: All agent-tools return `ToolResult<T>` JSON for predictable AI-agent parsing
+- **Concurrent task safety**: Directory-based file locks protect shared task-file updates during parallel builder execution

--- a/.rp1/context/index.md
+++ b/.rp1/context/index.md
@@ -2,12 +2,12 @@
 
 **Type**: Monorepo
 **Languages**: TypeScript, TSX, Markdown, JSON, YAML, TOML, Shell, CSS, HTML
-**Version**: 0.7.1-dev
-**Updated**: 2026-06-30
+**Version**: 0.7.11-dev
+**Updated**: 2026-07-03
 
 ## Project Summary
 
-rp1 is a Bun/TypeScript CLI and plugin monorepo for authoring, building, and running AI agent workflows across Claude Code, OpenCode, Codex, Antigravity, and Gemini. It combines markdown-defined skills and agents, tracked runtime state with deterministic workflow bootstrap, the Arcade dashboard with notifications and contextual commands, a multi-platform build pipeline with per-agent model/effort tiering and arcade tracking controls, catalog-driven skill discovery, and a progressively loaded knowledge base.
+rp1 is a Bun/TypeScript CLI and plugin monorepo for authoring, building, and running AI agent workflows across Claude Code, OpenCode, Codex, Copilot, and Antigravity. It combines markdown-defined skills and agents, tracked runtime state with deterministic workflow bootstrap, the Arcade dashboard with notifications and contextual commands, a multi-platform build pipeline with per-agent model/effort tiering, user-controllable install-time model tier remapping via `settings.toml`, catalog-driven skill discovery, and a progressively loaded knowledge base.
 
 ## Quick Reference
 
@@ -23,11 +23,11 @@ rp1 is a Bun/TypeScript CLI and plugin monorepo for authoring, building, and run
 
 | File | Lines | Load For |
 |------|-------|----------|
-| architecture.md | 73 | System design, layers, data flow, integrations |
-| interaction-model.md | 61 | Cross-surface semantics, workflow states, notifications, accessibility |
-| modules.md | 71 | Module boundaries, responsibilities, dependency highlights |
-| patterns.md | 63 | Code conventions, workflow idioms, extension patterns |
-| concept_map.md | 129 | Domain concepts, terminology, bounded contexts |
+| architecture.md | 81 | System design, layers, data flow, integrations |
+| interaction-model.md | 66 | Cross-surface semantics, workflow states, notifications, accessibility |
+| modules.md | 80 | Module boundaries, responsibilities, dependency highlights |
+| patterns.md | 76 | Code conventions, workflow idioms, extension patterns |
+| concept_map.md | 142 | Domain concepts, terminology, bounded contexts |
 
 ## Task-Based Loading
 
@@ -37,6 +37,7 @@ rp1 is a Bun/TypeScript CLI and plugin monorepo for authoring, building, and run
 | Bug investigation | `architecture.md`, `modules.md` |
 | Feature implementation | `modules.md`, `patterns.md` |
 | Frontend / UX / surface work | `interaction-model.md`, `modules.md`, `patterns.md` |
+| Model tiering / settings work | `modules.md` (settings module), `patterns.md`, `concept_map.md` (Model Settings context) |
 | Strategic or system-wide analysis | All KB files |
 
 ## How to Load
@@ -50,9 +51,10 @@ Read: .rp1/context/{filename}
 ```text
 cli/
 ├── src/               # CLI commands, agent-tools, build pipeline, init/install flows
-│   ├── commands/      # User-facing CLI commands including build, migrate, and arcade
+│   ├── commands/      # User-facing CLI commands including build, migrate, arcade, and settings
 │   ├── agent-tools/   # Workflow protocol tools (emit, workflow-bootstrap, resolve-args, feedback, root-dir, etc.)
 │   ├── build/         # Multi-platform artifact build pipeline with model/effort tiering + arcade tracking
+│   ├── settings/      # Install-time model tier remapping (loader, presets, rewriter, apply, validator)
 │   ├── catalog/       # Skill/agent catalog registry with distribution scoping
 │   ├── install/       # Host-tool installation and verification
 │   ├── migrate/       # Project migration with stanza upgrades and DB backfill
@@ -64,7 +66,7 @@ plugins/
 ├── dev/               # Build workflows, blueprinting, PR review, feature delivery
 └── utils/             # Prompt writing, tersification, eval helpers
 docs/
-└── reference/         # User-facing reference docs for CLI, plugins, web UI, and platform tags
+└── reference/         # User-facing reference docs for CLI, configuration, plugins, web UI, and platform tags
 evals/                 # Prompt attestation with content-addressable hashing and dockerized execution
 ```
 

--- a/.rp1/context/interaction-model.md
+++ b/.rp1/context/interaction-model.md
@@ -1,28 +1,29 @@
 # rp1 - Interaction Model
 
 **Project**: rp1
-**Analysis Date**: 2026-06-30
-**Surfaces**: CLI, Host Tool Integration, Arcade Web UI, Agent Tools CLI, Agent .md frontmatter, Reference Docs, Init Wizard
+**Analysis Date**: 2026-07-03
+**Surfaces**: CLI, Host Tool Integration, Arcade Web UI, Agent Tools CLI, Agent .md frontmatter, Settings Configuration, Reference Docs, Init Wizard
 
 ## Experience Principles
 
 - **Observable workflows** — long-running skills expose named runs, explicit phase transitions, gate pauses, and registered artifacts.
 - **Evidence before questions** — interactive workflows read repo/KB material first and ask only for material-changing decisions.
 - **Durable handoffs** — intermediate artifacts are source-of-truth handoffs preserved across review/block/cancel paths.
-- **Automation-aware CLI** — machine-friendly modes (`--json`, `--lint`, `hook-json`, `--daemon-only`); build validates agent frontmatter and emits structured errors/warnings without blocking on human input.
-- **Fail-fast with actionable diagnostics** — build-time validation surfaces the file, the invalid value, and the allowed set so the agent author can fix without guesswork.
+- **Automation-aware CLI** — machine-friendly modes (`--json`, `--lint`, `hook-json`, `--daemon-only`, `--dry-run`, `--preset`); build and settings emit structured errors/warnings without blocking on human input.
+- **Fail-fast with actionable diagnostics** — build-time and settings validation surface the file, the invalid value, and the allowed set so the author can fix without guesswork.
+- **Non-blocking degradation** — optional post-install steps (tier remapping re-apply, protected-agent warnings, cache refresh) log diagnostics but never interrupt the primary workflow.
 - **Attention-proportional notification** — notifications categorized by attention level with bulk dismiss.
-- **Progressive detail disclosure** — secondary metadata (frontmatter, run invocation context) hidden by default, toggled via contextual commands, persisted in sessionStorage.
+- **Progressive detail disclosure** — secondary metadata hidden by default, toggled via contextual commands, persisted in sessionStorage.
 
 ## Actors & Surfaces
 
 | Actor | Goals | Surfaces |
 |-------|-------|----------|
-| End user | Execute workflows, monitor runs, review artifacts, give feedback | CLI, Host Tool, Arcade |
-| **Agent author** | Set model tier + effort in agent frontmatter; get build-time validation feedback | Agent `.md` frontmatter, `rp1 build`, Agent Tools CLI |
+| End user | Execute workflows, monitor runs, review artifacts, give feedback, control model cost/capability trade-offs | CLI, Host Tool, Arcade, `settings.toml` |
+| Agent author | Set model tier + effort in agent frontmatter; get build-time validation feedback | Agent `.md` frontmatter, `rp1 build`, Agent Tools CLI |
 | CI system | Validate/lint, produce JSON build output | `rp1 build --json --lint` |
 
-**Agent `.md` frontmatter** is a declarative configuration surface: authors set `model: deep|standard|fast|inherit` and optional `effort: low|medium|high|xhigh|max`, plus tools/arguments. `rp1 build` resolves and validates these.
+**Agent `.md` frontmatter**: authors set `model: frontier|deep|standard|fast|inherit` and optional `effort: low|medium|high|xhigh|max`. **Settings configuration** (`~/.config/rp1/settings.toml` user, `.rp1/settings.toml` project): users declare `[models]` presets or per-platform tier remappings that override build defaults without rebuilding.
 
 ## User-Visible States
 
@@ -31,8 +32,10 @@
 | running / waiting_for_user / completed / failed | Workflow phase lifecycle | Arcade, Host Tool, Agent Tools |
 | blocked / cancelled | Unresolved facts; user-stopped (work preserved) | Host Tool |
 | kb_stale | KB behind HEAD; continue/rebuild/cancel gate | Host Tool |
-| **build_validation_error** | Unknown model tier/effort; build halts that agent, exits 1, lists allowed values | CLI (`rp1 build`) |
-| **build_validation_warning** | Valid but sub-optimal (fast+effort, protected-agent downgrade); build continues | CLI (`rp1 build`) |
+| build_validation_error | Unknown model tier/effort; build halts that agent, exits 1, lists allowed values | CLI (`rp1 build`) |
+| build_validation_warning | Valid but sub-optimal (fast+effort, protected-agent downgrade); build continues | CLI (`rp1 build`) |
+| settings_validation_error | Invalid TOML syntax or tier remapping semantics (bad preset, platform, model ID); `settings validate` exits 1 | CLI (`rp1 settings validate`) |
+| tier_remapping_applied | Agent artifacts rewritten per user mapping; count reported; idempotent re-run reports "already up to date" (distinct from "nothing matched") | CLI (`rp1 settings apply`, `rp1 update`) |
 | connection_status / annotation_status / notification_attention | Arcade live-update + feedback + triage signals | Arcade |
 
 ## Feedback Loops
@@ -41,15 +44,17 @@
 - **Artifact registration** — emit `artifact_registered` with `storageRoot` → Arcade resolves and shows the file.
 - **Annotation feedback** — user annotates/edits in Arcade → runtime persists → agents read via `feedback read` → replies update UI over WS.
 - **Notification lifecycle** — events produce deduplicated notifications; toasts auto-dismiss (6s); sidebar groups by attention.
-- **Build-time tier & effort validation** — `rp1 build` parses frontmatter → `validateAgentTierAndEffort` (errors halt with file+allowed values; warnings print to stderr and continue) → `resolveTier`/`resolveEffort` → platform-native config emitted.
-- **Emit-driven run projection / snapshot reconciliation / recovery fallback** — Arcade reduces events into `LiveRunIndex`, reconnects with saved cursor, and falls back to REST when replay is impossible.
+- **Build-time tier & effort validation** — `rp1 build` parses frontmatter → `validateAgentTierAndEffort` (errors halt with file+allowed values; warnings continue) → `resolveTier`/`resolveEffort` → platform-native config emitted.
+- **Settings tier remapping apply** — `rp1 settings apply` (or `rp1 update` auto-reapply) loads config/preset → validates semantics → discovers installed agents → rewrites model/effort fields → reports modified count + effort adjustments + protected-agent warnings. `--dry-run` previews.
+- **Emit-driven run projection / snapshot reconciliation** — Arcade reduces events into `LiveRunIndex`, reconnects with saved cursor, falls back to REST when replay is impossible.
 
 ## Cross-Surface Deltas
 
-- **Model tier resolution** — same abstract tier resolves to different vendor IDs per platform (CC: opus/sonnet/haiku; Codex: o3/o4-mini/gpt-4.1-nano; OpenCode/Antigravity: Anthropic names; Gemini: gemini-2.5-pro/flash; Copilot: tiering omitted). `inherit` emits no model field anywhere (backward compatible).
-- **Effort field resolution** — CC emits `effort` (5 levels); Codex emits `model_reasoning_effort` (clamped to 3); OpenCode emits `reasoningEffort` for OpenAI-provider models (clamped), omits for Anthropic/unknown; Antigravity/Gemini/Copilot omit; fast tier always omits.
-- **Agent template output format** — CC/OpenCode emit YAML frontmatter; Codex emits TOML; all three conditionally omit model (inherit) and effort (undefined/unsupported).
-- **Plugin install** — CC uses MCP registration; OpenCode copies filesystem artifacts; Codex uses its own path.
+- **Model tier resolution** — same abstract tier resolves to different vendor IDs per platform (CC: fable/opus/sonnet/haiku; Codex: gpt-5.5/gpt-5.4/gpt-5.4-mini; Antigravity: gemini-3.1-pro/gemini-3.5-flash; OpenCode/Copilot: tiering omitted → inherit). `inherit` emits no model field anywhere.
+- **Effort field resolution** — CC emits `effort` (5 levels); Codex emits `model_reasoning_effort` (`max` clamps to `xhigh`); OpenCode/Copilot/Antigravity omit; fast tier always omits. Settings rewriter strips effort when a remap lands on a fast-class model.
+- **Tier remapping scope** — `settings apply` rewrites only CC (.md frontmatter) and Codex (.toml) artifacts; other platforms lack per-agent model fields in installed artifacts (validator warning coverage for antigravity is a known gap — it currently no-ops silently).
+- **Agent template output format** — CC/OpenCode emit YAML frontmatter; Codex emits TOML; all conditionally omit model (inherit) and effort (unsupported).
+- **Plugin install** — CC uses MCP registration; OpenCode copies filesystem artifacts; Codex uses its own path; Antigravity uses generated workflow assets. Gemini platform retired.
 - **Execution vs observability** — host tools do the work; Agent Tools carry protocol; Arcade shows passive status.
 
 ## Accessibility & Discoverability
@@ -58,4 +63,4 @@ Keyboard-first Arcade (roving tabindex, single-key suppression during text entry
 
 ## Related KB
 
-- Surfaces map to `architecture.md` layers · build internals in `modules.md` · conventions in `patterns.md`
+- Surfaces map to `architecture.md` layers · build/settings internals in `modules.md` · conventions in `patterns.md`

--- a/.rp1/context/modules.md
+++ b/.rp1/context/modules.md
@@ -1,20 +1,21 @@
 # Module & Component Breakdown
 
 **Project**: rp1
-**Analysis Date**: 2026-06-30
-**Modules Analyzed**: 22
+**Analysis Date**: 2026-07-03
+**Modules Analyzed**: 23
 
 ## Core Modules
 
 | Module | Purpose | Files | Key Files |
 |--------|---------|-------|-----------|
-| `cli/commands` | User-facing CLI commands (build, arcade, migrate, init) | 27 | build.ts, arcade.ts |
+| `cli/commands` | User-facing CLI commands (build, arcade, migrate, init, settings, install, update, verify, uninstall) | 27 | build.ts, arcade.ts, settings.ts |
 | `cli/agent-tools` | emit, workflow-bootstrap, resolve-args, state-machine, task, feedback | 59 | emit/index.ts, workflow-bootstrap.ts |
-| `cli/build` | Multi-platform artifact pipeline with per-agent model tiering + effort resolution | 51 | command.ts, models.ts, parser.ts, validator.ts, **tier-resolution.ts**, template-context.ts, template-engine.ts |
+| `cli/build` | Multi-platform artifact pipeline with per-agent model tiering, effort resolution, and frontier tier | 59 | command.ts, models.ts, parser.ts, validator.ts, **tier-resolution.ts**, template-context.ts, platform-definitions.ts |
+| `cli/settings` | **New** — install-time model tier remapping via `settings.toml` `[models]` sections and presets (budget/standard/premium) | 6 | apply.ts, rewriter.ts, presets.ts, loader.ts, models.ts, validator.ts |
 | `cli/catalog` | Skill/agent catalog registry (distribution scope, arcadeTracked) | 3 | catalog-generator.ts |
-| `cli/install` | Install artifacts into host tools (staging, backup/rollback, verify) | 22 | verifier.ts |
+| `cli/install` | Install artifacts into host tools (staging, backup/rollback, verify) for claude-code, codex, copilot, antigravity | 34 | verifier.ts, installer.ts, asset-extractor.ts |
 | `cli/init` | Project init with context detection, fence markers, Ink UI | 23 | — |
-| `cli/shared` | Errors, fp-ts helpers, events, logging, directory resolution | 15 | errors.ts, logger.ts |
+| `cli/shared` | Errors, fp-ts helpers, events, logging, directory + settings path resolution | 15 | errors.ts, logger.ts, settings.ts |
 | `web-ui/server` | Bun HTTP/WS server, REST APIs, file watching, notifications | 16 | registry.ts |
 | `web-ui/daemon` | Daemon lifecycle + diagnostic logging | 4 | — |
 | `web-ui/frontend` | React SPA: pages, hooks, providers, artifact viewers | 190 | — |
@@ -25,46 +26,54 @@
 
 ## Key Components (build pipeline)
 
-### tier-resolution (`cli/src/build/tier-resolution.ts`) — new
-Centralized tier-to-model and effort-to-field resolution dictionary. Pure functions, no side effects, called per-agent per-platform during the build loop.
-- `resolveTier(tier, platform) → modelId | null` — maps abstract tier to platform-specific model ID via `TIER_MODEL_MAP` (3 tiers × 5 platforms); returns `null` for `inherit`, unmapped platforms (copilot), so the template omits the field.
-- `resolveEffort(effort, tier, platform, resolvedModel) → {fieldName, value} | null` — platform/provider-specific effort field; derives provider (anthropic/openai) from the resolved model ID for OpenCode; clamps 5-level effort to 3-level for OpenAI/Codex; returns `null` for fast tier and unsupported platforms.
-- Depends on `models` (ModelTier/EffortLevel) and `template-context` (BuildPlatform).
+### tier-resolution (`cli/src/build/tier-resolution.ts`)
+Centralized tier-to-model and effort-to-field resolution. Pure functions, called per-agent per-platform at build time AND by the settings module at install time.
+- `resolveTier(tier, platform) → modelId | null` — maps abstract tier (frontier/deep/standard/fast) to platform model ID via exported `TIER_MODEL_MAP` (Claude Code, Codex, Antigravity; OpenCode/Copilot omitted = inherit); `null` for `inherit`/unmapped.
+- `resolveEffort(effort, tier, platform) → {fieldName, value} | null` — `effort` (CC, 5 levels) or `model_reasoning_effort` (Codex, `max`→`xhigh` clamp); `null` for fast tier and no-effort platforms.
+- Shared helpers for settings validation: `getValidModelIdsForPlatform`, `modelSupportsEffort`, `getPlatformsWithModelSupport` — single source of truth preventing build/remap divergence.
 
 ### build models (`cli/src/build/models.ts`)
-Defines `ModelTier`/`EffortLevel` unions + parallel `VALID_MODEL_TIERS`/`VALID_EFFORT_LEVELS` arrays, the `PROTECTED_AGENTS` set (14 frontier-critical agents), and `ClaudeCodeAgent.effort?`. Also `BuildConfig`, `ArtifactResult`, `BundleManifest`, and platform artifact interfaces.
+`ModelTier` union (frontier/deep/standard/fast/inherit) + `VALID_MODEL_TIERS`; `TIER_RANK` ordered map (frontier=3, deep=2, standard=1, fast=0) for downgrade comparison; `EffortLevel` + `VALID_EFFORT_LEVELS`; `PROTECTED_AGENTS` set (14 reasoning-critical agents); **`BundleAgentEntry`** extending `BundleAssetEntry` with optional tier/effort carried through the build-to-install chain; `BuildConfig`, `ArtifactResult`, `BundleManifest`.
 
-### build validator (`cli/src/build/validator.ts`)
-L1 (syntax) + L2 (schema) validation plus `validateAgentTierAndEffort(agent, model, effort, file) → {errors, warnings}` for **all** platforms: errors on unknown tier/effort (blocking); warnings on fast+effort and protected-agent downgrade (advisory).
+### build validator / command / template-context
+`validator.ts`: L1+L2 validation plus `validateAgentTierAndEffort` (errors block, warnings advise on fast+effort and protected downgrade). `command.ts`: validation gate → `resolveTier`/`resolveEffort` → embeds tier/effort into `BundleAgentEntry`. `template-context.ts`: `BuildPlatform` union (opencode, claude-code, codex, copilot, antigravity), `AgentArtifactData` with optional `effortFieldName`/`effortValue`.
 
-### build command (`cli/src/build/command.ts`)
-Orchestrates multi-platform builds. Integrates the validation gate then `resolveTier`/`resolveEffort` into the agent build loop before constructing template context. Uses `fp-ts` `pipe(... TE.chain ...)`.
+## Key Components (settings module — new)
 
-### template-context (`cli/src/build/template-context.ts`) / codex/models.ts
-`AgentArtifactData` and `CodexAgent` gain optional `effortFieldName`/`effortValue`, consumed by Liquid templates at render time.
+### settings-apply (`cli/src/settings/apply.ts`)
+Install-time remapping orchestrator: `resolveConfig` (preset + per-platform overrides, optional `globalSettingsPath` seam) → `validateTierRemappings` → `discoverAgents` (from `EMBEDDED_MANIFEST` via `getBundledAssets()`) → `applyRemappingsToAgents` (delegates to rewriter; counts modified vs `agentsAlreadyCurrent`) → report + CC plugin cache refresh (failures become warnings). `applyTierRemappingsIfConfigured` is the update-hook no-op wrapper. Filesystem ops injected via `ApplyDeps`.
 
-### agent Liquid templates (`cli/src/build/templates/`)
-Per-platform conditional emission: Claude Code (YAML `model` + `effort`), Codex (TOML `model` + `model_reasoning_effort`), OpenCode (YAML `model` + provider-keyed effort pass-through). Inherit/undefined/unsupported → field omitted (byte-identical opt-out).
+### settings-rewriter (`cli/src/settings/rewriter.ts`)
+Pure-function artifact rewriter: CC YAML frontmatter and Codex TOML targeted line replacement (multiline-string guard protects `developer_instructions` bodies); strips effort when the remapped model is fast-class; protected-agent downgrade warnings via reverse tier lookup + `TIER_RANK`. Only claude-code and codex are rewritable.
+
+### settings-loader / presets / validator / models
+`loader.ts`: parses `[arguments.*]` + `[models.*]` from TOML with project>user merge, module-level cache (`resetSettingsCache`), `TIER_KEYS` derived from `VALID_MODEL_TIERS`. `presets.ts`: budget/standard/premium complete tier-to-model profiles (CC + Codex; `RemappableTier` excludes frontier/inherit). `validator.ts`: TOML syntax + semantic checks (preset names, platforms, model IDs, effort preview) using tier-resolution helpers. `models.ts`: `PlatformTierMap`, `TierRemappingConfig`.
+
+### settings-command (`cli/src/commands/settings.ts`)
+`validate` (syntax + semantics, exit 1 on errors), `apply` (`--preset`, `--dry-run`; distinguishes "already up to date" from "nothing matched"), `presets` (list mappings).
 
 ## Module Dependencies (highlights)
 
-- `cli/build/command` → `cli/build/tier-resolution` (resolveTier/resolveEffort per agent/platform).
-- `cli/build/tier-resolution` → `cli/build/models`, `cli/build/template-context`.
-- `cli/build/validator` → `cli/build/models` (VALID_* arrays, PROTECTED_AGENTS).
-- `cli/build/templates` → `cli/build/template-context` (consume effortFieldName/effortValue at render).
-- `cli/agent-tools/emit` → `state-machine`, `web-ui/daemon` (lazy).
-- `plugins/*` → `cli/agent-tools` (emit, resolve-args, bootstrap conventions); `plugins/dev` → `plugins/base` (runtime).
-- External: fp-ts, liquidjs, commander, yaml, bun:sqlite.
+- `cli/build/command` → `cli/build/tier-resolution` (per-agent resolution) → `cli/build/models`, `cli/build/template-context`.
+- `cli/settings/apply` → `settings/{loader,rewriter,validator,presets}`, `cli/assets/reader` (embedded manifest), `cli/install/claudecode/marketplace`.
+- `cli/settings/{rewriter,validator}` → `cli/build/tier-resolution` (canonical `TIER_MODEL_MAP` + helpers) and `cli/build/models` (`PROTECTED_AGENTS`, `TIER_RANK`).
+- `cli/commands/update` → `cli/settings/apply` (auto re-apply after plugin update, try/catch isolated).
+- `cli/scripts/generate-asset-imports.ts` → propagates `BundleAgentEntry.tier/effort` into `EMBEDDED_MANIFEST` (`if (import.meta.main)` guarded); `cli/assets/reader.ts` `AssetEntry` widened with optional tier/effort.
+- `cli/agent-tools/emit` → `state-machine`, `web-ui/daemon` (lazy); `plugins/*` → `cli/agent-tools`; `plugins/dev` → `plugins/base` (runtime).
+- External: fp-ts, liquidjs, commander, yaml, bun:sqlite, chalk.
 
 ## Module Metrics
 
 | Module | Files | LOC (approx) | Components |
 |--------|-------|--------------|------------|
-| `cli/build` | 51 | ~15,159 | 12 |
+| `cli/build` | 59 | ~9,562 | 6 |
+| `cli/settings` | 6 | ~1,534 | 6 |
+| `cli/install` | 34 | ~10,981 | 4 |
+| `cli/catalog` | 3 | ~1,173 | 1 |
 
 ## Cross-Module Patterns
 
-Skill-Agent Delegation · Tracked Workflow Bootstrap · State-Machine + Emit Discipline · Async-Mutex Registry · Notification Auto-Generation · Catalog Registry · Multi-Platform Build · **Abstract Tier Resolution** (one `TIER_MODEL_MAP` update propagates to all agents at that tier on next build).
+Skill-Agent Delegation · Tracked Workflow Bootstrap · State-Machine + Emit Discipline · Async-Mutex Registry · Notification Auto-Generation · Catalog Registry · Multi-Platform Build (5 targets) · **Abstract Tier Resolution** (one `TIER_MODEL_MAP` update propagates everywhere) · **Build-to-Install Tier Metadata Chain** (`BundleAgentEntry` → embedded manifest → apply) · **Settings Two-Level Merge** (project > user) · **Update Hook Auto-Reapply** (tier preferences survive plugin updates).
 
 ## Related KB
 

--- a/.rp1/context/patterns.md
+++ b/.rp1/context/patterns.md
@@ -1,11 +1,11 @@
 # Implementation Patterns
 
 **Project**: rp1
-**Last Updated**: 2026-06-30
+**Last Updated**: 2026-07-03
 
 ## Naming & Organization
 
-- Feature-scoped directories (`cli/src/commands/`, `cli/src/build/`); prompt assets use kebab-case skill folders with `SKILL.md`.
+- Feature-scoped directories (`cli/src/commands/`, `cli/src/build/`, `cli/src/settings/`); prompt assets use kebab-case skill folders with `SKILL.md`.
 - CLI camelCase verbs; React hooks prefix `use`; error factories match their `_tag` (`usageError`, `runtimeError`).
 - Parameters UPPER_SNAKE_CASE (`/^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$/`); relative TS imports keep `.js` suffixes; web-ui uses `@/`; CSS classes use `rp1-` prefix to avoid Tailwind collisions.
 
@@ -13,24 +13,29 @@
 
 - **Enum tables**: string-literal unions with parallel `VALID_*` arrays for build-time validation — `ModelTier`/`VALID_MODEL_TIERS`, `EffortLevel`/`VALID_EFFORT_LEVELS`, `SkillCategory`, `WorkflowRunPolicy`, `Status`, `EventType`.
 - Discriminated unions: `_tag` on `CLIError`, `type` on `EventPayload`.
-- `readonly` + `as const` throughout; persisted artifacts are source-of-truth snapshots.
-- **Tier abstraction**: abstract tier aliases (deep/standard/fast/inherit) decoupled from vendor model IDs via the centralized `TIER_MODEL_MAP` — single update point on vendor model releases. `PROTECTED_AGENTS` guards frontier-critical agents from accidental downgrade.
+- `readonly` + `Readonly<Record<...>>` + `as const` throughout; persisted artifacts are source-of-truth snapshots.
+- **Tier abstraction**: abstract tier aliases (frontier/deep/standard/fast/inherit) decoupled from vendor model IDs via the centralized `TIER_MODEL_MAP` — single update point on vendor model releases. `PROTECTED_AGENTS` + `TIER_RANK` guard reasoning-critical agents from accidental downgrade. Compile-time safety: `Exclude<ModelTier, "inherit">` keys on `TIER_MODEL_MAP` and `TIER_RANK` force compile errors if a tier is added without mappings.
+- **Build-to-install metadata chain**: `BundleAgentEntry` extends `BundleAssetEntry` with optional `tier`/`effort`, preserved through bundle manifests → `generate-asset-imports.ts` → `EMBEDDED_MANIFEST`, so install-time remapping works from the compiled binary without source frontmatter.
 
 ## Error Handling
 
 - Returns `Either`/`TaskEither<CLIError, A>`; formatted once at the CLI boundary via `formatError`; `tryCatchTE` wraps async.
 - Parent skills gate on hard failures; batch workflows tolerate partial success. L1 (syntax) then L2 (schema) validation staging.
-- **Warnings vs errors**: `validateAgentTierAndEffort` returns `{errors[], warnings[]}` — errors halt agent processing, warnings emit advisories (fast-tier effort, protected-agent downgrade).
+- **Warnings vs errors**: `validateAgentTierAndEffort` and `validateTierRemappings` return `{errors[], warnings[]}` — errors halt processing, warnings emit advisories (fast-tier effort, protected-agent downgrade, unsupported platform).
+- **Non-blocking degradation**: optional post-update steps (tier remapping re-apply, plugin cache refresh) wrap in try/catch, surface warnings, and never abort the parent lifecycle.
 
 ## Validation & Boundaries
 
 - **Additive-field propagation**: a new frontmatter field flows `parser → model interface → validator → tier-resolution → template context → Liquid templates` without breaking existing paths. Established for `arcadeTracked`; extended identically for `model` (ModelTier) and `effort` (EffortLevel).
 - Each definition validated field-by-field with early return on first error.
+- **Single-source validation sets**: settings validator imports shared helpers (`getValidModelIdsForPlatform`, `modelSupportsEffort`, `getPlatformsWithModelSupport`) from `tier-resolution.ts` — no separate allowlists; derive runtime sets from canonical maps (e.g. `TIER_KEYS` from `VALID_MODEL_TIERS`) instead of hand-copying.
 
 ## Build Pipeline
 
-- **Tier resolution**: `resolveTier` maps tier→platform model ID via `TIER_MODEL_MAP` (null for `inherit`/unmapped). `resolveEffort` derives provider from the resolved model ID (closed-world assumption) and returns a platform/provider `{fieldName, value}` — `effort` (Claude Code), `model_reasoning_effort` (Codex), `reasoningEffort` (OpenAI-on-OpenCode); omits for fast tier, unknown provider, or null platform config.
-- **LiquidJS whitespace control (CRITICAL)**: production engine (`template-engine.ts`) uses `greedy:true`. Golden-file tests MUST replicate the identical config (`greedy:true`, `strictVariables`, `strictFilters`, `lenientIf`) — config drift lets whitespace bugs ship undetected. Use `{%- endif %}` (no trailing dash) when a newline separator must survive after an `endif`; a trailing `{%- endif -%}` under `greedy:true` strips the separator and concatenates adjacent fields (this caused invalid Codex TOML). Gate optional fields on `model != "inherit"` / `effortValue` so opt-out output is byte-identical to legacy.
+- **Tier resolution**: `resolveTier` maps tier→platform model ID via `TIER_MODEL_MAP` (null for `inherit`/unmapped). `resolveEffort` returns a platform-specific `{fieldName, value}` — `effort` (Claude Code, 5 levels), `model_reasoning_effort` (Codex, `max` clamps to `xhigh`); omits for fast tier and platforms without effort support (OpenCode, Copilot, Antigravity).
+- **Install-time tier remapping (late binding)**: user `settings.toml` `[models]`/`[models.<platform>]` sections (or presets budget/standard/premium) drive `rp1 settings apply`: load → validate → discover agents from the embedded manifest → rewrite installed artifacts (CC YAML frontmatter, Codex TOML targeted line replacement) → report modified/already-current counts. `rp1 update` re-applies automatically. Idempotent: rewriter reports `modified=false` when target equals current.
+- **LiquidJS whitespace control (CRITICAL)**: production engine (`template-engine.ts`) uses `greedy:true`. Golden-file tests MUST replicate the identical config — config drift lets whitespace bugs ship undetected. Use `{%- endif %}` (no trailing dash) when a newline separator must survive. Gate optional fields on `model != "inherit"` / `effortValue` so opt-out output is byte-identical to legacy.
+- **Script entrypoint guard**: `cli/scripts/` executables wrap top-level execution in `if (import.meta.main)` so test imports of exported functions are side-effect-free.
 - **fp-ts pipeline**: `pipe(loadConfig, TE.fromEither, TE.chain(...))`; prefer clear `map`/`flatMap`/`isLeft` over abstractions.
 
 ## Observability
@@ -41,6 +46,7 @@
 
 - Tests under `cli/src/__tests__/` mirror feature areas with shared helpers (temp dirs, env save/restore, Either/TaskEither unwrap).
 - **Golden-file tests** validate rendered template output; the test Liquid engine config MUST match production (`greedy:true`) or whitespace bugs ship undetected.
+- **Hermetic settings tests**: any code path reading `~/.config/rp1/settings.toml` accepts an optional `globalSettingsPath` injection seam (`loadAllArgumentDefaults`, `loadTierRemappings`, `resolveConfig`); tests point it at an isolated nonexistent path so real developer config never leaks into assertions. Contract tests guard shape parity between `BundleAgentEntry` and the embedded manifest generator.
 - Evals share assertions under `evals/suites/shared/`.
 
 ## I/O & Integration
@@ -53,6 +59,13 @@
 ## Concurrency & Async
 
 - `withRegistryLock` async mutex serializes registry read-modify-write; functional state updaters dedup concurrent WS toasts; heavy subsystems (daemon, LiquidJS) loaded via dynamic `import()` and excluded from the compiled binary.
+- **Module-level cache with explicit reset**: settings loader caches parsed TOML per invocation lifetime; `resetSettingsCache()` exists solely for test isolation.
+- **Directory-based file lock**: parallel task-builders serialize shared task-file updates via `mkdir .task-file.lock` atomicity (sleep-poll on contention, always release).
+
+## Dependency Injection & Configuration
+
+- **Optional-parameter seams**: `ApplyDeps` interface injects `readFile`/`writeFile`/`fileExists`/`refreshClaudeCodePlugins` with `DEFAULT_DEPS` production binding; `globalSettingsPath` threads through loader/apply for isolation.
+- **TOML settings, two-level merge**: project `.rp1/settings.toml` > user `~/.config/rp1/settings.toml`, per key for both `[arguments.*]` and `[models.*]`; loader normalizes lower-kebab → UPPER_SNAKE. Blessed presets (`presets.ts`) provide complete tier-to-model profiles that explicit overrides supersede.
 
 ## Extension Mechanisms
 

--- a/cli/scripts/generate-asset-imports.ts
+++ b/cli/scripts/generate-asset-imports.ts
@@ -697,7 +697,9 @@ export const IS_BUNDLED = true;
 	}
 }
 
-generate().catch((e) => {
-	console.error("Failed to generate asset imports:", e);
-	process.exit(1);
-});
+if (import.meta.main) {
+	generate().catch((e) => {
+		console.error("Failed to generate asset imports:", e);
+		process.exit(1);
+	});
+}

--- a/cli/scripts/generate-asset-imports.ts
+++ b/cli/scripts/generate-asset-imports.ts
@@ -19,7 +19,7 @@ import { existsSync } from "node:fs";
 import { readdir, readFile, stat, writeFile } from "node:fs/promises";
 import { basename, dirname, join, relative, resolve, sep } from "node:path";
 import { parse as parseYaml } from "yaml";
-import type { BundleManifest } from "../src/build/models.js";
+import type { BundleAgentEntry, BundleManifest } from "../src/build/models.js";
 import {
 	collectScopedCatalogRegistry,
 	renderInitSkillAwarenessBlock,
@@ -70,13 +70,13 @@ const TOOLS_GENERATED = join(
 );
 const INIT_GENERATED = join(CLI_DIR, "src/init/templates/generated.ts");
 
-interface DiscoveredPlatform {
+export interface DiscoveredPlatform {
 	name: string;
 	distDir: string;
 	manifest: BundleManifest;
 }
 
-interface AssetImport {
+export interface AssetImport {
 	varName: string;
 	importPath: string;
 	outputName: string;
@@ -84,6 +84,7 @@ interface AssetImport {
 	category:
 		| "agent"
 		| "skill"
+		| "command"
 		| "state-machine"
 		| "webui"
 		| "teach-me"
@@ -92,6 +93,8 @@ interface AssetImport {
 	plugin?: "base" | "dev" | "utils";
 	platform?: string;
 	inlineContent?: string;
+	tier?: string;
+	effort?: string;
 }
 
 /**
@@ -152,7 +155,9 @@ async function discoverPlatforms(): Promise<DiscoveredPlatform[]> {
 /**
  * Collect plugin assets from a single platform's bundle manifest.
  */
-function collectPlatformAssets(platform: DiscoveredPlatform): AssetImport[] {
+export function collectPlatformAssets(
+	platform: DiscoveredPlatform,
+): AssetImport[] {
 	const imports: AssetImport[] = [];
 	const platformPrefix = platform.name.replace(/-/g, "_");
 
@@ -183,7 +188,8 @@ function collectPlatformAssets(platform: DiscoveredPlatform): AssetImport[] {
 		// Agents
 		for (const agent of plugin.agents) {
 			const fullPath = join(platform.distDir, agent.path);
-			imports.push({
+			const bundleAgent = agent as BundleAgentEntry;
+			const entry: AssetImport = {
 				varName: toVarName(`${platformPrefix}_${pluginName}_agent`, agent.name),
 				importPath: getImportPath(fullPath),
 				outputName: agent.name,
@@ -191,7 +197,10 @@ function collectPlatformAssets(platform: DiscoveredPlatform): AssetImport[] {
 				category: "agent",
 				plugin: pluginName,
 				platform: platform.name,
-			});
+			};
+			if (bundleAgent.tier) entry.tier = bundleAgent.tier;
+			if (bundleAgent.effort) entry.effort = bundleAgent.effort;
+			imports.push(entry);
 		}
 
 		// Skills
@@ -402,6 +411,18 @@ async function generateInitTemplates(): Promise<void> {
 }
 
 /**
+ * Format an agent asset entry, conditionally including tier and effort fields.
+ */
+export function formatAgentEntry(a: AssetImport): string {
+	let s = `{ name: "${a.outputName}", path: ${a.varName}`;
+	if (a.fileName) s += `, fileName: "${a.fileName}"`;
+	if (a.tier) s += `, tier: "${a.tier}"`;
+	if (a.effort) s += `, effort: "${a.effort}"`;
+	s += " }";
+	return s;
+}
+
+/**
  * Generate the platform block for a single discovered platform.
  */
 function generatePlatformBlock(
@@ -422,7 +443,7 @@ function generatePlatformBlock(
 
 	const baseAgents = platformAssets
 		.filter((a) => a.category === "agent" && a.plugin === "base")
-		.map(formatEntry);
+		.map(formatAgentEntry);
 
 	const baseSkills = platformAssets
 		.filter((a) => a.category === "skill" && a.plugin === "base")
@@ -430,7 +451,7 @@ function generatePlatformBlock(
 
 	const devAgents = platformAssets
 		.filter((a) => a.category === "agent" && a.plugin === "dev")
-		.map(formatEntry);
+		.map(formatAgentEntry);
 
 	const devCommands = platformAssets
 		.filter((a) => a.category === "command" && a.plugin === "dev")
@@ -446,7 +467,7 @@ function generatePlatformBlock(
 
 	const utilsAgents = platformAssets
 		.filter((a) => a.category === "agent" && a.plugin === "utils")
-		.map(formatEntry);
+		.map(formatAgentEntry);
 
 	const utilsSkills = platformAssets
 		.filter((a) => a.category === "skill" && a.plugin === "utils")

--- a/cli/src/__tests__/build/command.test.ts
+++ b/cli/src/__tests__/build/command.test.ts
@@ -1020,6 +1020,95 @@ Fast agent content.
 		expect(cdxContent).toContain('model = "gpt-5.4-mini"');
 		expect(cdxContent).not.toContain("model_reasoning_effort");
 	});
+
+	test("BundleAgentEntry includes tier and effort metadata in bundle assets", async () => {
+		const projectRoot = join(tempDir, "project-manifest-tier");
+		await writeFixture(
+			projectRoot,
+			"plugins/base/skills/sample/SKILL.md",
+			`---
+name: sample
+description: "Sample skill with enough text to pass build validation"
+metadata:
+  category: development
+  is_workflow: false
+---
+
+Sample skill content.
+`,
+		);
+		await writeFixture(
+			projectRoot,
+			"plugins/base/agents/deep-agent.md",
+			`---
+name: deep-agent
+description: "Agent with deep tier and high effort for manifest metadata test"
+tools: Read
+model: deep
+effort: high
+---
+
+Deep agent content for manifest metadata test.
+`,
+		);
+		await writeFixture(
+			projectRoot,
+			"plugins/base/agents/fast-agent.md",
+			`---
+name: fast-agent
+description: "Agent with fast tier and no effort for manifest metadata test"
+tools: Read
+model: fast
+---
+
+Fast agent content for manifest metadata test.
+`,
+		);
+		await writeFixture(
+			projectRoot,
+			"plugins/base/agents/inherit-agent.md",
+			`---
+name: inherit-agent
+description: "Agent with inherit model for manifest metadata test"
+tools: Read
+model: inherit
+---
+
+Inherit agent content for manifest metadata test.
+`,
+		);
+
+		const out = join(outputDir, "manifest-tier");
+		const result = await buildPlatformPlugin(
+			"base",
+			projectRoot,
+			out,
+			claudeCodeDef,
+			noopLogger,
+			true,
+			false,
+		);
+
+		expect(result.summary.errors).toEqual([]);
+		expect(result.summary.agents).toBe(3);
+
+		const deepEntry = result.assets.agents.find((a) => a.name === "deep-agent");
+		expect(deepEntry).toBeDefined();
+		expect(deepEntry!.tier).toBe("deep");
+		expect(deepEntry!.effort).toBe("high");
+
+		const fastEntry = result.assets.agents.find((a) => a.name === "fast-agent");
+		expect(fastEntry).toBeDefined();
+		expect(fastEntry!.tier).toBe("fast");
+		expect(fastEntry!.effort).toBeUndefined();
+
+		const inheritEntry = result.assets.agents.find(
+			(a) => a.name === "inherit-agent",
+		);
+		expect(inheritEntry).toBeDefined();
+		expect(inheritEntry!.tier).toBe("inherit");
+		expect(inheritEntry!.effort).toBeUndefined();
+	});
 });
 
 describe("ParseCache", () => {

--- a/cli/src/__tests__/commands/update/tier-remapping-hook.test.ts
+++ b/cli/src/__tests__/commands/update/tier-remapping-hook.test.ts
@@ -6,6 +6,7 @@
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
+import * as E from "fp-ts/lib/Either.js";
 import {
 	type AgentFileEntry,
 	type ApplyDeps,
@@ -104,6 +105,8 @@ describe("applyTierRemappingsIfConfigured (update hook)", () => {
 				return fs.existsSync(path);
 			},
 			refreshClaudeCodePlugins: async () => {},
+			getBundledAssets: () =>
+				E.left({ _tag: "UsageError", message: "not bundled" } as never),
 		};
 
 		const result = applyRemappingsToAgents(

--- a/cli/src/__tests__/commands/update/tier-remapping-hook.test.ts
+++ b/cli/src/__tests__/commands/update/tier-remapping-hook.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Tests for the tier remapping hook in the update flow.
+ * Verifies that applyTierRemappingsIfConfigured behaves correctly
+ * as a post-install hook: no-op when unconfigured, applies when configured.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import {
+	type AgentFileEntry,
+	type ApplyDeps,
+	applyRemappingsToAgents,
+	applyTierRemappingsIfConfigured,
+} from "../../../settings/apply.js";
+import { resetSettingsCache } from "../../../settings/loader.js";
+import {
+	cleanupTempDir,
+	createTempDir,
+	writeFixture,
+} from "../../helpers/index.js";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const CC_AGENT_DEEP = [
+	"---",
+	"model: opus",
+	"effort: high",
+	"---",
+	"",
+	"# Feature Architect",
+	"",
+	"You are a feature architect.",
+].join("\n");
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+let tempDir: string;
+
+beforeEach(async () => {
+	resetSettingsCache();
+	tempDir = await createTempDir("update-hook");
+});
+
+afterEach(async () => {
+	await cleanupTempDir(tempDir);
+});
+
+describe("applyTierRemappingsIfConfigured (update hook)", () => {
+	test("returns early with no output when no [models] config exists", async () => {
+		const result = await applyTierRemappingsIfConfigured(tempDir);
+
+		expect(result.applied).toBe(false);
+		expect(result.agentsModified).toBe(0);
+	});
+
+	test("returns early when settings.toml exists without [models] section", async () => {
+		await writeFixture(
+			tempDir,
+			".rp1/settings.toml",
+			["[arguments]", 'AFK = "true"'].join("\n"),
+		);
+
+		const result = await applyTierRemappingsIfConfigured(tempDir);
+
+		expect(result.applied).toBe(false);
+		expect(result.agentsModified).toBe(0);
+	});
+
+	test("applies remappings when [models] config exists and agents match", async () => {
+		await writeFixture(
+			tempDir,
+			".rp1/settings.toml",
+			["[models.claude-code]", 'deep = "sonnet"'].join("\n"),
+		);
+
+		const agentPath = await writeFixture(
+			tempDir,
+			"agents/feature-architect.md",
+			CC_AGENT_DEEP,
+		);
+
+		const agents: AgentFileEntry[] = [
+			{
+				name: "feature-architect",
+				filePath: agentPath,
+				tier: "deep",
+				effort: "high",
+				platform: "claude-code",
+			},
+		];
+
+		const deps: ApplyDeps = {
+			readFile: (path) => readFileSync(path, "utf-8"),
+			writeFile: (path, content) => {
+				const fs = require("node:fs");
+				fs.writeFileSync(path, content, "utf-8");
+			},
+			fileExists: (path) => {
+				const fs = require("node:fs");
+				return fs.existsSync(path);
+			},
+			refreshClaudeCodePlugins: async () => {},
+		};
+
+		const result = applyRemappingsToAgents(
+			agents,
+			{ "claude-code": { deep: "sonnet" } },
+			false,
+			deps,
+		);
+
+		expect(result.applied).toBe(true);
+		expect(result.agentsModified).toBe(1);
+
+		const updated = readFileSync(agentPath, "utf-8");
+		expect(updated).toContain("model: sonnet");
+		expect(updated).not.toContain("model: opus");
+	});
+
+	test("applies remappings when preset is configured", async () => {
+		await writeFixture(
+			tempDir,
+			".rp1/settings.toml",
+			["[models]", 'preset = "budget"'].join("\n"),
+		);
+
+		const result = await applyTierRemappingsIfConfigured(tempDir);
+
+		// applied is false because no installed agents exist at the temp path,
+		// but the function progresses past the "no config" early return
+		// (it attempts to apply, proving it detected the config)
+		expect(result).toBeDefined();
+		expect(typeof result.applied).toBe("boolean");
+		expect(typeof result.agentsModified).toBe("number");
+	});
+});

--- a/cli/src/__tests__/scripts/generate-asset-imports.test.ts
+++ b/cli/src/__tests__/scripts/generate-asset-imports.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, test } from "bun:test";
+import {
+	type AssetImport,
+	collectPlatformAssets,
+	type DiscoveredPlatform,
+	formatAgentEntry,
+} from "../../../scripts/generate-asset-imports.ts";
+import type { BundleManifest } from "../../build/models.js";
+
+function makeMinimalManifest(
+	agents: BundleManifest["plugins"]["base"]["agents"],
+): BundleManifest {
+	return {
+		plugins: {
+			base: {
+				name: "rp1-base",
+				commands: [],
+				agents,
+				skills: [],
+				stateMachines: [],
+				verbatimFiles: [],
+			},
+			dev: {
+				name: "rp1-dev",
+				commands: [],
+				agents: [],
+				skills: [],
+				stateMachines: [],
+				verbatimFiles: [],
+			},
+			utils: {
+				name: "rp1-utils",
+				commands: [],
+				agents: [],
+				skills: [],
+				stateMachines: [],
+				verbatimFiles: [],
+			},
+		},
+		version: "0.0.0-test",
+		buildTimestamp: "2026-01-01T00:00:00Z",
+	};
+}
+
+function makePlatform(manifest: BundleManifest): DiscoveredPlatform {
+	return {
+		name: "claude-code",
+		distDir: "/tmp/test-dist/claude-code",
+		manifest,
+	};
+}
+
+describe("collectPlatformAssets", () => {
+	test("preserves tier and effort from BundleAgentEntry", () => {
+		const manifest = makeMinimalManifest([
+			{
+				name: "task-builder",
+				path: "dev/agents/task-builder.md",
+				tier: "deep",
+				effort: "high",
+			},
+			{
+				name: "speedrun-builder",
+				path: "dev/agents/speedrun-builder.md",
+				tier: "standard",
+				effort: "medium",
+			},
+		]);
+		const platform = makePlatform(manifest);
+
+		const assets = collectPlatformAssets(platform);
+		const agentAssets = assets.filter((a) => a.category === "agent");
+
+		expect(agentAssets).toHaveLength(2);
+
+		const taskBuilder = agentAssets.find(
+			(a) => a.outputName === "task-builder",
+		);
+		expect(taskBuilder).toBeDefined();
+		expect(taskBuilder!.tier).toBe("deep");
+		expect(taskBuilder!.effort).toBe("high");
+
+		const speedrunBuilder = agentAssets.find(
+			(a) => a.outputName === "speedrun-builder",
+		);
+		expect(speedrunBuilder).toBeDefined();
+		expect(speedrunBuilder!.tier).toBe("standard");
+		expect(speedrunBuilder!.effort).toBe("medium");
+	});
+
+	test("omits tier and effort when not present in BundleAgentEntry", () => {
+		const manifest = makeMinimalManifest([
+			{ name: "generic-agent", path: "base/agents/generic.md" },
+		]);
+		const platform = makePlatform(manifest);
+
+		const assets = collectPlatformAssets(platform);
+		const agentAssets = assets.filter((a) => a.category === "agent");
+
+		expect(agentAssets).toHaveLength(1);
+		expect(agentAssets[0].tier).toBeUndefined();
+		expect(agentAssets[0].effort).toBeUndefined();
+	});
+
+	test("preserves tier without effort and vice versa", () => {
+		const manifest = makeMinimalManifest([
+			{ name: "tier-only", path: "base/agents/tier-only.md", tier: "fast" },
+			{
+				name: "effort-only",
+				path: "base/agents/effort-only.md",
+				effort: "low",
+			},
+		]);
+		const platform = makePlatform(manifest);
+
+		const assets = collectPlatformAssets(platform);
+		const agentAssets = assets.filter((a) => a.category === "agent");
+
+		const tierOnly = agentAssets.find((a) => a.outputName === "tier-only");
+		expect(tierOnly!.tier).toBe("fast");
+		expect(tierOnly!.effort).toBeUndefined();
+
+		const effortOnly = agentAssets.find((a) => a.outputName === "effort-only");
+		expect(effortOnly!.tier).toBeUndefined();
+		expect(effortOnly!.effort).toBe("low");
+	});
+});
+
+describe("formatAgentEntry", () => {
+	test("emits tier and effort in output string", () => {
+		const entry: AssetImport = {
+			varName: "claude_code_dev_agent_task_builder",
+			importPath: "../../dist/claude-code/dev/agents/task-builder.md",
+			outputName: "task-builder",
+			fileName: "task-builder.md",
+			category: "agent",
+			plugin: "dev",
+			platform: "claude-code",
+			tier: "deep",
+			effort: "high",
+		};
+
+		const result = formatAgentEntry(entry);
+
+		expect(result).toContain('tier: "deep"');
+		expect(result).toContain('effort: "high"');
+		expect(result).toContain('name: "task-builder"');
+		expect(result).toContain('fileName: "task-builder.md"');
+	});
+
+	test("omits tier and effort when not set", () => {
+		const entry: AssetImport = {
+			varName: "claude_code_base_agent_generic",
+			importPath: "../../dist/claude-code/base/agents/generic.md",
+			outputName: "generic",
+			category: "agent",
+			plugin: "base",
+			platform: "claude-code",
+		};
+
+		const result = formatAgentEntry(entry);
+
+		expect(result).not.toContain("tier:");
+		expect(result).not.toContain("effort:");
+		expect(result).toContain('name: "generic"');
+	});
+
+	test("emits tier without effort", () => {
+		const entry: AssetImport = {
+			varName: "claude_code_base_agent_fast_agent",
+			importPath: "../../dist/claude-code/base/agents/fast-agent.md",
+			outputName: "fast-agent",
+			category: "agent",
+			plugin: "base",
+			platform: "claude-code",
+			tier: "fast",
+		};
+
+		const result = formatAgentEntry(entry);
+
+		expect(result).toContain('tier: "fast"');
+		expect(result).not.toContain("effort:");
+	});
+});

--- a/cli/src/__tests__/settings/apply.test.ts
+++ b/cli/src/__tests__/settings/apply.test.ts
@@ -2,7 +2,7 @@
  * Unit tests for the tier remapping apply orchestrator.
  */
 
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import * as E from "fp-ts/lib/Either.js";
@@ -73,6 +73,8 @@ const createDeps = (): ApplyDeps => ({
 		return fs.existsSync(path);
 	},
 	refreshClaudeCodePlugins: async () => {},
+	getBundledAssets: () =>
+		E.left({ _tag: "UsageError", message: "not bundled" } as never),
 });
 
 // ---------------------------------------------------------------------------
@@ -635,16 +637,14 @@ describe("applyTierRemappings - cache refresh warnings", () => {
 				},
 			},
 		},
+		webui: [],
 		version: "0.0.0-test",
 		buildTimestamp: new Date().toISOString(),
 	};
 
-	test("produces warning when refreshClaudeCodePlugins throws", async () => {
-		mock.module("../../assets/reader.js", () => ({
-			getBundledAssets: () => E.right(minimalManifest),
-			ALL_PLUGIN_KEYS: ["base", "dev", "utils"],
-		}));
+	const isolatedGlobalSettings = () => join(tempDir, "no-global-settings.toml");
 
+	test("produces warning when refreshClaudeCodePlugins throws", async () => {
 		await writeFixture(
 			tempDir,
 			".rp1/settings.toml",
@@ -668,10 +668,15 @@ describe("applyTierRemappings - cache refresh warnings", () => {
 			refreshClaudeCodePlugins: async () => {
 				throw new Error("plugin cache connection refused");
 			},
+			getBundledAssets: () => E.right(minimalManifest),
 		};
 
 		const result = await applyTierRemappings(
-			{ projectRoot: tempDir, dryRun: false },
+			{
+				projectRoot: tempDir,
+				dryRun: false,
+				globalSettingsPath: isolatedGlobalSettings(),
+			},
 			deps,
 		);
 

--- a/cli/src/__tests__/settings/apply.test.ts
+++ b/cli/src/__tests__/settings/apply.test.ts
@@ -1,0 +1,513 @@
+/**
+ * Unit tests for the tier remapping apply orchestrator.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import {
+	type AgentFileEntry,
+	type ApplyDeps,
+	applyRemappingsToAgents,
+	resolveConfig,
+} from "../../settings/apply.js";
+import { resetSettingsCache } from "../../settings/loader.js";
+import {
+	cleanupTempDir,
+	createTempDir,
+	writeFixture,
+} from "../helpers/index.js";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const CC_AGENT_DEEP = [
+	"---",
+	"model: opus",
+	"effort: high",
+	"---",
+	"",
+	"# Feature Architect",
+	"",
+	"You are a feature architect.",
+].join("\n");
+
+const CC_AGENT_STANDARD = [
+	"---",
+	"model: sonnet",
+	"---",
+	"",
+	"# Task Builder",
+	"",
+	"You are a task builder.",
+].join("\n");
+
+const CODEX_AGENT_DEEP = [
+	'name = "rp1-dev-feature-architect"',
+	'description = "Designs features"',
+	'model = "gpt-5.5"',
+	'model_reasoning_effort = "high"',
+	"",
+	"developer_instructions = '''",
+	"This is the multiline",
+	"developer instructions.",
+	"'''",
+].join("\n");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const createDeps = (): ApplyDeps => ({
+	readFile: (path) => readFileSync(path, "utf-8"),
+	writeFile: (path, content) => {
+		const fs = require("node:fs");
+		fs.writeFileSync(path, content, "utf-8");
+	},
+	fileExists: (path) => {
+		const fs = require("node:fs");
+		return fs.existsSync(path);
+	},
+	refreshClaudeCodePlugins: async () => {},
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+let tempDir: string;
+
+beforeEach(async () => {
+	resetSettingsCache();
+	tempDir = await createTempDir("apply");
+});
+
+afterEach(async () => {
+	await cleanupTempDir(tempDir);
+});
+
+describe("applyRemappingsToAgents", () => {
+	test("updates Claude Code agent model field when tier is remapped", async () => {
+		const agentPath = await writeFixture(
+			tempDir,
+			"agents/feature-architect.md",
+			CC_AGENT_DEEP,
+		);
+
+		const agents: AgentFileEntry[] = [
+			{
+				name: "feature-architect",
+				filePath: agentPath,
+				tier: "deep",
+				effort: "high",
+				platform: "claude-code",
+			},
+		];
+
+		const result = applyRemappingsToAgents(
+			agents,
+			{ "claude-code": { deep: "sonnet" } },
+			false,
+			createDeps(),
+		);
+
+		expect(result.agentsModified).toBe(1);
+		expect(result.applied).toBe(true);
+
+		const updated = readFileSync(agentPath, "utf-8");
+		expect(updated).toContain("model: sonnet");
+		expect(updated).not.toContain("model: opus");
+		expect(updated).toContain("# Feature Architect");
+		expect(updated).toContain("You are a feature architect.");
+	});
+
+	test("dry-run reports changes without modifying files", async () => {
+		const agentPath = await writeFixture(
+			tempDir,
+			"agents/feature-architect.md",
+			CC_AGENT_DEEP,
+		);
+
+		const agents: AgentFileEntry[] = [
+			{
+				name: "feature-architect",
+				filePath: agentPath,
+				tier: "deep",
+				effort: "high",
+				platform: "claude-code",
+			},
+		];
+
+		const result = applyRemappingsToAgents(
+			agents,
+			{ "claude-code": { deep: "sonnet" } },
+			true,
+			createDeps(),
+		);
+
+		expect(result.agentsModified).toBe(1);
+		expect(result.applied).toBe(true);
+
+		const content = readFileSync(agentPath, "utf-8");
+		expect(content).toBe(CC_AGENT_DEEP);
+	});
+
+	test("skips agents with tiers not present in remapping", async () => {
+		const agentPath = await writeFixture(
+			tempDir,
+			"agents/task-builder.md",
+			CC_AGENT_STANDARD,
+		);
+
+		const agents: AgentFileEntry[] = [
+			{
+				name: "task-builder",
+				filePath: agentPath,
+				tier: "standard",
+				platform: "claude-code",
+			},
+		];
+
+		const result = applyRemappingsToAgents(
+			agents,
+			{ "claude-code": { deep: "sonnet" } },
+			false,
+			createDeps(),
+		);
+
+		expect(result.agentsModified).toBe(0);
+		expect(result.applied).toBe(false);
+	});
+
+	test("skips agents on platforms without remappings", async () => {
+		const agentPath = await writeFixture(
+			tempDir,
+			"agents/feature-architect.md",
+			CC_AGENT_DEEP,
+		);
+
+		const agents: AgentFileEntry[] = [
+			{
+				name: "feature-architect",
+				filePath: agentPath,
+				tier: "deep",
+				effort: "high",
+				platform: "claude-code",
+			},
+		];
+
+		const result = applyRemappingsToAgents(
+			agents,
+			{ codex: { deep: "gpt-5.4" } },
+			false,
+			createDeps(),
+		);
+
+		expect(result.agentsModified).toBe(0);
+	});
+
+	test("produces warning for unreadable agent artifact and continues", async () => {
+		const goodPath = await writeFixture(
+			tempDir,
+			"agents/task-builder.md",
+			CC_AGENT_DEEP,
+		);
+
+		const agents: AgentFileEntry[] = [
+			{
+				name: "broken-agent",
+				filePath: "/nonexistent/path/agent.md",
+				tier: "deep",
+				platform: "claude-code",
+			},
+			{
+				name: "task-builder",
+				filePath: goodPath,
+				tier: "deep",
+				effort: "high",
+				platform: "claude-code",
+			},
+		];
+
+		const result = applyRemappingsToAgents(
+			agents,
+			{ "claude-code": { deep: "sonnet" } },
+			false,
+			createDeps(),
+		);
+
+		expect(result.warnings.length).toBeGreaterThan(0);
+		expect(result.warnings[0]).toContain("broken-agent");
+		expect(result.agentsModified).toBe(1);
+	});
+
+	test("reports effort adjustments when remapping to fast-class model", async () => {
+		const agentPath = await writeFixture(
+			tempDir,
+			"agents/feature-architect.md",
+			CC_AGENT_DEEP,
+		);
+
+		const agents: AgentFileEntry[] = [
+			{
+				name: "feature-architect",
+				filePath: agentPath,
+				tier: "deep",
+				effort: "high",
+				platform: "claude-code",
+			},
+		];
+
+		const result = applyRemappingsToAgents(
+			agents,
+			{ "claude-code": { deep: "haiku" } },
+			false,
+			createDeps(),
+		);
+
+		expect(result.agentsModified).toBe(1);
+		expect(result.effortAdjustments).toHaveLength(1);
+		expect(result.effortAdjustments[0].agentName).toBe("feature-architect");
+		expect(result.effortAdjustments[0].action).toBe("stripped");
+
+		const updated = readFileSync(agentPath, "utf-8");
+		expect(updated).toContain("model: haiku");
+		expect(updated).not.toContain("effort:");
+	});
+
+	test("reports protected agent downgrade warnings", async () => {
+		const agentPath = await writeFixture(
+			tempDir,
+			"agents/feature-architect.md",
+			CC_AGENT_DEEP,
+		);
+
+		const agents: AgentFileEntry[] = [
+			{
+				name: "feature-architect",
+				filePath: agentPath,
+				tier: "deep",
+				effort: "high",
+				platform: "claude-code",
+			},
+		];
+
+		const result = applyRemappingsToAgents(
+			agents,
+			{ "claude-code": { deep: "haiku" } },
+			false,
+			createDeps(),
+		);
+
+		expect(result.protectedWarnings).toHaveLength(1);
+		expect(result.protectedWarnings[0].agentName).toBe("feature-architect");
+	});
+
+	test("updates Codex TOML agent model field", async () => {
+		const agentPath = await writeFixture(
+			tempDir,
+			"agents/rp1-dev-feature-architect.toml",
+			CODEX_AGENT_DEEP,
+		);
+
+		const agents: AgentFileEntry[] = [
+			{
+				name: "feature-architect",
+				filePath: agentPath,
+				tier: "deep",
+				effort: "high",
+				platform: "codex",
+			},
+		];
+
+		const result = applyRemappingsToAgents(
+			agents,
+			{ codex: { deep: "gpt-5.4" } },
+			false,
+			createDeps(),
+		);
+
+		expect(result.agentsModified).toBe(1);
+		const updated = readFileSync(agentPath, "utf-8");
+		expect(updated).toContain('model = "gpt-5.4"');
+		expect(updated).not.toContain('model = "gpt-5.5"');
+		expect(updated).toContain("developer_instructions = '''");
+	});
+
+	test("handles multiple agents across platforms", async () => {
+		const ccPath = await writeFixture(
+			tempDir,
+			"cc/feature-architect.md",
+			CC_AGENT_DEEP,
+		);
+		const codexPath = await writeFixture(
+			tempDir,
+			"codex/rp1-dev-feature-architect.toml",
+			CODEX_AGENT_DEEP,
+		);
+
+		const agents: AgentFileEntry[] = [
+			{
+				name: "feature-architect",
+				filePath: ccPath,
+				tier: "deep",
+				effort: "high",
+				platform: "claude-code",
+			},
+			{
+				name: "feature-architect",
+				filePath: codexPath,
+				tier: "deep",
+				effort: "high",
+				platform: "codex",
+			},
+		];
+
+		const result = applyRemappingsToAgents(
+			agents,
+			{
+				"claude-code": { deep: "sonnet" },
+				codex: { deep: "gpt-5.4" },
+			},
+			false,
+			createDeps(),
+		);
+
+		expect(result.agentsModified).toBe(2);
+	});
+
+	test("skips agents with inherit tier", async () => {
+		const agentPath = await writeFixture(
+			tempDir,
+			"agents/agent.md",
+			CC_AGENT_STANDARD,
+		);
+
+		const agents: AgentFileEntry[] = [
+			{
+				name: "some-agent",
+				filePath: agentPath,
+				tier: "inherit",
+				platform: "claude-code",
+			},
+		];
+
+		const result = applyRemappingsToAgents(
+			agents,
+			{ "claude-code": { deep: "sonnet", standard: "haiku" } },
+			false,
+			createDeps(),
+		);
+
+		expect(result.agentsModified).toBe(0);
+	});
+
+	test("summary includes all counts across agents", async () => {
+		const path1 = await writeFixture(
+			tempDir,
+			"agents/feature-architect.md",
+			CC_AGENT_DEEP,
+		);
+		const path2 = await writeFixture(
+			tempDir,
+			"agents/task-builder.md",
+			CC_AGENT_STANDARD,
+		);
+
+		const agents: AgentFileEntry[] = [
+			{
+				name: "feature-architect",
+				filePath: path1,
+				tier: "deep",
+				effort: "high",
+				platform: "claude-code",
+			},
+			{
+				name: "task-builder",
+				filePath: path2,
+				tier: "standard",
+				platform: "claude-code",
+			},
+		];
+
+		const result = applyRemappingsToAgents(
+			agents,
+			{ "claude-code": { deep: "haiku", standard: "haiku" } },
+			false,
+			createDeps(),
+		);
+
+		expect(result.agentsModified).toBe(2);
+		expect(result.effortAdjustments.length).toBeGreaterThanOrEqual(1);
+		expect(result.protectedWarnings.length).toBeGreaterThanOrEqual(1);
+	});
+});
+
+describe("resolveConfig", () => {
+	test("loads config from settings.toml", async () => {
+		await writeFixture(
+			tempDir,
+			".rp1/settings.toml",
+			["[models.claude-code]", 'deep = "sonnet"'].join("\n"),
+		);
+
+		const { config, errors } = await resolveConfig(tempDir);
+		expect(errors).toHaveLength(0);
+		expect(config.platforms["claude-code"]?.deep).toBe("sonnet");
+	});
+
+	test("resolves named preset from CLI flag", async () => {
+		const { config, errors } = await resolveConfig(tempDir, "budget");
+		expect(errors).toHaveLength(0);
+		expect(config.preset).toBe("budget");
+		expect(config.platforms["claude-code"]?.deep).toBe("haiku");
+		expect(config.platforms.codex?.deep).toBe("gpt-5.4-mini");
+	});
+
+	test("returns error for unknown preset", async () => {
+		const { errors } = await resolveConfig(tempDir, "nonexistent");
+		expect(errors.length).toBeGreaterThan(0);
+		expect(errors[0]).toContain("nonexistent");
+	});
+
+	test("CLI preset replaces custom mapping entirely", async () => {
+		await writeFixture(
+			tempDir,
+			".rp1/settings.toml",
+			["[models.claude-code]", 'deep = "sonnet"', 'standard = "haiku"'].join(
+				"\n",
+			),
+		);
+
+		const { config, errors } = await resolveConfig(tempDir, "premium");
+		expect(errors).toHaveLength(0);
+		expect(config.platforms["claude-code"]?.deep).toBe("opus");
+		expect(config.platforms["claude-code"]?.standard).toBe("sonnet");
+	});
+
+	test("settings.toml preset merges with per-platform overrides", async () => {
+		await writeFixture(
+			tempDir,
+			".rp1/settings.toml",
+			[
+				"[models]",
+				'preset = "budget"',
+				"",
+				"[models.claude-code]",
+				'deep = "sonnet"',
+			].join("\n"),
+		);
+
+		const { config, errors } = await resolveConfig(tempDir);
+		expect(errors).toHaveLength(0);
+		expect(config.platforms["claude-code"]?.deep).toBe("sonnet");
+		expect(config.platforms["claude-code"]?.standard).toBe("haiku");
+	});
+
+	test("returns empty config when no settings exist", async () => {
+		const { config, errors } = await resolveConfig(tempDir);
+		expect(errors).toHaveLength(0);
+		expect(Object.keys(config.platforms)).toHaveLength(0);
+		expect(config.preset).toBeUndefined();
+	});
+});

--- a/cli/src/__tests__/settings/apply.test.ts
+++ b/cli/src/__tests__/settings/apply.test.ts
@@ -380,6 +380,66 @@ describe("applyRemappingsToAgents", () => {
 		expect(result.agentsModified).toBe(2);
 	});
 
+	test("returns agentsAlreadyCurrent when artifact already has the target model", async () => {
+		const agentPath = await writeFixture(
+			tempDir,
+			"agents/feature-architect.md",
+			CC_AGENT_DEEP,
+		);
+
+		const agents: AgentFileEntry[] = [
+			{
+				name: "feature-architect",
+				filePath: agentPath,
+				tier: "deep",
+				effort: "high",
+				platform: "claude-code",
+			},
+		];
+
+		const result = applyRemappingsToAgents(
+			agents,
+			{ "claude-code": { deep: "opus" } },
+			false,
+			createDeps(),
+		);
+
+		expect(result.agentsModified).toBe(0);
+		expect(result.agentsAlreadyCurrent).toBe(1);
+		expect(result.applied).toBe(false);
+
+		const content = readFileSync(agentPath, "utf-8");
+		expect(content).toBe(CC_AGENT_DEEP);
+	});
+
+	test("returns both counters at zero when no remapping matches agent tier", async () => {
+		const agentPath = await writeFixture(
+			tempDir,
+			"agents/task-builder.md",
+			CC_AGENT_STANDARD,
+		);
+
+		const agents: AgentFileEntry[] = [
+			{
+				name: "task-builder",
+				filePath: agentPath,
+				tier: "standard",
+				platform: "claude-code",
+			},
+		];
+
+		const result = applyRemappingsToAgents(
+			agents,
+			{ "claude-code": { deep: "sonnet" } },
+			false,
+			createDeps(),
+		);
+
+		expect(result.agentsModified).toBe(0);
+		expect(result.agentsAlreadyCurrent).toBe(0);
+		expect(result.applied).toBe(false);
+	});
+
 	test("skips agents with inherit tier", async () => {
 		const agentPath = await writeFixture(
 			tempDir,
@@ -448,6 +508,11 @@ describe("applyRemappingsToAgents", () => {
 });
 
 describe("resolveConfig", () => {
+	// Isolated global settings path to prevent tests from reading the
+	// developer's real ~/.config/rp1/settings.toml (mirrors the
+	// loadAllArgumentDefaults injection seam from b838b9f6).
+	const isolatedGlobalSettings = () => join(tempDir, "no-global-settings.toml");
+
 	test("loads config from settings.toml", async () => {
 		await writeFixture(
 			tempDir,
@@ -455,13 +520,21 @@ describe("resolveConfig", () => {
 			["[models.claude-code]", 'deep = "sonnet"'].join("\n"),
 		);
 
-		const { config, errors } = await resolveConfig(tempDir);
+		const { config, errors } = await resolveConfig(
+			tempDir,
+			undefined,
+			isolatedGlobalSettings(),
+		);
 		expect(errors).toHaveLength(0);
 		expect(config.platforms["claude-code"]?.deep).toBe("sonnet");
 	});
 
 	test("resolves named preset from CLI flag", async () => {
-		const { config, errors } = await resolveConfig(tempDir, "budget");
+		const { config, errors } = await resolveConfig(
+			tempDir,
+			"budget",
+			isolatedGlobalSettings(),
+		);
 		expect(errors).toHaveLength(0);
 		expect(config.preset).toBe("budget");
 		expect(config.platforms["claude-code"]?.deep).toBe("haiku");
@@ -469,7 +542,11 @@ describe("resolveConfig", () => {
 	});
 
 	test("returns error for unknown preset", async () => {
-		const { errors } = await resolveConfig(tempDir, "nonexistent");
+		const { errors } = await resolveConfig(
+			tempDir,
+			"nonexistent",
+			isolatedGlobalSettings(),
+		);
 		expect(errors.length).toBeGreaterThan(0);
 		expect(errors[0]).toContain("nonexistent");
 	});
@@ -483,7 +560,11 @@ describe("resolveConfig", () => {
 			),
 		);
 
-		const { config, errors } = await resolveConfig(tempDir, "premium");
+		const { config, errors } = await resolveConfig(
+			tempDir,
+			"premium",
+			isolatedGlobalSettings(),
+		);
 		expect(errors).toHaveLength(0);
 		expect(config.platforms["claude-code"]?.deep).toBe("opus");
 		expect(config.platforms["claude-code"]?.standard).toBe("sonnet");
@@ -502,14 +583,22 @@ describe("resolveConfig", () => {
 			].join("\n"),
 		);
 
-		const { config, errors } = await resolveConfig(tempDir);
+		const { config, errors } = await resolveConfig(
+			tempDir,
+			undefined,
+			isolatedGlobalSettings(),
+		);
 		expect(errors).toHaveLength(0);
 		expect(config.platforms["claude-code"]?.deep).toBe("sonnet");
 		expect(config.platforms["claude-code"]?.standard).toBe("haiku");
 	});
 
 	test("returns empty config when no settings exist", async () => {
-		const { config, errors } = await resolveConfig(tempDir);
+		const { config, errors } = await resolveConfig(
+			tempDir,
+			undefined,
+			isolatedGlobalSettings(),
+		);
 		expect(errors).toHaveLength(0);
 		expect(Object.keys(config.platforms)).toHaveLength(0);
 		expect(config.preset).toBeUndefined();

--- a/cli/src/__tests__/settings/apply.test.ts
+++ b/cli/src/__tests__/settings/apply.test.ts
@@ -2,12 +2,16 @@
  * Unit tests for the tier remapping apply orchestrator.
  */
 
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import * as E from "fp-ts/lib/Either.js";
+import { DEFAULT_MARKETPLACE_DIR } from "../../install/claudecode/marketplace.js";
 import {
 	type AgentFileEntry,
 	type ApplyDeps,
 	applyRemappingsToAgents,
+	applyTierRemappings,
 	resolveConfig,
 } from "../../settings/apply.js";
 import { resetSettingsCache } from "../../settings/loader.js";
@@ -509,5 +513,84 @@ describe("resolveConfig", () => {
 		expect(errors).toHaveLength(0);
 		expect(Object.keys(config.platforms)).toHaveLength(0);
 		expect(config.preset).toBeUndefined();
+	});
+});
+
+describe("applyTierRemappings - cache refresh warnings", () => {
+	const emptyPlugin = {
+		name: "",
+		agents: [],
+		commands: [],
+		skills: [],
+		stateMachines: [],
+		verbatimFiles: [],
+	};
+
+	const minimalManifest = {
+		platforms: {
+			"claude-code": {
+				plugins: {
+					base: {
+						...emptyPlugin,
+						name: "rp1-base",
+						agents: [
+							{
+								name: "feature-architect",
+								path: "",
+								tier: "deep",
+								effort: "high",
+							},
+						],
+					},
+					dev: { ...emptyPlugin, name: "rp1-dev" },
+				},
+			},
+		},
+		version: "0.0.0-test",
+		buildTimestamp: new Date().toISOString(),
+	};
+
+	test("produces warning when refreshClaudeCodePlugins throws", async () => {
+		mock.module("../../assets/reader.js", () => ({
+			getBundledAssets: () => E.right(minimalManifest),
+			ALL_PLUGIN_KEYS: ["base", "dev", "utils"],
+		}));
+
+		await writeFixture(
+			tempDir,
+			".rp1/settings.toml",
+			["[models.claude-code]", 'deep = "sonnet"'].join("\n"),
+		);
+
+		const expectedPath = join(
+			DEFAULT_MARKETPLACE_DIR,
+			"base",
+			"agents",
+			"feature-architect.md",
+		);
+
+		const deps: ApplyDeps = {
+			readFile: (path) => {
+				if (path === expectedPath) return CC_AGENT_DEEP;
+				throw new Error(`unexpected read: ${path}`);
+			},
+			writeFile: () => {},
+			fileExists: (path) => path === expectedPath,
+			refreshClaudeCodePlugins: async () => {
+				throw new Error("plugin cache connection refused");
+			},
+		};
+
+		const result = await applyTierRemappings(
+			{ projectRoot: tempDir, dryRun: false },
+			deps,
+		);
+
+		expect(result.agentsModified).toBe(1);
+		const refreshWarning = result.warnings.find((w) =>
+			w.includes("plugin cache"),
+		);
+		expect(refreshWarning).toBeDefined();
+		expect(refreshWarning).toContain("connection refused");
 	});
 });

--- a/cli/src/__tests__/settings/loader.test.ts
+++ b/cli/src/__tests__/settings/loader.test.ts
@@ -3,6 +3,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { join } from "node:path";
 import {
 	loadAllArgumentDefaults,
 	loadArgumentDefaultsForSkill,
@@ -15,6 +16,10 @@ import {
 } from "../helpers/index.js";
 
 let tempDir: string;
+
+/** Path to a nonexistent global settings file within tempDir, isolating tests from ~/.config/rp1/settings.toml. */
+const isolatedGlobalPath = (): string =>
+	join(tempDir, ".no-global", "settings.toml");
 
 beforeEach(async () => {
 	resetSettingsCache();
@@ -125,7 +130,7 @@ describe("loadArgumentDefaultsForSkill", () => {
 
 describe("loadAllArgumentDefaults", () => {
 	test("returns empty when no settings files exist", async () => {
-		const result = await loadAllArgumentDefaults(tempDir);
+		const result = await loadAllArgumentDefaults(tempDir, isolatedGlobalPath());
 		expect(result).toEqual({});
 	});
 
@@ -143,7 +148,7 @@ describe("loadAllArgumentDefaults", () => {
 			].join("\n"),
 		);
 
-		const result = await loadAllArgumentDefaults(tempDir);
+		const result = await loadAllArgumentDefaults(tempDir, isolatedGlobalPath());
 		expect(result).toEqual({
 			build: { AFK: false, GIT_COMMIT: true },
 			"build-fast": { AFK: false },
@@ -157,7 +162,7 @@ describe("loadAllArgumentDefaults", () => {
 			`[arguments.build]\nPLATFORM = "claude-code"\n`,
 		);
 
-		const result = await loadAllArgumentDefaults(tempDir);
+		const result = await loadAllArgumentDefaults(tempDir, isolatedGlobalPath());
 		expect(result).toEqual({
 			build: { PLATFORM: "claude-code" },
 		});
@@ -177,7 +182,7 @@ describe("loadAllArgumentDefaults", () => {
 			].join("\n"),
 		);
 
-		const result = await loadAllArgumentDefaults(tempDir);
+		const result = await loadAllArgumentDefaults(tempDir, isolatedGlobalPath());
 		expect(result).toEqual({
 			build: { AFK: false, GIT_COMMIT: true },
 			"build-fast": { AFK: true },

--- a/cli/src/__tests__/settings/presets.test.ts
+++ b/cli/src/__tests__/settings/presets.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Unit tests for blessed preset definitions (budget, standard, premium).
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+	getPreset,
+	listPresets,
+	VALID_PRESET_NAMES,
+} from "../../settings/presets.js";
+
+const REMAPPABLE_TIERS = ["deep", "standard", "fast"] as const;
+const PRESET_PLATFORMS = ["claude-code", "codex"] as const;
+
+describe("preset definitions", () => {
+	test("budget preset maps every remappable tier for Claude Code and Codex", () => {
+		const preset = getPreset("budget");
+		expect(preset).toBeDefined();
+		for (const platform of PRESET_PLATFORMS) {
+			const mapping = preset!.platforms[platform];
+			expect(mapping).toBeDefined();
+			for (const tier of REMAPPABLE_TIERS) {
+				expect(mapping![tier]).toBeString();
+				expect(mapping![tier].length).toBeGreaterThan(0);
+			}
+		}
+	});
+
+	test("standard preset maps every remappable tier for Claude Code and Codex", () => {
+		const preset = getPreset("standard");
+		expect(preset).toBeDefined();
+		for (const platform of PRESET_PLATFORMS) {
+			const mapping = preset!.platforms[platform];
+			expect(mapping).toBeDefined();
+			for (const tier of REMAPPABLE_TIERS) {
+				expect(mapping![tier]).toBeString();
+				expect(mapping![tier].length).toBeGreaterThan(0);
+			}
+		}
+	});
+
+	test("premium preset maps every remappable tier for Claude Code and Codex", () => {
+		const preset = getPreset("premium");
+		expect(preset).toBeDefined();
+		for (const platform of PRESET_PLATFORMS) {
+			const mapping = preset!.platforms[platform];
+			expect(mapping).toBeDefined();
+			for (const tier of REMAPPABLE_TIERS) {
+				expect(mapping![tier]).toBeString();
+				expect(mapping![tier].length).toBeGreaterThan(0);
+			}
+		}
+	});
+
+	test("premium preset matches TIER_MODEL_MAP build defaults", () => {
+		const preset = getPreset("premium")!;
+		expect(preset.platforms["claude-code"]!.deep).toBe("opus");
+		expect(preset.platforms["claude-code"]!.standard).toBe("sonnet");
+		expect(preset.platforms["claude-code"]!.fast).toBe("haiku");
+		expect(preset.platforms.codex!.deep).toBe("gpt-5.5");
+		expect(preset.platforms.codex!.standard).toBe("gpt-5.4");
+		expect(preset.platforms.codex!.fast).toBe("gpt-5.4-mini");
+	});
+
+	test("budget preset uses only fast-class models", () => {
+		const preset = getPreset("budget")!;
+		expect(preset.platforms["claude-code"]!.deep).toBe("haiku");
+		expect(preset.platforms["claude-code"]!.standard).toBe("haiku");
+		expect(preset.platforms["claude-code"]!.fast).toBe("haiku");
+		expect(preset.platforms.codex!.deep).toBe("gpt-5.4-mini");
+		expect(preset.platforms.codex!.standard).toBe("gpt-5.4-mini");
+		expect(preset.platforms.codex!.fast).toBe("gpt-5.4-mini");
+	});
+
+	test("standard preset collapses deep to sonnet-class", () => {
+		const preset = getPreset("standard")!;
+		expect(preset.platforms["claude-code"]!.deep).toBe("sonnet");
+		expect(preset.platforms["claude-code"]!.standard).toBe("sonnet");
+		expect(preset.platforms["claude-code"]!.fast).toBe("haiku");
+		expect(preset.platforms.codex!.deep).toBe("gpt-5.4");
+		expect(preset.platforms.codex!.standard).toBe("gpt-5.4");
+		expect(preset.platforms.codex!.fast).toBe("gpt-5.4-mini");
+	});
+});
+
+describe("getPreset", () => {
+	test("returns undefined for unknown preset name", () => {
+		expect(getPreset("nonexistent")).toBeUndefined();
+	});
+
+	test("returns correct preset for each valid name", () => {
+		for (const name of VALID_PRESET_NAMES) {
+			const preset = getPreset(name);
+			expect(preset).toBeDefined();
+			expect(preset!.name).toBe(name);
+		}
+	});
+});
+
+describe("listPresets", () => {
+	test("returns all three presets in order", () => {
+		const presets = listPresets();
+		expect(presets).toHaveLength(3);
+		expect(presets[0].name).toBe("budget");
+		expect(presets[1].name).toBe("standard");
+		expect(presets[2].name).toBe("premium");
+	});
+
+	test("each preset has a non-empty description", () => {
+		for (const preset of listPresets()) {
+			expect(preset.description).toBeString();
+			expect(preset.description.length).toBeGreaterThan(0);
+		}
+	});
+});
+
+describe("VALID_PRESET_NAMES", () => {
+	test("contains exactly budget, standard, premium", () => {
+		expect(VALID_PRESET_NAMES).toEqual(["budget", "standard", "premium"]);
+	});
+});

--- a/cli/src/__tests__/settings/rewriter.test.ts
+++ b/cli/src/__tests__/settings/rewriter.test.ts
@@ -3,8 +3,8 @@
  */
 
 import { describe, expect, test } from "bun:test";
+import { modelSupportsEffort } from "../../build/tier-resolution.js";
 import {
-	modelSupportsEffort,
 	type RewriteAgentParams,
 	rewriteAgentArtifact,
 } from "../../settings/rewriter.js";
@@ -201,6 +201,37 @@ describe("rewriteAgentArtifact - Codex", () => {
 		expect(result.modified).toBe(true);
 		expect(result.content).toContain('model = "gpt-5.4"');
 		expect(result.content).not.toContain("model_reasoning_effort");
+	});
+
+	test("does not rewrite model-like text inside multiline developer_instructions", () => {
+		const content = [
+			'name = "rp1-dev-test-agent"',
+			'description = "Agent with model ref in instructions"',
+			'model = "gpt-5.5"',
+			"",
+			"developer_instructions = '''",
+			"When configuring the model, set:",
+			'model = "some-other-model"',
+			"in the config file.",
+			"'''",
+		].join("\n");
+
+		const params: RewriteAgentParams = {
+			content,
+			agentName: "test-agent",
+			newModel: "gpt-5.4",
+			originalTier: "deep",
+			platform: "codex",
+		};
+
+		const result = rewriteAgentArtifact(params);
+
+		expect(result.modified).toBe(true);
+		// The top-level model should be rewritten
+		const lines = result.content.split("\n");
+		expect(lines[2]).toBe('model = "gpt-5.4"');
+		// The model inside developer_instructions must NOT be rewritten
+		expect(result.content).toContain('model = "some-other-model"');
 	});
 });
 

--- a/cli/src/__tests__/settings/rewriter.test.ts
+++ b/cli/src/__tests__/settings/rewriter.test.ts
@@ -164,7 +164,6 @@ describe("rewriteAgentArtifact - Codex", () => {
 		expect(result.content).not.toContain('model = "gpt-5.5"');
 		// developer_instructions must be preserved verbatim
 		const diStart = "developer_instructions = '''";
-		const diEnd = "'''";
 		const originalDI = CODEX_AGENT_WITH_EFFORT.slice(
 			CODEX_AGENT_WITH_EFFORT.indexOf(diStart),
 		);

--- a/cli/src/__tests__/settings/rewriter.test.ts
+++ b/cli/src/__tests__/settings/rewriter.test.ts
@@ -1,0 +1,401 @@
+/**
+ * Unit tests for artifact rewriter with effort correction and protected-agent warnings.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+	modelSupportsEffort,
+	type RewriteAgentParams,
+	rewriteAgentArtifact,
+} from "../../settings/rewriter.js";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const CC_AGENT_WITH_EFFORT = [
+	"---",
+	"model: opus",
+	"effort: high",
+	"---",
+	"",
+	"## Host Context",
+	"",
+	"This is the agent prompt body content.",
+	"",
+	"It should remain byte-identical after rewriting.",
+].join("\n");
+
+const CC_AGENT_NO_EFFORT = [
+	"---",
+	"model: haiku",
+	"---",
+	"",
+	"## Host Context",
+	"",
+	"Body content without effort.",
+].join("\n");
+
+const CODEX_AGENT_WITH_EFFORT = [
+	'name = "rp1-dev-feature-architect"',
+	'description = "Designs features with deep architectural analysis"',
+	'model = "gpt-5.5"',
+	'model_reasoning_effort = "high"',
+	"",
+	"developer_instructions = '''",
+	"This is the multiline",
+	"developer instructions.",
+	"",
+	"It should remain verbatim after rewriting.",
+	"'''",
+].join("\n");
+
+const CODEX_AGENT_NO_EFFORT = [
+	'name = "rp1-dev-build-task-parser"',
+	'description = "Extracts structured task information"',
+	'model = "gpt-5.4-mini"',
+	"",
+	"developer_instructions = '''",
+	"Multiline content here.",
+	"'''",
+].join("\n");
+
+// ---------------------------------------------------------------------------
+// Claude Code rewriting
+// ---------------------------------------------------------------------------
+
+describe("rewriteAgentArtifact - Claude Code", () => {
+	test("rewrites model field in YAML frontmatter and preserves body byte-identical", () => {
+		const params: RewriteAgentParams = {
+			content: CC_AGENT_WITH_EFFORT,
+			agentName: "strategic-advisor",
+			newModel: "sonnet",
+			originalTier: "deep",
+			originalEffort: "high",
+			platform: "claude-code",
+		};
+
+		const result = rewriteAgentArtifact(params);
+
+		expect(result.modified).toBe(true);
+		// Frontmatter should contain new model
+		expect(result.content).toContain("model: sonnet");
+		expect(result.content).not.toContain("model: opus");
+		// Body must be byte-identical
+		const bodyAfterFrontmatter = result.content
+			.split("---\n")
+			.slice(2)
+			.join("---\n");
+		const originalBody = CC_AGENT_WITH_EFFORT.split("---\n")
+			.slice(2)
+			.join("---\n");
+		expect(bodyAfterFrontmatter).toBe(originalBody);
+	});
+
+	test("preserves effort field when remapped model supports effort", () => {
+		const params: RewriteAgentParams = {
+			content: CC_AGENT_WITH_EFFORT,
+			agentName: "strategic-advisor",
+			newModel: "sonnet",
+			originalTier: "deep",
+			originalEffort: "high",
+			platform: "claude-code",
+		};
+
+		const result = rewriteAgentArtifact(params);
+
+		expect(result.content).toContain("effort: high");
+		expect(result.effortAdjustment).toBeUndefined();
+	});
+
+	test("returns modified=false when model is already the target", () => {
+		const params: RewriteAgentParams = {
+			content: CC_AGENT_WITH_EFFORT,
+			agentName: "strategic-advisor",
+			newModel: "opus",
+			originalTier: "deep",
+			originalEffort: "high",
+			platform: "claude-code",
+		};
+
+		const result = rewriteAgentArtifact(params);
+
+		expect(result.modified).toBe(false);
+		expect(result.content).toBe(CC_AGENT_WITH_EFFORT);
+	});
+
+	test("handles agent without effort field", () => {
+		const params: RewriteAgentParams = {
+			content: CC_AGENT_NO_EFFORT,
+			agentName: "build-task-parser",
+			newModel: "sonnet",
+			originalTier: "fast",
+			platform: "claude-code",
+		};
+
+		const result = rewriteAgentArtifact(params);
+
+		expect(result.modified).toBe(true);
+		expect(result.content).toContain("model: sonnet");
+		expect(result.content).not.toContain("effort:");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Codex rewriting
+// ---------------------------------------------------------------------------
+
+describe("rewriteAgentArtifact - Codex", () => {
+	test("rewrites model field and preserves multiline developer_instructions", () => {
+		const params: RewriteAgentParams = {
+			content: CODEX_AGENT_WITH_EFFORT,
+			agentName: "feature-architect",
+			newModel: "gpt-5.4",
+			originalTier: "deep",
+			originalEffort: "high",
+			platform: "codex",
+		};
+
+		const result = rewriteAgentArtifact(params);
+
+		expect(result.modified).toBe(true);
+		// Model should be updated
+		expect(result.content).toContain('model = "gpt-5.4"');
+		expect(result.content).not.toContain('model = "gpt-5.5"');
+		// developer_instructions must be preserved verbatim
+		const diStart = "developer_instructions = '''";
+		const diEnd = "'''";
+		const originalDI = CODEX_AGENT_WITH_EFFORT.slice(
+			CODEX_AGENT_WITH_EFFORT.indexOf(diStart),
+		);
+		const resultDI = result.content.slice(result.content.indexOf(diStart));
+		expect(resultDI).toBe(originalDI);
+	});
+
+	test("preserves effort field when remapped model supports effort", () => {
+		const params: RewriteAgentParams = {
+			content: CODEX_AGENT_WITH_EFFORT,
+			agentName: "feature-architect",
+			newModel: "gpt-5.4",
+			originalTier: "deep",
+			originalEffort: "high",
+			platform: "codex",
+		};
+
+		const result = rewriteAgentArtifact(params);
+
+		expect(result.content).toContain('model_reasoning_effort = "high"');
+		expect(result.effortAdjustment).toBeUndefined();
+	});
+
+	test("handles agent without effort field", () => {
+		const params: RewriteAgentParams = {
+			content: CODEX_AGENT_NO_EFFORT,
+			agentName: "build-task-parser",
+			newModel: "gpt-5.4",
+			originalTier: "fast",
+			platform: "codex",
+		};
+
+		const result = rewriteAgentArtifact(params);
+
+		expect(result.modified).toBe(true);
+		expect(result.content).toContain('model = "gpt-5.4"');
+		expect(result.content).not.toContain("model_reasoning_effort");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Effort stripping
+// ---------------------------------------------------------------------------
+
+describe("effort correction", () => {
+	test("strips effort when deep tier remapped to haiku (fast-class model)", () => {
+		const params: RewriteAgentParams = {
+			content: CC_AGENT_WITH_EFFORT,
+			agentName: "strategic-advisor",
+			newModel: "haiku",
+			originalTier: "deep",
+			originalEffort: "high",
+			platform: "claude-code",
+		};
+
+		const result = rewriteAgentArtifact(params);
+
+		expect(result.modified).toBe(true);
+		expect(result.content).toContain("model: haiku");
+		expect(result.content).not.toContain("effort:");
+		// Effort adjustment should be reported
+		expect(result.effortAdjustment).toBeDefined();
+		expect(result.effortAdjustment!.agentName).toBe("strategic-advisor");
+		expect(result.effortAdjustment!.originalEffort).toBe("high");
+		expect(result.effortAdjustment!.action).toBe("stripped");
+	});
+
+	test("strips Codex effort when remapped to fast-class model", () => {
+		const params: RewriteAgentParams = {
+			content: CODEX_AGENT_WITH_EFFORT,
+			agentName: "feature-architect",
+			newModel: "gpt-5.4-mini",
+			originalTier: "deep",
+			originalEffort: "high",
+			platform: "codex",
+		};
+
+		const result = rewriteAgentArtifact(params);
+
+		expect(result.modified).toBe(true);
+		expect(result.content).toContain('model = "gpt-5.4-mini"');
+		expect(result.content).not.toContain("model_reasoning_effort");
+		expect(result.effortAdjustment).toBeDefined();
+		expect(result.effortAdjustment!.action).toBe("stripped");
+	});
+
+	test("no effort adjustment when agent has no original effort", () => {
+		const params: RewriteAgentParams = {
+			content: CC_AGENT_NO_EFFORT,
+			agentName: "build-task-parser",
+			newModel: "sonnet",
+			originalTier: "fast",
+			platform: "claude-code",
+		};
+
+		const result = rewriteAgentArtifact(params);
+
+		expect(result.effortAdjustment).toBeUndefined();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Protected agent warnings
+// ---------------------------------------------------------------------------
+
+describe("protected agent warnings", () => {
+	test("emits warning when protected agent remapped from deep to haiku", () => {
+		const params: RewriteAgentParams = {
+			content: CC_AGENT_WITH_EFFORT,
+			agentName: "feature-architect",
+			newModel: "haiku",
+			originalTier: "deep",
+			originalEffort: "high",
+			platform: "claude-code",
+		};
+
+		const result = rewriteAgentArtifact(params);
+
+		expect(result.protectedWarning).toBeDefined();
+		expect(result.protectedWarning!.agentName).toBe("feature-architect");
+		expect(result.protectedWarning!.message).toContain("feature-architect");
+	});
+
+	test("no warning for non-protected agent downgrade", () => {
+		const params: RewriteAgentParams = {
+			content: CC_AGENT_WITH_EFFORT,
+			agentName: "some-regular-agent",
+			newModel: "haiku",
+			originalTier: "deep",
+			originalEffort: "high",
+			platform: "claude-code",
+		};
+
+		const result = rewriteAgentArtifact(params);
+
+		expect(result.protectedWarning).toBeUndefined();
+	});
+
+	test("no warning when protected agent stays at same or higher tier", () => {
+		const params: RewriteAgentParams = {
+			content: CC_AGENT_WITH_EFFORT,
+			agentName: "feature-architect",
+			newModel: "sonnet",
+			originalTier: "standard",
+			originalEffort: "high",
+			platform: "claude-code",
+		};
+
+		const result = rewriteAgentArtifact(params);
+
+		expect(result.protectedWarning).toBeUndefined();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Platform skipping
+// ---------------------------------------------------------------------------
+
+describe("unsupported platforms", () => {
+	test("skips copilot with no error", () => {
+		const params: RewriteAgentParams = {
+			content: "some content",
+			agentName: "test-agent",
+			newModel: "sonnet",
+			originalTier: "deep",
+			platform: "copilot",
+		};
+
+		const result = rewriteAgentArtifact(params);
+
+		expect(result.modified).toBe(false);
+		expect(result.content).toBe("some content");
+	});
+
+	test("skips opencode with no error", () => {
+		const params: RewriteAgentParams = {
+			content: "some content",
+			agentName: "test-agent",
+			newModel: "sonnet",
+			originalTier: "deep",
+			platform: "opencode",
+		};
+
+		const result = rewriteAgentArtifact(params);
+
+		expect(result.modified).toBe(false);
+		expect(result.content).toBe("some content");
+	});
+
+	test("skips antigravity with no error", () => {
+		const params: RewriteAgentParams = {
+			content: "some content",
+			agentName: "test-agent",
+			newModel: "sonnet",
+			originalTier: "deep",
+			platform: "antigravity",
+		};
+
+		const result = rewriteAgentArtifact(params);
+
+		expect(result.modified).toBe(false);
+		expect(result.content).toBe("some content");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// modelSupportsEffort
+// ---------------------------------------------------------------------------
+
+describe("modelSupportsEffort", () => {
+	test("returns false for haiku on claude-code (fast-class)", () => {
+		expect(modelSupportsEffort("haiku", "claude-code")).toBe(false);
+	});
+
+	test("returns true for opus on claude-code", () => {
+		expect(modelSupportsEffort("opus", "claude-code")).toBe(true);
+	});
+
+	test("returns true for sonnet on claude-code", () => {
+		expect(modelSupportsEffort("sonnet", "claude-code")).toBe(true);
+	});
+
+	test("returns false for gpt-5.4-mini on codex (fast-class)", () => {
+		expect(modelSupportsEffort("gpt-5.4-mini", "codex")).toBe(false);
+	});
+
+	test("returns true for gpt-5.5 on codex", () => {
+		expect(modelSupportsEffort("gpt-5.5", "codex")).toBe(true);
+	});
+
+	test("returns true for unknown model (conservative: assume supports effort)", () => {
+		expect(modelSupportsEffort("custom-model", "claude-code")).toBe(true);
+	});
+});

--- a/cli/src/__tests__/settings/tier-remapping-validation.test.ts
+++ b/cli/src/__tests__/settings/tier-remapping-validation.test.ts
@@ -1,0 +1,258 @@
+/**
+ * Unit tests for tier remapping settings validation.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { BundleAgentEntry } from "../../build/models.js";
+import type { TierRemappingConfig } from "../../settings/models.js";
+import { validateTierRemappings } from "../../settings/validator.js";
+
+describe("validateTierRemappings", () => {
+	test("returns valid result for correct config", () => {
+		const config: TierRemappingConfig = {
+			platforms: {
+				"claude-code": { deep: "sonnet", standard: "sonnet", fast: "haiku" },
+			},
+		};
+
+		const result = validateTierRemappings(config);
+		expect(result.valid).toBe(true);
+		expect(result.errors).toHaveLength(0);
+		expect(result.warnings).toHaveLength(0);
+	});
+
+	test("returns valid for empty config", () => {
+		const config: TierRemappingConfig = { platforms: {} };
+		const result = validateTierRemappings(config);
+		expect(result.valid).toBe(true);
+		expect(result.errors).toHaveLength(0);
+	});
+
+	test("errors on unrecognized model identifier listing valid options", () => {
+		const config: TierRemappingConfig = {
+			platforms: {
+				"claude-code": { deep: "nonexistent" },
+			},
+		};
+
+		const result = validateTierRemappings(config);
+		expect(result.valid).toBe(false);
+		expect(result.errors.length).toBeGreaterThan(0);
+
+		const errorMsg = result.errors[0];
+		expect(errorMsg).toContain("nonexistent");
+		expect(errorMsg).toContain("opus");
+		expect(errorMsg).toContain("sonnet");
+		expect(errorMsg).toContain("haiku");
+	});
+
+	test("errors on invalid model ID for codex platform", () => {
+		const config: TierRemappingConfig = {
+			platforms: {
+				codex: { standard: "invalid-model" },
+			},
+		};
+
+		const result = validateTierRemappings(config);
+		expect(result.valid).toBe(false);
+		expect(result.errors[0]).toContain("invalid-model");
+		expect(result.errors[0]).toContain("gpt-5.4");
+	});
+
+	test("warns on unknown platform name (forward compatibility)", () => {
+		const config: TierRemappingConfig = {
+			platforms: {
+				"future-platform": { deep: "some-model" },
+			} as TierRemappingConfig["platforms"],
+		};
+
+		const result = validateTierRemappings(config);
+		expect(result.valid).toBe(true);
+		expect(result.warnings.length).toBeGreaterThan(0);
+		expect(result.warnings[0]).toContain("future-platform");
+		expect(result.warnings[0]).toContain("unknown platform");
+	});
+
+	test("warns on unsupported platform with no model fields (copilot)", () => {
+		const config: TierRemappingConfig = {
+			platforms: {
+				copilot: { deep: "some-model" },
+			},
+		};
+
+		const result = validateTierRemappings(config);
+		expect(result.valid).toBe(true);
+		expect(result.warnings.length).toBeGreaterThan(0);
+		expect(result.warnings[0]).toContain("copilot");
+		expect(result.warnings[0]).toContain("no effect");
+	});
+
+	test("warns on unsupported platform with no model fields (opencode)", () => {
+		const config: TierRemappingConfig = {
+			platforms: {
+				opencode: { deep: "some-model" },
+			},
+		};
+
+		const result = validateTierRemappings(config);
+		expect(result.valid).toBe(true);
+		expect(result.warnings.length).toBeGreaterThan(0);
+		expect(result.warnings[0]).toContain("opencode");
+		expect(result.warnings[0]).toContain("no effect");
+	});
+
+	test("reports effort adjustment when remapping to fast-class model", () => {
+		const config: TierRemappingConfig = {
+			platforms: {
+				"claude-code": { deep: "haiku" },
+			},
+		};
+
+		const agents: readonly BundleAgentEntry[] = [
+			{
+				name: "feature-architect",
+				path: "agents/feature-architect.md",
+				tier: "deep",
+				effort: "high",
+			},
+			{
+				name: "task-builder",
+				path: "agents/task-builder.md",
+				tier: "deep",
+				effort: "medium",
+			},
+		];
+
+		const result = validateTierRemappings(config, agents);
+		expect(result.effortAdjustments.length).toBeGreaterThan(0);
+		expect(
+			result.effortAdjustments.some((a) => a.includes("feature-architect")),
+		).toBe(true);
+		expect(
+			result.effortAdjustments.some((a) => a.includes("task-builder")),
+		).toBe(true);
+	});
+
+	test("no effort adjustments when remapped model supports effort", () => {
+		const config: TierRemappingConfig = {
+			platforms: {
+				"claude-code": { deep: "sonnet" },
+			},
+		};
+
+		const agents: readonly BundleAgentEntry[] = [
+			{
+				name: "feature-architect",
+				path: "agents/feature-architect.md",
+				tier: "deep",
+				effort: "high",
+			},
+		];
+
+		const result = validateTierRemappings(config, agents);
+		expect(result.effortAdjustments).toHaveLength(0);
+	});
+
+	test("skips effort adjustment for agents without effort set", () => {
+		const config: TierRemappingConfig = {
+			platforms: {
+				"claude-code": { deep: "haiku" },
+			},
+		};
+
+		const agents: readonly BundleAgentEntry[] = [
+			{
+				name: "speedrun-builder",
+				path: "agents/speedrun-builder.md",
+				tier: "deep",
+			},
+		];
+
+		const result = validateTierRemappings(config, agents);
+		expect(result.effortAdjustments).toHaveLength(0);
+	});
+
+	test("validates preset name when specified", () => {
+		const config: TierRemappingConfig = {
+			preset: "nonexistent-preset",
+			platforms: {},
+		};
+
+		const result = validateTierRemappings(config);
+		expect(result.valid).toBe(false);
+		expect(result.errors[0]).toContain("nonexistent-preset");
+		expect(result.errors[0]).toContain("budget");
+		expect(result.errors[0]).toContain("standard");
+		expect(result.errors[0]).toContain("premium");
+	});
+
+	test("accepts valid preset names", () => {
+		const config: TierRemappingConfig = {
+			preset: "budget",
+			platforms: {},
+		};
+
+		const result = validateTierRemappings(config);
+		expect(result.valid).toBe(true);
+	});
+
+	test("validates multiple errors across platforms", () => {
+		const config: TierRemappingConfig = {
+			platforms: {
+				"claude-code": { deep: "bad-model-1" },
+				codex: { standard: "bad-model-2" },
+			},
+		};
+
+		const result = validateTierRemappings(config);
+		expect(result.valid).toBe(false);
+		expect(result.errors.length).toBe(2);
+		expect(result.errors[0]).toContain("bad-model-1");
+		expect(result.errors[1]).toContain("bad-model-2");
+	});
+
+	test("effort adjustments for codex platform", () => {
+		const config: TierRemappingConfig = {
+			platforms: {
+				codex: { deep: "gpt-5.4-mini" },
+			},
+		};
+
+		const agents: readonly BundleAgentEntry[] = [
+			{
+				name: "feature-architect",
+				path: "agents/feature-architect.md",
+				tier: "deep",
+				effort: "high",
+			},
+		];
+
+		const result = validateTierRemappings(config, agents);
+		expect(result.effortAdjustments.length).toBeGreaterThan(0);
+		expect(result.effortAdjustments[0]).toContain("feature-architect");
+	});
+
+	test("valid config with codex platform mappings", () => {
+		const config: TierRemappingConfig = {
+			platforms: {
+				codex: { deep: "gpt-5.5", standard: "gpt-5.4", fast: "gpt-5.4-mini" },
+			},
+		};
+
+		const result = validateTierRemappings(config);
+		expect(result.valid).toBe(true);
+		expect(result.errors).toHaveLength(0);
+	});
+
+	test("antigravity platform accepts valid model IDs", () => {
+		const config: TierRemappingConfig = {
+			platforms: {
+				antigravity: { deep: "gemini-3.1-pro", standard: "gemini-3.5-flash" },
+			},
+		};
+
+		const result = validateTierRemappings(config);
+		expect(result.valid).toBe(true);
+		expect(result.errors).toHaveLength(0);
+	});
+});

--- a/cli/src/__tests__/settings/tier-remapping-validation.test.ts
+++ b/cli/src/__tests__/settings/tier-remapping-validation.test.ts
@@ -244,7 +244,7 @@ describe("validateTierRemappings", () => {
 		expect(result.errors).toHaveLength(0);
 	});
 
-	test("antigravity platform accepts valid model IDs", () => {
+	test("antigravity platform produces cannot-rewrite warning", () => {
 		const config: TierRemappingConfig = {
 			platforms: {
 				antigravity: { deep: "gemini-3.1-pro", standard: "gemini-3.5-flash" },
@@ -254,5 +254,8 @@ describe("validateTierRemappings", () => {
 		const result = validateTierRemappings(config);
 		expect(result.valid).toBe(true);
 		expect(result.errors).toHaveLength(0);
+		expect(result.warnings.length).toBeGreaterThan(0);
+		expect(result.warnings[0]).toContain("antigravity");
+		expect(result.warnings[0]).toContain("no effect");
 	});
 });

--- a/cli/src/__tests__/settings/tier-remapping.test.ts
+++ b/cli/src/__tests__/settings/tier-remapping.test.ts
@@ -3,6 +3,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { join } from "node:path";
 import {
 	loadTierRemappings,
 	resetSettingsCache,
@@ -25,8 +26,10 @@ afterEach(async () => {
 });
 
 describe("loadTierRemappings", () => {
+	const isolatedGlobalSettings = () => join(tempDir, "no-global-settings.toml");
+
 	test("returns empty config when no settings files exist", async () => {
-		const result = await loadTierRemappings(tempDir);
+		const result = await loadTierRemappings(tempDir, isolatedGlobalSettings());
 		expect(result.preset).toBeUndefined();
 		expect(result.platforms).toEqual({});
 	});
@@ -43,7 +46,7 @@ describe("loadTierRemappings", () => {
 			].join("\n"),
 		);
 
-		const result = await loadTierRemappings(tempDir);
+		const result = await loadTierRemappings(tempDir, isolatedGlobalSettings());
 		expect(result.platforms["claude-code"]).toBeDefined();
 		expect(result.platforms["claude-code"]!.deep).toBe("sonnet");
 		expect(result.platforms["claude-code"]!.standard).toBe("sonnet");
@@ -57,7 +60,7 @@ describe("loadTierRemappings", () => {
 			["[models]", 'preset = "budget"'].join("\n"),
 		);
 
-		const result = await loadTierRemappings(tempDir);
+		const result = await loadTierRemappings(tempDir, isolatedGlobalSettings());
 		expect(result.preset).toBe("budget");
 		expect(result.platforms).toEqual({});
 	});
@@ -78,7 +81,7 @@ describe("loadTierRemappings", () => {
 			].join("\n"),
 		);
 
-		const result = await loadTierRemappings(tempDir);
+		const result = await loadTierRemappings(tempDir, isolatedGlobalSettings());
 		expect(result.preset).toBe("budget");
 		expect(result.platforms["claude-code"]!.deep).toBe("sonnet");
 		expect(result.platforms.codex!.deep).toBe("gpt-5.4");
@@ -91,7 +94,7 @@ describe("loadTierRemappings", () => {
 			["[models.claude-code]", 'deep = "sonnet"'].join("\n"),
 		);
 
-		const result = await loadTierRemappings(tempDir);
+		const result = await loadTierRemappings(tempDir, isolatedGlobalSettings());
 		const ccMap = result.platforms["claude-code"]!;
 		expect(ccMap.deep).toBe("sonnet");
 		expect(ccMap.standard).toBeUndefined();
@@ -106,7 +109,7 @@ describe("loadTierRemappings", () => {
 			["[arguments.build]", "AFK = false"].join("\n"),
 		);
 
-		const result = await loadTierRemappings(tempDir);
+		const result = await loadTierRemappings(tempDir, isolatedGlobalSettings());
 		expect(result.preset).toBeUndefined();
 		expect(result.platforms).toEqual({});
 	});
@@ -123,7 +126,7 @@ describe("loadTierRemappings", () => {
 			].join("\n"),
 		);
 
-		const result = await loadTierRemappings(tempDir);
+		const result = await loadTierRemappings(tempDir, isolatedGlobalSettings());
 		const ccMap = result.platforms["claude-code"]!;
 		expect(ccMap.deep).toBe("sonnet");
 		expect(ccMap.standard).toBeUndefined();
@@ -137,7 +140,7 @@ describe("loadTierRemappings", () => {
 			"this is not valid toml {{{}}}",
 		);
 
-		const result = await loadTierRemappings(tempDir);
+		const result = await loadTierRemappings(tempDir, isolatedGlobalSettings());
 		expect(result.preset).toBeUndefined();
 		expect(result.platforms).toEqual({});
 	});
@@ -158,7 +161,7 @@ describe("loadTierRemappings", () => {
 			].join("\n"),
 		);
 
-		const result = await loadTierRemappings(tempDir);
+		const result = await loadTierRemappings(tempDir, isolatedGlobalSettings());
 		expect(Object.keys(result.platforms)).toHaveLength(2);
 		expect(result.platforms["claude-code"]!.deep).toBe("sonnet");
 		expect(result.platforms.codex!.deep).toBe("gpt-5.5");
@@ -178,7 +181,7 @@ describe("loadTierRemappings", () => {
 		// We can verify project values are present - user-level settings
 		// at ~/.config/rp1/settings.toml can't be controlled in isolation,
 		// but the project values should appear in the result.
-		const result = await loadTierRemappings(tempDir);
+		const result = await loadTierRemappings(tempDir, isolatedGlobalSettings());
 		expect(result.platforms["claude-code"]!.deep).toBe("sonnet");
 		expect(result.platforms["claude-code"]!.standard).toBe("haiku");
 	});
@@ -190,7 +193,7 @@ describe("loadTierRemappings", () => {
 			["[models.claude-code]", 'deep = "sonnet"'].join("\n"),
 		);
 
-		const first = await loadTierRemappings(tempDir);
+		const first = await loadTierRemappings(tempDir, isolatedGlobalSettings());
 		expect(first.platforms["claude-code"]!.deep).toBe("sonnet");
 
 		// Change the file, should still get cached result
@@ -200,7 +203,7 @@ describe("loadTierRemappings", () => {
 			["[models.claude-code]", 'deep = "opus"'].join("\n"),
 		);
 
-		const second = await loadTierRemappings(tempDir);
+		const second = await loadTierRemappings(tempDir, isolatedGlobalSettings());
 		expect(second.platforms["claude-code"]!.deep).toBe("sonnet");
 	});
 
@@ -211,7 +214,7 @@ describe("loadTierRemappings", () => {
 			["[models.claude-code]", 'deep = "sonnet"'].join("\n"),
 		);
 
-		const first = await loadTierRemappings(tempDir);
+		const first = await loadTierRemappings(tempDir, isolatedGlobalSettings());
 		expect(first.platforms["claude-code"]!.deep).toBe("sonnet");
 
 		await writeFixture(
@@ -222,7 +225,7 @@ describe("loadTierRemappings", () => {
 
 		resetSettingsCache();
 
-		const second = await loadTierRemappings(tempDir);
+		const second = await loadTierRemappings(tempDir, isolatedGlobalSettings());
 		expect(second.platforms["claude-code"]!.deep).toBe("opus");
 	});
 
@@ -233,7 +236,7 @@ describe("loadTierRemappings", () => {
 			["[models]", "preset = 42"].join("\n"),
 		);
 
-		const result = await loadTierRemappings(tempDir);
+		const result = await loadTierRemappings(tempDir, isolatedGlobalSettings());
 		expect(result.preset).toBeUndefined();
 	});
 });

--- a/cli/src/__tests__/settings/tier-remapping.test.ts
+++ b/cli/src/__tests__/settings/tier-remapping.test.ts
@@ -1,0 +1,239 @@
+/**
+ * Unit tests for tier remapping settings loader.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+	loadTierRemappings,
+	resetSettingsCache,
+} from "../../settings/loader.js";
+import {
+	cleanupTempDir,
+	createTempDir,
+	writeFixture,
+} from "../helpers/index.js";
+
+let tempDir: string;
+
+beforeEach(async () => {
+	resetSettingsCache();
+	tempDir = await createTempDir("tier-remapping");
+});
+
+afterEach(async () => {
+	await cleanupTempDir(tempDir);
+});
+
+describe("loadTierRemappings", () => {
+	test("returns empty config when no settings files exist", async () => {
+		const result = await loadTierRemappings(tempDir);
+		expect(result.preset).toBeUndefined();
+		expect(result.platforms).toEqual({});
+	});
+
+	test("parses [models.claude-code] section with tier mappings", async () => {
+		await writeFixture(
+			tempDir,
+			".rp1/settings.toml",
+			[
+				"[models.claude-code]",
+				'deep = "sonnet"',
+				'standard = "sonnet"',
+				'fast = "haiku"',
+			].join("\n"),
+		);
+
+		const result = await loadTierRemappings(tempDir);
+		expect(result.platforms["claude-code"]).toBeDefined();
+		expect(result.platforms["claude-code"]!.deep).toBe("sonnet");
+		expect(result.platforms["claude-code"]!.standard).toBe("sonnet");
+		expect(result.platforms["claude-code"]!.fast).toBe("haiku");
+	});
+
+	test("parses preset from [models] section", async () => {
+		await writeFixture(
+			tempDir,
+			".rp1/settings.toml",
+			["[models]", 'preset = "budget"'].join("\n"),
+		);
+
+		const result = await loadTierRemappings(tempDir);
+		expect(result.preset).toBe("budget");
+		expect(result.platforms).toEqual({});
+	});
+
+	test("parses preset alongside platform-specific overrides", async () => {
+		await writeFixture(
+			tempDir,
+			".rp1/settings.toml",
+			[
+				"[models]",
+				'preset = "budget"',
+				"",
+				"[models.claude-code]",
+				'deep = "sonnet"',
+				"",
+				"[models.codex]",
+				'deep = "gpt-5.4"',
+			].join("\n"),
+		);
+
+		const result = await loadTierRemappings(tempDir);
+		expect(result.preset).toBe("budget");
+		expect(result.platforms["claude-code"]!.deep).toBe("sonnet");
+		expect(result.platforms.codex!.deep).toBe("gpt-5.4");
+	});
+
+	test("omitted tiers are absent from parsed config", async () => {
+		await writeFixture(
+			tempDir,
+			".rp1/settings.toml",
+			["[models.claude-code]", 'deep = "sonnet"'].join("\n"),
+		);
+
+		const result = await loadTierRemappings(tempDir);
+		const ccMap = result.platforms["claude-code"]!;
+		expect(ccMap.deep).toBe("sonnet");
+		expect(ccMap.standard).toBeUndefined();
+		expect(ccMap.fast).toBeUndefined();
+		expect(ccMap.frontier).toBeUndefined();
+	});
+
+	test("returns empty config when settings has no [models] section", async () => {
+		await writeFixture(
+			tempDir,
+			".rp1/settings.toml",
+			["[arguments.build]", "AFK = false"].join("\n"),
+		);
+
+		const result = await loadTierRemappings(tempDir);
+		expect(result.preset).toBeUndefined();
+		expect(result.platforms).toEqual({});
+	});
+
+	test("ignores non-string values in tier mappings", async () => {
+		await writeFixture(
+			tempDir,
+			".rp1/settings.toml",
+			[
+				"[models.claude-code]",
+				'deep = "sonnet"',
+				"standard = 42",
+				"fast = true",
+			].join("\n"),
+		);
+
+		const result = await loadTierRemappings(tempDir);
+		const ccMap = result.platforms["claude-code"]!;
+		expect(ccMap.deep).toBe("sonnet");
+		expect(ccMap.standard).toBeUndefined();
+		expect(ccMap.fast).toBeUndefined();
+	});
+
+	test("handles malformed TOML gracefully", async () => {
+		await writeFixture(
+			tempDir,
+			".rp1/settings.toml",
+			"this is not valid toml {{{}}}",
+		);
+
+		const result = await loadTierRemappings(tempDir);
+		expect(result.preset).toBeUndefined();
+		expect(result.platforms).toEqual({});
+	});
+
+	test("parses multiple platforms", async () => {
+		await writeFixture(
+			tempDir,
+			".rp1/settings.toml",
+			[
+				"[models.claude-code]",
+				'deep = "sonnet"',
+				'standard = "haiku"',
+				"",
+				"[models.codex]",
+				'deep = "gpt-5.5"',
+				'standard = "gpt-5.4"',
+				'fast = "gpt-5.4-mini"',
+			].join("\n"),
+		);
+
+		const result = await loadTierRemappings(tempDir);
+		expect(Object.keys(result.platforms)).toHaveLength(2);
+		expect(result.platforms["claude-code"]!.deep).toBe("sonnet");
+		expect(result.platforms.codex!.deep).toBe("gpt-5.5");
+		expect(result.platforms.codex!.fast).toBe("gpt-5.4-mini");
+	});
+
+	test("project-level settings override user-level per-platform", async () => {
+		// Project-level has claude-code overrides
+		await writeFixture(
+			tempDir,
+			".rp1/settings.toml",
+			["[models.claude-code]", 'deep = "sonnet"', 'standard = "haiku"'].join(
+				"\n",
+			),
+		);
+
+		// We can verify project values are present - user-level settings
+		// at ~/.config/rp1/settings.toml can't be controlled in isolation,
+		// but the project values should appear in the result.
+		const result = await loadTierRemappings(tempDir);
+		expect(result.platforms["claude-code"]!.deep).toBe("sonnet");
+		expect(result.platforms["claude-code"]!.standard).toBe("haiku");
+	});
+
+	test("caches tier remapping results across calls", async () => {
+		await writeFixture(
+			tempDir,
+			".rp1/settings.toml",
+			["[models.claude-code]", 'deep = "sonnet"'].join("\n"),
+		);
+
+		const first = await loadTierRemappings(tempDir);
+		expect(first.platforms["claude-code"]!.deep).toBe("sonnet");
+
+		// Change the file, should still get cached result
+		await writeFixture(
+			tempDir,
+			".rp1/settings.toml",
+			["[models.claude-code]", 'deep = "opus"'].join("\n"),
+		);
+
+		const second = await loadTierRemappings(tempDir);
+		expect(second.platforms["claude-code"]!.deep).toBe("sonnet");
+	});
+
+	test("resetSettingsCache forces fresh read for tier remappings", async () => {
+		await writeFixture(
+			tempDir,
+			".rp1/settings.toml",
+			["[models.claude-code]", 'deep = "sonnet"'].join("\n"),
+		);
+
+		const first = await loadTierRemappings(tempDir);
+		expect(first.platforms["claude-code"]!.deep).toBe("sonnet");
+
+		await writeFixture(
+			tempDir,
+			".rp1/settings.toml",
+			["[models.claude-code]", 'deep = "opus"'].join("\n"),
+		);
+
+		resetSettingsCache();
+
+		const second = await loadTierRemappings(tempDir);
+		expect(second.platforms["claude-code"]!.deep).toBe("opus");
+	});
+
+	test("ignores non-string preset value", async () => {
+		await writeFixture(
+			tempDir,
+			".rp1/settings.toml",
+			["[models]", "preset = 42"].join("\n"),
+		);
+
+		const result = await loadTierRemappings(tempDir);
+		expect(result.preset).toBeUndefined();
+	});
+});

--- a/cli/src/assets/reader.ts
+++ b/cli/src/assets/reader.ts
@@ -15,6 +15,8 @@ export interface AssetEntry {
 	path: string;
 	content?: string;
 	fileName?: string;
+	tier?: string;
+	effort?: string;
 }
 
 /**

--- a/cli/src/build/command.ts
+++ b/cli/src/build/command.ts
@@ -41,6 +41,7 @@ import {
 import type {
 	BuildConfig,
 	BuildSummary,
+	BundleAgentEntry,
 	BundleAssetEntry,
 	BundlePluginAssets,
 	EffortLevel,
@@ -534,7 +535,7 @@ export const buildPlatformPlugin = async (
 ): Promise<PlatformBuildResult> => {
 	const errors: string[] = [];
 	const commandEntries: BundleAssetEntry[] = [];
-	const agentEntries: BundleAssetEntry[] = [];
+	const agentEntries: BundleAgentEntry[] = [];
 	const skillEntries: BundleAssetEntry[] = [];
 	const skillFileEntries: BundleAssetEntry[] = [];
 	const stateMachineEntries: BundleAssetEntry[] = [];
@@ -948,7 +949,12 @@ export const buildPlatformPlugin = async (
 
 		if (definition.producesBundleAssets) {
 			const relativePath = `${pluginName}/agents/${agentFilename}`;
-			agentEntries.push({ name: ccAgent.name, path: relativePath });
+			agentEntries.push({
+				name: ccAgent.name,
+				path: relativePath,
+				tier: ccAgent.model as ModelTier,
+				...(ccAgent.effort && { effort: ccAgent.effort as EffortLevel }),
+			});
 		}
 
 		// Track Codex agent metadata in build state for postPluginBuild hooks

--- a/cli/src/build/index.ts
+++ b/cli/src/build/index.ts
@@ -27,6 +27,7 @@ export type {
 	ArtifactResult,
 	BuildConfig,
 	BuildSummary,
+	BundleAgentEntry,
 	BundleAssetEntry,
 	BundleManifest,
 	BundlePluginAssets,

--- a/cli/src/build/models.ts
+++ b/cli/src/build/models.ts
@@ -314,6 +314,17 @@ export interface BundleAssetEntry {
 }
 
 /**
+ * Extended asset entry for agents carrying build-time tier metadata.
+ * The optional tier and effort fields preserve the agent's abstract tier identity
+ * and effort level through the build-to-install chain, enabling install-time
+ * remapping without access to source frontmatter.
+ */
+export interface BundleAgentEntry extends BundleAssetEntry {
+	readonly tier?: ModelTier;
+	readonly effort?: EffortLevel;
+}
+
+/**
  * OpenCode plugin asset entry for bundling.
  * Represents a plugin that responds to OpenCode events (e.g., update notifications).
  */
@@ -328,7 +339,7 @@ export interface OpenCodePluginAsset {
 export interface BundlePluginAssets {
 	readonly name: string;
 	readonly commands: readonly BundleAssetEntry[];
-	readonly agents: readonly BundleAssetEntry[];
+	readonly agents: readonly BundleAgentEntry[];
 	readonly skills: readonly BundleAssetEntry[];
 	readonly stateMachines: readonly BundleAssetEntry[];
 	readonly verbatimFiles: readonly BundleAssetEntry[];

--- a/cli/src/build/tier-resolution.ts
+++ b/cli/src/build/tier-resolution.ts
@@ -29,7 +29,7 @@ import type { BuildPlatform } from "./template-context.js";
  * gemini-3.5-flash for standard/fast).
  *
  */
-const TIER_MODEL_MAP: Readonly<
+export const TIER_MODEL_MAP: Readonly<
 	Record<Exclude<ModelTier, "inherit">, Partial<Record<BuildPlatform, string>>>
 > = {
 	frontier: {

--- a/cli/src/build/tier-resolution.ts
+++ b/cli/src/build/tier-resolution.ts
@@ -96,6 +96,67 @@ const PLATFORM_EFFORT: Readonly<
 };
 
 // ---------------------------------------------------------------------------
+// Shared helpers for settings validation and artifact rewriting
+// ---------------------------------------------------------------------------
+
+/**
+ * Collect all distinct model identifiers for a given platform from TIER_MODEL_MAP.
+ * Used by the settings validator to check user-supplied model IDs against the
+ * canonical set, keeping a single source of truth (no separate allowlist).
+ */
+export function getValidModelIdsForPlatform(
+	platform: BuildPlatform,
+): readonly string[] {
+	const ids = new Set<string>();
+	for (const tier of Object.keys(TIER_MODEL_MAP) as Exclude<
+		ModelTier,
+		"inherit"
+	>[]) {
+		const id = TIER_MODEL_MAP[tier][platform];
+		if (id) ids.add(id);
+	}
+	return [...ids];
+}
+
+/**
+ * Determine whether a given model ID supports effort control on a platform.
+ * A model supports effort when:
+ * 1. The platform itself supports per-agent effort (non-null PLATFORM_EFFORT), AND
+ * 2. The model is not the fast-class model for that platform.
+ *
+ * Shared between build-time validation and install-time remapping to prevent
+ * effort-capability logic divergence.
+ */
+export function modelSupportsEffort(
+	modelId: string,
+	platform: BuildPlatform,
+): boolean {
+	const config = PLATFORM_EFFORT[platform];
+	if (!config) return false;
+	const fastModel = TIER_MODEL_MAP.fast[platform];
+	return modelId !== fastModel;
+}
+
+/**
+ * Return platforms that have per-agent model field support in TIER_MODEL_MAP.
+ * Platforms absent from all TIER_MODEL_MAP entries (copilot, opencode) are excluded.
+ */
+export function getPlatformsWithModelSupport(): readonly BuildPlatform[] {
+	const platforms = new Set<BuildPlatform>();
+	for (const tier of Object.keys(TIER_MODEL_MAP) as Exclude<
+		ModelTier,
+		"inherit"
+	>[]) {
+		for (const platform of Object.keys(
+			TIER_MODEL_MAP[tier],
+		) as BuildPlatform[]) {
+			platforms.add(platform);
+		}
+	}
+	return [...platforms];
+}
+
+// ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
 

--- a/cli/src/commands/settings.ts
+++ b/cli/src/commands/settings.ts
@@ -96,8 +96,52 @@ Examples:
 
 		console.log();
 
-		// Summary
+		let overallValid = result.valid;
+
+		// Tier remapping semantic validation (only when TOML syntax is valid)
 		if (result.valid) {
+			const { loadTierRemappings } = await import("../settings/loader.js");
+			const { validateTierRemappings } = await import(
+				"../settings/validator.js"
+			);
+
+			const tierConfig = await loadTierRemappings(process.cwd());
+			const hasTierConfig =
+				tierConfig.preset !== undefined ||
+				Object.keys(tierConfig.platforms).length > 0;
+
+			if (hasTierConfig) {
+				console.log();
+				console.log(chalk.bold("Tier Remapping Validation"));
+				console.log();
+
+				const tierResult = validateTierRemappings(tierConfig);
+
+				for (const error of tierResult.errors) {
+					console.log(`  ${chalk.red("Error:")} ${error}`);
+				}
+				for (const warning of tierResult.warnings) {
+					console.log(`  ${chalk.yellow("Warning:")} ${warning}`);
+				}
+				for (const adjustment of tierResult.effortAdjustments) {
+					console.log(`  ${chalk.yellow("Effort:")} ${adjustment}`);
+				}
+
+				if (!tierResult.valid) {
+					overallValid = false;
+				} else if (
+					tierResult.warnings.length === 0 &&
+					tierResult.effortAdjustments.length === 0
+				) {
+					console.log(`  ${chalk.green("Tier remappings are valid.")}`);
+				}
+			}
+		}
+
+		console.log();
+
+		// Summary
+		if (overallValid) {
 			console.log(chalk.green("All settings files are valid."));
 			process.exit(0);
 		} else {

--- a/cli/src/commands/settings.ts
+++ b/cli/src/commands/settings.ts
@@ -221,6 +221,12 @@ Examples:
 						`[dry-run] Would modify ${result.agentsModified} agent artifact(s).`,
 					),
 				);
+			} else if (result.agentsAlreadyCurrent > 0) {
+				console.log(
+					chalk.green(
+						`All ${result.agentsAlreadyCurrent} matching agent(s) already up to date.`,
+					),
+				);
 			} else {
 				console.log(
 					chalk.dim("No agents would be modified with the current remappings."),
@@ -230,6 +236,12 @@ Examples:
 			console.log(
 				chalk.green(
 					`Applied tier remappings to ${result.agentsModified} agent artifact(s).`,
+				),
+			);
+		} else if (result.agentsAlreadyCurrent > 0) {
+			console.log(
+				chalk.green(
+					`All ${result.agentsAlreadyCurrent} matching agent(s) already up to date.`,
 				),
 			);
 		} else {

--- a/cli/src/commands/settings.ts
+++ b/cli/src/commands/settings.ts
@@ -6,6 +6,8 @@ import { Command } from "commander";
  *
  * Subcommands:
  * - validate: Validate settings file syntax
+ * - apply: Apply tier remappings to installed agent artifacts
+ * - presets: List available tier remapping presets
  */
 export const settingsCommand = new Command("settings")
 	.description("Manage rp1 settings")
@@ -18,9 +20,15 @@ Settings Files:
 
 Subcommands:
   validate    Check settings files for TOML syntax errors
+  apply       Apply tier remappings to installed agent artifacts
+  presets     List available tier remapping presets
 
 Examples:
-  rp1 settings validate    Validate all settings files
+  rp1 settings validate           Validate all settings files
+  rp1 settings apply              Apply tier remappings from settings.toml
+  rp1 settings apply --preset budget  Apply a named preset
+  rp1 settings apply --dry-run    Preview changes without modifying files
+  rp1 settings presets            List available presets
 `,
 	);
 
@@ -148,4 +156,126 @@ Examples:
 			console.log(chalk.red("Settings validation failed."));
 			process.exit(1);
 		}
+	});
+
+/**
+ * Apply subcommand: apply tier remappings to installed agent artifacts.
+ *
+ * Orchestrates: load config -> validate -> discover -> rewrite -> report.
+ * Supports --preset for direct preset application and --dry-run for preview.
+ */
+settingsCommand
+	.command("apply")
+	.description("Apply tier remappings to installed agent artifacts")
+	.option("--preset <name>", "Apply a named preset directly")
+	.option("--dry-run", "Preview changes without modifying files", false)
+	.addHelpText(
+		"after",
+		`
+Applies model tier remappings from settings.toml (or a named preset)
+to all installed agent artifacts. Only platforms with declared remappings
+are modified.
+
+Options:
+  --preset <name>  Apply a named preset (budget, standard, premium)
+  --dry-run        Preview changes without modifying files
+
+Examples:
+  rp1 settings apply                  Apply from settings.toml
+  rp1 settings apply --preset budget  Apply the budget preset
+  rp1 settings apply --dry-run        Preview what would change
+`,
+	)
+	.action(async (options: { preset?: string; dryRun: boolean }) => {
+		const { applyTierRemappings } = await import("../settings/apply.js");
+
+		const result = await applyTierRemappings({
+			projectRoot: process.cwd(),
+			preset: options.preset,
+			dryRun: options.dryRun,
+		});
+
+		// Report warnings
+		for (const warning of result.warnings) {
+			console.log(`${chalk.yellow("Warning:")} ${warning}`);
+		}
+
+		// Report effort adjustments
+		for (const adjustment of result.effortAdjustments) {
+			console.log(
+				`${chalk.yellow("Effort adjusted:")} ${adjustment.agentName} — ${adjustment.reason}`,
+			);
+		}
+
+		// Report protected agent warnings
+		for (const warning of result.protectedWarnings) {
+			console.log(`${chalk.yellow("Protected agent:")} ${warning.message}`);
+		}
+
+		console.log();
+
+		if (result.dryRun) {
+			if (result.agentsModified > 0) {
+				console.log(
+					chalk.cyan(
+						`[dry-run] Would modify ${result.agentsModified} agent artifact(s).`,
+					),
+				);
+			} else {
+				console.log(
+					chalk.dim("No agents would be modified with the current remappings."),
+				);
+			}
+		} else if (result.applied) {
+			console.log(
+				chalk.green(
+					`Applied tier remappings to ${result.agentsModified} agent artifact(s).`,
+				),
+			);
+		} else {
+			console.log(
+				chalk.dim("No agents were modified. Check your [models] settings."),
+			);
+		}
+	});
+
+/**
+ * Presets subcommand: list available tier remapping presets.
+ */
+settingsCommand
+	.command("presets")
+	.description("List available tier remapping presets")
+	.addHelpText(
+		"after",
+		`
+Displays all available presets with their tier-to-model mappings.
+Use with 'rp1 settings apply --preset <name>' to apply a preset.
+
+Examples:
+  rp1 settings presets
+`,
+	)
+	.action(async () => {
+		const { listPresets } = await import("../settings/presets.js");
+
+		const presets = listPresets();
+
+		console.log(chalk.bold("Available Presets"));
+		console.log();
+
+		for (const preset of presets) {
+			console.log(`  ${chalk.cyan(preset.name)} — ${preset.description}`);
+
+			for (const [platform, tierMap] of Object.entries(preset.platforms)) {
+				console.log(`    ${chalk.dim(platform)}:`);
+				for (const [tier, model] of Object.entries(tierMap)) {
+					console.log(`      ${tier}: ${model}`);
+				}
+			}
+			console.log();
+		}
+
+		console.log(
+			chalk.dim("Apply a preset: rp1 settings apply --preset <name>"),
+		);
 	});

--- a/cli/src/commands/update/index.ts
+++ b/cli/src/commands/update/index.ts
@@ -733,6 +733,16 @@ export const executeUpdateAction = async (
 						`Re-applied tier remappings (${remappingResult.agentsModified} agents).`,
 					),
 				);
+			} else if (
+				remappingResult.agentsAlreadyCurrent > 0 &&
+				remappingResult.agentsModified === 0
+			) {
+				const { dim } = getColorFns(isTTY);
+				console.log(
+					dim(
+						`Tier remappings: all ${remappingResult.agentsAlreadyCurrent} matching agent(s) already up to date.`,
+					),
+				);
 			}
 		} catch (error) {
 			const { yellow } = getColorFns(isTTY);

--- a/cli/src/commands/update/index.ts
+++ b/cli/src/commands/update/index.ts
@@ -722,16 +722,22 @@ export const executeUpdateAction = async (
 	);
 
 	if (pluginResult.success && !options.dryRun) {
-		const remappingResult = await applyTierRemappingsIfConfigured(
-			process.cwd(),
-		);
-		if (remappingResult.applied) {
-			const { green } = getColorFns(isTTY);
-			console.log(
-				green(
-					`Re-applied tier remappings (${remappingResult.agentsModified} agents).`,
-				),
+		try {
+			const remappingResult = await applyTierRemappingsIfConfigured(
+				process.cwd(),
 			);
+			if (remappingResult.applied) {
+				const { green } = getColorFns(isTTY);
+				console.log(
+					green(
+						`Re-applied tier remappings (${remappingResult.agentsModified} agents).`,
+					),
+				);
+			}
+		} catch (error) {
+			const { yellow } = getColorFns(isTTY);
+			const message = error instanceof Error ? error.message : String(error);
+			console.log(yellow(`Tier remapping failed (non-blocking): ${message}`));
 		}
 	}
 

--- a/cli/src/commands/update/index.ts
+++ b/cli/src/commands/update/index.ts
@@ -35,6 +35,7 @@ import {
 	getInstalledVersion,
 } from "../../lib/version.js";
 import { executeMigrate, formatMigrateSummary } from "../../migrate/index.js";
+import { applyTierRemappingsIfConfigured } from "../../settings/apply.js";
 import {
 	type InstallContext,
 	installAllDetectedTools,
@@ -719,6 +720,21 @@ export const executeUpdateAction = async (
 		lifecycleLogger,
 		isTTY,
 	);
+
+	if (pluginResult.success && !options.dryRun) {
+		const remappingResult = await applyTierRemappingsIfConfigured(
+			process.cwd(),
+		);
+		if (remappingResult.applied) {
+			const { green } = getColorFns(isTTY);
+			console.log(
+				green(
+					`Re-applied tier remappings (${remappingResult.agentsModified} agents).`,
+				),
+			);
+		}
+	}
+
 	let migrationResult: PostUpdatePhaseResult;
 	if (pluginResult.success) {
 		migrationResult = await runProjectMigrations(

--- a/cli/src/settings/apply.ts
+++ b/cli/src/settings/apply.ts
@@ -53,6 +53,7 @@ export interface ApplyOptions {
 export interface ApplyResult {
 	readonly applied: boolean;
 	readonly agentsModified: number;
+	readonly agentsAlreadyCurrent: number;
 	readonly effortAdjustments: readonly EffortAdjustment[];
 	readonly protectedWarnings: readonly ProtectedWarning[];
 	readonly warnings: readonly string[];
@@ -192,6 +193,7 @@ export function applyRemappingsToAgents(
 	deps: ApplyDeps,
 ): ApplyResult {
 	let agentsModified = 0;
+	let agentsAlreadyCurrent = 0;
 	const effortAdjustments: EffortAdjustment[] = [];
 	const protectedWarnings: ProtectedWarning[] = [];
 	const warnings: string[] = [];
@@ -225,7 +227,10 @@ export function applyRemappingsToAgents(
 			platform: agent.platform,
 		});
 
-		if (!result.modified) continue;
+		if (!result.modified) {
+			agentsAlreadyCurrent++;
+			continue;
+		}
 
 		if (!dryRun) {
 			try {
@@ -251,6 +256,7 @@ export function applyRemappingsToAgents(
 	return {
 		applied: agentsModified > 0,
 		agentsModified,
+		agentsAlreadyCurrent,
 		effortAdjustments,
 		protectedWarnings,
 		warnings,
@@ -268,13 +274,19 @@ export function applyRemappingsToAgents(
  * When a preset is specified via CLI flag, it replaces custom mappings entirely.
  * When the preset comes from settings.toml, per-platform overrides in the same
  * file are merged on top of preset values (per merge semantics from T2).
+ *
+ * @param globalSettingsPath - Override path to user-level settings file. Exposed for test isolation.
  */
 export async function resolveConfig(
 	projectRoot: string,
 	preset?: string,
+	globalSettingsPath?: string,
 ): Promise<{ config: TierRemappingConfig; errors: string[] }> {
 	const errors: string[] = [];
-	const settingsConfig = await loadTierRemappings(projectRoot);
+	const settingsConfig = await loadTierRemappings(
+		projectRoot,
+		globalSettingsPath,
+	);
 
 	const effectivePreset = preset ?? settingsConfig.preset;
 
@@ -330,6 +342,7 @@ export async function applyTierRemappings(
 	const emptyResult: ApplyResult = {
 		applied: false,
 		agentsModified: 0,
+		agentsAlreadyCurrent: 0,
 		effortAdjustments: [],
 		protectedWarnings: [],
 		warnings: [],
@@ -425,6 +438,7 @@ export async function applyTierRemappings(
 	return {
 		applied: result.applied,
 		agentsModified: result.agentsModified,
+		agentsAlreadyCurrent: result.agentsAlreadyCurrent,
 		effortAdjustments: result.effortAdjustments,
 		protectedWarnings: result.protectedWarnings,
 		warnings: allWarnings,
@@ -442,14 +456,18 @@ export async function applyTierRemappings(
  */
 export async function applyTierRemappingsIfConfigured(
 	projectRoot: string,
-): Promise<{ applied: boolean; agentsModified: number }> {
+): Promise<{
+	applied: boolean;
+	agentsModified: number;
+	agentsAlreadyCurrent: number;
+}> {
 	const settingsConfig = await loadTierRemappings(projectRoot);
 	const hasConfig =
 		settingsConfig.preset !== undefined ||
 		Object.keys(settingsConfig.platforms).length > 0;
 
 	if (!hasConfig) {
-		return { applied: false, agentsModified: 0 };
+		return { applied: false, agentsModified: 0, agentsAlreadyCurrent: 0 };
 	}
 
 	const result = await applyTierRemappings({
@@ -460,6 +478,7 @@ export async function applyTierRemappingsIfConfigured(
 	return {
 		applied: result.applied,
 		agentsModified: result.agentsModified,
+		agentsAlreadyCurrent: result.agentsAlreadyCurrent,
 	};
 }
 

--- a/cli/src/settings/apply.ts
+++ b/cli/src/settings/apply.ts
@@ -1,0 +1,467 @@
+/**
+ * Apply orchestrator for user-controlled model tier remapping.
+ *
+ * Orchestrates: load config -> validate -> discover agents -> rewrite -> report.
+ * The core rewriting logic (`applyRemappingsToAgents`) is separated from
+ * manifest/filesystem discovery for testability -- tests provide agent entries
+ * and temp file paths directly.
+ */
+
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { basename, join } from "node:path";
+import * as E from "fp-ts/lib/Either.js";
+import type { BundledAssets } from "../assets/reader.js";
+import { ALL_PLUGIN_KEYS, getBundledAssets } from "../assets/reader.js";
+import type {
+	BundleAgentEntry,
+	EffortLevel,
+	ModelTier,
+} from "../build/models.js";
+import type { BuildPlatform } from "../build/template-context.js";
+import { DEFAULT_MARKETPLACE_DIR } from "../install/claudecode/marketplace.js";
+import { loadTierRemappings } from "./loader.js";
+import type { PlatformTierMap, TierRemappingConfig } from "./models.js";
+import { getPreset } from "./presets.js";
+import {
+	type EffortAdjustment,
+	type ProtectedWarning,
+	rewriteAgentArtifact,
+} from "./rewriter.js";
+import { validateTierRemappings } from "./validator.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Agent with metadata and resolved filesystem path for rewriting. */
+export interface AgentFileEntry {
+	readonly name: string;
+	readonly filePath: string;
+	readonly tier?: ModelTier;
+	readonly effort?: EffortLevel;
+	readonly platform: BuildPlatform;
+}
+
+/** Options for the apply operation. */
+export interface ApplyOptions {
+	readonly projectRoot: string;
+	readonly preset?: string;
+	readonly dryRun: boolean;
+}
+
+/** Result of applying tier remappings. */
+export interface ApplyResult {
+	readonly applied: boolean;
+	readonly agentsModified: number;
+	readonly effortAdjustments: readonly EffortAdjustment[];
+	readonly protectedWarnings: readonly ProtectedWarning[];
+	readonly warnings: readonly string[];
+	readonly dryRun: boolean;
+}
+
+/** Filesystem and external command dependencies for testability. */
+export interface ApplyDeps {
+	readonly readFile: (path: string) => string;
+	readonly writeFile: (path: string, content: string) => void;
+	readonly fileExists: (path: string) => boolean;
+	readonly refreshClaudeCodePlugins: () => Promise<void>;
+}
+
+// ---------------------------------------------------------------------------
+// Default production dependencies
+// ---------------------------------------------------------------------------
+
+async function defaultRefreshClaudeCodePlugins(): Promise<void> {
+	const { exec } = await import("node:child_process");
+	const { promisify } = await import("node:util");
+	const execAsync = promisify(exec);
+
+	const plugins = ["rp1-base", "rp1-dev", "rp1-utils"];
+	for (const plugin of plugins) {
+		try {
+			await execAsync(
+				`claude plugin update "${plugin}@rp1-local" --scope user`,
+				{ timeout: 15000 },
+			);
+		} catch {
+			// Best effort -- some plugins might not be installed
+		}
+	}
+}
+
+const DEFAULT_DEPS: ApplyDeps = {
+	readFile: (path) => readFileSync(path, "utf-8"),
+	writeFile: (path, content) => writeFileSync(path, content, "utf-8"),
+	fileExists: existsSync,
+	refreshClaudeCodePlugins: defaultRefreshClaudeCodePlugins,
+};
+
+// ---------------------------------------------------------------------------
+// Agent filename derivation (matches asset-extractor logic)
+// ---------------------------------------------------------------------------
+
+/**
+ * Derive the installed filename for an agent on a given platform.
+ * Replicates the filename derivation from the asset extractor so the apply
+ * command can locate installed artifacts without re-extracting.
+ */
+function deriveInstalledFilename(
+	agent: BundleAgentEntry,
+	pluginName: string,
+	platform: BuildPlatform,
+): string {
+	if (agent.fileName) return agent.fileName;
+	if (agent.path && agent.path.length > 0) return basename(agent.path);
+	return platform === "codex"
+		? `${pluginName}-${agent.name}.toml`
+		: `${agent.name}.md`;
+}
+
+// ---------------------------------------------------------------------------
+// Agent discovery from manifest
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a list of agent file entries from the bundled manifest for a platform.
+ * Resolves each agent's installed file path and filters to files that exist.
+ */
+export function discoverAgents(
+	assets: BundledAssets,
+	platform: BuildPlatform,
+	claudeCodeMarketplaceDir: string,
+	codexAgentsDir: string | null,
+	fileExists: (path: string) => boolean,
+): readonly AgentFileEntry[] {
+	const bundledPlatform = assets.platforms[platform];
+	if (!bundledPlatform) return [];
+
+	const entries: AgentFileEntry[] = [];
+
+	for (const pluginKey of ALL_PLUGIN_KEYS) {
+		const plugin = bundledPlatform.plugins[pluginKey];
+		if (!plugin) continue;
+
+		for (const agent of plugin.agents) {
+			const bundleAgent = agent as BundleAgentEntry;
+			const filename = deriveInstalledFilename(
+				bundleAgent,
+				plugin.name,
+				platform,
+			);
+
+			let filePath: string | null = null;
+			if (platform === "claude-code") {
+				filePath = join(
+					claudeCodeMarketplaceDir,
+					pluginKey,
+					"agents",
+					filename,
+				);
+			} else if (platform === "codex" && codexAgentsDir) {
+				filePath = join(codexAgentsDir, filename);
+			}
+
+			if (!filePath || !fileExists(filePath)) continue;
+
+			entries.push({
+				name: bundleAgent.name,
+				filePath,
+				tier: bundleAgent.tier,
+				effort: bundleAgent.effort,
+				platform,
+			});
+		}
+	}
+
+	return entries;
+}
+
+// ---------------------------------------------------------------------------
+// Core rewriting loop
+// ---------------------------------------------------------------------------
+
+/**
+ * Apply tier remappings to a list of agent files.
+ * Reads each agent artifact, rewrites model/effort fields, writes the result.
+ * Unparseable artifacts produce a warning and are skipped.
+ */
+export function applyRemappingsToAgents(
+	agents: readonly AgentFileEntry[],
+	remappings: Readonly<Partial<Record<BuildPlatform, PlatformTierMap>>>,
+	dryRun: boolean,
+	deps: ApplyDeps,
+): ApplyResult {
+	let agentsModified = 0;
+	const effortAdjustments: EffortAdjustment[] = [];
+	const protectedWarnings: ProtectedWarning[] = [];
+	const warnings: string[] = [];
+
+	for (const agent of agents) {
+		const platformMap = remappings[agent.platform];
+		if (!platformMap) continue;
+
+		if (!agent.tier || agent.tier === "inherit") continue;
+
+		const remappedTier = agent.tier as Exclude<ModelTier, "inherit">;
+		const newModel = platformMap[remappedTier];
+		if (!newModel) continue;
+
+		let content: string;
+		try {
+			content = deps.readFile(agent.filePath);
+		} catch (e) {
+			warnings.push(
+				`Could not read agent artifact '${agent.name}' at ${agent.filePath}: ${e instanceof Error ? e.message : String(e)}`,
+			);
+			continue;
+		}
+
+		const result = rewriteAgentArtifact({
+			content,
+			agentName: agent.name,
+			newModel,
+			originalTier: agent.tier,
+			originalEffort: agent.effort,
+			platform: agent.platform,
+		});
+
+		if (!result.modified) continue;
+
+		if (!dryRun) {
+			try {
+				deps.writeFile(agent.filePath, result.content);
+			} catch (e) {
+				warnings.push(
+					`Could not write agent artifact '${agent.name}' at ${agent.filePath}: ${e instanceof Error ? e.message : String(e)}`,
+				);
+				continue;
+			}
+		}
+
+		agentsModified++;
+
+		if (result.effortAdjustment) {
+			effortAdjustments.push(result.effortAdjustment);
+		}
+		if (result.protectedWarning) {
+			protectedWarnings.push(result.protectedWarning);
+		}
+	}
+
+	return {
+		applied: agentsModified > 0,
+		agentsModified,
+		effortAdjustments,
+		protectedWarnings,
+		warnings,
+		dryRun,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Config resolution
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve tier remapping config from settings.toml and/or a --preset flag.
+ *
+ * When a preset is specified via CLI flag, it replaces custom mappings entirely.
+ * When the preset comes from settings.toml, per-platform overrides in the same
+ * file are merged on top of preset values (per merge semantics from T2).
+ */
+export async function resolveConfig(
+	projectRoot: string,
+	preset?: string,
+): Promise<{ config: TierRemappingConfig; errors: string[] }> {
+	const errors: string[] = [];
+	const settingsConfig = await loadTierRemappings(projectRoot);
+
+	const effectivePreset = preset ?? settingsConfig.preset;
+
+	if (effectivePreset) {
+		const presetConfig = getPreset(effectivePreset);
+		if (!presetConfig) {
+			errors.push(
+				`Unknown preset '${effectivePreset}'. Run 'rp1 settings presets' to list available presets.`,
+			);
+			return { config: settingsConfig, errors };
+		}
+
+		const platforms: Record<string, PlatformTierMap> = {};
+
+		for (const [platform, tierMap] of Object.entries(presetConfig.platforms)) {
+			platforms[platform] = { ...tierMap };
+		}
+
+		// When preset comes from settings.toml (not CLI), merge per-platform
+		// overrides from settings on top of preset values
+		if (!preset) {
+			for (const [platform, tierMap] of Object.entries(
+				settingsConfig.platforms,
+			)) {
+				if (tierMap) {
+					platforms[platform] = { ...(platforms[platform] ?? {}), ...tierMap };
+				}
+			}
+		}
+
+		return {
+			config: { preset: effectivePreset, platforms },
+			errors,
+		};
+	}
+
+	return { config: settingsConfig, errors };
+}
+
+// ---------------------------------------------------------------------------
+// Full orchestrator
+// ---------------------------------------------------------------------------
+
+/**
+ * Full apply orchestrator: load -> validate -> discover -> rewrite -> report.
+ *
+ * Called by the `rp1 settings apply` command and (indirectly) by the update hook.
+ */
+export async function applyTierRemappings(
+	options: ApplyOptions,
+	deps: ApplyDeps = DEFAULT_DEPS,
+): Promise<ApplyResult> {
+	const emptyResult: ApplyResult = {
+		applied: false,
+		agentsModified: 0,
+		effortAdjustments: [],
+		protectedWarnings: [],
+		warnings: [],
+		dryRun: options.dryRun,
+	};
+
+	// 1. Resolve config
+	const { config, errors: configErrors } = await resolveConfig(
+		options.projectRoot,
+		options.preset,
+	);
+
+	if (configErrors.length > 0) {
+		return { ...emptyResult, warnings: configErrors };
+	}
+
+	const hasRemappings = Object.keys(config.platforms).length > 0;
+	if (!hasRemappings) {
+		return emptyResult;
+	}
+
+	// 2. Validate
+	const validation = validateTierRemappings(config);
+	if (!validation.valid) {
+		return {
+			...emptyResult,
+			warnings: [...validation.errors, ...validation.warnings],
+		};
+	}
+
+	// 3. Get embedded manifest for agent tier metadata
+	const manifestResult = getBundledAssets();
+	if (E.isLeft(manifestResult)) {
+		return {
+			...emptyResult,
+			warnings: [
+				"Bundled assets not available. Tier remapping requires a bundled binary. " +
+					"Install from a release binary to use this feature.",
+			],
+		};
+	}
+
+	const assets = manifestResult.right;
+
+	// 4. Discover agents per platform with remappings
+	const allAgents: AgentFileEntry[] = [];
+	const codexAgentsDir = resolveCodexAgentsDir();
+
+	for (const platform of Object.keys(config.platforms) as BuildPlatform[]) {
+		const platformAgents = discoverAgents(
+			assets,
+			platform,
+			DEFAULT_MARKETPLACE_DIR,
+			codexAgentsDir,
+			deps.fileExists,
+		);
+		allAgents.push(...platformAgents);
+	}
+
+	// 5. Apply remappings
+	const result = applyRemappingsToAgents(
+		allAgents,
+		config.platforms,
+		options.dryRun,
+		deps,
+	);
+
+	// 6. Post-apply: refresh Claude Code plugin cache if we modified CC artifacts
+	const claudeCodeModified =
+		!options.dryRun &&
+		result.agentsModified > 0 &&
+		config.platforms["claude-code"] !== undefined;
+
+	if (claudeCodeModified) {
+		try {
+			await deps.refreshClaudeCodePlugins();
+		} catch {
+			// Append warning if cache refresh fails
+		}
+	}
+
+	// Combine validation warnings with apply warnings
+	const allWarnings = [...validation.warnings, ...result.warnings];
+
+	return {
+		applied: result.applied,
+		agentsModified: result.agentsModified,
+		effortAdjustments: result.effortAdjustments,
+		protectedWarnings: result.protectedWarnings,
+		warnings: allWarnings,
+		dryRun: options.dryRun,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Update hook convenience
+// ---------------------------------------------------------------------------
+
+/**
+ * Apply tier remappings only if configured. No-op when no [models] config exists.
+ * Designed for the update hook (T7) -- returns early with no output when unconfigured.
+ */
+export async function applyTierRemappingsIfConfigured(
+	projectRoot: string,
+): Promise<{ applied: boolean; agentsModified: number }> {
+	const settingsConfig = await loadTierRemappings(projectRoot);
+	const hasConfig =
+		settingsConfig.preset !== undefined ||
+		Object.keys(settingsConfig.platforms).length > 0;
+
+	if (!hasConfig) {
+		return { applied: false, agentsModified: 0 };
+	}
+
+	const result = await applyTierRemappings({
+		projectRoot,
+		dryRun: false,
+	});
+
+	return {
+		applied: result.applied,
+		agentsModified: result.agentsModified,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Resolve the Codex agents install directory without importing the installer module. */
+function resolveCodexAgentsDir(): string | null {
+	const home = process.env.HOME;
+	if (!home) return null;
+	return join(home, ".codex", "agents", "rp1");
+}

--- a/cli/src/settings/apply.ts
+++ b/cli/src/settings/apply.ts
@@ -403,16 +403,24 @@ export async function applyTierRemappings(
 		result.agentsModified > 0 &&
 		config.platforms["claude-code"] !== undefined;
 
+	const refreshWarnings: string[] = [];
 	if (claudeCodeModified) {
 		try {
 			await deps.refreshClaudeCodePlugins();
-		} catch {
-			// Append warning if cache refresh fails
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			refreshWarnings.push(
+				`Claude Code plugin cache refresh failed: ${message}`,
+			);
 		}
 	}
 
 	// Combine validation warnings with apply warnings
-	const allWarnings = [...validation.warnings, ...result.warnings];
+	const allWarnings = [
+		...validation.warnings,
+		...result.warnings,
+		...refreshWarnings,
+	];
 
 	return {
 		applied: result.applied,

--- a/cli/src/settings/apply.ts
+++ b/cli/src/settings/apply.ts
@@ -10,8 +10,12 @@
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { basename, join } from "node:path";
 import * as E from "fp-ts/lib/Either.js";
+import type { CLIError } from "../../shared/errors.js";
 import type { BundledAssets } from "../assets/reader.js";
-import { ALL_PLUGIN_KEYS, getBundledAssets } from "../assets/reader.js";
+import {
+	ALL_PLUGIN_KEYS,
+	getBundledAssets as getBundledAssetsReal,
+} from "../assets/reader.js";
 import type {
 	BundleAgentEntry,
 	EffortLevel,
@@ -47,6 +51,8 @@ export interface ApplyOptions {
 	readonly projectRoot: string;
 	readonly preset?: string;
 	readonly dryRun: boolean;
+	/** Override path to user-level settings file. Exposed for test isolation. */
+	readonly globalSettingsPath?: string;
 }
 
 /** Result of applying tier remappings. */
@@ -66,6 +72,7 @@ export interface ApplyDeps {
 	readonly writeFile: (path: string, content: string) => void;
 	readonly fileExists: (path: string) => boolean;
 	readonly refreshClaudeCodePlugins: () => Promise<void>;
+	readonly getBundledAssets: () => E.Either<CLIError, BundledAssets>;
 }
 
 // ---------------------------------------------------------------------------
@@ -95,6 +102,7 @@ const DEFAULT_DEPS: ApplyDeps = {
 	writeFile: (path, content) => writeFileSync(path, content, "utf-8"),
 	fileExists: existsSync,
 	refreshClaudeCodePlugins: defaultRefreshClaudeCodePlugins,
+	getBundledAssets: getBundledAssetsReal,
 };
 
 // ---------------------------------------------------------------------------
@@ -353,6 +361,7 @@ export async function applyTierRemappings(
 	const { config, errors: configErrors } = await resolveConfig(
 		options.projectRoot,
 		options.preset,
+		options.globalSettingsPath,
 	);
 
 	if (configErrors.length > 0) {
@@ -374,7 +383,7 @@ export async function applyTierRemappings(
 	}
 
 	// 3. Get embedded manifest for agent tier metadata
-	const manifestResult = getBundledAssets();
+	const manifestResult = deps.getBundledAssets();
 	if (E.isLeft(manifestResult)) {
 		return {
 			...emptyResult,

--- a/cli/src/settings/loader.ts
+++ b/cli/src/settings/loader.ts
@@ -238,14 +238,16 @@ export const loadArgumentDefaultsForSkill = async (
  * Merge precedence: project settings > user settings (per-skill, per-argument).
  *
  * @param projectRoot - Project root directory (contains `.rp1/`)
+ * @param globalSettingsPath - Override path to user-level settings file (defaults to ~/.config/rp1/settings.toml). Exposed for test isolation.
  * @returns Merged argument defaults keyed by skill name
  */
 export const loadAllArgumentDefaults = async (
 	projectRoot: string,
+	globalSettingsPath?: string,
 ): Promise<SettingsArgumentDefaults> => {
 	const [projectDefaults, userDefaults] = await Promise.all([
 		loadArgumentsFromFile(resolveLocalSettingsPath(projectRoot)),
-		loadArgumentsFromFile(resolveGlobalSettingsPath()),
+		loadArgumentsFromFile(globalSettingsPath ?? resolveGlobalSettingsPath()),
 	]);
 
 	const allSkillNames = new Set([

--- a/cli/src/settings/loader.ts
+++ b/cli/src/settings/loader.ts
@@ -3,6 +3,8 @@ import {
 	resolveGlobalSettingsPath,
 	resolveLocalSettingsPath,
 } from "../../shared/settings.js";
+import type { BuildPlatform } from "../build/template-context.js";
+import type { PlatformTierMap, TierRemappingConfig } from "./models.js";
 
 /** Argument defaults for a single skill/agent, keyed by UPPER_SNAKE_CASE argument name. */
 export type ArgumentDefaults = Readonly<
@@ -14,9 +16,16 @@ export type SettingsArgumentDefaults = Readonly<
 	Record<string, ArgumentDefaults>
 >;
 
+/** Parsed models section from a single settings file. */
+type ParsedModelsSection = Readonly<{
+	preset?: string;
+	platforms: Readonly<Partial<Record<BuildPlatform, PlatformTierMap>>>;
+}>;
+
 type ParsedSettingsFile = Readonly<{
 	arguments: SettingsArgumentDefaults;
 	directories: Record<string, never>;
+	models: ParsedModelsSection;
 }>;
 
 const isPlainRecord = (
@@ -49,6 +58,64 @@ const normalizeArgumentKey = (key: string): string => {
 	return key;
 };
 
+/** Reserved keys under [models] that are not platform names. */
+const MODELS_RESERVED_KEYS = new Set(["preset"]);
+
+/** Known tier keys that map to model identifiers. */
+const TIER_KEYS = new Set(["frontier", "deep", "standard", "fast"]);
+
+/**
+ * Extract tier-to-model mappings from a platform sub-table under [models].
+ * Only string values for known tier keys are included; other entries are ignored.
+ */
+const parsePlatformTierMap = (
+	table: Readonly<Record<string, unknown>>,
+): PlatformTierMap | null => {
+	const map: Record<string, string> = {};
+	let hasEntries = false;
+
+	for (const [key, value] of Object.entries(table)) {
+		if (TIER_KEYS.has(key) && typeof value === "string") {
+			map[key] = value;
+			hasEntries = true;
+		}
+	}
+
+	return hasEntries ? (map as PlatformTierMap) : null;
+};
+
+/**
+ * Extract the models section from parsed TOML.
+ * Handles both `[models]` (preset) and `[models.<platform>]` (tier mappings).
+ */
+const parseModelsSection = (
+	parsed: Record<string, unknown>,
+): ParsedModelsSection => {
+	const modelsSection = parsed.models;
+	const emptyModels: ParsedModelsSection = { platforms: {} };
+
+	if (!isPlainRecord(modelsSection)) {
+		return emptyModels;
+	}
+
+	const preset =
+		typeof modelsSection.preset === "string" ? modelsSection.preset : undefined;
+
+	const platforms: Record<string, PlatformTierMap> = {};
+
+	for (const [key, value] of Object.entries(modelsSection)) {
+		if (MODELS_RESERVED_KEYS.has(key)) continue;
+		if (!isPlainRecord(value)) continue;
+
+		const tierMap = parsePlatformTierMap(value);
+		if (tierMap) {
+			platforms[key] = tierMap;
+		}
+	}
+
+	return { preset, platforms };
+};
+
 const parseSettingsFileStrict = (filePath: string): ParsedSettingsFile => {
 	const cached = settingsCache.get(filePath);
 	if (cached) {
@@ -56,7 +123,11 @@ const parseSettingsFileStrict = (filePath: string): ParsedSettingsFile => {
 	}
 
 	if (!existsSync(filePath)) {
-		const empty: ParsedSettingsFile = { arguments: {}, directories: {} };
+		const empty: ParsedSettingsFile = {
+			arguments: {},
+			directories: {},
+			models: { platforms: {} },
+		};
 		settingsCache.set(filePath, empty);
 		return empty;
 	}
@@ -90,14 +161,21 @@ const parseSettingsFileStrict = (filePath: string): ParsedSettingsFile => {
 			}
 		}
 
+		const models = parseModelsSection(parsed);
+
 		const result: ParsedSettingsFile = {
 			arguments: argumentDefaults,
 			directories: {},
+			models,
 		};
 		settingsCache.set(filePath, result);
 		return result;
 	} catch {
-		const empty: ParsedSettingsFile = { arguments: {}, directories: {} };
+		const empty: ParsedSettingsFile = {
+			arguments: {},
+			directories: {},
+			models: { platforms: {} },
+		};
 		settingsCache.set(filePath, empty);
 		return empty;
 	}
@@ -184,4 +262,64 @@ export const loadAllArgumentDefaults = async (
 	}
 
 	return result;
+};
+
+/**
+ * Load the `[models]` section from a single settings file.
+ * Returns the parsed models section when present, or an empty structure.
+ */
+const loadModelsFromFile = (filePath: string): ParsedModelsSection => {
+	return parseSettingsFileStrict(filePath).models;
+};
+
+/**
+ * Merge two platform tier maps, where `override` entries take precedence
+ * over `base` entries for the same tier.
+ */
+const mergePlatformTierMaps = (
+	base: PlatformTierMap,
+	override: PlatformTierMap,
+): PlatformTierMap => {
+	return { ...base, ...override };
+};
+
+/**
+ * Load tier remapping configuration from both project-level and user-level
+ * settings files.
+ *
+ * Merge precedence: project settings > user settings (per-platform, per-tier).
+ * Project-level preset overrides user-level preset.
+ *
+ * @param projectRoot - Project root directory (contains `.rp1/`)
+ * @returns Merged tier remapping configuration
+ */
+export const loadTierRemappings = async (
+	projectRoot: string,
+): Promise<TierRemappingConfig> => {
+	const projectModels = loadModelsFromFile(
+		resolveLocalSettingsPath(projectRoot),
+	);
+	const userModels = loadModelsFromFile(resolveGlobalSettingsPath());
+
+	const preset = projectModels.preset ?? userModels.preset;
+
+	const allPlatforms = new Set([
+		...Object.keys(userModels.platforms),
+		...Object.keys(projectModels.platforms),
+	]);
+
+	const platforms: Record<string, PlatformTierMap> = {};
+
+	for (const platform of allPlatforms) {
+		const userMap = userModels.platforms[platform as BuildPlatform];
+		const projectMap = projectModels.platforms[platform as BuildPlatform];
+
+		if (userMap && projectMap) {
+			platforms[platform] = mergePlatformTierMaps(userMap, projectMap);
+		} else {
+			platforms[platform] = (projectMap ?? userMap)!;
+		}
+	}
+
+	return { preset, platforms };
 };

--- a/cli/src/settings/loader.ts
+++ b/cli/src/settings/loader.ts
@@ -3,6 +3,7 @@ import {
 	resolveGlobalSettingsPath,
 	resolveLocalSettingsPath,
 } from "../../shared/settings.js";
+import { VALID_MODEL_TIERS } from "../build/models.js";
 import type { BuildPlatform } from "../build/template-context.js";
 import type { PlatformTierMap, TierRemappingConfig } from "./models.js";
 
@@ -61,8 +62,10 @@ const normalizeArgumentKey = (key: string): string => {
 /** Reserved keys under [models] that are not platform names. */
 const MODELS_RESERVED_KEYS = new Set(["preset"]);
 
-/** Known tier keys that map to model identifiers. */
-const TIER_KEYS = new Set(["frontier", "deep", "standard", "fast"]);
+/** Known tier keys that map to model identifiers (derived from canonical source). */
+const TIER_KEYS: ReadonlySet<string> = new Set(
+	VALID_MODEL_TIERS.filter((t) => t !== "inherit"),
+);
 
 /**
  * Extract tier-to-model mappings from a platform sub-table under [models].

--- a/cli/src/settings/loader.ts
+++ b/cli/src/settings/loader.ts
@@ -296,15 +296,19 @@ const mergePlatformTierMaps = (
  * Project-level preset overrides user-level preset.
  *
  * @param projectRoot - Project root directory (contains `.rp1/`)
+ * @param globalSettingsPath - Override path to user-level settings file (defaults to ~/.config/rp1/settings.toml). Exposed for test isolation.
  * @returns Merged tier remapping configuration
  */
 export const loadTierRemappings = async (
 	projectRoot: string,
+	globalSettingsPath?: string,
 ): Promise<TierRemappingConfig> => {
 	const projectModels = loadModelsFromFile(
 		resolveLocalSettingsPath(projectRoot),
 	);
-	const userModels = loadModelsFromFile(resolveGlobalSettingsPath());
+	const userModels = loadModelsFromFile(
+		globalSettingsPath ?? resolveGlobalSettingsPath(),
+	);
 
 	const preset = projectModels.preset ?? userModels.preset;
 

--- a/cli/src/settings/models.ts
+++ b/cli/src/settings/models.ts
@@ -1,0 +1,33 @@
+/**
+ * Type definitions for user-controllable model tier remapping settings.
+ *
+ * These types model the `[models]` and `[models.<platform>]` sections in
+ * settings.toml, allowing users to declare abstract-tier-to-model remappings
+ * that are applied at install time without requiring the build pipeline.
+ */
+
+import type { ModelTier } from "../build/models.js";
+import type { BuildPlatform } from "../build/template-context.js";
+
+/**
+ * Per-platform tier-to-model mapping from user settings.
+ *
+ * Each key is a concrete tier (excluding "inherit") and each value is
+ * the user-chosen model identifier string for that tier on a given platform.
+ * Omitted tiers preserve the build-time default.
+ */
+export type PlatformTierMap = Readonly<
+	Partial<Record<Exclude<ModelTier, "inherit">, string>>
+>;
+
+/**
+ * Complete tier remapping configuration parsed from settings.toml.
+ *
+ * Combines an optional preset name with per-platform tier overrides.
+ * Within a file, explicit `[models.<platform>]` entries take precedence
+ * over the preset's values for that platform.
+ */
+export interface TierRemappingConfig {
+	readonly preset?: string;
+	readonly platforms: Readonly<Partial<Record<BuildPlatform, PlatformTierMap>>>;
+}

--- a/cli/src/settings/presets.ts
+++ b/cli/src/settings/presets.ts
@@ -1,0 +1,131 @@
+/**
+ * Blessed preset configurations for tier-to-model remapping.
+ *
+ * Ships three presets (budget, standard, premium) that define complete
+ * tier-to-model mappings per platform. The premium preset matches the
+ * current TIER_MODEL_MAP build defaults so users can verify their
+ * install matches the shipped configuration.
+ */
+
+import type { ModelTier } from "../build/models.js";
+import type { BuildPlatform } from "../build/template-context.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Remappable tier names exposed in presets (excludes inherit and frontier). */
+type RemappableTier = Extract<ModelTier, "deep" | "standard" | "fast">;
+
+/** Per-platform tier-to-model mapping within a preset. Complete (non-Partial). */
+export type PresetPlatformMap = Readonly<Record<RemappableTier, string>>;
+
+/** Valid preset names. */
+export type PresetName = "budget" | "standard" | "premium";
+
+/** Valid preset name values for runtime validation. */
+export const VALID_PRESET_NAMES: readonly PresetName[] = [
+	"budget",
+	"standard",
+	"premium",
+] as const;
+
+/** Named preset configuration with complete tier-to-model mappings per platform. */
+export interface PresetConfig {
+	readonly name: PresetName;
+	readonly description: string;
+	readonly platforms: Readonly<
+		Partial<Record<BuildPlatform, PresetPlatformMap>>
+	>;
+}
+
+// ---------------------------------------------------------------------------
+// Preset definitions
+// ---------------------------------------------------------------------------
+
+/**
+ * Blessed presets ordered by cost: budget < standard < premium.
+ *
+ * - **budget**: All tiers use fast-class models. Minimizes cost at the
+ *   expense of reasoning quality on deep/standard agents.
+ * - **standard**: Collapses deep tier to sonnet-class. For users without
+ *   Opus access or wanting a balance of cost and capability.
+ * - **premium**: Matches current TIER_MODEL_MAP build defaults. Full
+ *   capability with frontier-class models at the deep tier.
+ *
+ * Only Claude Code and Codex are mapped; other platforms (copilot,
+ * opencode, antigravity) do not support per-agent model fields in
+ * their installed artifacts.
+ */
+const PRESETS: Readonly<Record<PresetName, PresetConfig>> = {
+	budget: {
+		name: "budget",
+		description: "Cost-optimized: uses only fast-class models across all tiers",
+		platforms: {
+			"claude-code": {
+				deep: "haiku",
+				standard: "haiku",
+				fast: "haiku",
+			},
+			codex: {
+				deep: "gpt-5.4-mini",
+				standard: "gpt-5.4-mini",
+				fast: "gpt-5.4-mini",
+			},
+		},
+	},
+	standard: {
+		name: "standard",
+		description:
+			"Balanced: collapses deep tier to sonnet-class for users without Opus access",
+		platforms: {
+			"claude-code": {
+				deep: "sonnet",
+				standard: "sonnet",
+				fast: "haiku",
+			},
+			codex: {
+				deep: "gpt-5.4",
+				standard: "gpt-5.4",
+				fast: "gpt-5.4-mini",
+			},
+		},
+	},
+	premium: {
+		name: "premium",
+		description:
+			"Full capability: matches build defaults with frontier-class models at deep tier",
+		platforms: {
+			"claude-code": {
+				deep: "opus",
+				standard: "sonnet",
+				fast: "haiku",
+			},
+			codex: {
+				deep: "gpt-5.5",
+				standard: "gpt-5.4",
+				fast: "gpt-5.4-mini",
+			},
+		},
+	},
+};
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Look up a preset by name.
+ * @returns The preset configuration, or undefined if the name is not recognized.
+ */
+export function getPreset(name: string): PresetConfig | undefined {
+	return PRESETS[name as PresetName];
+}
+
+/**
+ * List all available presets ordered budget -> standard -> premium.
+ * @returns Array of all preset configurations.
+ */
+export function listPresets(): readonly PresetConfig[] {
+	return VALID_PRESET_NAMES.map((name) => PRESETS[name]);
+}

--- a/cli/src/settings/rewriter.ts
+++ b/cli/src/settings/rewriter.ts
@@ -109,7 +109,7 @@ function checkProtectedDowngrade(
 // Platforms that support model-field rewriting
 // ---------------------------------------------------------------------------
 
-const REWRITABLE_PLATFORMS: ReadonlySet<BuildPlatform> = new Set([
+export const REWRITABLE_PLATFORMS: ReadonlySet<BuildPlatform> = new Set([
 	"claude-code",
 	"codex",
 ]);

--- a/cli/src/settings/rewriter.ts
+++ b/cli/src/settings/rewriter.ts
@@ -12,7 +12,10 @@
 import type { EffortLevel, ModelTier } from "../build/models.js";
 import { PROTECTED_AGENTS, TIER_RANK } from "../build/models.js";
 import type { BuildPlatform } from "../build/template-context.js";
-import { TIER_MODEL_MAP } from "../build/tier-resolution.js";
+import {
+	modelSupportsEffort,
+	TIER_MODEL_MAP,
+} from "../build/tier-resolution.js";
 
 // ---------------------------------------------------------------------------
 // Result types
@@ -46,26 +49,6 @@ export interface RewriteAgentParams {
 	readonly originalTier: ModelTier;
 	readonly originalEffort?: EffortLevel;
 	readonly platform: BuildPlatform;
-}
-
-// ---------------------------------------------------------------------------
-// Effort capability
-// ---------------------------------------------------------------------------
-
-/**
- * Determine whether a given model ID supports effort control on a platform.
- *
- * A model supports effort if it does NOT match the fast-tier model for the
- * platform in TIER_MODEL_MAP. Unknown models are conservatively assumed to
- * support effort (avoids incorrectly stripping effort from custom models).
- */
-export function modelSupportsEffort(
-	modelId: string,
-	platform: BuildPlatform,
-): boolean {
-	const fastModel = TIER_MODEL_MAP.fast[platform];
-	if (fastModel === undefined) return true;
-	return modelId !== fastModel;
 }
 
 // ---------------------------------------------------------------------------
@@ -251,8 +234,8 @@ function rewriteCodex(
 			continue;
 		}
 
-		// Detect start of multiline string
-		if (line.includes("'''") && !line.endsWith("'''")) {
+		// Detect start of multiline string (assignment opening: `key = '''`)
+		if (line.includes("=") && line.endsWith("'''")) {
 			inMultilineString = true;
 		}
 

--- a/cli/src/settings/rewriter.ts
+++ b/cli/src/settings/rewriter.ts
@@ -1,0 +1,339 @@
+/**
+ * Artifact rewriter for install-time tier remapping.
+ *
+ * Pure-function module that transforms agent artifacts to reflect user-declared
+ * tier-to-model remappings. Handles:
+ * - Claude Code (.md): YAML frontmatter model/effort field updates
+ * - Codex (.toml): targeted line-level model/effort field replacement
+ * - Effort correction: strips effort when remapped model is fast-class
+ * - Protected agent warnings: alerts on reasoning-critical agent downgrades
+ */
+
+import type { EffortLevel, ModelTier } from "../build/models.js";
+import { PROTECTED_AGENTS, TIER_RANK } from "../build/models.js";
+import type { BuildPlatform } from "../build/template-context.js";
+import { TIER_MODEL_MAP } from "../build/tier-resolution.js";
+
+// ---------------------------------------------------------------------------
+// Result types
+// ---------------------------------------------------------------------------
+
+export interface EffortAdjustment {
+	readonly agentName: string;
+	readonly originalEffort: string;
+	readonly action: "stripped" | "preserved";
+	readonly reason: string;
+}
+
+export interface ProtectedWarning {
+	readonly agentName: string;
+	readonly originalTier: string;
+	readonly newModel: string;
+	readonly message: string;
+}
+
+export interface RewriteAgentOutput {
+	readonly content: string;
+	readonly modified: boolean;
+	readonly effortAdjustment?: EffortAdjustment;
+	readonly protectedWarning?: ProtectedWarning;
+}
+
+export interface RewriteAgentParams {
+	readonly content: string;
+	readonly agentName: string;
+	readonly newModel: string;
+	readonly originalTier: ModelTier;
+	readonly originalEffort?: EffortLevel;
+	readonly platform: BuildPlatform;
+}
+
+// ---------------------------------------------------------------------------
+// Effort capability
+// ---------------------------------------------------------------------------
+
+/**
+ * Determine whether a given model ID supports effort control on a platform.
+ *
+ * A model supports effort if it does NOT match the fast-tier model for the
+ * platform in TIER_MODEL_MAP. Unknown models are conservatively assumed to
+ * support effort (avoids incorrectly stripping effort from custom models).
+ */
+export function modelSupportsEffort(
+	modelId: string,
+	platform: BuildPlatform,
+): boolean {
+	const fastModel = TIER_MODEL_MAP.fast[platform];
+	if (fastModel === undefined) return true;
+	return modelId !== fastModel;
+}
+
+// ---------------------------------------------------------------------------
+// Protected agent downgrade check
+// ---------------------------------------------------------------------------
+
+/**
+ * Reverse-lookup: determine which tier a model ID belongs to on a platform.
+ * Returns null for custom/unknown models not found in TIER_MODEL_MAP.
+ */
+function effectiveTierForModel(
+	modelId: string,
+	platform: BuildPlatform,
+): Exclude<ModelTier, "inherit"> | null {
+	const tiers = ["frontier", "deep", "standard", "fast"] as const;
+	for (const tier of tiers) {
+		if (TIER_MODEL_MAP[tier][platform] === modelId) return tier;
+	}
+	return null;
+}
+
+function checkProtectedDowngrade(
+	agentName: string,
+	originalTier: ModelTier,
+	newModel: string,
+	platform: BuildPlatform,
+): ProtectedWarning | undefined {
+	if (!PROTECTED_AGENTS.has(agentName)) return undefined;
+	if (originalTier === "inherit") return undefined;
+
+	const originalRank = TIER_RANK[originalTier];
+	const newTier = effectiveTierForModel(newModel, platform);
+
+	// For unknown models, warn conservatively since we cannot verify capability
+	if (newTier === null) {
+		return {
+			agentName,
+			originalTier,
+			newModel,
+			message: `Protected agent "${agentName}" remapped from ${originalTier} to unknown model "${newModel}"; verify it meets reasoning requirements`,
+		};
+	}
+
+	const newRank = TIER_RANK[newTier];
+	if (newRank < originalRank) {
+		return {
+			agentName,
+			originalTier,
+			newModel,
+			message: `Protected agent "${agentName}" downgraded from ${originalTier} (rank ${originalRank}) to ${newTier} (rank ${newRank}) via model "${newModel}"; may degrade reasoning quality`,
+		};
+	}
+
+	return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Platforms that support model-field rewriting
+// ---------------------------------------------------------------------------
+
+const REWRITABLE_PLATFORMS: ReadonlySet<BuildPlatform> = new Set([
+	"claude-code",
+	"codex",
+]);
+
+// ---------------------------------------------------------------------------
+// Claude Code rewriter (.md with YAML frontmatter)
+// ---------------------------------------------------------------------------
+
+function rewriteClaudeCode(
+	content: string,
+	newModel: string,
+	originalEffort: EffortLevel | undefined,
+	supportsEffort: boolean,
+): { content: string; modified: boolean } {
+	const frontmatterMatch = content.match(/^---\n([\s\S]*?)\n---\n/);
+
+	if (!frontmatterMatch) {
+		// No frontmatter — construct one with model field
+		const newFrontmatter =
+			supportsEffort && originalEffort
+				? `---\nmodel: ${newModel}\neffort: ${originalEffort}\n---\n`
+				: `---\nmodel: ${newModel}\n---\n`;
+		return { content: newFrontmatter + content, modified: true };
+	}
+
+	const originalFrontmatter = frontmatterMatch[1];
+	const body = content.slice(frontmatterMatch[0].length);
+
+	// Parse frontmatter lines, update model, handle effort
+	const lines = originalFrontmatter.split("\n");
+	const updatedLines: string[] = [];
+	let modelFound = false;
+	let effortFound = false;
+	let currentModel = "";
+
+	for (const line of lines) {
+		const modelMatch = line.match(/^model:\s*(.+)$/);
+		if (modelMatch) {
+			currentModel = modelMatch[1].trim();
+			modelFound = true;
+			updatedLines.push(`model: ${newModel}`);
+			continue;
+		}
+
+		const effortMatch = line.match(/^effort:\s*(.+)$/);
+		if (effortMatch) {
+			effortFound = true;
+			if (supportsEffort) {
+				updatedLines.push(line);
+			}
+			// When !supportsEffort, skip the line (strip effort)
+			continue;
+		}
+
+		updatedLines.push(line);
+	}
+
+	if (!modelFound) {
+		updatedLines.unshift(`model: ${newModel}`);
+	}
+
+	const newFrontmatter = updatedLines.join("\n");
+
+	// Re-check: if currentModel was already newModel and effort unchanged, not modified
+	if (currentModel === newModel && (!effortFound || supportsEffort)) {
+		return { content, modified: false };
+	}
+
+	return {
+		content: `---\n${newFrontmatter}\n---\n${body}`,
+		modified: true,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Codex rewriter (.toml with targeted line replacement)
+// ---------------------------------------------------------------------------
+
+function rewriteCodex(
+	content: string,
+	newModel: string,
+	_originalEffort: EffortLevel | undefined,
+	supportsEffort: boolean,
+): { content: string; modified: boolean } {
+	const lines = content.split("\n");
+	const updatedLines: string[] = [];
+	let modified = false;
+	let inMultilineString = false;
+
+	for (const line of lines) {
+		// Track multiline string boundaries (triple-quoted '''...''')
+		if (inMultilineString) {
+			updatedLines.push(line);
+			if (line.includes("'''")) {
+				inMultilineString = false;
+			}
+			continue;
+		}
+
+		// Match model = "..." line
+		const modelMatch = line.match(/^model\s*=\s*"([^"]*)"$/);
+		if (modelMatch) {
+			const currentModel = modelMatch[1];
+			if (currentModel !== newModel) {
+				updatedLines.push(`model = "${newModel}"`);
+				modified = true;
+			} else {
+				updatedLines.push(line);
+			}
+			continue;
+		}
+
+		// Match model_reasoning_effort = "..." line
+		const effortMatch = line.match(/^model_reasoning_effort\s*=\s*"([^"]*)"$/);
+		if (effortMatch) {
+			if (supportsEffort) {
+				updatedLines.push(line);
+			} else {
+				// Strip effort line
+				modified = true;
+			}
+			continue;
+		}
+
+		// Detect start of multiline string
+		if (line.includes("'''") && !line.endsWith("'''")) {
+			inMultilineString = true;
+		}
+
+		updatedLines.push(line);
+	}
+
+	if (!modified) {
+		return { content, modified: false };
+	}
+
+	return { content: updatedLines.join("\n"), modified: true };
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Rewrite a single agent artifact according to the tier remapping.
+ *
+ * Dispatches to platform-specific rewriters, applies effort correction,
+ * and checks for protected-agent downgrades. Platforms without model-field
+ * support (copilot, opencode, antigravity) are skipped with no error.
+ */
+export function rewriteAgentArtifact(
+	params: RewriteAgentParams,
+): RewriteAgentOutput {
+	const {
+		content,
+		agentName,
+		newModel,
+		originalTier,
+		originalEffort,
+		platform,
+	} = params;
+
+	// Skip unsupported platforms
+	if (!REWRITABLE_PLATFORMS.has(platform)) {
+		return { content, modified: false };
+	}
+
+	const supportsEffort = modelSupportsEffort(newModel, platform);
+
+	// Platform-specific rewrite
+	let rewriteResult: { content: string; modified: boolean };
+	if (platform === "claude-code") {
+		rewriteResult = rewriteClaudeCode(
+			content,
+			newModel,
+			originalEffort,
+			supportsEffort,
+		);
+	} else {
+		rewriteResult = rewriteCodex(
+			content,
+			newModel,
+			originalEffort,
+			supportsEffort,
+		);
+	}
+
+	// Effort adjustment reporting
+	let effortAdjustment: EffortAdjustment | undefined;
+	if (originalEffort && !supportsEffort && rewriteResult.modified) {
+		effortAdjustment = {
+			agentName,
+			originalEffort,
+			action: "stripped",
+			reason: `Model "${newModel}" is fast-class on ${platform} and does not support effort control`,
+		};
+	}
+
+	// Protected agent downgrade warning
+	const protectedWarning = rewriteResult.modified
+		? checkProtectedDowngrade(agentName, originalTier, newModel, platform)
+		: undefined;
+
+	return {
+		content: rewriteResult.content,
+		modified: rewriteResult.modified,
+		effortAdjustment,
+		protectedWarning,
+	};
+}

--- a/cli/src/settings/validator.ts
+++ b/cli/src/settings/validator.ts
@@ -17,12 +17,12 @@ import {
 import type { BundleAgentEntry } from "../build/models.js";
 import type { BuildPlatform } from "../build/template-context.js";
 import {
-	getPlatformsWithModelSupport,
 	getValidModelIdsForPlatform,
 	modelSupportsEffort,
 } from "../build/tier-resolution.js";
 import type { TierRemappingConfig } from "./models.js";
 import { VALID_PRESET_NAMES } from "./presets.js";
+import { REWRITABLE_PLATFORMS } from "./rewriter.js";
 
 /**
  * Load a single settings file for validation purposes.
@@ -168,8 +168,6 @@ export function validateTierRemappings(
 		);
 	}
 
-	const supportedPlatforms = new Set(getPlatformsWithModelSupport());
-
 	for (const [platformKey, tierMap] of Object.entries(config.platforms)) {
 		if (!KNOWN_PLATFORMS.has(platformKey)) {
 			warnings.push(
@@ -180,9 +178,9 @@ export function validateTierRemappings(
 
 		const platform = platformKey as BuildPlatform;
 
-		if (!supportedPlatforms.has(platform)) {
+		if (!REWRITABLE_PLATFORMS.has(platform)) {
 			warnings.push(
-				`Remapping for '${platform}' will have no effect: this platform does not support per-agent model fields`,
+				`Remapping for '${platform}' will have no effect: installed artifacts for this platform cannot be rewritten`,
 			);
 			continue;
 		}

--- a/cli/src/settings/validator.ts
+++ b/cli/src/settings/validator.ts
@@ -1,6 +1,7 @@
 /**
  * Settings file validation.
- * Validates TOML syntax in global and local rp1 settings files.
+ * Validates TOML syntax in global and local rp1 settings files,
+ * and semantic validation for [models.*] tier remapping sections.
  */
 
 export {
@@ -12,6 +13,16 @@ import {
 	resolveGlobalSettingsPath,
 	resolveLocalSettingsPath,
 } from "../../shared/settings.js";
+
+import type { BundleAgentEntry } from "../build/models.js";
+import type { BuildPlatform } from "../build/template-context.js";
+import {
+	getPlatformsWithModelSupport,
+	getValidModelIdsForPlatform,
+	modelSupportsEffort,
+} from "../build/tier-resolution.js";
+import type { TierRemappingConfig } from "./models.js";
+import { VALID_PRESET_NAMES } from "./presets.js";
 
 /**
  * Load a single settings file for validation purposes.
@@ -103,3 +114,107 @@ export const validateSettings = async (
 
 	return { valid, globalFile, localFile };
 };
+
+// ---------------------------------------------------------------------------
+// Tier remapping validation
+// ---------------------------------------------------------------------------
+
+/** Semantic validation result for [models.*] tier remapping configuration. */
+export interface TierRemappingValidationResult {
+	readonly valid: boolean;
+	readonly errors: readonly string[];
+	readonly warnings: readonly string[];
+	readonly effortAdjustments: readonly string[];
+}
+
+/** Known BuildPlatform values for platform-name validation. */
+const KNOWN_PLATFORMS: ReadonlySet<string> = new Set<BuildPlatform>([
+	"claude-code",
+	"codex",
+	"opencode",
+	"copilot",
+	"antigravity",
+]);
+
+/**
+ * Validate a tier remapping configuration for correctness.
+ *
+ * Checks:
+ * 1. Preset name (if set) is a known preset.
+ * 2. Platform names are known BuildPlatform values (unknown → warning).
+ * 3. Platforms without model-field support (copilot, opencode) → warning.
+ * 4. Model IDs are valid for the target platform (invalid → error with valid options).
+ * 5. Effort compatibility: agents that would have effort stripped (when agent metadata provided).
+ *
+ * @param config - Parsed tier remapping configuration
+ * @param agentEntries - Optional agent manifest entries for effort compatibility preview
+ */
+export function validateTierRemappings(
+	config: TierRemappingConfig,
+	agentEntries?: readonly BundleAgentEntry[],
+): TierRemappingValidationResult {
+	const errors: string[] = [];
+	const warnings: string[] = [];
+	const effortAdjustments: string[] = [];
+
+	if (
+		config.preset !== undefined &&
+		!VALID_PRESET_NAMES.includes(
+			config.preset as (typeof VALID_PRESET_NAMES)[number],
+		)
+	) {
+		errors.push(
+			`Unknown preset '${config.preset}'. Valid presets: ${VALID_PRESET_NAMES.join(", ")}`,
+		);
+	}
+
+	const supportedPlatforms = new Set(getPlatformsWithModelSupport());
+
+	for (const [platformKey, tierMap] of Object.entries(config.platforms)) {
+		if (!KNOWN_PLATFORMS.has(platformKey)) {
+			warnings.push(
+				`'${platformKey}' is an unknown platform; remapping will be ignored. Known platforms: ${[...KNOWN_PLATFORMS].join(", ")}`,
+			);
+			continue;
+		}
+
+		const platform = platformKey as BuildPlatform;
+
+		if (!supportedPlatforms.has(platform)) {
+			warnings.push(
+				`Remapping for '${platform}' will have no effect: this platform does not support per-agent model fields`,
+			);
+			continue;
+		}
+
+		if (!tierMap) continue;
+
+		const validIds = getValidModelIdsForPlatform(platform);
+
+		for (const [tier, modelId] of Object.entries(tierMap)) {
+			if (!validIds.includes(modelId)) {
+				errors.push(
+					`Invalid model '${modelId}' for ${platform} tier '${tier}'. Valid models: ${validIds.join(", ")}`,
+				);
+				continue;
+			}
+
+			if (agentEntries && !modelSupportsEffort(modelId, platform)) {
+				for (const agent of agentEntries) {
+					if (agent.tier === tier && agent.effort !== undefined) {
+						effortAdjustments.push(
+							`Agent '${agent.name}' (tier: ${tier}, effort: ${agent.effort}) will have effort stripped when remapped to '${modelId}' on ${platform}`,
+						);
+					}
+				}
+			}
+		}
+	}
+
+	return {
+		valid: errors.length === 0,
+		errors,
+		warnings,
+		effortAdjustments,
+	};
+}

--- a/docs/getting-started/rp1-directory.md
+++ b/docs/getting-started/rp1-directory.md
@@ -19,6 +19,7 @@ rp1 stores all project-specific data in a `.rp1/` directory at your project root
 │   ├── state.json            # Build state tracking (shareable)
 │   └── meta.json             # Local paths (NOT shareable - add to .gitignore)
 ├── config/                   # Project configuration
+├── settings.toml             # Project settings (model tiers, argument defaults)
 ├── work/                     # Work artifacts (ignored by git)
 │   ├── charter.md            # Project charter (from /blueprint)
 │   ├── prds/                 # Product requirement documents
@@ -30,8 +31,13 @@ rp1 stores all project-specific data in a `.rp1/` directory at your project root
 │   │       ├── tasks.md
 │   │       └── field-notes.md
 │   └── archives/             # Completed/archived features
-└── settings.toml             # Project settings
 ```
+
+The `settings.toml` file can include a `[models]` section for remapping
+abstract model tiers (deep, standard, fast) to concrete model identifiers per
+platform. This lets you control which models rp1 agents use without rebuilding.
+See [Configuration](../reference/configuration.md) for the full schema and
+available presets.
 
 ---
 

--- a/docs/reference/cli/index.md
+++ b/docs/reference/cli/index.md
@@ -15,6 +15,7 @@ AI assistant session.
 | [`update`](update.md) | Update rp1 CLI and plugins |
 | [`uninstall`](uninstall.md) | Remove rp1 project setup or host-specific assets |
 | [`check-update`](check-update.md) | Check for CLI and stanza updates |
+| [`settings`](settings.md) | Manage settings files and model tier remappings |
 | [`rp1 migrate`](rp1-migrate.md) | Migrate older projects into the project-local `.rp1/` layout |
 | [Fence Versioning](fence-versioning.md) | How fence version markers work |
 

--- a/docs/reference/cli/settings.md
+++ b/docs/reference/cli/settings.md
@@ -1,0 +1,127 @@
+# settings
+
+Manage rp1 settings files and model tier remappings.
+
+---
+
+## Synopsis
+
+```bash
+rp1 settings validate
+rp1 settings apply [options]
+rp1 settings presets
+```
+
+## Description
+
+`rp1 settings` provides subcommands for validating settings files, applying
+model tier remappings to installed agent artifacts, and listing available
+presets.
+
+rp1 reads settings from two locations:
+
+| Location | Path |
+|----------|------|
+| Global (user) | `~/.config/rp1/settings.toml` |
+| Local (project) | `.rp1/settings.toml` |
+
+When both files exist, project settings take precedence over user settings
+(per-platform, per-tier). See [Configuration](../configuration.md) for the
+full settings.toml reference.
+
+## Subcommands
+
+### validate
+
+Check settings files for TOML syntax errors and tier remapping semantic
+validity.
+
+```bash
+rp1 settings validate
+```
+
+Validates both global and local settings files. Missing files are not
+considered errors. When TOML syntax is valid and a `[models]` section exists,
+also runs semantic validation on the tier remapping configuration (preset
+names, platform names, model IDs).
+
+**Exit codes:**
+
+| Code | Meaning |
+|------|---------|
+| `0` | All files valid (or do not exist) |
+| `1` | One or more files have syntax or semantic errors |
+
+### apply
+
+Apply tier remappings to installed agent artifacts.
+
+```bash
+rp1 settings apply
+rp1 settings apply --preset budget
+rp1 settings apply --dry-run
+```
+
+Orchestrates: load config, validate, discover installed agents, rewrite
+model/effort fields, report results. Only platforms with declared remappings
+are modified (currently Claude Code and Codex).
+
+**Options:**
+
+| Option | Description |
+|--------|-------------|
+| `--preset <name>` | Apply a named preset directly, ignoring settings.toml `[models]` |
+| `--dry-run` | Preview changes without modifying files |
+
+When `--preset` is passed on the command line, it replaces custom mappings
+entirely. When the preset comes from settings.toml, per-platform overrides in
+the same file are merged on top of preset values.
+
+After modifying Claude Code artifacts, the command refreshes the Claude Code
+plugin cache so changes take effect in the current session.
+
+### presets
+
+List available tier remapping presets with their per-platform model mappings.
+
+```bash
+rp1 settings presets
+```
+
+Displays all presets ordered by cost (budget, standard, premium) with the
+concrete model ID for each tier on each supported platform.
+
+**Available presets:**
+
+| Preset | Description |
+|--------|-------------|
+| `budget` | Cost-optimized: uses only fast-class models across all tiers |
+| `standard` | Balanced: collapses deep tier to sonnet-class for users without Opus access |
+| `premium` | Full capability: matches build defaults with frontier-class models at deep tier |
+
+See [Configuration](../configuration.md#presets) for the full preset model
+mappings.
+
+## Examples
+
+```bash
+# Validate all settings files
+rp1 settings validate
+
+# Apply tier remappings from settings.toml
+rp1 settings apply
+
+# Apply the budget preset directly
+rp1 settings apply --preset budget
+
+# Preview what would change without modifying files
+rp1 settings apply --dry-run
+
+# List available presets with their model mappings
+rp1 settings presets
+```
+
+## See Also
+
+- [Configuration](../configuration.md) - settings.toml `[models]` reference
+- [update](update.md) - Automatic re-apply after plugin refresh

--- a/docs/reference/cli/update.md
+++ b/docs/reference/cli/update.md
@@ -102,6 +102,20 @@ Refreshing Antigravity assets restores the generated workflow assets. Run
 `rp1 verify antigravity --workflow <workflow-id>` after refresh to see workflow
 attribution and any dynamic delegation limitation.
 
+## Tier Remapping Re-apply
+
+After refreshing plugins, `rp1 update` automatically re-applies model tier
+remappings from your `[models]` configuration in settings.toml. This ensures
+that updated agent artifacts retain your model preferences without requiring
+a manual `rp1 settings apply`.
+
+The re-apply is non-blocking: if no `[models]` section is configured, the step
+is silently skipped. If remapping encounters warnings (e.g., protected agent
+downgrades), they are logged but do not interrupt the update.
+
+See [Configuration](../configuration.md) for the `[models]` schema and
+[`settings`](settings.md) for manual apply and validation commands.
+
 ## Safety
 
 rp1 validates the downloaded binary before replacing the current one, so a bad
@@ -146,5 +160,7 @@ rp1 verify antigravity --workflow <workflow-id>
 - [install](install.md)
 - [verify](verify.md)
 - [uninstall](uninstall.md)
+- [settings](settings.md) - Manual model tier remapping and validation
+- [Configuration](../configuration.md) - settings.toml `[models]` reference
 - [Antigravity CLI Platform Guide](../platforms/antigravity.md)
 - [Troubleshooting](../../troubleshooting/index.md)

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -1,0 +1,235 @@
+# Configuration
+
+rp1 settings are stored in TOML files at two locations. Project-level settings
+take precedence over user-level settings when both exist.
+
+| Scope | Path |
+|-------|------|
+| User (global) | `~/.config/rp1/settings.toml` |
+| Project (local) | `.rp1/settings.toml` |
+
+---
+
+## Model Tier Remapping
+
+The `[models]` section lets you remap abstract model tiers (deep, standard,
+fast) to concrete model identifiers per platform. This controls which models
+rp1 agents use after installation, without requiring a rebuild.
+
+### Schema
+
+```toml
+[models]
+preset = "standard"              # Optional: apply a named preset as base
+
+[models.claude-code]             # Per-platform tier overrides
+deep = "sonnet"
+standard = "sonnet"
+fast = "haiku"
+
+[models.codex]
+deep = "gpt-5.4"
+standard = "gpt-5.4"
+fast = "gpt-5.4-mini"
+```
+
+### Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `preset` | string | Named preset to use as base configuration. Valid values: `budget`, `standard`, `premium` |
+| `[models.<platform>]` | table | Per-platform tier-to-model mappings. Supported platforms: `claude-code`, `codex` |
+
+### Tier Keys
+
+Each platform sub-table accepts these tier keys:
+
+| Tier | Description |
+|------|-------------|
+| `deep` | Reasoning-intensive agents (architects, reviewers, investigators) |
+| `standard` | General-purpose agents (builders, editors, reporters) |
+| `fast` | Lightweight agents (discovery, formatting, simple transforms) |
+
+Omitted tiers keep the build-time default model for that platform.
+
+### Valid Model Identifiers
+
+| Platform | Valid Models |
+|----------|-------------|
+| `claude-code` | `opus`, `sonnet`, `haiku`, `fable` |
+| `codex` | `gpt-5.5`, `gpt-5.4`, `gpt-5.4-mini` |
+
+Other platforms (`copilot`, `opencode`, `antigravity`) do not support per-agent
+model fields in their installed artifacts. Remappings for these platforms
+produce a validation warning and have no effect.
+
+---
+
+## Presets
+
+Presets are complete tier-to-model configurations ordered by cost. Use a preset
+as a starting point, optionally overriding individual tiers per platform.
+
+### budget
+
+Cost-optimized: uses only fast-class models across all tiers.
+
+| Platform | deep | standard | fast |
+|----------|------|----------|------|
+| `claude-code` | `haiku` | `haiku` | `haiku` |
+| `codex` | `gpt-5.4-mini` | `gpt-5.4-mini` | `gpt-5.4-mini` |
+
+### standard
+
+Balanced: collapses deep tier to sonnet-class for users without Opus access.
+
+| Platform | deep | standard | fast |
+|----------|------|----------|------|
+| `claude-code` | `sonnet` | `sonnet` | `haiku` |
+| `codex` | `gpt-5.4` | `gpt-5.4` | `gpt-5.4-mini` |
+
+### premium
+
+Full capability: matches build defaults with frontier-class models at deep
+tier.
+
+| Platform | deep | standard | fast |
+|----------|------|----------|------|
+| `claude-code` | `opus` | `sonnet` | `haiku` |
+| `codex` | `gpt-5.5` | `gpt-5.4` | `gpt-5.4-mini` |
+
+---
+
+## Merge Precedence
+
+When both user and project settings define `[models]` sections:
+
+1. **Preset**: project-level preset overrides user-level preset.
+2. **Per-platform tiers**: project-level tier mappings override user-level
+   mappings for the same platform and tier. Tiers defined only at the
+   user level are preserved.
+3. **Preset + overrides**: when a preset is set in settings.toml (not via
+   `--preset` CLI flag), explicit `[models.<platform>]` entries in the same
+   file are merged on top of preset values.
+
+### Example: Hybrid Configuration
+
+User-level `~/.config/rp1/settings.toml`:
+
+```toml
+[models]
+preset = "standard"
+```
+
+Project-level `.rp1/settings.toml`:
+
+```toml
+[models.claude-code]
+deep = "opus"
+```
+
+Result: the standard preset applies as the base, but the project overrides
+the Claude Code deep tier to `opus`. All other tiers remain at preset values.
+
+---
+
+## Effort Auto-Strip
+
+When a tier is remapped to a fast-class model (e.g., `haiku` on Claude Code,
+`gpt-5.4-mini` on Codex), the effort field is automatically stripped from
+agent artifacts during `rp1 settings apply`. Fast-class models do not support
+effort control, so the effort parameter would have no effect.
+
+The apply command reports each effort adjustment so you can see which agents
+are affected.
+
+---
+
+## Protected Agent Warnings
+
+Certain reasoning-critical agents are marked as protected. When a remapping
+would downgrade a protected agent to a lower tier than its build default, the
+apply command emits a warning. The remapping is still applied, but the warning
+alerts you that reasoning quality may be reduced.
+
+Protected agents include architects, reviewers, investigators, and other
+agents where reasoning depth directly affects output quality.
+
+---
+
+## Automatic Re-apply
+
+When you run `rp1 update` to refresh plugins, rp1 automatically re-applies
+your `[models]` tier remappings if configured. This ensures that updated
+agent artifacts retain your model preferences. The re-apply is non-blocking:
+failures produce warnings but do not interrupt the update.
+
+See [`rp1 update`](cli/update.md) for details.
+
+---
+
+## Configuration Examples
+
+### Preset Only
+
+Apply the standard preset with no customization:
+
+```toml
+[models]
+preset = "standard"
+```
+
+### Custom Per-Platform
+
+Set specific models per platform without a preset:
+
+```toml
+[models.claude-code]
+deep = "sonnet"
+standard = "sonnet"
+fast = "haiku"
+
+[models.codex]
+deep = "gpt-5.4"
+fast = "gpt-5.4-mini"
+```
+
+Omitted tiers (e.g., `standard` under `[models.codex]`) keep the build
+default.
+
+### Preset with Overrides
+
+Use a preset as a base and override specific tiers:
+
+```toml
+[models]
+preset = "budget"
+
+[models.claude-code]
+deep = "sonnet"
+```
+
+Result: all tiers start at budget values, but Claude Code deep is upgraded
+to `sonnet`.
+
+---
+
+## Validation
+
+Run `rp1 settings validate` to check your configuration for:
+
+- TOML syntax errors in both settings files
+- Unknown preset names
+- Unknown or unsupported platform names
+- Invalid model identifiers for a platform
+- Effort compatibility warnings
+
+See [`rp1 settings validate`](cli/settings.md#validate) for exit codes and
+output details.
+
+---
+
+## See Also
+
+- [`settings`](cli/settings.md) - CLI command reference for validate, apply, and presets
+- [The `.rp1` Directory](../getting-started/rp1-directory.md) - Project directory structure

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -59,9 +59,9 @@ Omitted tiers keep the build-time default model for that platform.
 | `claude-code` | `opus`, `sonnet`, `haiku`, `fable` |
 | `codex` | `gpt-5.5`, `gpt-5.4`, `gpt-5.4-mini` |
 
-Other platforms (`copilot`, `opencode`, `antigravity`) do not support per-agent
-model fields in their installed artifacts. Remappings for these platforms
-produce a validation warning and have no effect.
+Other platforms (`copilot`, `opencode`, `antigravity`) cannot have their
+installed artifacts rewritten. Remappings for these platforms produce a
+validation warning and have no effect.
 
 ---
 

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -18,6 +18,7 @@ available when you need the complete command list.
 | Check available updates | [`check-update`](cli/check-update.md) |
 | Update rp1 and refresh installed plugins from a workflow | [`self-update`](base/self-update.md) |
 | Migrate an older project layout | [`rp1 migrate`](cli/rp1-migrate.md) |
+| Configure model tier remappings | [`configuration`](configuration.md), [`settings`](cli/settings.md) |
 
 [:octicons-arrow-right-24: CLI Reference](cli/index.md)
 


### PR DESCRIPTION
## Summary

Makes model and effort tiers user-controllable per machine, resolved late (at install/update time) instead of baked in at build time:

- **`[models]` / `[models.<platform>]` sections in `settings.toml`** parse into tier remappings with project > user merge precedence (`cli/src/settings/models.ts`, `loader.ts`)
- **`rp1 settings apply`** (`--preset`, `--dry-run`) rewrites installed agent artifacts to the user's tier mapping; **`rp1 settings presets`** lists mappings; semantic validation is wired into **`rp1 settings validate`**
- **`rp1 update` re-applies remappings automatically** after plugin updates — the late-binding piece: users keep their tier choices across releases
- **Three blessed presets** (`budget`, `standard`, `premium`) validated against `TIER_MODEL_MAP` as the single source of truth
- **Artifact rewriter** handles Claude Code YAML frontmatter and Codex TOML with targeted line replacement (experimentally verified byte-safe for multiline `developer_instructions`), auto-strips effort when remapping to fast-class models (with user-visible notices), and warns on protected-agent downgrades without blocking
- **Bundle manifests now carry per-agent `tier`/`effort` metadata** (`BundleAgentEntry`) so install-time resolution works directly from bundles

## Test plan

- 100+ new tests across loader, presets, rewriter, validator, apply, and the update hook
- Full cli suite: 3219/3220 passing (single failure is a pre-existing env-flaky daemon port-conflict test); Biome lint/format and `tsc` clean
- All 9 requirements verified against acceptance criteria (rp1 build readiness: WARN/proceed-with-notes, 0 blockers)
- Includes a drive-by fix making 4 pre-existing `loadAllArgumentDefaults` tests hermetic against the developer's global `~/.config/rp1/settings.toml`

## Follow-ups (docs, non-blocking)

- [x] `docs/reference/cli/settings.md` — settings commands (added in d1708845)
- [x] `docs/reference/configuration.md` — settings format (added in d1708845)
- [x] `.rp1/context/patterns.md` — tier abstraction pattern (added in e8592d2c)
- [x] `.rp1/context/modules.md` — settings module (added in e8592d2c)

🤖 Generated using: 🎮 [rp1.run](https://rp1.run)

