### PR TITLE
feat(storage): dual-mode directory resolution with [storage] settings, project_id DB keying, and container fallback (storage-decoupling P2.1)

### DIFF
--- a/cli/shared/directory-resolution.ts
+++ b/cli/shared/directory-resolution.ts
@@ -205,7 +205,7 @@ const buildDirectorySet = (params: {
 }): ResolvedDirectorySet => {
 	const projectRoot = path.resolve(params.projectRoot);
 	const projectId = readProjectId(projectRoot);
-	const { kbRoot, workRoot } = computeDirectoryPaths(
+	const { kbRoot, workRoot, effectiveMode } = computeDirectoryPaths(
 		projectRoot,
 		projectId,
 		params.storageMode,
@@ -219,7 +219,7 @@ const buildDirectorySet = (params: {
 		codeRoot: path.resolve(params.codeRoot),
 		isWorktree: params.isWorktree,
 		worktreeName: params.worktreeName,
-		storageMode: params.storageMode,
+		storageMode: effectiveMode,
 	};
 };
 

--- a/cli/shared/directory-resolution.ts
+++ b/cli/shared/directory-resolution.ts
@@ -6,6 +6,12 @@ import * as E from "fp-ts/lib/Either.js";
 import type { CLIError } from "./errors.js";
 import { notFoundError } from "./errors.js";
 import { PROJECT_ID_FILENAME, readProjectId } from "./project-id.js";
+import type { StorageMode } from "./storage-mode.js";
+import {
+	computeDirectoryPaths,
+	isContainerEnvironment,
+	readStorageMode,
+} from "./storage-mode.js";
 
 export type ProjectRootSource = "walk_up" | "git_common_dir";
 
@@ -17,6 +23,7 @@ export interface ResolvedDirectorySet {
 	readonly codeRoot: string;
 	readonly isWorktree: boolean;
 	readonly worktreeName?: string;
+	readonly storageMode: StorageMode;
 }
 
 export interface DirectoryResolutionOptions {
@@ -184,23 +191,35 @@ const normalizeProjectKey = (projectRoot: string): string => {
 
 export { normalizeProjectKey };
 
+const resolveEffectiveMode = (projectRoot: string): StorageMode => {
+	if (isContainerEnvironment()) return "local";
+	return readStorageMode(projectRoot);
+};
+
 const buildDirectorySet = (params: {
 	projectRoot: string;
 	codeRoot: string;
 	isWorktree: boolean;
 	worktreeName?: string;
+	storageMode: StorageMode;
 }): ResolvedDirectorySet => {
 	const projectRoot = path.resolve(params.projectRoot);
 	const projectId = readProjectId(projectRoot);
+	const { kbRoot, workRoot } = computeDirectoryPaths(
+		projectRoot,
+		projectId,
+		params.storageMode,
+	);
 
 	return {
 		projectRoot,
 		projectId,
-		kbRoot: path.join(projectRoot, ".rp1", "context"),
-		workRoot: path.join(projectRoot, ".rp1", "work"),
+		kbRoot,
+		workRoot,
 		codeRoot: path.resolve(params.codeRoot),
 		isWorktree: params.isWorktree,
 		worktreeName: params.worktreeName,
+		storageMode: params.storageMode,
 	};
 };
 
@@ -249,6 +268,7 @@ export const resolveDirectorySet = (
 						codeRoot: gitContext.topLevel,
 						isWorktree: true,
 						worktreeName: gitContext.branch,
+						storageMode: resolveEffectiveMode(commonDirProjectRoot),
 					}),
 				);
 			}
@@ -269,6 +289,7 @@ export const resolveDirectorySet = (
 				projectRoot: walkedResult.root,
 				codeRoot: walkedResult.root,
 				isWorktree: false,
+				storageMode: resolveEffectiveMode(walkedResult.root),
 			}),
 		);
 	}

--- a/cli/shared/storage-mode.ts
+++ b/cli/shared/storage-mode.ts
@@ -16,6 +16,7 @@ export const VALID_STORAGE_MODES: readonly StorageMode[] = [
 export interface DirectoryPaths {
 	readonly kbRoot: string;
 	readonly workRoot: string;
+	readonly effectiveMode: StorageMode;
 }
 
 export const computeDirectoryPaths = (
@@ -28,12 +29,14 @@ export const computeDirectoryPaths = (
 		return {
 			kbRoot: join(centralBase, "context"),
 			workRoot: join(centralBase, "work"),
+			effectiveMode: "central",
 		};
 	}
 
 	return {
 		kbRoot: join(projectRoot, ".rp1", "context"),
 		workRoot: join(projectRoot, ".rp1", "work"),
+		effectiveMode: "local",
 	};
 };
 

--- a/cli/shared/storage-mode.ts
+++ b/cli/shared/storage-mode.ts
@@ -1,0 +1,106 @@
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import {
+	resolveGlobalSettingsPath,
+	resolveLocalSettingsPath,
+} from "./settings.js";
+
+export type StorageMode = "local" | "central";
+
+export const VALID_STORAGE_MODES: readonly StorageMode[] = [
+	"local",
+	"central",
+] as const;
+
+export interface DirectoryPaths {
+	readonly kbRoot: string;
+	readonly workRoot: string;
+}
+
+export const computeDirectoryPaths = (
+	projectRoot: string,
+	projectId: string | undefined,
+	mode: StorageMode,
+): DirectoryPaths => {
+	if (mode === "central" && projectId !== undefined) {
+		const centralBase = join(homedir(), ".rp1", "projects", projectId);
+		return {
+			kbRoot: join(centralBase, "context"),
+			workRoot: join(centralBase, "work"),
+		};
+	}
+
+	return {
+		kbRoot: join(projectRoot, ".rp1", "context"),
+		workRoot: join(projectRoot, ".rp1", "work"),
+	};
+};
+
+let containerDetectionResult: boolean | undefined;
+
+export const isContainerEnvironment = (): boolean => {
+	if (containerDetectionResult !== undefined) {
+		return containerDetectionResult;
+	}
+
+	const result =
+		existsSync("/.dockerenv") ||
+		process.env.REMOTE_CONTAINERS !== undefined ||
+		process.env.CODESPACES !== undefined;
+
+	containerDetectionResult = result;
+	return result;
+};
+
+export const resetContainerDetectionCache = (): void => {
+	containerDetectionResult = undefined;
+};
+
+const isPlainRecord = (
+	value: unknown,
+): value is Readonly<Record<string, unknown>> =>
+	value !== null && typeof value === "object" && !Array.isArray(value);
+
+const parseStorageModeFromFile = (
+	filePath: string,
+): StorageMode | undefined => {
+	if (!existsSync(filePath)) return undefined;
+
+	try {
+		const text = readFileSync(filePath, "utf-8");
+		const parsed = Bun.TOML.parse(text) as Record<string, unknown>;
+		const storageSection = parsed.storage;
+
+		if (!isPlainRecord(storageSection)) return undefined;
+
+		const mode = storageSection.mode;
+		if (
+			typeof mode === "string" &&
+			(VALID_STORAGE_MODES as readonly string[]).includes(mode)
+		) {
+			return mode as StorageMode;
+		}
+
+		return undefined;
+	} catch {
+		return undefined;
+	}
+};
+
+export const readStorageMode = (
+	projectRoot: string,
+	globalSettingsPath?: string,
+): StorageMode => {
+	const projectMode = parseStorageModeFromFile(
+		resolveLocalSettingsPath(projectRoot),
+	);
+	if (projectMode !== undefined) return projectMode;
+
+	const userMode = parseStorageModeFromFile(
+		globalSettingsPath ?? resolveGlobalSettingsPath(),
+	);
+	if (userMode !== undefined) return userMode;
+
+	return "local";
+};

--- a/cli/src/__tests__/agent-tools/emit/database.test.ts
+++ b/cli/src/__tests__/agent-tools/emit/database.test.ts
@@ -39,6 +39,7 @@ import {
 	getEventsSince,
 	getMaxEventId,
 	getProjectRunStats,
+	getProjectRunStatsByIds,
 	getRecentEventsForRun,
 	getRunById,
 	getRunsByAttentionStatus,
@@ -3640,6 +3641,112 @@ describe("emit database", () => {
 				.get("run-legacy") as { flow: string } | null;
 			expect(row?.flow).toBe("build");
 		});
+
+		test("matches run by project_id when available", async () => {
+			const dbPath = join(tempDir, "resume-project-id.db");
+			const db = await expectTaskRight(getEmitDatabase(dbPath));
+
+			insertRun(db, {
+				id: "run-pid",
+				flow: "build",
+				featureId: "feat-pid",
+				projectPath: "/project/old-path",
+				rp1ProjectRoot: "/project/old-path",
+				projectId: "stable-project-id",
+			});
+
+			insertEvent(db, {
+				runId: "run-pid",
+				type: "status_change",
+				step: "step1",
+				data: JSON.stringify({ status: "running" }),
+			});
+			deriveRunStatus(db, "run-pid");
+
+			const result = findOrCreateRun(db, {
+				flow: "build",
+				featureId: "feat-pid",
+				projectPath: "/project/new-path",
+				rp1ProjectRoot: "/project/new-path",
+				projectId: "stable-project-id",
+			});
+
+			expect(result.runId).toBe("run-pid");
+			expect(result.resumed).toBe(true);
+		});
+
+		test("falls back to rp1_project_root for rows with NULL project_id", async () => {
+			const dbPath = join(tempDir, "resume-null-pid-fallback.db");
+			const db = await expectTaskRight(getEmitDatabase(dbPath));
+
+			insertRun(db, {
+				id: "run-no-pid",
+				flow: "build",
+				featureId: "feat-no-pid",
+				projectPath: "/project/fallback",
+				rp1ProjectRoot: "/project/fallback",
+			});
+
+			db.prepare("UPDATE runs SET project_id = NULL WHERE id = ?").run(
+				"run-no-pid",
+			);
+
+			insertEvent(db, {
+				runId: "run-no-pid",
+				type: "status_change",
+				step: "step1",
+				data: JSON.stringify({ status: "running" }),
+			});
+			deriveRunStatus(db, "run-no-pid");
+
+			const result = findOrCreateRun(db, {
+				flow: "build",
+				featureId: "feat-no-pid",
+				projectPath: "/project/fallback",
+				rp1ProjectRoot: "/project/fallback",
+			});
+
+			expect(result.runId).toBe("run-no-pid");
+			expect(result.resumed).toBe(true);
+		});
+
+		test("matches legacy unknown flow by project_id", async () => {
+			const dbPath = join(tempDir, "resume-legacy-pid.db");
+			const db = await expectTaskRight(getEmitDatabase(dbPath));
+
+			insertRun(db, {
+				id: "run-legacy-pid",
+				flow: "unknown",
+				featureId: "feat-legacy-pid",
+				projectPath: "/project/legacy-path",
+				rp1ProjectRoot: "/project/legacy-path",
+				projectId: "stable-legacy-id",
+			});
+
+			insertEvent(db, {
+				runId: "run-legacy-pid",
+				type: "status_change",
+				step: "step1",
+				data: JSON.stringify({ status: "running" }),
+			});
+			deriveRunStatus(db, "run-legacy-pid");
+
+			const result = findOrCreateRun(db, {
+				flow: "build",
+				featureId: "feat-legacy-pid",
+				projectPath: "/project/different-path",
+				rp1ProjectRoot: "/project/different-path",
+				projectId: "stable-legacy-id",
+			});
+
+			expect(result.runId).toBe("run-legacy-pid");
+			expect(result.resumed).toBe(true);
+
+			const row = db
+				.prepare("SELECT flow FROM runs WHERE id = ?")
+				.get("run-legacy-pid") as { flow: string } | null;
+			expect(row?.flow).toBe("build");
+		});
 	});
 
 	describe("findOrCreateWorkflowRun", () => {
@@ -5514,6 +5621,56 @@ describe("emit database", () => {
 			const db = await expectTaskRight(getEmitDatabase(dbPath));
 
 			const stats = getProjectRunStats(db, []);
+
+			expect(stats.size).toBe(0);
+		});
+	});
+
+	describe("getProjectRunStatsByIds", () => {
+		test("returns run count and last activity per project_id", async () => {
+			const dbPath = join(tempDir, "project-stats-by-id.db");
+			const db = await expectTaskRight(getEmitDatabase(dbPath));
+
+			insertRun(db, {
+				id: "run-si1",
+				flow: "build",
+				featureId: "feat",
+				projectPath: "/project/alpha",
+				projectId: "pid-alpha",
+			});
+			insertRun(db, {
+				id: "run-si2",
+				flow: "review",
+				featureId: "feat",
+				projectPath: "/project/alpha-alt",
+				projectId: "pid-alpha",
+			});
+			insertRun(db, {
+				id: "run-si3",
+				flow: "build",
+				featureId: "feat",
+				projectPath: "/project/beta",
+				projectId: "pid-beta",
+			});
+
+			const stats = getProjectRunStatsByIds(db, [
+				"pid-alpha",
+				"pid-beta",
+				"pid-missing",
+			]);
+
+			expect(stats.get("pid-alpha")?.runCount).toBe(2);
+			expect(stats.get("pid-alpha")?.lastActivityAt).toBeTruthy();
+			expect(stats.get("pid-beta")?.runCount).toBe(1);
+			expect(stats.get("pid-missing")?.runCount).toBe(0);
+			expect(stats.get("pid-missing")?.lastActivityAt).toBeNull();
+		});
+
+		test("returns empty map for empty project id list", async () => {
+			const dbPath = join(tempDir, "project-stats-by-id-empty.db");
+			const db = await expectTaskRight(getEmitDatabase(dbPath));
+
+			const stats = getProjectRunStatsByIds(db, []);
 
 			expect(stats.size).toBe(0);
 		});

--- a/cli/src/__tests__/agent-tools/rp1-root-dir/resolver.test.ts
+++ b/cli/src/__tests__/agent-tools/rp1-root-dir/resolver.test.ts
@@ -100,6 +100,15 @@ describe("rp1-root-dir resolver", () => {
 			expect(result.workRoot).toBe(join(standardRepoRoot, ".rp1", "work"));
 			expect(result.codeRoot).toBe(standardRepoRoot);
 			expect(result.worktreeName).toBeUndefined();
+			expect(result.storageMode).toBe("local");
+		});
+
+		test("includes storageMode in output for agent and bootstrap consumers", async () => {
+			const result = await expectTaskRight(resolveRp1Root(standardRepoRoot));
+
+			expect(result.storageMode).toBeDefined();
+			expect(typeof result.storageMode).toBe("string");
+			expect(["local", "central"]).toContain(result.storageMode);
 		});
 
 		test("returns correct projectRoot from subdirectory of standard repo", async () => {

--- a/cli/src/__tests__/settings/loader-storage.test.ts
+++ b/cli/src/__tests__/settings/loader-storage.test.ts
@@ -4,6 +4,7 @@
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { join } from "node:path";
+import { readStorageMode } from "../../../shared/storage-mode.js";
 import { loadStorageMode, resetSettingsCache } from "../../settings/loader.js";
 import {
 	cleanupTempDir,
@@ -173,6 +174,36 @@ describe("two-level merge for storage mode", () => {
 
 		const result = await loadStorageMode(tempDir, globalPath);
 		expect(result).toBe("local");
+	});
+});
+
+describe("cross-verification: loadStorageMode delegates to readStorageMode", () => {
+	test("loadStorageMode and readStorageMode return identical results for central mode", async () => {
+		const globalPath = isolatedGlobalPath();
+		await writeFixture(
+			tempDir,
+			".rp1/settings.toml",
+			`[storage]\nmode = "central"\n`,
+		);
+
+		const loaderResult = await loadStorageMode(tempDir, globalPath);
+		const sharedResult = readStorageMode(tempDir, globalPath);
+		expect(loaderResult).toBe(sharedResult);
+		expect(loaderResult).toBe("central");
+	});
+
+	test("loadStorageMode and readStorageMode return identical results for absent section", async () => {
+		const globalPath = isolatedGlobalPath();
+		await writeFixture(
+			tempDir,
+			".rp1/settings.toml",
+			`[arguments.build]\nAFK = false\n`,
+		);
+
+		const loaderResult = await loadStorageMode(tempDir, globalPath);
+		const sharedResult = readStorageMode(tempDir, globalPath);
+		expect(loaderResult).toBe(sharedResult);
+		expect(loaderResult).toBe("local");
 	});
 });
 

--- a/cli/src/__tests__/settings/loader-storage.test.ts
+++ b/cli/src/__tests__/settings/loader-storage.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Unit tests for TOML [storage] section parsing and two-level merge.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { join } from "node:path";
+import { loadStorageMode, resetSettingsCache } from "../../settings/loader.js";
+import {
+	cleanupTempDir,
+	createTempDir,
+	writeFixture,
+} from "../helpers/index.js";
+
+let tempDir: string;
+
+/** Path to a nonexistent global settings file within tempDir, isolating tests from ~/.config/rp1/settings.toml. */
+const isolatedGlobalPath = (): string =>
+	join(tempDir, ".no-global", "settings.toml");
+
+beforeEach(async () => {
+	resetSettingsCache();
+	tempDir = await createTempDir("settings-loader-storage");
+});
+
+afterEach(async () => {
+	await cleanupTempDir(tempDir);
+});
+
+describe("parseStorageSection via loadStorageMode", () => {
+	test("returns 'local' when no settings files exist", async () => {
+		const result = await loadStorageMode(tempDir, isolatedGlobalPath());
+		expect(result).toBe("local");
+	});
+
+	test("parses [storage] section with mode = 'central'", async () => {
+		await writeFixture(
+			tempDir,
+			".rp1/settings.toml",
+			`[storage]\nmode = "central"\n`,
+		);
+
+		const result = await loadStorageMode(tempDir, isolatedGlobalPath());
+		expect(result).toBe("central");
+	});
+
+	test("parses [storage] section with mode = 'local'", async () => {
+		await writeFixture(
+			tempDir,
+			".rp1/settings.toml",
+			`[storage]\nmode = "local"\n`,
+		);
+
+		const result = await loadStorageMode(tempDir, isolatedGlobalPath());
+		expect(result).toBe("local");
+	});
+
+	test("returns 'local' when [storage] section is absent", async () => {
+		await writeFixture(
+			tempDir,
+			".rp1/settings.toml",
+			`[arguments.build]\nAFK = false\n`,
+		);
+
+		const result = await loadStorageMode(tempDir, isolatedGlobalPath());
+		expect(result).toBe("local");
+	});
+
+	test("ignores invalid mode values and falls back to 'local'", async () => {
+		await writeFixture(
+			tempDir,
+			".rp1/settings.toml",
+			`[storage]\nmode = "cloud"\n`,
+		);
+
+		const result = await loadStorageMode(tempDir, isolatedGlobalPath());
+		expect(result).toBe("local");
+	});
+
+	test("ignores non-string mode values", async () => {
+		await writeFixture(tempDir, ".rp1/settings.toml", `[storage]\nmode = 42\n`);
+
+		const result = await loadStorageMode(tempDir, isolatedGlobalPath());
+		expect(result).toBe("local");
+	});
+
+	test("coexists with other sections without interference", async () => {
+		await writeFixture(
+			tempDir,
+			".rp1/settings.toml",
+			[
+				"[arguments.build]",
+				"AFK = false",
+				"",
+				"[models.claude-code]",
+				'deep = "claude-sonnet-4-20250514"',
+				"",
+				"[storage]",
+				'mode = "central"',
+				"",
+				"[arcade]",
+				'theme = "dark"',
+			].join("\n"),
+		);
+
+		const result = await loadStorageMode(tempDir, isolatedGlobalPath());
+		expect(result).toBe("central");
+	});
+});
+
+describe("two-level merge for storage mode", () => {
+	test("project-level overrides user-level mode", async () => {
+		const globalPath = join(tempDir, "global-config", "settings.toml");
+
+		await writeFixture(
+			tempDir,
+			"global-config/settings.toml",
+			`[storage]\nmode = "central"\n`,
+		);
+		await writeFixture(
+			tempDir,
+			".rp1/settings.toml",
+			`[storage]\nmode = "local"\n`,
+		);
+
+		const result = await loadStorageMode(tempDir, globalPath);
+		expect(result).toBe("local");
+	});
+
+	test("user-level value used when project-level omits [storage]", async () => {
+		const globalPath = join(tempDir, "global-config", "settings.toml");
+
+		await writeFixture(
+			tempDir,
+			"global-config/settings.toml",
+			`[storage]\nmode = "central"\n`,
+		);
+		await writeFixture(
+			tempDir,
+			".rp1/settings.toml",
+			`[arguments.build]\nAFK = false\n`,
+		);
+
+		const result = await loadStorageMode(tempDir, globalPath);
+		expect(result).toBe("central");
+	});
+
+	test("returns 'local' when neither level has [storage]", async () => {
+		const globalPath = join(tempDir, "global-config", "settings.toml");
+
+		await writeFixture(
+			tempDir,
+			"global-config/settings.toml",
+			`[arguments.build]\nAFK = false\n`,
+		);
+		await writeFixture(
+			tempDir,
+			".rp1/settings.toml",
+			`[arguments.build]\nGIT_COMMIT = true\n`,
+		);
+
+		const result = await loadStorageMode(tempDir, globalPath);
+		expect(result).toBe("local");
+	});
+
+	test("user-level invalid mode falls through to default 'local'", async () => {
+		const globalPath = join(tempDir, "global-config", "settings.toml");
+
+		await writeFixture(
+			tempDir,
+			"global-config/settings.toml",
+			`[storage]\nmode = "invalid"\n`,
+		);
+
+		const result = await loadStorageMode(tempDir, globalPath);
+		expect(result).toBe("local");
+	});
+});
+
+describe("storage mode cache behavior", () => {
+	test("resetSettingsCache forces fresh read of storage mode", async () => {
+		await writeFixture(
+			tempDir,
+			".rp1/settings.toml",
+			`[storage]\nmode = "local"\n`,
+		);
+
+		const first = await loadStorageMode(tempDir, isolatedGlobalPath());
+		expect(first).toBe("local");
+
+		await writeFixture(
+			tempDir,
+			".rp1/settings.toml",
+			`[storage]\nmode = "central"\n`,
+		);
+
+		resetSettingsCache();
+
+		const second = await loadStorageMode(tempDir, isolatedGlobalPath());
+		expect(second).toBe("central");
+	});
+});

--- a/cli/src/__tests__/shared/cross-site-resolution.test.ts
+++ b/cli/src/__tests__/shared/cross-site-resolution.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { join } from "node:path";
+import { computeDirectoryPaths } from "../../../shared/storage-mode.js";
+import { resolveDirectories } from "../../agent-tools/resolve-args/resolver.js";
+import { cleanupTempDir, createTempDir } from "../helpers/index.js";
+
+let tempDir: string;
+
+beforeEach(async () => {
+	tempDir = await createTempDir("cross-site-resolution");
+});
+
+afterEach(async () => {
+	await cleanupTempDir(tempDir);
+});
+
+describe("cross-site path consistency", () => {
+	test("resolve-args fallback produces same paths as computeDirectoryPaths in local mode", () => {
+		const fallback = resolveDirectories(tempDir);
+		const shared = computeDirectoryPaths(
+			fallback.projectRoot,
+			undefined,
+			"local",
+		);
+
+		expect(fallback.kbRoot).toBe(shared.kbRoot);
+		expect(fallback.workRoot).toBe(shared.workRoot);
+	});
+
+	test("emit defaultKbRoot/defaultWorkRoot delegate to computeDirectoryPaths (structural)", () => {
+		const projectRoot = join(tempDir, "some-project");
+		const expected = computeDirectoryPaths(projectRoot, undefined, "local");
+
+		expect(expected.kbRoot).toBe(join(projectRoot, ".rp1", "context"));
+		expect(expected.workRoot).toBe(join(projectRoot, ".rp1", "work"));
+	});
+
+	test("all resolution sites agree on local-mode paths for any project root", () => {
+		const projectRoot = join(tempDir, "test-project");
+
+		const shared = computeDirectoryPaths(projectRoot, undefined, "local");
+		const fallback = resolveDirectories(projectRoot);
+
+		expect(fallback.kbRoot).toBe(shared.kbRoot);
+		expect(fallback.workRoot).toBe(shared.workRoot);
+		expect(fallback.kbRoot).toBe(join(projectRoot, ".rp1", "context"));
+		expect(fallback.workRoot).toBe(join(projectRoot, ".rp1", "work"));
+	});
+});

--- a/cli/src/__tests__/shared/directory-resolution.test.ts
+++ b/cli/src/__tests__/shared/directory-resolution.test.ts
@@ -503,6 +503,7 @@ describe("directory resolution", () => {
 
 				expect(result.right.kbRoot).toBe(join(noIdProject, ".rp1", "context"));
 				expect(result.right.workRoot).toBe(join(noIdProject, ".rp1", "work"));
+				expect(result.right.storageMode).toBe("local");
 			} finally {
 				console.warn = origWarn;
 			}

--- a/cli/src/__tests__/shared/directory-resolution.test.ts
+++ b/cli/src/__tests__/shared/directory-resolution.test.ts
@@ -1,10 +1,11 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { writeFileSync } from "node:fs";
 import { mkdir, realpath, rm, symlink } from "node:fs/promises";
-import { tmpdir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import * as E from "fp-ts/lib/Either.js";
 import { resolveDirectorySet } from "../../../shared/directory-resolution.js";
+import { resetContainerDetectionCache } from "../../../shared/storage-mode.js";
 import {
 	createInitialCommit,
 	createTestWorktree,
@@ -21,6 +22,7 @@ describe("directory resolution", () => {
 	let linkedWorktreePath: string;
 	let gitRepoWithoutRp1: string;
 	let plainDirectory: string;
+	let centralProject: string;
 	let originalRp1ProjectRoot: string | undefined;
 	let originalRp1Root: string | undefined;
 	let originalRp1KbRoot: string | undefined;
@@ -72,6 +74,18 @@ describe("directory resolution", () => {
 
 		plainDirectory = join(tempBase, "plain-directory");
 		await mkdir(plainDirectory, { recursive: true });
+
+		centralProject = join(tempBase, "project-central");
+		await mkdir(join(centralProject, ".rp1"), { recursive: true });
+		writeFileSync(
+			join(centralProject, ".rp1", "project_id"),
+			"cc0e8400-e29b-41d4-a716-446655440000",
+		);
+		await writeFixture(
+			centralProject,
+			".rp1/settings.toml",
+			'[storage]\nmode = "central"',
+		);
 	});
 
 	afterAll(async () => {
@@ -96,6 +110,7 @@ describe("directory resolution", () => {
 			process.env.RP1_WORK_ROOT = originalRp1WorkRoot;
 		}
 
+		resetContainerDetectionCache();
 		await removeTestWorktree(worktreeMainRoot, linkedWorktreePath, true);
 		await rm(tempBase, { recursive: true, force: true });
 	});
@@ -392,5 +407,105 @@ describe("directory resolution", () => {
 
 		expect(result.right.kbRoot).toBe(join(projectRoot, ".rp1", "context"));
 		expect(result.right.workRoot).toBe(join(projectRoot, ".rp1", "work"));
+	});
+
+	describe("storage mode resolution", () => {
+		test("resolves central-mode paths when storage mode is central", () => {
+			resetContainerDetectionCache();
+			const result = resolveDirectorySet(centralProject);
+			expect(E.isRight(result)).toBe(true);
+			if (E.isLeft(result)) return;
+
+			const home = homedir();
+			expect(result.right.kbRoot).toBe(
+				join(
+					home,
+					".rp1",
+					"projects",
+					"cc0e8400-e29b-41d4-a716-446655440000",
+					"context",
+				),
+			);
+			expect(result.right.workRoot).toBe(
+				join(
+					home,
+					".rp1",
+					"projects",
+					"cc0e8400-e29b-41d4-a716-446655440000",
+					"work",
+				),
+			);
+			expect(result.right.storageMode).toBe("central");
+			expect(result.right.projectRoot).toBe(centralProject);
+		});
+
+		test("container environment overrides central to local silently", () => {
+			resetContainerDetectionCache();
+			const origCodespaces = process.env.CODESPACES;
+			process.env.CODESPACES = "true";
+
+			const origWarn = console.warn;
+			const warnings: string[] = [];
+			console.warn = (...args: unknown[]) => {
+				warnings.push(String(args[0]));
+			};
+
+			try {
+				const result = resolveDirectorySet(centralProject);
+				expect(E.isRight(result)).toBe(true);
+				if (E.isLeft(result)) return;
+
+				expect(result.right.kbRoot).toBe(
+					join(centralProject, ".rp1", "context"),
+				);
+				expect(result.right.workRoot).toBe(
+					join(centralProject, ".rp1", "work"),
+				);
+				expect(result.right.storageMode).toBe("local");
+				expect(warnings.filter((w) => w.includes("container"))).toHaveLength(0);
+			} finally {
+				console.warn = origWarn;
+				if (origCodespaces === undefined) {
+					delete process.env.CODESPACES;
+				} else {
+					process.env.CODESPACES = origCodespaces;
+				}
+				resetContainerDetectionCache();
+			}
+		});
+
+		test("includes storageMode: local for default projects", () => {
+			resetContainerDetectionCache();
+			const result = resolveDirectorySet(nestedPath);
+			expect(E.isRight(result)).toBe(true);
+			if (E.isLeft(result)) return;
+
+			expect(result.right.storageMode).toBe("local");
+		});
+
+		test("central mode degrades to local when project_id is missing", async () => {
+			resetContainerDetectionCache();
+			const noIdProject = join(centralProject, "..", "project-central-no-id");
+			await mkdir(join(noIdProject, ".rp1"), { recursive: true });
+			await writeFixture(
+				noIdProject,
+				".rp1/settings.toml",
+				'[storage]\nmode = "central"',
+			);
+
+			const origWarn = console.warn;
+			console.warn = () => {};
+
+			try {
+				const result = resolveDirectorySet(noIdProject);
+				expect(E.isRight(result)).toBe(true);
+				if (E.isLeft(result)) return;
+
+				expect(result.right.kbRoot).toBe(join(noIdProject, ".rp1", "context"));
+				expect(result.right.workRoot).toBe(join(noIdProject, ".rp1", "work"));
+			} finally {
+				console.warn = origWarn;
+			}
+		});
 	});
 });

--- a/cli/src/__tests__/shared/storage-mode.test.ts
+++ b/cli/src/__tests__/shared/storage-mode.test.ts
@@ -1,0 +1,305 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import {
+	computeDirectoryPaths,
+	isContainerEnvironment,
+	readStorageMode,
+	resetContainerDetectionCache,
+	type StorageMode,
+	VALID_STORAGE_MODES,
+} from "../../../shared/storage-mode.js";
+import {
+	cleanupTempDir,
+	createTempDir,
+	writeFixture,
+} from "../helpers/index.js";
+
+let tempDir: string;
+
+beforeEach(async () => {
+	resetContainerDetectionCache();
+	tempDir = await createTempDir("storage-mode");
+});
+
+afterEach(async () => {
+	await cleanupTempDir(tempDir);
+});
+
+describe("StorageMode types", () => {
+	test("VALID_STORAGE_MODES contains local and central", () => {
+		expect(VALID_STORAGE_MODES).toContain("local");
+		expect(VALID_STORAGE_MODES).toContain("central");
+		expect(VALID_STORAGE_MODES).toHaveLength(2);
+	});
+
+	test("StorageMode type accepts valid values", () => {
+		const local: StorageMode = "local";
+		const central: StorageMode = "central";
+		expect(local).toBe("local");
+		expect(central).toBe("central");
+	});
+});
+
+describe("readStorageMode", () => {
+	test("returns local when no settings.toml exists", () => {
+		const result = readStorageMode(tempDir);
+		expect(result).toBe("local");
+	});
+
+	test("returns local when settings.toml has no [storage] section", async () => {
+		await writeFixture(
+			tempDir,
+			".rp1/settings.toml",
+			"[arguments.build]\nAFK = false\n",
+		);
+
+		const result = readStorageMode(tempDir);
+		expect(result).toBe("local");
+	});
+
+	test("returns central when [storage] mode = central", async () => {
+		await writeFixture(
+			tempDir,
+			".rp1/settings.toml",
+			'[storage]\nmode = "central"\n',
+		);
+
+		const result = readStorageMode(tempDir);
+		expect(result).toBe("central");
+	});
+
+	test("returns local when [storage] mode = local", async () => {
+		await writeFixture(
+			tempDir,
+			".rp1/settings.toml",
+			'[storage]\nmode = "local"\n',
+		);
+
+		const result = readStorageMode(tempDir);
+		expect(result).toBe("local");
+	});
+
+	test("rejects invalid mode values and defaults to local", async () => {
+		await writeFixture(
+			tempDir,
+			".rp1/settings.toml",
+			'[storage]\nmode = "invalid"\n',
+		);
+
+		const result = readStorageMode(tempDir);
+		expect(result).toBe("local");
+	});
+
+	test("rejects non-string mode values and defaults to local", async () => {
+		await writeFixture(tempDir, ".rp1/settings.toml", "[storage]\nmode = 42\n");
+
+		const result = readStorageMode(tempDir);
+		expect(result).toBe("local");
+	});
+
+	test("handles malformed TOML gracefully and defaults to local", async () => {
+		await writeFixture(
+			tempDir,
+			".rp1/settings.toml",
+			"this is not valid {{toml}}",
+		);
+
+		const result = readStorageMode(tempDir);
+		expect(result).toBe("local");
+	});
+
+	test("project settings override user settings (project central wins)", async () => {
+		const projectRoot = join(tempDir, "project");
+		const userConfigDir = join(tempDir, "user-config");
+
+		await writeFixture(
+			projectRoot,
+			".rp1/settings.toml",
+			'[storage]\nmode = "central"\n',
+		);
+		await writeFixture(
+			userConfigDir,
+			"rp1/settings.toml",
+			'[storage]\nmode = "local"\n',
+		);
+
+		const result = readStorageMode(
+			projectRoot,
+			join(userConfigDir, "rp1", "settings.toml"),
+		);
+		expect(result).toBe("central");
+	});
+
+	test("falls back to user settings when project has no [storage]", async () => {
+		const projectRoot = join(tempDir, "project");
+		const userConfigDir = join(tempDir, "user-config");
+
+		await writeFixture(
+			projectRoot,
+			".rp1/settings.toml",
+			"[arguments.build]\nAFK = false\n",
+		);
+		await writeFixture(
+			userConfigDir,
+			"rp1/settings.toml",
+			'[storage]\nmode = "central"\n',
+		);
+
+		const result = readStorageMode(
+			projectRoot,
+			join(userConfigDir, "rp1", "settings.toml"),
+		);
+		expect(result).toBe("central");
+	});
+
+	test("returns local when neither project nor user has [storage]", async () => {
+		const projectRoot = join(tempDir, "project");
+		const userConfigDir = join(tempDir, "user-config");
+
+		await writeFixture(
+			projectRoot,
+			".rp1/settings.toml",
+			"[arguments.build]\nAFK = false\n",
+		);
+		await writeFixture(
+			userConfigDir,
+			"rp1/settings.toml",
+			"[arguments.build]\nAFK = true\n",
+		);
+
+		const result = readStorageMode(
+			projectRoot,
+			join(userConfigDir, "rp1", "settings.toml"),
+		);
+		expect(result).toBe("local");
+	});
+
+	test("coexists with other settings sections", async () => {
+		await writeFixture(
+			tempDir,
+			".rp1/settings.toml",
+			[
+				"[arguments.build]",
+				"AFK = false",
+				"",
+				"[models.claude-code]",
+				'deep = "claude-sonnet-4-20250514"',
+				"",
+				"[storage]",
+				'mode = "central"',
+				"",
+				"[arcade]",
+				'theme = "dark"',
+			].join("\n"),
+		);
+
+		const result = readStorageMode(tempDir);
+		expect(result).toBe("central");
+	});
+});
+
+describe("computeDirectoryPaths", () => {
+	const projectRoot = "/projects/my-app";
+	const projectId = "550e8400-e29b-41d4-a716-446655440000";
+
+	test("local mode returns paths under projectRoot/.rp1/", () => {
+		const result = computeDirectoryPaths(projectRoot, projectId, "local");
+		expect(result.kbRoot).toBe(join(projectRoot, ".rp1", "context"));
+		expect(result.workRoot).toBe(join(projectRoot, ".rp1", "work"));
+	});
+
+	test("central mode returns paths under ~/.rp1/projects/<id>/", () => {
+		const result = computeDirectoryPaths(projectRoot, projectId, "central");
+		const expectedBase = join(homedir(), ".rp1", "projects", projectId);
+		expect(result.kbRoot).toBe(join(expectedBase, "context"));
+		expect(result.workRoot).toBe(join(expectedBase, "work"));
+	});
+
+	test("central mode degrades to local when projectId is undefined", () => {
+		const result = computeDirectoryPaths(projectRoot, undefined, "central");
+		expect(result.kbRoot).toBe(join(projectRoot, ".rp1", "context"));
+		expect(result.workRoot).toBe(join(projectRoot, ".rp1", "work"));
+	});
+
+	test("local mode with undefined projectId still returns local paths", () => {
+		const result = computeDirectoryPaths(projectRoot, undefined, "local");
+		expect(result.kbRoot).toBe(join(projectRoot, ".rp1", "context"));
+		expect(result.workRoot).toBe(join(projectRoot, ".rp1", "work"));
+	});
+
+	test("central mode paths are under ~/.rp1/ with no network I/O", () => {
+		const result = computeDirectoryPaths(projectRoot, projectId, "central");
+		const home = homedir();
+		expect(result.kbRoot.startsWith(join(home, ".rp1"))).toBe(true);
+		expect(result.workRoot.startsWith(join(home, ".rp1"))).toBe(true);
+	});
+});
+
+describe("isContainerEnvironment", () => {
+	let originalRemoteContainers: string | undefined;
+	let originalCodespaces: string | undefined;
+
+	beforeEach(() => {
+		originalRemoteContainers = process.env.REMOTE_CONTAINERS;
+		originalCodespaces = process.env.CODESPACES;
+		delete process.env.REMOTE_CONTAINERS;
+		delete process.env.CODESPACES;
+		resetContainerDetectionCache();
+	});
+
+	afterEach(() => {
+		if (originalRemoteContainers === undefined) {
+			delete process.env.REMOTE_CONTAINERS;
+		} else {
+			process.env.REMOTE_CONTAINERS = originalRemoteContainers;
+		}
+		if (originalCodespaces === undefined) {
+			delete process.env.CODESPACES;
+		} else {
+			process.env.CODESPACES = originalCodespaces;
+		}
+		resetContainerDetectionCache();
+	});
+
+	test("detects REMOTE_CONTAINERS environment variable", () => {
+		process.env.REMOTE_CONTAINERS = "true";
+		const result = isContainerEnvironment();
+		expect(result).toBe(true);
+	});
+
+	test("detects CODESPACES environment variable", () => {
+		process.env.CODESPACES = "true";
+		const result = isContainerEnvironment();
+		expect(result).toBe(true);
+	});
+
+	test("returns false when no container signals present", () => {
+		// On dev machines without /.dockerenv this should be false.
+		// We can only guarantee the env var checks here; /.dockerenv
+		// depends on the host. If /.dockerenv exists on the test host,
+		// the result will be true, which is correct behavior.
+		if (existsSync("/.dockerenv")) {
+			expect(isContainerEnvironment()).toBe(true);
+		} else {
+			expect(isContainerEnvironment()).toBe(false);
+		}
+	});
+
+	test("caches result for process lifetime", () => {
+		const first = isContainerEnvironment();
+		// After first call, changing env should not change the result
+		process.env.CODESPACES = "true";
+		const second = isContainerEnvironment();
+		expect(second).toBe(first);
+	});
+
+	test("resetContainerDetectionCache allows re-evaluation", () => {
+		isContainerEnvironment();
+		resetContainerDetectionCache();
+		process.env.CODESPACES = "true";
+		const second = isContainerEnvironment();
+		expect(second).toBe(true);
+	});
+});

--- a/cli/src/agent-tools/emit/database.ts
+++ b/cli/src/agent-tools/emit/database.ts
@@ -295,6 +295,8 @@ export interface ResumeRunInput {
 	readonly flow: string;
 	readonly featureId: string;
 	readonly projectPath: string;
+	readonly projectId?: string;
+	readonly rp1ProjectRoot?: string;
 }
 
 /** Result of a find-or-create run operation */
@@ -1747,12 +1749,20 @@ export const findOrCreateRun = (
 	db: Database,
 	input: ResumeRunInput,
 ): ResumeRunResult => {
+	const directories = resolveRunDirectories({
+		projectPath: input.projectPath,
+		rp1ProjectRoot: input.rp1ProjectRoot,
+		projectId: input.projectId,
+	});
+	const projectId = directories.projectId ?? null;
+	const rp1ProjectRoot = directories.rp1ProjectRoot;
+
 	const existing = db
 		.prepare(
 			`SELECT * FROM runs
 			 WHERE feature_id = ?
 			   AND flow = ?
-			   AND project_path = ?
+			   AND (project_id = ? OR (project_id IS NULL AND rp1_project_root = ?))
 			   AND status NOT IN (${NON_RESUMABLE_RUN_STATUS_PLACEHOLDERS})
 			 ORDER BY created_at DESC
 			 LIMIT 1`,
@@ -1760,7 +1770,8 @@ export const findOrCreateRun = (
 		.get(
 			input.featureId,
 			input.flow,
-			input.projectPath,
+			projectId,
+			rp1ProjectRoot,
 			...NON_RESUMABLE_RUN_STATUSES,
 		) as RunRow | null;
 
@@ -1773,14 +1784,15 @@ export const findOrCreateRun = (
 			`SELECT * FROM runs
 			 WHERE feature_id = ?
 			   AND flow = 'unknown'
-			   AND project_path = ?
+			   AND (project_id = ? OR (project_id IS NULL AND rp1_project_root = ?))
 			   AND status NOT IN (${NON_RESUMABLE_RUN_STATUS_PLACEHOLDERS})
 			 ORDER BY created_at DESC
 			 LIMIT 1`,
 		)
 		.get(
 			input.featureId,
-			input.projectPath,
+			projectId,
+			rp1ProjectRoot,
 			...NON_RESUMABLE_RUN_STATUSES,
 		) as RunRow | null;
 
@@ -1795,7 +1807,6 @@ export const findOrCreateRun = (
 	}
 
 	const newId = crypto.randomUUID();
-	const directories = resolveRunDirectories({ projectPath: input.projectPath });
 	db.prepare(
 		`INSERT INTO runs (
 		    id, flow, feature_id, project_path, rp1_project_root, rp1_kb_root,
@@ -1810,10 +1821,10 @@ export const findOrCreateRun = (
 		$flow: input.flow,
 		$featureId: input.featureId,
 		$projectPath: input.projectPath,
-		$rp1ProjectRoot: directories.rp1ProjectRoot,
+		$rp1ProjectRoot: rp1ProjectRoot,
 		$rp1KbRoot: directories.rp1KbRoot,
 		$rp1WorkRoot: directories.rp1WorkRoot,
-		$projectId: directories.projectId ?? null,
+		$projectId: projectId,
 	});
 
 	return { runId: newId, resumed: false };
@@ -2564,13 +2575,11 @@ const appendRunActivitySearchScopeConditions = (
 		values.push(opts.projectId);
 	}
 	if (opts.projectRoot != null) {
-		conditions.push("COALESCE(runs.rp1_project_root, runs.project_path) = ?");
+		conditions.push("runs.rp1_project_root = ?");
 		values.push(opts.projectRoot);
 	} else if (opts.projectRoots != null && opts.projectRoots.length > 0) {
 		const placeholders = opts.projectRoots.map(() => "?").join(", ");
-		conditions.push(
-			`COALESCE(runs.rp1_project_root, runs.project_path) IN (${placeholders})`,
-		);
+		conditions.push(`runs.rp1_project_root IN (${placeholders})`);
 		values.push(...opts.projectRoots);
 	}
 	if (opts.status != null) {
@@ -2877,13 +2886,11 @@ export const listRuns = (
 		conditions.push("project_id = ?");
 		filterValues.push(opts.projectId);
 	} else if (opts.projectPath != null) {
-		conditions.push("COALESCE(rp1_project_root, project_path) = ?");
+		conditions.push("rp1_project_root = ?");
 		filterValues.push(opts.projectPath);
 	} else if (opts.projectPaths != null && opts.projectPaths.length > 0) {
 		const placeholders = opts.projectPaths.map(() => "?").join(", ");
-		conditions.push(
-			`COALESCE(rp1_project_root, project_path) IN (${placeholders})`,
-		);
+		conditions.push(`rp1_project_root IN (${placeholders})`);
 		filterValues.push(...opts.projectPaths);
 	}
 	if (opts.status != null) {
@@ -3503,12 +3510,12 @@ export const getProjectRunStats = (
 
 	const rows = db
 		.prepare(
-			`SELECT COALESCE(rp1_project_root, project_path) as effective_project_path,
+			`SELECT rp1_project_root as effective_project_path,
 			        COUNT(*) as run_count,
 			        MAX(updated_at) as last_activity_at
 			 FROM runs
-			 WHERE COALESCE(rp1_project_root, project_path) IN (${placeholders})
-			 GROUP BY COALESCE(rp1_project_root, project_path)`,
+			 WHERE rp1_project_root IN (${placeholders})
+			 GROUP BY rp1_project_root`,
 		)
 		.all(...projectPaths) as {
 		effective_project_path: string;
@@ -3526,6 +3533,52 @@ export const getProjectRunStats = (
 	for (const path of projectPaths) {
 		if (!result.has(path)) {
 			result.set(path, { runCount: 0, lastActivityAt: null });
+		}
+	}
+
+	return result;
+};
+
+/**
+ * Get run statistics per project_id: run count and last activity timestamp.
+ */
+export const getProjectRunStatsByIds = (
+	db: Database,
+	projectIds: string[],
+): Map<string, ProjectRunStats> => {
+	const result = new Map<string, ProjectRunStats>();
+
+	if (projectIds.length === 0) {
+		return result;
+	}
+
+	const placeholders = projectIds.map(() => "?").join(", ");
+
+	const rows = db
+		.prepare(
+			`SELECT project_id,
+			        COUNT(*) as run_count,
+			        MAX(updated_at) as last_activity_at
+			 FROM runs
+			 WHERE project_id IN (${placeholders})
+			 GROUP BY project_id`,
+		)
+		.all(...projectIds) as {
+		project_id: string;
+		run_count: number;
+		last_activity_at: string | null;
+	}[];
+
+	for (const row of rows) {
+		result.set(row.project_id, {
+			runCount: row.run_count,
+			lastActivityAt: row.last_activity_at,
+		});
+	}
+
+	for (const id of projectIds) {
+		if (!result.has(id)) {
+			result.set(id, { runCount: 0, lastActivityAt: null });
 		}
 	}
 

--- a/cli/src/agent-tools/emit/database.ts
+++ b/cli/src/agent-tools/emit/database.ts
@@ -32,6 +32,7 @@ import {
 	isNamespacedLifecycleStep,
 } from "../../../shared/logical-step.js";
 import { readProjectId } from "../../../shared/project-id.js";
+import { computeDirectoryPaths } from "../../../shared/storage-mode.js";
 
 /** Current schema version. Bump when adding migrations. */
 export const LATEST_SCHEMA_VERSION = 18;
@@ -675,10 +676,10 @@ const NON_TERMINAL_STATUSES = new Set<Status>([
 ]);
 
 const defaultKbRoot = (projectRoot: string): string =>
-	join(projectRoot, ".rp1", "context");
+	computeDirectoryPaths(projectRoot, undefined, "local").kbRoot;
 
 const defaultWorkRoot = (projectRoot: string): string =>
-	join(projectRoot, ".rp1", "work");
+	computeDirectoryPaths(projectRoot, undefined, "local").workRoot;
 
 const getLegacyWorkDir = (projectRoot: string): string =>
 	join(resolve(projectRoot), ".rp1", "work");

--- a/cli/src/agent-tools/resolve-args/resolver.ts
+++ b/cli/src/agent-tools/resolve-args/resolver.ts
@@ -22,6 +22,7 @@ import {
 	parseError,
 	runtimeError,
 } from "../../../shared/errors.js";
+import { computeDirectoryPaths } from "../../../shared/storage-mode.js";
 import type {
 	ArgumentDefinition,
 	EnvironmentDefinition,
@@ -412,12 +413,17 @@ export const resolveImpliesChains = (
 
 const buildFallbackDirectories = (projectRoot: string): ResolvedDirectories => {
 	const resolvedProjectRoot = path.resolve(projectRoot);
+	const { kbRoot, workRoot } = computeDirectoryPaths(
+		resolvedProjectRoot,
+		undefined,
+		"local",
+	);
 
 	return {
 		projectRoot: resolvedProjectRoot,
 		projectId: undefined,
-		kbRoot: path.join(resolvedProjectRoot, ".rp1", "context"),
-		workRoot: path.join(resolvedProjectRoot, ".rp1", "work"),
+		kbRoot,
+		workRoot,
 		codeRoot: resolvedProjectRoot,
 		isWorktree: false,
 		status: "uninitialized",

--- a/cli/src/agent-tools/rp1-root-dir/models.ts
+++ b/cli/src/agent-tools/rp1-root-dir/models.ts
@@ -1,3 +1,5 @@
+import type { StorageMode } from "../../../shared/storage-mode.js";
+
 export interface Rp1RootResult {
 	readonly projectRoot: string;
 	readonly projectId: string | undefined;
@@ -6,4 +8,5 @@ export interface Rp1RootResult {
 	readonly codeRoot: string;
 	readonly isWorktree: boolean;
 	readonly worktreeName?: string;
+	readonly storageMode: StorageMode;
 }

--- a/cli/src/agent-tools/rp1-root-dir/resolver.ts
+++ b/cli/src/agent-tools/rp1-root-dir/resolver.ts
@@ -30,6 +30,7 @@ export const resolveRp1Root = (
 					codeRoot: directories.codeRoot,
 					isWorktree: directories.isWorktree,
 					worktreeName: directories.worktreeName,
+					storageMode: directories.storageMode,
 				}),
 			),
 		),

--- a/cli/src/settings/loader.ts
+++ b/cli/src/settings/loader.ts
@@ -4,6 +4,7 @@ import {
 	resolveLocalSettingsPath,
 } from "../../shared/settings.js";
 import {
+	readStorageMode,
 	type StorageMode,
 	VALID_STORAGE_MODES,
 } from "../../shared/storage-mode.js";
@@ -458,16 +459,11 @@ export const loadArcadeSettings = async (
 };
 
 /**
- * Load the `[storage]` section from a single settings file.
- * Returns the parsed storage section when present, or an empty structure.
- */
-const loadStorageFromFile = (filePath: string): ParsedStorageSection => {
-	return parseSettingsFileStrict(filePath).storage;
-};
-
-/**
  * Load storage mode from both project-level and user-level settings files,
  * applying two-level merge (project overrides user) with "local" as default.
+ *
+ * Delegates to the canonical `readStorageMode` implementation in
+ * `cli/shared/storage-mode.ts` to maintain a single merge implementation.
  *
  * @param projectRoot - Project root directory (contains `.rp1/`)
  * @param globalSettingsPath - Override path to user-level settings file (defaults to ~/.config/rp1/settings.toml). Exposed for test isolation.
@@ -477,12 +473,5 @@ export const loadStorageMode = async (
 	projectRoot: string,
 	globalSettingsPath?: string,
 ): Promise<StorageMode> => {
-	const projectStorage = loadStorageFromFile(
-		resolveLocalSettingsPath(projectRoot),
-	);
-	const userStorage = loadStorageFromFile(
-		globalSettingsPath ?? resolveGlobalSettingsPath(),
-	);
-
-	return projectStorage.mode ?? userStorage.mode ?? "local";
+	return readStorageMode(projectRoot, globalSettingsPath);
 };

--- a/cli/src/settings/loader.ts
+++ b/cli/src/settings/loader.ts
@@ -3,6 +3,10 @@ import {
 	resolveGlobalSettingsPath,
 	resolveLocalSettingsPath,
 } from "../../shared/settings.js";
+import {
+	type StorageMode,
+	VALID_STORAGE_MODES,
+} from "../../shared/storage-mode.js";
 import { VALID_MODEL_TIERS } from "../build/models.js";
 import type { BuildPlatform } from "../build/template-context.js";
 import type { PlatformTierMap, TierRemappingConfig } from "./models.js";
@@ -35,9 +39,14 @@ type ParsedArcadeSection = Readonly<{
 	downsampling?: Readonly<{ thresholdHours?: number }>;
 }>;
 
+/** Parsed storage section from a single settings file (partial -- keys may be absent). */
+type ParsedStorageSection = Readonly<{
+	mode?: StorageMode;
+}>;
+
 type ParsedSettingsFile = Readonly<{
 	arguments: SettingsArgumentDefaults;
-	directories: Record<string, never>;
+	storage: ParsedStorageSection;
 	models: ParsedModelsSection;
 	arcade: ParsedArcadeSection;
 }>;
@@ -166,6 +175,28 @@ const parseArcadeSection = (
 	return result;
 };
 
+/**
+ * Extract the storage section from parsed TOML.
+ * Returns only validated fields; invalid values are omitted so the default (local) applies.
+ */
+const parseStorageSection = (
+	parsed: Record<string, unknown>,
+): ParsedStorageSection => {
+	const storageSection = parsed.storage;
+	if (!isPlainRecord(storageSection)) {
+		return {};
+	}
+
+	if (
+		typeof storageSection.mode === "string" &&
+		(VALID_STORAGE_MODES as readonly string[]).includes(storageSection.mode)
+	) {
+		return { mode: storageSection.mode as StorageMode };
+	}
+
+	return {};
+};
+
 const parseSettingsFileStrict = (filePath: string): ParsedSettingsFile => {
 	const cached = settingsCache.get(filePath);
 	if (cached) {
@@ -175,7 +206,7 @@ const parseSettingsFileStrict = (filePath: string): ParsedSettingsFile => {
 	if (!existsSync(filePath)) {
 		const empty: ParsedSettingsFile = {
 			arguments: {},
-			directories: {},
+			storage: {},
 			models: { platforms: {} },
 			arcade: {},
 		};
@@ -214,10 +245,11 @@ const parseSettingsFileStrict = (filePath: string): ParsedSettingsFile => {
 
 		const models = parseModelsSection(parsed);
 		const arcade = parseArcadeSection(parsed);
+		const storage = parseStorageSection(parsed);
 
 		const result: ParsedSettingsFile = {
 			arguments: argumentDefaults,
-			directories: {},
+			storage,
 			models,
 			arcade,
 		};
@@ -226,7 +258,7 @@ const parseSettingsFileStrict = (filePath: string): ParsedSettingsFile => {
 	} catch {
 		const empty: ParsedSettingsFile = {
 			arguments: {},
-			directories: {},
+			storage: {},
 			models: { platforms: {} },
 			arcade: {},
 		};
@@ -423,4 +455,34 @@ export const loadArcadeSettings = async (
 		theme,
 		downsampling: { thresholdHours },
 	};
+};
+
+/**
+ * Load the `[storage]` section from a single settings file.
+ * Returns the parsed storage section when present, or an empty structure.
+ */
+const loadStorageFromFile = (filePath: string): ParsedStorageSection => {
+	return parseSettingsFileStrict(filePath).storage;
+};
+
+/**
+ * Load storage mode from both project-level and user-level settings files,
+ * applying two-level merge (project overrides user) with "local" as default.
+ *
+ * @param projectRoot - Project root directory (contains `.rp1/`)
+ * @param globalSettingsPath - Override path to user-level settings file (defaults to ~/.config/rp1/settings.toml). Exposed for test isolation.
+ * @returns Resolved StorageMode ("local" or "central")
+ */
+export const loadStorageMode = async (
+	projectRoot: string,
+	globalSettingsPath?: string,
+): Promise<StorageMode> => {
+	const projectStorage = loadStorageFromFile(
+		resolveLocalSettingsPath(projectRoot),
+	);
+	const userStorage = loadStorageFromFile(
+		globalSettingsPath ?? resolveGlobalSettingsPath(),
+	);
+
+	return projectStorage.mode ?? userStorage.mode ?? "local";
 };


### PR DESCRIPTION
## Summary

First P2 slice of the storage-decoupling initiative (PRD v1.1.0, phase plan P2 "Central Mode for New Projects"): makes rp1's directory resolution dual-mode. `kbRoot`/`workRoot` can now resolve either to the traditional `<repo>/.rp1/` (**local**, unchanged default) or to a per-user central store at `~/.rp1/projects/<project_id>/` (**central**), selected via `settings.toml [storage] mode`. Nothing in this PR changes rp1's default behavior — `rp1 init` still initializes local mode; the central default and platform grants land in the follow-up `storage-decoupling-central-init` slice.

## Changes

- **New `cli/shared/storage-mode.ts`** — `StorageMode` type, `readStorageMode()` (two-level TOML merge, project > user), `computeDirectoryPaths()` (single shared path derivation), `isContainerEnvironment()` (`/.dockerenv`, `REMOTE_CONTAINERS`, `CODESPACES`; cached)
- **`[storage]` settings section** — parsed in the settings loader following the `[arcade]` pattern; replaces the empty `directories` stub in `ParsedSettingsFile`; coexists with `[models]`/`[arguments]`/`[arcade]`; hermetic `globalSettingsPath` test seam
- **Resolver redirection** — `buildDirectorySet` delegates to `computeDirectoryPaths` with the effective mode (container detection silently forces local); `storageMode` added to `ResolvedDirectorySet` and surfaced in `rp1 agent-tools rp1-root-dir` output; worktrees key central resolution off the canonical project root's `project_id`, so all worktrees of a project share one store
- **Fallback-site alignment** — `buildFallbackDirectories` (resolve-args) and `defaultKbRoot`/`defaultWorkRoot` (emit DB) now delegate to the same shared function, pinned to local (fallbacks run without project context); a new cross-site test file asserts all three sites produce identical local-mode paths
- **DB re-keying** — `findOrCreateRun` re-keyed from bare `project_path` to `(project_id = ? OR (project_id IS NULL AND rp1_project_root = ?))` at both query branches, matching the `findWorkflowRunByIdentity` precedent; all 7 `COALESCE(rp1_project_root, project_path)` sites (5 unqualified + 2 table-qualified) replaced — run history now survives project moves and mode switches

## Verification

- All 8 requirements verified with test-level evidence: `.rp1/work/features/storage-decoupling-resolver/feature_verification_001.md`
- **Backward compatibility (hard requirement)**: absent `[storage]` section yields byte-identical local resolution; every pre-existing resolution/DB test passes unmodified
- Design hypotheses validated pre-implementation (the hypothesis gate caught the true COALESCE count and the correct fallback key before any code was written)
- Tests: 3313 pass / 0 fail (68 new); Biome lint + format clean; `tsc --noEmit` clean
- Comment hygiene: manifest-scoped sweep, zero removals needed
- Readiness: WARN/proceed-with-notes — sole threshold warning is a pre-existing 0.57% aggregate coverage shortfall in web-ui server routes, unrelated to this diff

## Notes for reviewers

- Six atomic conventional commits, one per task unit, in dependency order
- Deferred by design to sibling P2 slices: `rp1 init` central default + per-platform sandbox grants (`storage-decoupling-central-init`), harness selection wizard (`storage-decoupling-harness-wizard`)
- Known follow-ups carried as release notes: TD1–5 docs updates (KB files regenerate via feature-learning post-merge) and an inline comment documenting why fallback sites pin local mode

🤖 Generated using: 🎮 [rp1.run](https://rp1.run)