### PR TITLE
feat(init): harness selection wizard with persisted [harnesses] settings (storage-decoupling P2)

### DIFF
--- a/.rp1/context/architecture.md
+++ b/.rp1/context/architecture.md
@@ -2,7 +2,7 @@
 
 **Project**: rp1
 **Architecture Pattern**: Plugin-based CLI with tracked workflow state, artifact-backed handoffs, and multi-platform prompt compilation
-**Last Updated**: 2026-07-03
+**Last Updated**: 2026-07-08
 
 rp1 is a Bun/TypeScript CLI + plugin monorepo that compiles markdown-defined skills and agents into host-specific artifacts, tracks workflow runtime state as events, serves a live Arcade dashboard, and lets users remap agent model tiers on their own machines at install time.
 
@@ -12,7 +12,7 @@ rp1 is a Bun/TypeScript CLI + plugin monorepo that compiles markdown-defined ski
 flowchart TB
     Host["Host Tools<br/>Claude Code / OpenCode / Codex / Copilot / Antigravity"] --> CLI["rp1 CLI<br/>cli/src/main.ts"]
     CLI --> Skills["Plugin Skills & Agents<br/>plugins/base, dev, utils"]
-    CLI --> AgentTools["Agent Tools<br/>emit, workflow-bootstrap, resolve-args"]
+    CLI --> AgentTools["Agent Tools<br/>emit, workflow-bootstrap, resolve-args, rp1-root-dir"]
     CLI --> Build["Build Pipeline"]
     CLI --> Catalog["Catalog Registry"]
     CLI --> Settings["Settings<br/>apply, presets, rewriter"]
@@ -20,8 +20,9 @@ flowchart TB
     AgentTools --> Daemon["Arcade Daemon<br/>HTTP + WS"]
     Daemon --> Browser["Web Browser"]
     Daemon --> Registry["Project Registry<br/>async mutex"]
-    Skills --> KB[".rp1/context KB"]
-    Skills --> Work[".rp1/work artifacts"]
+    AgentTools -->|"storage-mode-aware<br/>path resolution"| PathRes["Resolved Paths<br/>kbRoot, workRoot, codeRoot"]
+    Skills -->|"resolved vars"| KB[".rp1/context KB"]
+    Skills -->|"resolved vars"| Work[".rp1/work artifacts"]
     Build --> Parse["parser"]
     Parse --> Validate["validator<br/>tier + effort + protected"]
     Validate --> TierRes["tier-resolution<br/>frontier/deep/standard/fast"]
@@ -39,13 +40,16 @@ flowchart TB
 - **Additive-Field Tier Resolution with Frontier Tier** — agent `model` tier (frontier/deep/standard/fast/inherit) and `effort` (low–max) are resolved at build time from abstract aliases to platform-specific model IDs. Frontier maps to fable (CC), gpt-5.5 (Codex), gemini-3.1-pro (Antigravity); Codex clamps effort `max`→`xhigh`; OpenCode provider-dependent effort logic removed.
 - **Install-Time Tier Remapping** — user-controlled post-install model remapping via `settings.toml` `[models.<platform>]` sections or presets (budget/standard/premium): load → validate against `TIER_MODEL_MAP` → discover agents from bundle metadata → rewrite CC (.md frontmatter) and Codex (.toml) artifacts in place → strip effort on fast-class remaps → warn on protected-agent downgrades. `rp1 update` re-applies automatically (try/catch isolated).
 - **Protected Agent Downgrade Guards** — 14 reasoning-critical agents flagged in `PROTECTED_AGENTS`; build and remapping emit warnings via `TIER_RANK` comparison when they would drop below deep.
+- **Grace-Fallback Settings Migration** — legacy `settings.json` arcade fields auto-migrate to `settings.toml` `[arcade]` in two places: the `rp1 migrate` workflow (`cli/src/migrate/arcade-settings.ts`, dry-run capable, renames originals to `.migrated`) and daemon startup via `arcade-settings-bridge.ts`. Both use the comment-preserving `arcade-writer` with idempotent key merge.
+- **Parallel Wave Dispatch with Strict Message Ordering** — the /build skill dispatches all ready verification/build agents back-to-back in a single message with no intervening prose, guaranteeing single-message parallel scheduling of task waves.
 - **Event-Sourced Runtime State** — all workflow state changes are `rp1 agent-tools emit` events persisted to SQLite and broadcast over WebSocket.
 - **State-Machine-Driven Workflows** — skills declare `stateDiagram-v2` phases; steps are validated against the graph at emit time.
 - **Map-Reduce Agent Orchestration** — heavy analysis fans out to narrow workers and rejoins through a parent orchestrator (KB build, PR review).
-- **Deterministic Workflow Bootstrap** — `workflow-bootstrap` resolves directories, arguments, and run identity atomically; skills declare `runPolicy` + `identityArgs`.
+- **Deterministic Workflow Bootstrap** — `workflow-bootstrap` resolves directories, arguments, and run identity atomically; skills declare `runPolicy` + `identityArgs`. Directory resolution is storage-mode-aware: `kbRoot`/`workRoot` may resolve outside the project tree under a non-default storage mode.
+- **Storage-Mode-Agnostic Path Resolution** — skills and agents reference KB/work directories through resolver-provided variables (`{kbRoot}`/`{workRoot}` in skills, `{KB_ROOT}`/`{WORK_ROOT}` in agent arguments), never literal paths. Build lint L014 enforces the contract. Prerequisite for pluggable storage backends (`settings.toml [storage] mode = local | central`).
 - **Artifact-Backed Handoffs** — inter-phase state persists as markdown/JSON under `.rp1/work/`.
-- **Catalog-as-Code** — the skill/agent catalog is derived from source frontmatter at build time.
-- **Worktree-Aware Code Editing** — agents distinguish `codeRoot` (edit target, worktree-aware) from `workRoot`/`kbRoot` (canonical `.rp1/`).
+- **Catalog-as-Code** — the skill/agent catalog is derived from source frontmatter at build time; checksums cover agent body content, so every prompt edit requires catalog regeneration.
+- **Worktree-Aware Code Editing** — agents distinguish `codeRoot` (edit target, worktree-aware) from `workRoot`/`kbRoot`, which resolve against the main repository even in worktree contexts.
 
 ## Layers
 
@@ -53,7 +57,7 @@ flowchart TB
 |-------|---------|-----------|
 | Interaction | User-facing CLI commands, host tool integration | `cli/src/commands/` |
 | Workflow Definition | Plugin skills + agents | `plugins/{base,dev,utils}/` |
-| Runtime Services | Agent tools, emit, bootstrap, resolve-args | `cli/src/agent-tools/` |
+| Runtime Services | Agent tools: emit, bootstrap, resolve-args, rp1-root-dir (storage-mode-aware) | `cli/src/agent-tools/` |
 | Build & Distribution | Multi-platform compile with tier resolution, validation, rendering, and install-time remapping | `cli/src/build/`, `cli/src/catalog/`, `cli/src/settings/` |
 | Presentation | Arcade SPA with real-time WS | `cli/web-ui/` |
 | Persistence | SQLite event store, KB, work artifacts, settings | `~/.rp1/rp1.db`, `.rp1/context/`, `.rp1/work/`, `settings.toml` |
@@ -64,7 +68,8 @@ flowchart TB
 - **Build Pipeline (per-agent artifact)**: parse frontmatter (model tier + effort) → validate tier/effort/protected → preprocess → `resolveTier` → concrete model ID → `resolveEffort` → `{fieldName, value}` → build `AgentArtifactData` + `BundleAgentEntry` (tier/effort metadata) → render platform Liquid template → lint → write platform artifacts.
 - **Install-Time Tier Remapping**: load `[models]` from project+user settings.toml (project wins) → resolve preset if any → validate (platforms, model IDs, effort compatibility) → discover installed agents via `BundleAgentEntry` metadata in the embedded manifest → rewrite artifacts → report modified / already-current / effort adjustments / protected warnings. Dry-run previews without writing.
 - **Event Pipeline**: skill/agent emits event → state-machine validation → SQLite persist → HTTP daemon notify → WebSocket broadcast to Arcade.
-- **KB Generation**: orchestrator selects mode (FULL/INCREMENTAL/FEATURE_LEARNING) → spatial analysis → parallel specialist agents → reconcile → write `.rp1/context/*.md` + `state.json`.
+- **KB Generation**: orchestrator selects mode (FULL/INCREMENTAL/FEATURE_LEARNING) → spatial analysis → parallel specialist agents (dispatched with resolved `KB_ROOT`) → reconcile → write `{kbRoot}/*.md` + `state.json`.
+- **Directory Resolution**: `rp1-root-dir` locates `.rp1/project_id` → checks active storage mode → returns `projectRoot`/`kbRoot`/`workRoot`/`codeRoot`; consumed by workflow-bootstrap and resolve-args, then passed to agents as dispatch arguments.
 
 ## Integration Points
 
@@ -75,6 +80,8 @@ flowchart TB
 ## Deployment
 
 Single-executable CLI per platform (darwin/linux/windows) via GitHub releases, plus a background Bun HTTP+WS daemon on port 7710 with PID-file lifecycle, version-aware restart, and NDJSON diagnostics. Config dir is OS-specific. Agent tier metadata ships inside the binary's embedded manifest, enabling settings-driven remapping without source access.
+
+Dockerized evals handle TLS-intercepting networks (e.g. Cloudflare WARP): `docker/eval-run.sh` exports the host gateway CA into `docker/certs/`, the Dockerfile bakes it into the container trust store, and `NODE_EXTRA_CA_CERTS` covers Node/bun downloads in-container.
 
 ## Related KB
 

--- a/.rp1/context/concept_map.md
+++ b/.rp1/context/concept_map.md
@@ -9,19 +9,19 @@
 |---------|------|-------------|
 | Plugin | entity | Capability pack (`rp1-base`, `rp1-dev`, `rp1-utils`) grouping skills and agents under a namespace with enforced dependency direction |
 | Skill | entity | User-facing workflow entry point defined by `SKILL.md` with typed arguments, optional state machine, event emission, and platform-tagged behavior. Declares `metadata.category` and `metadata.is_workflow` for discovery registry enrollment |
-| Agent | entity | Focused worker receiving pre-resolved parameters from a parent skill for bounded single-pass execution |
+| Agent | entity | Focused worker receiving pre-resolved parameters (including path variables like `KB_ROOT`, `WORK_ROOT`) from a parent skill for bounded single-pass execution |
 | Run | entity | Tracked workflow execution identified by `run-id`, governed by `run_policy` (fresh/resumable), advanced through explicit step and status events. Resumable runs carry `workIdentity` for identity-based matching |
 | Event | entity | Typed record emitted against a run: `status_change`, `artifact_registered`, `annotation_updated`, `waiting_for_user`, `btw_update`, `subflow_registered` |
 | Artifact | artifact | Registered output file with explicit `storageRoot` routing (project, work_dir, absolute). Types: markdown, code, diagram, diff, report, other |
 | Annotation | entity | Threaded inline feedback on an artifact for review, reply, and resolution. Anchored by text-selection, hidden-anchor, or line-based positions |
 | State Machine | entity | Mermaid `stateDiagram-v2` workflow graph whose state IDs must align with emitted step names. Parsed for validation |
-| Knowledge Base | resource | Structured project docs under `.rp1/context/`, loaded progressively as the repo knowledge source for KB-aware workflows |
+| Knowledge Base | resource | Structured project docs accessed via the resolved `{KB_ROOT}` variable (defaults to `.rp1/context/`; may resolve elsewhere under non-default storage modes), loaded progressively as the repo knowledge source |
 | Platform Tag | entity | Semantic Liquid tag (`dispatch_agent`, `ask_user`, `edit_model`, `plan_tool`) rendered per host by the build pipeline |
 | CanonicalName | entity | Normalized `plugin:artifact` identity translating namespaces across Claude Code, OpenCode, and Codex |
 | Project | entity | Registered workspace identified by `project_id`, resolved via directory walk-up or git worktree common-dir |
 | Task Queue | entity | Persistent work queue for cross-agent coordination with pending, in-progress, completed, failed, and cancelled states |
 | Notification | entity | System-generated message surfaced in Arcade, triggered by run status changes (completed/failed) or `waiting_for_user` events. Deduplicated per source |
-| Workflow Bootstrap | entity | Auto-injected initialization step resolving arguments, directories, and run identity in one atomic call |
+| Workflow Bootstrap | entity | Auto-injected initialization step resolving arguments, directories (`projectRoot`, `kbRoot`, `workRoot`, `codeRoot` via storage-mode-aware `rp1-root-dir`), and run identity in one atomic call |
 | Discovery Registry | entity | Canonical skill catalog built from frontmatter at build time. Drives CATALOG.md, init awareness blocks, `rp1 list --json`, and ambient suggestions |
 | Arcade Tracked | mechanism | Optional `metadata.arcade_tracked` boolean controlling Activity feed visibility without disabling workflow mechanics |
 | Platform Definition | entity | Data-driven build configuration capturing platform-varying behavior. Supported platforms: claude-code, opencode, codex, copilot, antigravity |
@@ -36,6 +36,9 @@
 | Preset | entity | Blessed tier-to-model profile (`budget`, `standard`, `premium`) for CC + Codex. Budget = fast-class everywhere; standard = deep collapses to sonnet-class; premium = build defaults |
 | Artifact Rewriter | mechanism | Pure-function module rewriting installed agent artifacts per remapping: CC YAML frontmatter, Codex TOML line replacement; strips effort on fast-class remaps; warns on protected downgrades |
 | Task File Lock | mechanism | Directory-based lock (`mkdir .task-file.lock`) serializing concurrent task-file updates during parallel builder execution |
+| ArcadeSettings | entity | User-configurable Arcade UI preferences from `settings.toml` `[arcade]`: `theme` (light/dark/system, validated against `VALID_ARCADE_THEMES`) + `[arcade.downsampling]` `thresholdHours`. Defaults: system theme, 24h threshold |
+| Settings Migration | mechanism | Automated legacy `settings.json` → canonical `settings.toml` conversion (arcade fields) at both global and project paths. Runs inside `rp1 migrate` and as daemon grace fallback; dry-run support; originals renamed `.migrated` for audit trail; idempotent merge never overwrites existing TOML keys |
+| Path Variable | mechanism | Parameterized directory placeholder declared in agent/skill frontmatter (`KB_ROOT`, `WORK_ROOT`, `CODE_ROOT`) and interpolated at dispatch time, decoupling prompt logic from storage layout. Two naming layers: UPPER_SNAKE in agent arguments, camelCase (`kbRoot`/`workRoot`) in skill dispatch blocks |
 
 ## Key Terminology
 
@@ -50,7 +53,9 @@
 | Skill Category | Nine-value enum (`development`, `investigation`, `quality`, `review`, `documentation`, `knowledge`, `strategy`, `planning`, `prompt`) for catalog grouping |
 | is_workflow | Boolean frontmatter flag distinguishing workflow-orchestrating skills from single-purpose skills |
 | arcade_tracked | Optional boolean metadata field controlling Arcade Activity feed visibility. Defaults to true |
-| Resolve Args | Auto-injected argument-resolution step merging user input, settings, env fallbacks, and schema defaults |
+| Resolve Args | Auto-injected argument-resolution step merging user input, settings, env fallbacks, and schema defaults; also resolves directory paths (`kbRoot`, `workRoot`) via `rp1-root-dir` |
+| Storage Mode | Abstraction in `rp1-root-dir` letting `kbRoot`/`workRoot` resolve to non-default locations outside the project tree. Default: local (subdirectories of `projectRoot`) |
+| codeRoot | Worktree-aware source directory from `rp1-root-dir`: the worktree path in git-worktree contexts, otherwise `projectRoot`. Used by code-writing agents |
 | Progressive Disclosure | Load `index.md` first, then only the KB files needed for the current task |
 | Bayesian Reconciliation | KB update method treating existing docs as prior hypotheses, revising only where new evidence justifies it |
 | Fence Marker | Versioned delimiter bracketing rp1-managed content in instruction files for staleness detection and upgrade |
@@ -95,6 +100,8 @@ BundleAgentEntry ──feeds──> Artifact Rewriter (build-time metadata → i
 TierRemappingConfig ──configures──> Artifact Rewriter (user settings drive substitutions)
 Preset ──provides defaults for──> TierRemappingConfig (explicit overrides supersede)
 Task File Lock ──protects──> Task Queue (serializes concurrent task-file writes)
+Workflow Bootstrap ──resolves──> Path Variable (kbRoot/workRoot/codeRoot from rp1-root-dir → dispatch parameters)
+Path Variable ──locates──> Knowledge Base (KB_ROOT resolves the storage-mode-aware KB directory)
 ```
 
 ## Agent Patterns
@@ -112,6 +119,7 @@ Task File Lock ──protects──> Task Queue (serializes concurrent task-file
 | Install-Time Tier Remapping | User model settings | Build embeds tier metadata in `BundleAgentEntry`; settings.toml overrides rewrite installed artifacts without rebuilding. Preset → validate → discover → rewrite → report |
 | Generator-Verifier Asymmetry | Agent classification | Generator agents (task-builder) run at standard tier because deep-tier verifiers (task-reviewer) validate their output — quality preserved, cost reduced |
 | Directory-Based File Lock | Parallel task-builder execution | `mkdir` atomicity serializes concurrent read-modify-write on shared task files; sleep-poll on contention; always release |
+| Variable-Based Path Interpolation | All agent and skill dispatch | Skills resolve `{kbRoot}`/`{workRoot}` via workflow-bootstrap; agents receive `{KB_ROOT}`/`{WORK_ROOT}` as frontmatter arguments. No literal path references — enables storage-mode redirection without prompt changes |
 
 ## Bounded Contexts
 
@@ -124,10 +132,11 @@ Task File Lock ──protects──> Task Queue (serializes concurrent task-file
 | Runtime Services | cli/src | Project, Run, Event, Workflow Bootstrap, Notification |
 | Dashboard | cli/web-ui | Arcade, Artifact, Annotation, Run Invocation Context |
 | Platform Abstraction | build pipeline | Platform Tag, CanonicalName, Platform Definition, ModelTier, EffortLevel, Tier Resolution, TIER_RANK |
-| Model Settings | cli/src/settings | TierRemappingConfig, Preset, Artifact Rewriter, BundleAgentEntry, Install-Time Tier Remapping |
+| Model Settings | cli/src/settings | TierRemappingConfig, Preset, Artifact Rewriter, BundleAgentEntry, Install-Time Tier Remapping, ArcadeSettings |
 | Discovery | cli/catalog | Discovery Registry, Guide, Skill Category, Arcade Tracked |
-| Project Lifecycle | cli/init, cli/migrate | Fence Versioning, Init Wizard, Project Migration |
+| Project Lifecycle | cli/init, cli/migrate | Fence Versioning, Init Wizard, Project Migration, Settings Migration |
 | Quality Assurance | evals/ | Attestation |
+| Storage Resolution | cli/src/agent-tools, build pipeline | Path Variable, Storage Mode, codeRoot, rp1-root-dir |
 
 ## Cross-Cutting Concerns
 
@@ -135,7 +144,8 @@ Task File Lock ──protects──> Task Queue (serializes concurrent task-file
 - **Human gates**: `waiting_for_user` emitted before prompts, visible in host tool and Arcade
 - **Traceable state**: Intermediates (`brief.md`, `scan_results.json`) persist under `.rp1/work/`
 - **State discipline**: Mermaid states, emitted steps, namespaced sub-agent steps, and logical step keys stay aligned
-- **Configuration resolution**: `resolve-args` + `workflow-bootstrap` unify argument, directory, and run creation; `settings.toml` layers (global, project) with preset and per-platform overrides for model tier remapping
+- **Configuration resolution**: `resolve-args` + `workflow-bootstrap` unify argument, directory, and run creation; `rp1-root-dir` provides storage-mode-aware path resolution; `settings.toml` layers (global, project) with preset and per-platform overrides for model tier remapping
+- **Storage-agnostic path resolution**: all prompts reference directories via path variables resolved at dispatch time, never hardcoded; build lint L014 enforces (no literal `rp1-root-dir` calls in parameterized skills)
 - **Platform portability**: Semantic tags, data-driven definitions, and tier resolution let one prompt target 5 hosts with appropriate model and effort settings
 - **Single-source discovery**: Frontmatter metadata drives all catalog views, avoiding drift
 - **Standard tool envelope**: All agent-tools return `ToolResult<T>` JSON for predictable AI-agent parsing

--- a/.rp1/context/index.md
+++ b/.rp1/context/index.md
@@ -1,13 +1,16 @@
+---
+rp1_doc_id: e56577c2-c3e0-48bb-b20b-2c69c103d940
+---
 # rp1 - Knowledge Base
 
 **Type**: Monorepo
 **Languages**: TypeScript, TSX, Markdown, JSON, YAML, TOML, Shell, CSS, HTML
 **Version**: 0.7.11-dev
-**Updated**: 2026-07-03
+**Updated**: 2026-07-08
 
 ## Project Summary
 
-rp1 is a Bun/TypeScript CLI and plugin monorepo for authoring, building, and running AI agent workflows across Claude Code, OpenCode, Codex, Copilot, and Antigravity. It combines markdown-defined skills and agents, tracked runtime state with deterministic workflow bootstrap, the Arcade dashboard with notifications and contextual commands, a multi-platform build pipeline with per-agent model/effort tiering, user-controllable install-time model tier remapping via `settings.toml`, catalog-driven skill discovery, and a progressively loaded knowledge base.
+rp1 is a Bun/TypeScript CLI and plugin monorepo for authoring, building, and running AI agent workflows across Claude Code, OpenCode, Codex, Copilot, and Antigravity. It combines markdown-defined skills and agents, tracked runtime state with deterministic workflow bootstrap, storage-mode-aware directory resolution (prompts reference `{KB_ROOT}`/`{WORK_ROOT}` variables, never literal paths), the Arcade dashboard with notifications and contextual commands, a multi-platform build pipeline with per-agent model/effort tiering, user-controllable install-time model tier remapping via `settings.toml`, catalog-driven skill discovery, and a progressively loaded knowledge base.
 
 ## Quick Reference
 
@@ -23,11 +26,11 @@ rp1 is a Bun/TypeScript CLI and plugin monorepo for authoring, building, and run
 
 | File | Lines | Load For |
 |------|-------|----------|
-| architecture.md | 81 | System design, layers, data flow, integrations |
-| interaction-model.md | 66 | Cross-surface semantics, workflow states, notifications, accessibility |
-| modules.md | 80 | Module boundaries, responsibilities, dependency highlights |
-| patterns.md | 76 | Code conventions, workflow idioms, extension patterns |
-| concept_map.md | 142 | Domain concepts, terminology, bounded contexts |
+| architecture.md | 88 | System design, layers, data flow, integrations |
+| interaction-model.md | 71 | Cross-surface semantics, workflow states, notifications, accessibility |
+| modules.md | 84 | Module boundaries, responsibilities, dependency highlights |
+| patterns.md | 81 | Code conventions, workflow idioms, extension patterns |
+| concept_map.md | 152 | Domain concepts, terminology, bounded contexts |
 
 ## Task-Based Loading
 
@@ -38,6 +41,7 @@ rp1 is a Bun/TypeScript CLI and plugin monorepo for authoring, building, and run
 | Feature implementation | `modules.md`, `patterns.md` |
 | Frontend / UX / surface work | `interaction-model.md`, `modules.md`, `patterns.md` |
 | Model tiering / settings work | `modules.md` (settings module), `patterns.md`, `concept_map.md` (Model Settings context) |
+| Prompt authoring / path variables | `patterns.md` (path variables, L014), `concept_map.md` (Storage Resolution context) |
 | Strategic or system-wide analysis | All KB files |
 
 ## How to Load
@@ -57,7 +61,7 @@ cli/
 │   ├── settings/      # Install-time model tier remapping (loader, presets, rewriter, apply, validator)
 │   ├── catalog/       # Skill/agent catalog registry with distribution scoping
 │   ├── install/       # Host-tool installation and verification
-│   ├── migrate/       # Project migration with stanza upgrades and DB backfill
+│   ├── migrate/       # Project migration with stanza upgrades, DB backfill, and arcade settings JSON→TOML migration
 │   └── init/          # Project initialization with versioned fence markers and Ink UI
 ├── shared/            # Errors, fp-ts helpers, events, logging, directory resolution
 └── web-ui/            # Arcade dashboard SPA with notifications, contextual commands, and Bun HTTP/WS server

--- a/.rp1/context/interaction-model.md
+++ b/.rp1/context/interaction-model.md
@@ -1,7 +1,7 @@
 # rp1 - Interaction Model
 
 **Project**: rp1
-**Analysis Date**: 2026-07-03
+**Analysis Date**: 2026-07-08
 **Surfaces**: CLI, Host Tool Integration, Arcade Web UI, Agent Tools CLI, Agent .md frontmatter, Settings Configuration, Reference Docs, Init Wizard
 
 ## Experience Principles
@@ -14,13 +14,14 @@
 - **Non-blocking degradation** — optional post-install steps (tier remapping re-apply, protected-agent warnings, cache refresh) log diagnostics but never interrupt the primary workflow.
 - **Attention-proportional notification** — notifications categorized by attention level with bulk dismiss.
 - **Progressive detail disclosure** — secondary metadata hidden by default, toggled via contextual commands, persisted in sessionStorage.
+- **Storage-mode transparency** — agents and skills reference KB/work directories via resolver variables (`{kbRoot}`/`{workRoot}` in skills; `{KB_ROOT}`/`{WORK_ROOT}` in agent arguments), never assuming physical locations; enables storage-mode redirection without prompt changes (lint L014 enforces).
 
 ## Actors & Surfaces
 
 | Actor | Goals | Surfaces |
 |-------|-------|----------|
 | End user | Execute workflows, monitor runs, review artifacts, give feedback, control model cost/capability trade-offs | CLI, Host Tool, Arcade, `settings.toml` |
-| Agent author | Set model tier + effort in agent frontmatter; get build-time validation feedback | Agent `.md` frontmatter, `rp1 build`, Agent Tools CLI |
+| Agent author | Set model tier + effort in agent frontmatter; declare `KB_ROOT`/`WORK_ROOT` argument variables; get build-time validation feedback | Agent `.md` frontmatter, `rp1 build`, Agent Tools CLI |
 | CI system | Validate/lint, produce JSON build output | `rp1 build --json --lint` |
 
 **Agent `.md` frontmatter**: authors set `model: frontier|deep|standard|fast|inherit` and optional `effort: low|medium|high|xhigh|max`. **Settings configuration** (`~/.config/rp1/settings.toml` user, `.rp1/settings.toml` project): users declare `[models]` presets or per-platform tier remappings that override build defaults without rebuilding.
@@ -37,6 +38,8 @@
 | settings_validation_error | Invalid TOML syntax or tier remapping semantics (bad preset, platform, model ID); `settings validate` exits 1 | CLI (`rp1 settings validate`) |
 | tier_remapping_applied | Agent artifacts rewritten per user mapping; count reported; idempotent re-run reports "already up to date" (distinct from "nothing matched") | CLI (`rp1 settings apply`, `rp1 update`) |
 | connection_status / annotation_status / notification_attention | Arcade live-update + feedback + triage signals | Arcade |
+| init step running / waiting_for_user / completed / failed / skipped | Init wizard step lifecycle; prompts (git-root, reinit, ancestor-project, gitignore preset) pause the step until the user chooses, then it re-executes | Init wizard UI, activity feed |
+| settings_created / settings_preserved | Init settings-setup created global/local `settings.toml` from template, or found existing files and left them untouched | Init wizard activity feed |
 
 ## Feedback Loops
 
@@ -46,7 +49,9 @@
 - **Notification lifecycle** — events produce deduplicated notifications; toasts auto-dismiss (6s); sidebar groups by attention.
 - **Build-time tier & effort validation** — `rp1 build` parses frontmatter → `validateAgentTierAndEffort` (errors halt with file+allowed values; warnings continue) → `resolveTier`/`resolveEffort` → platform-native config emitted.
 - **Settings tier remapping apply** — `rp1 settings apply` (or `rp1 update` auto-reapply) loads config/preset → validates semantics → discovers installed agents → rewrites model/effort fields → reports modified count + effort adjustments + protected-agent warnings. `--dry-run` previews.
+- **Storage-mode-aware directory resolution** — `rp1 agent-tools rp1-root-dir` returns `kbRoot`/`workRoot` respecting the active storage mode; skills receive resolved paths via workflow-bootstrap/resolve-args; agents receive them as dispatch arguments. Paths may resolve outside the project tree under non-default modes.
 - **Emit-driven run projection / snapshot reconciliation** — Arcade reduces events into `LiveRunIndex`, reconnects with saved cursor, falls back to REST when replay is impossible.
+- **Init wizard activity timeline** — `rp1 init` runs 11 ordered steps (registry → git-check → reinit-check → directory-setup → settings-setup → tool-detection → instruction-injection → gitignore-config → install-check → health-check → summary); each emits timestamped activities (info/success/warning/error). Plugin-install failures and health-check misses log as warnings, never fail the wizard. `--yes` applies non-interactive defaults; `--force-nested` bypasses the ancestor-project prompt.
 
 ## Cross-Surface Deltas
 

--- a/.rp1/context/modules.md
+++ b/.rp1/context/modules.md
@@ -1,7 +1,7 @@
 # Module & Component Breakdown
 
 **Project**: rp1
-**Analysis Date**: 2026-07-03
+**Analysis Date**: 2026-07-08
 **Modules Analyzed**: 23
 
 ## Core Modules
@@ -9,9 +9,10 @@
 | Module | Purpose | Files | Key Files |
 |--------|---------|-------|-----------|
 | `cli/commands` | User-facing CLI commands (build, arcade, migrate, init, settings, install, update, verify, uninstall) | 27 | build.ts, arcade.ts, settings.ts |
-| `cli/agent-tools` | emit, workflow-bootstrap, resolve-args, state-machine, task, feedback | 59 | emit/index.ts, workflow-bootstrap.ts |
+| `cli/agent-tools` | emit, workflow-bootstrap, resolve-args, state-machine, task, feedback, rp1-root-dir (storage-mode-aware directory resolution) | 59 | emit/index.ts, workflow-bootstrap.ts, rp1-root-dir |
 | `cli/build` | Multi-platform artifact pipeline with per-agent model tiering, effort resolution, and frontier tier | 59 | command.ts, models.ts, parser.ts, validator.ts, **tier-resolution.ts**, template-context.ts, platform-definitions.ts |
-| `cli/settings` | Install-time model tier remapping via `settings.toml` `[models]` sections and presets (budget/standard/premium); Arcade settings via `[arcade]` section (theme, downsampling) with two-level merge and daemon grace fallback | 7 | apply.ts, rewriter.ts, arcade-writer.ts, presets.ts, loader.ts, models.ts, validator.ts |
+| `cli/settings` | Install-time model tier remapping via `settings.toml` `[models]` sections and presets (budget/standard/premium); Arcade settings via `[arcade]` section (theme, downsampling) with two-level merge and daemon grace fallback | 8 | apply.ts, rewriter.ts, arcade-writer.ts, presets.ts, loader.ts, models.ts, validator.ts |
+| `cli/migrate` | Project structure migration: project ID, work dirs, gitignore, DB backfill, stanza upgrades, and Arcade settings JSON→TOML migration (`arcade-settings.ts`: detect legacy JSON at global+project paths, write via arcade-writer, rename to `.migrated`; dry-run + `globalConfigDir` test seam; result in `MigrateResult.arcadeSettings`) | 6 | index.ts, arcade-settings.ts, db-backfill.ts, stanza-upgrade.ts |
 | `cli/catalog` | Skill/agent catalog registry (distribution scope, arcadeTracked) | 3 | catalog-generator.ts |
 | `cli/install` | Install artifacts into host tools (staging, backup/rollback, verify) for claude-code, codex, copilot, antigravity | 34 | verifier.ts, installer.ts, asset-extractor.ts |
 | `cli/init` | Project init with context detection, fence markers, Ink UI | 23 | — |
@@ -19,9 +20,9 @@
 | `web-ui/server` | Bun HTTP/WS server, REST APIs, file watching, notifications | 16 | registry.ts |
 | `web-ui/daemon` | Daemon lifecycle + diagnostic logging | 4 | — |
 | `web-ui/frontend` | React SPA: pages, hooks, providers, artifact viewers | 190 | — |
-| `plugins/base` | KB, docs, writing, research, strategy, security, prompt pipeline | 98 | — |
-| `plugins/dev` | Build workflows, blueprint, PR review/walkthrough, feature delivery | 58 | — |
-| `plugins/utils` | Prompt tersification, eval helpers | 14 | — |
+| `plugins/base` | KB, docs, writing, research, strategy, security, prompt pipeline; agents declare `KB_ROOT` in frontmatter arguments | 109 | — |
+| `plugins/dev` | Build workflows, blueprint, PR review/walkthrough, feature delivery; agents declare `KB_ROOT`/`WORK_ROOT` arguments | 66 | — |
+| `plugins/utils` | Prompt tersification, eval helpers | 11 | — |
 | `evals` | Prompt attestation, content-addressable hashing, dockerized exec | 26 | — |
 
 ## Key Components (build pipeline)
@@ -41,7 +42,7 @@ Centralized tier-to-model and effort-to-field resolution. Pure functions, called
 ## Key Components (settings module — new)
 
 ### settings-apply (`cli/src/settings/apply.ts`)
-Install-time remapping orchestrator: `resolveConfig` (preset + per-platform overrides, optional `globalSettingsPath` seam) → `validateTierRemappings` → `discoverAgents` (from `EMBEDDED_MANIFEST` via `getBundledAssets()`) → `applyRemappingsToAgents` (delegates to rewriter; counts modified vs `agentsAlreadyCurrent`) → report + CC plugin cache refresh (failures become warnings). `applyTierRemappingsIfConfigured` is the update-hook no-op wrapper. Filesystem ops injected via `ApplyDeps`.
+Install-time remapping orchestrator: `resolveConfig` (preset + per-platform overrides, optional `globalSettingsPath` seam) → `validateTierRemappings` → `discoverAgents` (from `EMBEDDED_MANIFEST` via `getBundledAssets()`) → `applyRemappingsToAgents` (delegates to rewriter; counts modified vs `agentsAlreadyCurrent`) → report + CC plugin cache refresh (failures become warnings). `applyTierRemappingsIfConfigured` is the update-hook no-op wrapper. Filesystem ops and `getBundledAssets` injected via `ApplyDeps` (production binding imports `getBundledAssetsReal` explicitly to avoid a circular dependency).
 
 ### settings-rewriter (`cli/src/settings/rewriter.ts`)
 Pure-function artifact rewriter: CC YAML frontmatter and Codex TOML targeted line replacement (multiline-string guard protects `developer_instructions` bodies); strips effort when the remapped model is fast-class; protected-agent downgrade warnings via reverse tier lookup + `TIER_RANK`. Only claude-code and codex are rewritable.
@@ -61,6 +62,7 @@ Pure-function artifact rewriter: CC YAML frontmatter and Codex TOML targeted lin
 - `cli/web-ui/server` → `cli/src/settings/{loader,arcade-writer}` (cross-package import via `arcade-settings-bridge.ts` — narrow interface: `loadArcadeSettings`, `writeArcadeSection`, `resetSettingsCache`).
 - `cli/scripts/generate-asset-imports.ts` → propagates `BundleAgentEntry.tier/effort` into `EMBEDDED_MANIFEST` (`if (import.meta.main)` guarded); `cli/assets/reader.ts` `AssetEntry` widened with optional tier/effort.
 - `cli/agent-tools/emit` → `state-machine`, `web-ui/daemon` (lazy); `plugins/*` → `cli/agent-tools`; `plugins/dev` → `plugins/base` (runtime).
+- `plugins/*/skills` → `cli/agent-tools/rp1-root-dir` (runtime, via workflow-bootstrap/resolve-args): skills receive `{kbRoot}`/`{workRoot}` and pass them to agents as `KB_ROOT`/`WORK_ROOT` dispatch arguments — 30 agents declare `KB_ROOT`, 21 declare `WORK_ROOT`.
 - External: fp-ts, liquidjs, commander, yaml, bun:sqlite, chalk.
 
 ## Module Metrics
@@ -68,13 +70,14 @@ Pure-function artifact rewriter: CC YAML frontmatter and Codex TOML targeted lin
 | Module | Files | LOC (approx) | Components |
 |--------|-------|--------------|------------|
 | `cli/build` | 59 | ~9,562 | 6 |
-| `cli/settings` | 7 | ~1,700 | 7 |
+| `cli/settings` | 8 | ~2,100 | 8 |
+| `cli/migrate` | 6 | ~640 | 5 |
 | `cli/install` | 34 | ~10,981 | 4 |
 | `cli/catalog` | 3 | ~1,173 | 1 |
 
 ## Cross-Module Patterns
 
-Skill-Agent Delegation · Tracked Workflow Bootstrap · State-Machine + Emit Discipline · Async-Mutex Registry · Notification Auto-Generation · Catalog Registry · Multi-Platform Build (5 targets) · **Abstract Tier Resolution** (one `TIER_MODEL_MAP` update propagates everywhere) · **Build-to-Install Tier Metadata Chain** (`BundleAgentEntry` → embedded manifest → apply) · **Settings Two-Level Merge** (project > user for `[arguments]`, `[models]`, `[arcade]`) · **Update Hook Auto-Reapply** (tier preferences survive plugin updates) · **Daemon Grace Fallback** (legacy JSON auto-migrated to TOML on daemon start).
+Skill-Agent Delegation · Tracked Workflow Bootstrap · **Variable-Based Path Interpolation** (skills resolve `{kbRoot}`/`{workRoot}` via bootstrap, agents receive `KB_ROOT`/`WORK_ROOT` arguments; no literal `.rp1/` paths in prompts — prerequisite for `[storage]` mode redirection) · State-Machine + Emit Discipline · Async-Mutex Registry · Notification Auto-Generation · Catalog Registry (body-content checksums) · Multi-Platform Build (5 targets) · **Abstract Tier Resolution** (one `TIER_MODEL_MAP` update propagates everywhere) · **Build-to-Install Tier Metadata Chain** (`BundleAgentEntry` → embedded manifest → apply) · **Settings Two-Level Merge** (project > user for `[arguments]`, `[models]`, `[arcade]`) · **Update Hook Auto-Reapply** (tier preferences survive plugin updates) · **Daemon Grace Fallback** (legacy JSON auto-migrated to TOML on daemon start) · **Migrate-Integrated Settings Migration** (`rp1 migrate` runs the same JSON→TOML arcade migration explicitly, with `.migrated` audit trail).
 
 ## Related KB
 

--- a/.rp1/context/patterns.md
+++ b/.rp1/context/patterns.md
@@ -1,13 +1,14 @@
 # Implementation Patterns
 
 **Project**: rp1
-**Last Updated**: 2026-07-03
+**Last Updated**: 2026-07-08
 
 ## Naming & Organization
 
 - Feature-scoped directories (`cli/src/commands/`, `cli/src/build/`, `cli/src/settings/`); prompt assets use kebab-case skill folders with `SKILL.md`.
 - CLI camelCase verbs; React hooks prefix `use`; error factories match their `_tag` (`usageError`, `runtimeError`).
 - Parameters UPPER_SNAKE_CASE (`/^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$/`); relative TS imports keep `.js` suffixes; web-ui uses `@/`; CSS classes use `rp1-` prefix to avoid Tailwind collisions.
+- **Path variables (two-tier)**: skills reference project directories via `{kbRoot}`/`{workRoot}` (camelCase, from resolve-args/bootstrap); agents declare `KB_ROOT`/`WORK_ROOT` as UPPER_SNAKE frontmatter arguments. Dispatch blocks bridge the tiers with `KB_ROOT={kbRoot}` token syntax. Never hardcode literal `.rp1/context` or `.rp1/work` paths in prompts.
 
 ## Type & Data Modeling
 
@@ -30,6 +31,7 @@
 - **Additive-field propagation**: a new frontmatter field flows `parser → model interface → validator → tier-resolution → template context → Liquid templates` without breaking existing paths. Established for `arcadeTracked`; extended identically for `model` (ModelTier) and `effort` (EffortLevel).
 - Each definition validated field-by-field with early return on first error.
 - **Single-source validation sets**: settings validator imports shared helpers (`getValidModelIdsForPlatform`, `modelSupportsEffort`, `getPlatformsWithModelSupport`) from `tier-resolution.ts` — no separate allowlists; derive runtime sets from canonical maps (e.g. `TIER_KEYS` from `VALID_MODEL_TIERS`) instead of hand-copying.
+- **Build lint L014**: parameterized skills must not mention `rp1-root-dir` literally — directory resolution comes from the auto-injected Resolve Arguments section; the lint rule fails the build otherwise.
 
 ## Build Pipeline
 
@@ -37,6 +39,8 @@
 - **Install-time tier remapping (late binding)**: user `settings.toml` `[models]`/`[models.<platform>]` sections (or presets budget/standard/premium) drive `rp1 settings apply`: load → validate → discover agents from the embedded manifest → rewrite installed artifacts (CC YAML frontmatter, Codex TOML targeted line replacement) → report modified/already-current counts. `rp1 update` re-applies automatically. Idempotent: rewriter reports `modified=false` when target equals current.
 - **LiquidJS whitespace control (CRITICAL)**: production engine (`template-engine.ts`) uses `greedy:true`. Golden-file tests MUST replicate the identical config — config drift lets whitespace bugs ship undetected. Use `{%- endif %}` (no trailing dash) when a newline separator must survive. Gate optional fields on `model != "inherit"` / `effortValue` so opt-out output is byte-identical to legacy.
 - **Script entrypoint guard**: `cli/scripts/` executables wrap top-level execution in `if (import.meta.main)` so test imports of exported functions are side-effect-free.
+- **Migrate-integrated settings migration**: `migrateArcadeSettings` runs inside `executeMigrate()` (cli/src/migrate): detect legacy `settings.json` (global + project) → parse arcade fields with `VALID_ARCADE_THEMES` validation → write `[arcade]` via comment-preserving writer (idempotent, never overwrites existing keys) → rename source to `.migrated`. Dry-run detects without writing.
+- **Catalog checksums cover body content**: `catalog/agents.yaml` checksums hash agent body text, not just frontmatter — every prompt edit (even body-only) requires `just catalog-generate` with the regenerated catalog in the same commit.
 - **fp-ts pipeline**: `pipe(loadConfig, TE.fromEither, TE.chain(...))`; prefer clear `map`/`flatMap`/`isLeft` over abstractions.
 
 ## Observability
@@ -55,7 +59,7 @@
 - SQLite via `bun:sqlite` (runs, events, artifacts, annotations, notifications); upsert + source dedup.
 - Atomic writes via temp-file + rename (registry); PID file mode `0o600`.
 - `rp1 agent-tools emit` persists canonical events; daemon relays project-scoped WS envelopes. File artifacts keep `path`+`storageRoot`; URL artifacts register as `type: link` with deterministic identity (only curated run-output links).
-- **Directory-scoped I/O**: code edits resolve against `codeRoot` (worktree-aware); work/KB reads use `workRoot`/`kbRoot` (canonical `.rp1/`).
+- **Directory-scoped I/O**: code edits resolve against `codeRoot` (worktree-aware); work/KB reads use `workRoot`/`kbRoot` via `rp1-root-dir`, which respects the active storage mode — these paths may resolve outside the project tree when a non-default mode is configured.
 
 ## Concurrency & Async
 
@@ -65,7 +69,7 @@
 
 ## Dependency Injection & Configuration
 
-- **Optional-parameter seams**: `ApplyDeps` interface injects `readFile`/`writeFile`/`fileExists`/`refreshClaudeCodePlugins` with `DEFAULT_DEPS` production binding; `globalSettingsPath` threads through loader/apply for isolation.
+- **Optional-parameter seams**: `ApplyDeps` interface injects `readFile`/`writeFile`/`fileExists`/`refreshClaudeCodePlugins`/`getBundledAssets` with `DEFAULT_DEPS` production binding (imports `getBundledAssetsReal` explicitly to avoid a circular dependency); `globalSettingsPath` threads through loader/apply/migrate for isolation; `globalConfigDir` on `migrateArcadeSettings` isolates migration tests.
 - **TOML settings, two-level merge**: project `.rp1/settings.toml` > user `~/.config/rp1/settings.toml`, per key for `[arguments.*]`, `[models.*]`, and `[arcade]` sections; loader normalizes lower-kebab → UPPER_SNAKE for arguments. `[arcade]` section supports `theme` ("light"/"dark"/"system", default "system") and `[arcade.downsampling]` sub-table (`thresholdHours`, default 24); `loadArcadeSettings()` merges project over user with per-key granularity and returns typed `ArcadeSettings`. Blessed presets (`presets.ts`) provide complete tier-to-model profiles that explicit overrides supersede.
 
 ## Extension Mechanisms

--- a/cli/src/__tests__/commands/update-plugins-command.test.ts
+++ b/cli/src/__tests__/commands/update-plugins-command.test.ts
@@ -7,6 +7,7 @@ import type {
 	SupportedTool,
 	ToolsRegistry,
 } from "../../config/supported-tools.js";
+import type { DetectedTool } from "../../init/tool-detector.js";
 import type { InstallContext } from "../../shared/install-core.js";
 import { writeAntigravityBundleDistFixture } from "../helpers/antigravity-bundle.js";
 import { cleanupTempDir, createTempDir } from "../helpers/index.js";
@@ -105,6 +106,9 @@ const createCommandDeps = (
 				warnings: [],
 			}),
 	),
+	detectTools: (_toolsRegistry: ToolsRegistry) =>
+		TE.right({ detected: [] as DetectedTool[], missing: [] }),
+	getEffectiveHarnesses: (detection) => [...detection.detected],
 	...overrides,
 });
 
@@ -348,42 +352,47 @@ describe("update plugins command action", () => {
 	});
 
 	test("includes Antigravity in update-all as a successful command", async () => {
-		const installAllDetectedTools = mock(
-			(_toolsRegistry: ToolsRegistry, _ctx: InstallContext) =>
+		const antigravityDetected: DetectedTool = {
+			tool: {
+				...codexTool,
+				id: "antigravity",
+				name: "Antigravity CLI",
+			},
+			version: "0.0.0",
+			meetsMinVersion: true,
+		};
+		const detectToolsMock = (_toolsRegistry: ToolsRegistry) =>
+			TE.right({
+				detected: [antigravityDetected] as DetectedTool[],
+				missing: [],
+			});
+		const getEffectiveHarnessesMock = (detection: {
+			detected: readonly DetectedTool[];
+		}) => [...detection.detected];
+		const updateForSpecificTool = mock(
+			(_toolId: string, _toolsRegistry: ToolsRegistry, _ctx: InstallContext) =>
 				TE.right({
-					installed: 1,
-					detected: [
-						{
-							tool: {
-								...codexTool,
-								id: "antigravity",
-								name: "Antigravity CLI",
-							},
-							version: "0.0.0",
-							meetsMinVersion: true,
-						},
+					toolId: "antigravity",
+					toolName: "Antigravity CLI",
+					success: true,
+					restartRequired: false,
+					pluginsInstalled: ["rp1-base", "rp1-dev"],
+					details: [
+						"Lifecycle stage: update",
+						"Lifecycle result: refreshed",
+						"Next action: Restart Antigravity CLI, then run `rp1 verify antigravity`.",
 					],
-					results: [
-						{
-							toolId: "antigravity",
-							toolName: "Antigravity CLI",
-							success: true,
-							restartRequired: false,
-							pluginsInstalled: ["rp1-base", "rp1-dev"],
-							details: [
-								"Lifecycle stage: update",
-								"Lifecycle result: refreshed",
-								"Next action: Restart Antigravity CLI, then run `rp1 verify antigravity`.",
-							],
-							warnings: [],
-						},
-					],
+					warnings: [],
 				}),
 		);
 		await expect(
 			runPluginsCommand(
 				["update", "plugins", "all"],
-				createCommandDeps({ installAllDetectedTools }),
+				createCommandDeps({
+					detectTools: detectToolsMock,
+					getEffectiveHarnesses: getEffectiveHarnessesMock,
+					updateForSpecificTool,
+				}),
 			),
 		).rejects.toMatchObject({ code: 0 });
 
@@ -394,49 +403,57 @@ describe("update plugins command action", () => {
 	});
 
 	test("updates all tools and exits nonzero when any update fails", async () => {
-		const installAllDetectedTools = mock(
-			(_toolsRegistry: ToolsRegistry, _ctx: InstallContext) =>
-				TE.right({
-					installed: 1,
-					detected: [
-						{
-							tool: codexTool,
-							version: "0.1.0",
-							meetsMinVersion: true,
-						},
-						{
-							tool: { ...codexTool, id: "opencode", name: "OpenCode" },
-							version: "0.9.0",
-							meetsMinVersion: true,
-						},
-					],
-					results: [
-						{
-							toolId: "codex",
-							toolName: "Codex CLI",
-							success: true,
-							pluginsInstalled: ["rp1-base"],
-							warnings: [],
-						},
-						{
-							toolId: "opencode",
-							toolName: "OpenCode",
-							success: false,
-							pluginsInstalled: [],
-							warnings: ["manual restart required"],
-						},
-					],
-				}),
+		const codexDetected: DetectedTool = {
+			tool: codexTool,
+			version: "0.1.0",
+			meetsMinVersion: true,
+		};
+		const opencodeDetected: DetectedTool = {
+			tool: { ...codexTool, id: "opencode", name: "OpenCode" },
+			version: "0.9.0",
+			meetsMinVersion: true,
+		};
+		const detectToolsMock = (_toolsRegistry: ToolsRegistry) =>
+			TE.right({
+				detected: [codexDetected, opencodeDetected] as DetectedTool[],
+				missing: [],
+			});
+		const getEffectiveHarnessesMock = (detection: {
+			detected: readonly DetectedTool[];
+		}) => [...detection.detected];
+		const updateForSpecificTool = mock(
+			(toolId: string, _toolsRegistry: ToolsRegistry, _ctx: InstallContext) => {
+				if (toolId === "codex") {
+					return TE.right({
+						toolId: "codex",
+						toolName: "Codex CLI",
+						success: true,
+						pluginsInstalled: ["rp1-base"],
+						warnings: [],
+					});
+				}
+				return TE.right({
+					toolId: "opencode",
+					toolName: "OpenCode",
+					success: false,
+					pluginsInstalled: [],
+					warnings: ["manual restart required"],
+				});
+			},
 		);
 		await expect(
 			runPluginsCommand(
 				["update", "plugins", "all", "--yes"],
-				createCommandDeps({ installAllDetectedTools }),
+				createCommandDeps({
+					detectTools: detectToolsMock,
+					getEffectiveHarnesses: getEffectiveHarnessesMock,
+					updateForSpecificTool,
+				}),
 			),
 		).rejects.toMatchObject({ code: 1 });
 
-		expect(installAllDetectedTools.mock.calls[0]?.[0]).toBe(registry);
-		expect(installAllDetectedTools.mock.calls[0]?.[1]).toMatchObject({
+		expect(updateForSpecificTool.mock.calls[0]?.[0]).toBe("codex");
+		expect(updateForSpecificTool.mock.calls[0]?.[2]).toMatchObject({
 			dryRun: false,
 			skipPrompt: true,
 		});

--- a/cli/src/__tests__/init/steps/harness-selection.test.ts
+++ b/cli/src/__tests__/init/steps/harness-selection.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Unit tests for the harness-selection step business logic.
+ *
+ * Tests item building from detected tools, default selection resolution
+ * (fresh vs re-init), and stable-defaults fallback.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import type { SupportedTool } from "../../../config/supported-tools.js";
+import {
+	buildHarnessItems,
+	getStableDefaults,
+	resolveDefaultSelection,
+	writeHarnessSelection,
+} from "../../../init/steps/harness-selection.js";
+import type { DetectedTool } from "../../../init/tool-detector.js";
+import { resetSettingsCache } from "../../../settings/loader.js";
+import { cleanupTempDir, createTempDir } from "../../helpers/index.js";
+
+function makeTool(overrides: Partial<SupportedTool> = {}): SupportedTool {
+	return {
+		id: "claude-code",
+		name: "Claude Code",
+		binary: "claude",
+		min_version: "1.0.0",
+		instruction_file: "CLAUDE.md",
+		install_url: "https://example.com",
+		plugin_install_cmd: null,
+		capabilities: [],
+		...overrides,
+	};
+}
+
+function makeDetected(
+	toolOverrides: Partial<SupportedTool> = {},
+	version = "1.0.0",
+): DetectedTool {
+	return {
+		tool: makeTool(toolOverrides),
+		version,
+		meetsMinVersion: true,
+	};
+}
+
+describe("harness-selection step", () => {
+	describe("buildHarnessItems", () => {
+		test("maps detected tools to multi-select items", () => {
+			const detected: DetectedTool[] = [
+				makeDetected({ id: "claude-code", name: "Claude Code" }, "1.2.3"),
+				makeDetected(
+					{
+						id: "codex",
+						name: "Codex",
+						supportLevel: "experimental",
+					},
+					"0.5.0",
+				),
+			];
+
+			const items = buildHarnessItems(detected);
+
+			expect(items).toHaveLength(2);
+			expect(items[0].value).toBe("claude-code");
+			expect(items[0].label).toBe("Claude Code");
+			expect(items[0].isStable).toBe(true);
+			expect(items[0].description).toBe("v1.2.3");
+
+			expect(items[1].value).toBe("codex");
+			expect(items[1].label).toBe("Codex");
+			expect(items[1].isStable).toBe(false);
+			expect(items[1].description).toBe("v0.5.0 (experimental)");
+		});
+
+		test("filters out disabled tools", () => {
+			const detected: DetectedTool[] = [
+				makeDetected({ id: "claude-code", enabled: false }),
+				makeDetected({ id: "opencode", name: "OpenCode" }),
+			];
+
+			const items = buildHarnessItems(detected);
+
+			expect(items).toHaveLength(1);
+			expect(items[0].value).toBe("opencode");
+		});
+
+		test("handles unknown version", () => {
+			const detected: DetectedTool[] = [
+				makeDetected({ id: "claude-code" }, "unknown"),
+			];
+
+			const items = buildHarnessItems(detected);
+
+			expect(items[0].description).toBeUndefined();
+		});
+	});
+
+	describe("getStableDefaults", () => {
+		test("returns only stable harness IDs", () => {
+			const items = [
+				{ value: "claude-code", label: "Claude Code", isStable: true },
+				{ value: "codex", label: "Codex", isStable: false },
+				{ value: "opencode", label: "OpenCode", isStable: true },
+			];
+
+			const defaults = getStableDefaults(items);
+
+			expect(defaults).toEqual(["claude-code", "opencode"]);
+		});
+
+		test("returns empty array when no stable harnesses", () => {
+			const items = [{ value: "codex", label: "Codex", isStable: false }];
+
+			expect(getStableDefaults(items)).toEqual([]);
+		});
+	});
+
+	describe("resolveDefaultSelection", () => {
+		let tempDir: string;
+		let settingsPath: string;
+
+		beforeEach(async () => {
+			resetSettingsCache();
+			tempDir = await createTempDir("harness-selection-test");
+			settingsPath = join(tempDir, "settings.toml");
+		});
+
+		afterEach(async () => {
+			resetSettingsCache();
+			await cleanupTempDir(tempDir);
+		});
+
+		test("returns stable defaults when no persisted selection exists", () => {
+			const items = [
+				{ value: "claude-code", label: "Claude Code", isStable: true },
+				{ value: "codex", label: "Codex", isStable: false },
+			];
+
+			const defaults = resolveDefaultSelection(items, settingsPath);
+
+			expect(defaults).toEqual(["claude-code"]);
+		});
+
+		test("returns persisted selection filtered to detected harnesses on re-init", () => {
+			mkdirSync(tempDir, { recursive: true });
+			writeFileSync(
+				settingsPath,
+				'[harnesses]\nenabled = ["claude-code", "codex", "copilot"]\n',
+			);
+
+			const items = [
+				{ value: "claude-code", label: "Claude Code", isStable: true },
+				{ value: "opencode", label: "OpenCode", isStable: true },
+			];
+
+			const defaults = resolveDefaultSelection(items, settingsPath);
+
+			// "copilot" and "codex" not in detected -> filtered out
+			// "opencode" detected but not in persisted -> not included
+			expect(defaults).toEqual(["claude-code"]);
+		});
+
+		test("returns empty when persisted selection has no overlap with detected", () => {
+			mkdirSync(tempDir, { recursive: true });
+			writeFileSync(settingsPath, '[harnesses]\nenabled = ["copilot"]\n');
+
+			const items = [
+				{ value: "claude-code", label: "Claude Code", isStable: true },
+			];
+
+			const defaults = resolveDefaultSelection(items, settingsPath);
+
+			expect(defaults).toEqual([]);
+		});
+	});
+
+	describe("writeHarnessSelection integration", () => {
+		let tempDir: string;
+		let settingsPath: string;
+
+		beforeEach(async () => {
+			resetSettingsCache();
+			tempDir = await createTempDir("harness-write-test");
+			settingsPath = join(tempDir, "settings.toml");
+		});
+
+		afterEach(async () => {
+			resetSettingsCache();
+			await cleanupTempDir(tempDir);
+		});
+
+		test("creates settings file and writes selection", () => {
+			writeHarnessSelection(["claude-code", "opencode"], settingsPath);
+
+			const content = readFileSync(settingsPath, "utf-8");
+			expect(content).toContain("[harnesses]");
+			expect(content).toContain('enabled = ["claude-code", "opencode"]');
+		});
+	});
+});

--- a/cli/src/__tests__/init/ui/components/MultiSelectPrompt.test.tsx
+++ b/cli/src/__tests__/init/ui/components/MultiSelectPrompt.test.tsx
@@ -1,0 +1,268 @@
+/**
+ * Unit tests for MultiSelectPrompt component.
+ * Tests rendering, default selection state, and checkbox display.
+ *
+ * NOTE: Keyboard interaction tests (space toggle, enter submit) are omitted
+ * because ink-testing-library's stdin simulation doesn't reliably trigger
+ * Ink's useInput hook (same limitation as SelectPrompt tests).
+ *
+ * These tests focus on:
+ * - Component rendering (items display correctly)
+ * - Default selection state (checked/unchecked indicators)
+ * - Navigation hint display
+ * - Edge cases (single item, empty defaults, all defaults)
+ */
+
+import { describe, expect, test } from "bun:test";
+import { render } from "ink-testing-library";
+import {
+	type MultiSelectItem,
+	MultiSelectPrompt,
+} from "../../../../init/ui/components/MultiSelectPrompt.js";
+
+describe("MultiSelectPrompt", () => {
+	describe("basic rendering", () => {
+		test("renders prompt message", () => {
+			const items: MultiSelectItem[] = [
+				{ value: "a", label: "Item A" },
+				{ value: "b", label: "Item B" },
+			];
+
+			const { lastFrame } = render(
+				<MultiSelectPrompt
+					message="Select harnesses"
+					items={items}
+					onSubmit={() => {}}
+				/>,
+			);
+			const output = lastFrame();
+
+			expect(output).toContain("Select harnesses");
+		});
+
+		test("renders all items", () => {
+			const items: MultiSelectItem[] = [
+				{ value: "claude", label: "Claude Code" },
+				{ value: "codex", label: "Codex" },
+				{ value: "copilot", label: "Copilot" },
+			];
+
+			const { lastFrame } = render(
+				<MultiSelectPrompt
+					message="Select"
+					items={items}
+					onSubmit={() => {}}
+				/>,
+			);
+			const output = lastFrame();
+
+			expect(output).toContain("Claude Code");
+			expect(output).toContain("Codex");
+			expect(output).toContain("Copilot");
+		});
+
+		test("shows multi-select navigation hint", () => {
+			const items: MultiSelectItem[] = [{ value: "a", label: "Item A" }];
+
+			const { lastFrame } = render(
+				<MultiSelectPrompt message="Test" items={items} onSubmit={() => {}} />,
+			);
+			const output = lastFrame();
+
+			expect(output).toContain("Space");
+			expect(output).toContain("toggle");
+			expect(output).toContain("Enter");
+			expect(output).toContain("confirm");
+		});
+	});
+
+	describe("default selection state", () => {
+		test("items are unchecked when no defaultSelected provided", () => {
+			const items: MultiSelectItem[] = [
+				{ value: "a", label: "Item A" },
+				{ value: "b", label: "Item B" },
+			];
+
+			const { lastFrame } = render(
+				<MultiSelectPrompt
+					message="Select"
+					items={items}
+					onSubmit={() => {}}
+				/>,
+			);
+			const output = lastFrame() ?? "";
+
+			// checkboxOff = ☐, checkboxOn = ☒
+			// With no defaults, no items should show checkboxOn
+			expect(output).not.toContain("☒"); // ☒
+		});
+
+		test("defaultSelected items are pre-checked", () => {
+			const items: MultiSelectItem[] = [
+				{ value: "claude", label: "Claude Code" },
+				{ value: "codex", label: "Codex" },
+				{ value: "copilot", label: "Copilot" },
+			];
+
+			const { lastFrame } = render(
+				<MultiSelectPrompt
+					message="Select"
+					items={items}
+					defaultSelected={["claude", "copilot"]}
+					onSubmit={() => {}}
+				/>,
+			);
+			const output = lastFrame() ?? "";
+
+			// Count checked checkboxes - should be 2
+			const checkedCount = (output.match(/☒/g) || []).length;
+			expect(checkedCount).toBe(2);
+
+			// Count unchecked checkboxes - should be 1
+			const uncheckedCount = (output.match(/☐/g) || []).length;
+			expect(uncheckedCount).toBe(1);
+		});
+
+		test("all items pre-checked when all in defaultSelected", () => {
+			const items: MultiSelectItem[] = [
+				{ value: "a", label: "Item A" },
+				{ value: "b", label: "Item B" },
+			];
+
+			const { lastFrame } = render(
+				<MultiSelectPrompt
+					message="Select"
+					items={items}
+					defaultSelected={["a", "b"]}
+					onSubmit={() => {}}
+				/>,
+			);
+			const output = lastFrame() ?? "";
+
+			const checkedCount = (output.match(/☒/g) || []).length;
+			expect(checkedCount).toBe(2);
+			expect(output).not.toContain("☐"); // no unchecked
+		});
+	});
+
+	describe("focus and description", () => {
+		test("first item is focused by default", () => {
+			const items: MultiSelectItem[] = [
+				{ value: "a", label: "Item A", description: "Desc A" },
+				{ value: "b", label: "Item B", description: "Desc B" },
+			];
+
+			const { lastFrame } = render(
+				<MultiSelectPrompt
+					message="Select"
+					items={items}
+					onSubmit={() => {}}
+				/>,
+			);
+			const output = lastFrame();
+
+			// Only focused item's description is shown
+			expect(output).toContain("Desc A");
+			expect(output).not.toContain("Desc B");
+		});
+
+		test("items without descriptions render without error", () => {
+			const items: MultiSelectItem[] = [
+				{ value: "a", label: "Item A" },
+				{ value: "b", label: "Item B" },
+			];
+
+			const { lastFrame } = render(
+				<MultiSelectPrompt
+					message="Select"
+					items={items}
+					onSubmit={() => {}}
+				/>,
+			);
+			const output = lastFrame();
+
+			expect(output).toContain("Item A");
+			expect(output).toContain("Item B");
+		});
+	});
+
+	describe("edge cases", () => {
+		test("handles single item", () => {
+			const items: MultiSelectItem[] = [
+				{ value: "only", label: "Only Item", description: "The only choice" },
+			];
+
+			const { lastFrame } = render(
+				<MultiSelectPrompt
+					message="Select"
+					items={items}
+					onSubmit={() => {}}
+				/>,
+			);
+			const output = lastFrame();
+
+			expect(output).toContain("Only Item");
+			expect(output).toContain("The only choice");
+		});
+
+		test("handles many items", () => {
+			const items: MultiSelectItem[] = Array.from({ length: 8 }, (_, i) => ({
+				value: `item-${i}`,
+				label: `Item ${i + 1}`,
+			}));
+
+			const { lastFrame } = render(
+				<MultiSelectPrompt
+					message="Select"
+					items={items}
+					onSubmit={() => {}}
+				/>,
+			);
+			const output = lastFrame();
+
+			for (let i = 1; i <= 8; i++) {
+				expect(output).toContain(`Item ${i}`);
+			}
+		});
+
+		test("ignores defaultSelected values not in items", () => {
+			const items: MultiSelectItem[] = [
+				{ value: "a", label: "Item A" },
+				{ value: "b", label: "Item B" },
+			];
+
+			const { lastFrame } = render(
+				<MultiSelectPrompt
+					message="Select"
+					items={items}
+					defaultSelected={["a", "nonexistent"]}
+					onSubmit={() => {}}
+				/>,
+			);
+			const output = lastFrame() ?? "";
+
+			// Only "a" should be checked (1 checked checkbox)
+			const checkedCount = (output.match(/☒/g) || []).length;
+			expect(checkedCount).toBe(1);
+		});
+
+		test("empty defaultSelected array works like no defaults", () => {
+			const items: MultiSelectItem[] = [
+				{ value: "a", label: "Item A" },
+				{ value: "b", label: "Item B" },
+			];
+
+			const { lastFrame } = render(
+				<MultiSelectPrompt
+					message="Select"
+					items={items}
+					defaultSelected={[]}
+					onSubmit={() => {}}
+				/>,
+			);
+			const output = lastFrame() ?? "";
+
+			expect(output).not.toContain("☒");
+		});
+	});
+});

--- a/cli/src/__tests__/init/ui/components/MultiSelectPrompt.test.tsx
+++ b/cli/src/__tests__/init/ui/components/MultiSelectPrompt.test.tsx
@@ -1,6 +1,7 @@
 /**
  * Unit tests for MultiSelectPrompt component.
- * Tests rendering, default selection state, and checkbox display.
+ * Tests rendering, default selection state, checkbox display, and
+ * re-render stability (regression for event-loop freeze on state updates).
  *
  * NOTE: Keyboard interaction tests (space toggle, enter submit) are omitted
  * because ink-testing-library's stdin simulation doesn't reliably trigger
@@ -11,6 +12,7 @@
  * - Default selection state (checked/unchecked indicators)
  * - Navigation hint display
  * - Edge cases (single item, empty defaults, all defaults)
+ * - Re-render stability with changing props
  */
 
 import { describe, expect, test } from "bun:test";
@@ -263,6 +265,76 @@ describe("MultiSelectPrompt", () => {
 			const output = lastFrame() ?? "";
 
 			expect(output).not.toContain("☒");
+		});
+	});
+
+	describe("re-render stability", () => {
+		test("survives parent re-render with new items array reference", () => {
+			const makeItems = (): MultiSelectItem[] => [
+				{ value: "a", label: "Item A" },
+				{ value: "b", label: "Item B" },
+			];
+
+			const { lastFrame, rerender } = render(
+				<MultiSelectPrompt
+					message="Select"
+					items={makeItems()}
+					defaultSelected={["a"]}
+					onSubmit={() => {}}
+				/>,
+			);
+
+			const first = lastFrame() ?? "";
+			expect(first).toContain("Item A");
+
+			rerender(
+				<MultiSelectPrompt
+					message="Select"
+					items={makeItems()}
+					defaultSelected={["a"]}
+					onSubmit={() => {}}
+				/>,
+			);
+
+			const second = lastFrame() ?? "";
+			expect(second).toContain("Item A");
+			expect(second).toContain("Item B");
+
+			const checkedCount = (second.match(/☒/g) || []).length;
+			expect(checkedCount).toBe(1);
+		});
+
+		test("preserves selection state across re-renders with new prop references", () => {
+			const items: MultiSelectItem[] = [
+				{ value: "x", label: "X" },
+				{ value: "y", label: "Y" },
+			];
+
+			const { lastFrame, rerender } = render(
+				<MultiSelectPrompt
+					message="Pick"
+					items={[...items]}
+					defaultSelected={["x", "y"]}
+					onSubmit={() => {}}
+				/>,
+			);
+
+			const before = lastFrame() ?? "";
+			const checkedBefore = (before.match(/☒/g) || []).length;
+			expect(checkedBefore).toBe(2);
+
+			rerender(
+				<MultiSelectPrompt
+					message="Pick"
+					items={[...items]}
+					defaultSelected={["x", "y"]}
+					onSubmit={() => {}}
+				/>,
+			);
+
+			const after = lastFrame() ?? "";
+			const checkedAfter = (after.match(/☒/g) || []).length;
+			expect(checkedAfter).toBe(2);
 		});
 	});
 });

--- a/cli/src/__tests__/init/ui/hooks/useWizardState.test.ts
+++ b/cli/src/__tests__/init/ui/hooks/useWizardState.test.ts
@@ -104,6 +104,7 @@ describe("useWizardState", () => {
 				"git-check",
 				"reinit-check",
 				"tool-detection",
+				"harness-selection",
 				"install-check",
 				"directory-setup",
 				"settings-setup",
@@ -146,7 +147,7 @@ describe("useWizardState", () => {
 		});
 
 		test("returns last step for final index", () => {
-			const state = createTestState({ currentStepIndex: 10 });
+			const state = createTestState({ currentStepIndex: 11 });
 			const current = getCurrentStep(state);
 
 			expect(current?.id).toBe("summary");

--- a/cli/src/__tests__/settings/harness-writer.test.ts
+++ b/cli/src/__tests__/settings/harness-writer.test.ts
@@ -1,0 +1,214 @@
+/**
+ * Unit tests for comment-preserving writeHarnessSelection().
+ * Verifies preservation of existing TOML content, idempotency,
+ * create vs update, and empty array handling.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { writeHarnessSelection } from "../../settings/harness-writer.js";
+import { resetSettingsCache } from "../../settings/loader.js";
+import {
+	cleanupTempDir,
+	createTempDir,
+	writeFixture,
+} from "../helpers/index.js";
+
+let tempDir: string;
+
+beforeEach(async () => {
+	tempDir = await createTempDir("settings-harness-writer");
+	resetSettingsCache();
+});
+
+afterEach(async () => {
+	await cleanupTempDir(tempDir);
+});
+
+const readFile = (path: string): string => readFileSync(path, "utf-8");
+
+describe("writeHarnessSelection", () => {
+	test("creates new TOML file with [harnesses] section when file does not exist", () => {
+		const filePath = join(tempDir, "settings.toml");
+
+		writeHarnessSelection(["claude-code", "codex"], filePath);
+
+		const content = readFile(filePath);
+		expect(content).toContain("[harnesses]");
+		expect(content).toContain('enabled = ["claude-code", "codex"]');
+	});
+
+	test("preserves existing [models] and [arcade] sections when writing [harnesses]", async () => {
+		const filePath = join(tempDir, "settings.toml");
+		const existingContent = [
+			"[models.claude-code]",
+			'standard = "claude-sonnet-4-20250514"',
+			"",
+			"[arcade]",
+			'theme = "dark"',
+			"",
+		].join("\n");
+
+		await writeFixture(tempDir, "settings.toml", existingContent);
+
+		writeHarnessSelection(["claude-code"], filePath);
+
+		const content = readFile(filePath);
+		expect(content).toContain("[models.claude-code]");
+		expect(content).toContain('standard = "claude-sonnet-4-20250514"');
+		expect(content).toContain("[arcade]");
+		expect(content).toContain('theme = "dark"');
+		expect(content).toContain("[harnesses]");
+		expect(content).toContain('enabled = ["claude-code"]');
+	});
+
+	test("preserves existing comments verbatim when appending [harnesses]", async () => {
+		const filePath = join(tempDir, "settings.toml");
+		const existingContent = [
+			"# My custom model settings",
+			"[models.claude-code]",
+			"# Use the latest sonnet for standard tier",
+			'standard = "claude-sonnet-4-20250514"',
+			"",
+		].join("\n");
+
+		await writeFixture(tempDir, "settings.toml", existingContent);
+
+		writeHarnessSelection(["claude-code", "codex"], filePath);
+
+		const content = readFile(filePath);
+		expect(content).toContain("# My custom model settings");
+		expect(content).toContain("# Use the latest sonnet for standard tier");
+		expect(content).toContain('standard = "claude-sonnet-4-20250514"');
+	});
+
+	test("updates existing [harnesses] section in place", async () => {
+		const filePath = join(tempDir, "settings.toml");
+		const existingContent = [
+			"[harnesses]",
+			'enabled = ["claude-code"]',
+			"",
+		].join("\n");
+
+		await writeFixture(tempDir, "settings.toml", existingContent);
+
+		writeHarnessSelection(["claude-code", "codex", "copilot"], filePath);
+
+		const content = readFile(filePath);
+		expect(content).toContain('enabled = ["claude-code", "codex", "copilot"]');
+		// No duplicate headers
+		const headers = content.match(/^\[harnesses\]$/gm);
+		expect(headers).toHaveLength(1);
+		// No duplicate enabled keys
+		const enabledKeys = content.match(/^enabled\s*=/gm);
+		expect(enabledKeys).toHaveLength(1);
+	});
+
+	test("is idempotent: repeated writes with same value produce identical content", () => {
+		const filePath = join(tempDir, "settings.toml");
+		const harnesses = ["claude-code", "codex"];
+
+		writeHarnessSelection(harnesses, filePath);
+		const first = readFile(filePath);
+
+		writeHarnessSelection(harnesses, filePath);
+		const second = readFile(filePath);
+
+		expect(second).toBe(first);
+	});
+
+	test("handles empty array", () => {
+		const filePath = join(tempDir, "settings.toml");
+
+		writeHarnessSelection([], filePath);
+
+		const content = readFile(filePath);
+		expect(content).toContain("[harnesses]");
+		expect(content).toContain("enabled = []");
+	});
+
+	test("handles single harness", () => {
+		const filePath = join(tempDir, "settings.toml");
+
+		writeHarnessSelection(["codex"], filePath);
+
+		const content = readFile(filePath);
+		expect(content).toContain('enabled = ["codex"]');
+	});
+
+	test("updates [harnesses] between other sections without corrupting them", async () => {
+		const filePath = join(tempDir, "settings.toml");
+		const existingContent = [
+			"[models.claude-code]",
+			'standard = "claude-sonnet-4-20250514"',
+			"",
+			"[harnesses]",
+			'enabled = ["claude-code"]',
+			"",
+			"[arcade]",
+			'theme = "dark"',
+			"",
+		].join("\n");
+
+		await writeFixture(tempDir, "settings.toml", existingContent);
+
+		writeHarnessSelection(["claude-code", "codex"], filePath);
+
+		const content = readFile(filePath);
+		expect(content).toContain("[models.claude-code]");
+		expect(content).toContain('standard = "claude-sonnet-4-20250514"');
+		expect(content).toContain('enabled = ["claude-code", "codex"]');
+		expect(content).toContain("[arcade]");
+		expect(content).toContain('theme = "dark"');
+	});
+
+	test("preserves comments within [harnesses] section", async () => {
+		const filePath = join(tempDir, "settings.toml");
+		const existingContent = [
+			"[harnesses]",
+			"# Selected harnesses for this machine",
+			'enabled = ["claude-code"]',
+			"",
+		].join("\n");
+
+		await writeFixture(tempDir, "settings.toml", existingContent);
+
+		writeHarnessSelection(["claude-code", "codex"], filePath);
+
+		const content = readFile(filePath);
+		expect(content).toContain("# Selected harnesses for this machine");
+		expect(content).toContain('enabled = ["claude-code", "codex"]');
+	});
+
+	test("creates parent directories when needed", () => {
+		const filePath = join(tempDir, "nested", "dir", "settings.toml");
+
+		writeHarnessSelection(["claude-code"], filePath);
+
+		const content = readFile(filePath);
+		expect(content).toContain("[harnesses]");
+		expect(content).toContain('enabled = ["claude-code"]');
+	});
+
+	test("byte-level round-trip: existing content before [harnesses] is identical", async () => {
+		const filePath = join(tempDir, "settings.toml");
+		const existingContent = [
+			"# Top-level comment",
+			"",
+			"[arguments.build]",
+			"AFK = true",
+			"",
+			"[models.claude-code]",
+			'deep = "claude-opus-4-20250514"',
+			"",
+		].join("\n");
+
+		await writeFixture(tempDir, "settings.toml", existingContent);
+
+		writeHarnessSelection(["claude-code", "codex"], filePath);
+
+		const content = readFile(filePath);
+		expect(content.startsWith(existingContent)).toBe(true);
+	});
+});

--- a/cli/src/__tests__/settings/loader-harnesses.test.ts
+++ b/cli/src/__tests__/settings/loader-harnesses.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Unit tests for TOML [harnesses] section parsing and loadEnabledHarnesses().
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { join } from "node:path";
+import {
+	loadEnabledHarnesses,
+	resetSettingsCache,
+} from "../../settings/loader.js";
+import {
+	cleanupTempDir,
+	createTempDir,
+	writeFixture,
+} from "../helpers/index.js";
+
+let tempDir: string;
+
+/** Path to a nonexistent global settings file within tempDir, isolating tests from ~/.config/rp1/settings.toml. */
+const isolatedGlobalPath = (): string =>
+	join(tempDir, "global-config", "settings.toml");
+
+beforeEach(async () => {
+	resetSettingsCache();
+	tempDir = await createTempDir("settings-loader-harnesses");
+});
+
+afterEach(async () => {
+	await cleanupTempDir(tempDir);
+});
+
+describe("loadEnabledHarnesses", () => {
+	test("returns undefined when settings file does not exist", () => {
+		const result = loadEnabledHarnesses(isolatedGlobalPath());
+		expect(result).toBeUndefined();
+	});
+
+	test("returns undefined when [harnesses] section is absent", async () => {
+		await writeFixture(
+			tempDir,
+			"global-config/settings.toml",
+			`[arguments.build]\nAFK = false\n`,
+		);
+
+		const result = loadEnabledHarnesses(isolatedGlobalPath());
+		expect(result).toBeUndefined();
+	});
+
+	test("parses valid [harnesses] section with enabled array", async () => {
+		await writeFixture(
+			tempDir,
+			"global-config/settings.toml",
+			["[harnesses]", 'enabled = ["claude-code", "codex"]'].join("\n"),
+		);
+
+		const result = loadEnabledHarnesses(isolatedGlobalPath());
+		expect(result).toEqual(["claude-code", "codex"]);
+	});
+
+	test("parses empty enabled array", async () => {
+		await writeFixture(
+			tempDir,
+			"global-config/settings.toml",
+			["[harnesses]", "enabled = []"].join("\n"),
+		);
+
+		const result = loadEnabledHarnesses(isolatedGlobalPath());
+		expect(result).toEqual([]);
+	});
+
+	test("returns undefined when enabled is not an array", async () => {
+		await writeFixture(
+			tempDir,
+			"global-config/settings.toml",
+			["[harnesses]", 'enabled = "claude-code"'].join("\n"),
+		);
+
+		const result = loadEnabledHarnesses(isolatedGlobalPath());
+		expect(result).toBeUndefined();
+	});
+
+	test("filters out non-string entries in enabled array", async () => {
+		await writeFixture(
+			tempDir,
+			"global-config/settings.toml",
+			["[harnesses]", 'enabled = ["claude-code", 42, "codex", true]'].join(
+				"\n",
+			),
+		);
+
+		const result = loadEnabledHarnesses(isolatedGlobalPath());
+		expect(result).toEqual(["claude-code", "codex"]);
+	});
+
+	test("returns undefined when [harnesses] section has no enabled key", async () => {
+		await writeFixture(
+			tempDir,
+			"global-config/settings.toml",
+			["[harnesses]", 'other_key = "value"'].join("\n"),
+		);
+
+		const result = loadEnabledHarnesses(isolatedGlobalPath());
+		expect(result).toBeUndefined();
+	});
+
+	test("coexists with other settings sections", async () => {
+		await writeFixture(
+			tempDir,
+			"global-config/settings.toml",
+			[
+				"[arguments.build]",
+				"AFK = false",
+				"",
+				"[models.claude-code]",
+				'deep = "claude-sonnet-4-20250514"',
+				"",
+				"[harnesses]",
+				'enabled = ["claude-code", "codex", "copilot"]',
+				"",
+				"[arcade]",
+				'theme = "dark"',
+				"",
+				"[storage]",
+				'mode = "central"',
+			].join("\n"),
+		);
+
+		const result = loadEnabledHarnesses(isolatedGlobalPath());
+		expect(result).toEqual(["claude-code", "codex", "copilot"]);
+	});
+
+	test("returns a defensive copy (not the internal array)", async () => {
+		await writeFixture(
+			tempDir,
+			"global-config/settings.toml",
+			["[harnesses]", 'enabled = ["claude-code"]'].join("\n"),
+		);
+
+		const first = loadEnabledHarnesses(isolatedGlobalPath());
+		const second = loadEnabledHarnesses(isolatedGlobalPath());
+		expect(first).toEqual(second);
+		expect(first).not.toBe(second);
+	});
+
+	test("handles malformed TOML gracefully", async () => {
+		await writeFixture(
+			tempDir,
+			"global-config/settings.toml",
+			"[harnesses\nenabled = broken",
+		);
+
+		const result = loadEnabledHarnesses(isolatedGlobalPath());
+		expect(result).toBeUndefined();
+	});
+});
+
+describe("loadEnabledHarnesses cache behavior", () => {
+	test("resetSettingsCache forces fresh read", async () => {
+		await writeFixture(
+			tempDir,
+			"global-config/settings.toml",
+			["[harnesses]", 'enabled = ["claude-code"]'].join("\n"),
+		);
+
+		const first = loadEnabledHarnesses(isolatedGlobalPath());
+		expect(first).toEqual(["claude-code"]);
+
+		await writeFixture(
+			tempDir,
+			"global-config/settings.toml",
+			["[harnesses]", 'enabled = ["claude-code", "codex"]'].join("\n"),
+		);
+
+		resetSettingsCache();
+
+		const second = loadEnabledHarnesses(isolatedGlobalPath());
+		expect(second).toEqual(["claude-code", "codex"]);
+	});
+});

--- a/cli/src/__tests__/shared/effective-harnesses.test.ts
+++ b/cli/src/__tests__/shared/effective-harnesses.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Tests for getEffectiveHarnesses() -- harness selection filter for update/migrate.
+ *
+ * Regression targets:
+ * - Absent [harnesses] enabled returns all detected stable (backward compat, REQ-006)
+ * - Persisted selection filters to intersection of detected + selected
+ * - Empty intersection returns empty array (no silent fallback)
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { SupportedTool } from "../../config/supported-tools.js";
+import type {
+	DetectedTool,
+	ToolDetectionResult,
+} from "../../init/tool-detector.js";
+import { resetSettingsCache } from "../../settings/loader.js";
+
+const makeTool = (
+	id: string,
+	name: string,
+	supportLevel?: "stable" | "experimental" | "degraded",
+): SupportedTool => ({
+	id,
+	name,
+	binary: id,
+	min_version: "0.0.0",
+	instruction_file: `${id}.md`,
+	install_url: `https://example.com/${id}`,
+	plugin_install_cmd: null,
+	supportLevel,
+	capabilities: [],
+});
+
+const makeDetected = (tool: SupportedTool): DetectedTool => ({
+	tool,
+	version: "1.0.0",
+	meetsMinVersion: true,
+});
+
+const claudeCode = makeTool("claude-code", "Claude Code", "stable");
+const opencode = makeTool("opencode", "OpenCode", "stable");
+const codex = makeTool("codex", "Codex", "stable");
+const copilot = makeTool("copilot", "Copilot", "stable");
+const antigravity = makeTool("antigravity", "Antigravity", "experimental");
+
+describe("getEffectiveHarnesses", () => {
+	let tempDir: string;
+	let settingsPath: string;
+
+	beforeEach(() => {
+		tempDir = join(tmpdir(), `rp1-eff-harness-test-${Date.now()}`);
+		mkdirSync(tempDir, { recursive: true });
+		settingsPath = join(tempDir, "settings.toml");
+		resetSettingsCache();
+	});
+
+	afterEach(() => {
+		rmSync(tempDir, { recursive: true, force: true });
+		resetSettingsCache();
+	});
+
+	const loadGetEffectiveHarnesses = async () => {
+		const mod = await import("../../shared/install-core.js");
+		return mod.getEffectiveHarnesses;
+	};
+
+	test("returns all detected stable when no selection persisted (REQ-006 backward compat)", async () => {
+		const getEffectiveHarnesses = await loadGetEffectiveHarnesses();
+
+		const detection: ToolDetectionResult = {
+			detected: [
+				makeDetected(claudeCode),
+				makeDetected(opencode),
+				makeDetected(antigravity),
+			],
+			missing: [codex, copilot],
+		};
+
+		// No settings file exists -- loadEnabledHarnesses returns undefined
+		const result = getEffectiveHarnesses(detection, settingsPath);
+
+		// Should return only stable detected tools (claude-code, opencode), not antigravity (experimental)
+		expect(result.map((d) => d.tool.id)).toEqual(["claude-code", "opencode"]);
+	});
+
+	test("returns intersection of detected and persisted selection", async () => {
+		const getEffectiveHarnesses = await loadGetEffectiveHarnesses();
+
+		writeFileSync(
+			settingsPath,
+			'[harnesses]\nenabled = ["claude-code", "codex"]\n',
+		);
+
+		const detection: ToolDetectionResult = {
+			detected: [
+				makeDetected(claudeCode),
+				makeDetected(opencode),
+				makeDetected(codex),
+			],
+			missing: [copilot],
+		};
+
+		const result = getEffectiveHarnesses(detection, settingsPath);
+
+		// opencode is detected but not in enabled list -- excluded
+		// codex is in enabled list and detected -- included
+		expect(result.map((d) => d.tool.id)).toEqual(["claude-code", "codex"]);
+	});
+
+	test("returns empty array when no detected tools match selection", async () => {
+		const getEffectiveHarnesses = await loadGetEffectiveHarnesses();
+
+		writeFileSync(settingsPath, '[harnesses]\nenabled = ["copilot"]\n');
+
+		const detection: ToolDetectionResult = {
+			detected: [makeDetected(claudeCode), makeDetected(opencode)],
+			missing: [copilot, codex],
+		};
+
+		const result = getEffectiveHarnesses(detection, settingsPath);
+
+		expect(result).toEqual([]);
+	});
+
+	test("empty enabled array returns empty array (user explicitly deselected all)", async () => {
+		const getEffectiveHarnesses = await loadGetEffectiveHarnesses();
+
+		writeFileSync(settingsPath, "[harnesses]\nenabled = []\n");
+
+		const detection: ToolDetectionResult = {
+			detected: [makeDetected(claudeCode)],
+			missing: [],
+		};
+
+		const result = getEffectiveHarnesses(detection, settingsPath);
+
+		expect(result).toEqual([]);
+	});
+
+	test("preserves order from detected tools", async () => {
+		const getEffectiveHarnesses = await loadGetEffectiveHarnesses();
+
+		writeFileSync(
+			settingsPath,
+			'[harnesses]\nenabled = ["codex", "claude-code", "opencode"]\n',
+		);
+
+		const detection: ToolDetectionResult = {
+			detected: [
+				makeDetected(opencode),
+				makeDetected(claudeCode),
+				makeDetected(codex),
+			],
+			missing: [],
+		};
+
+		const result = getEffectiveHarnesses(detection, settingsPath);
+
+		// Order should follow detected order, not enabled order
+		expect(result.map((d) => d.tool.id)).toEqual([
+			"opencode",
+			"claude-code",
+			"codex",
+		]);
+	});
+
+	test("includes experimental tools when explicitly selected", async () => {
+		const getEffectiveHarnesses = await loadGetEffectiveHarnesses();
+
+		writeFileSync(
+			settingsPath,
+			'[harnesses]\nenabled = ["claude-code", "antigravity"]\n',
+		);
+
+		const detection: ToolDetectionResult = {
+			detected: [makeDetected(claudeCode), makeDetected(antigravity)],
+			missing: [],
+		};
+
+		const result = getEffectiveHarnesses(detection, settingsPath);
+
+		// Explicit selection overrides support level filtering
+		expect(result.map((d) => d.tool.id)).toEqual([
+			"claude-code",
+			"antigravity",
+		]);
+	});
+});

--- a/cli/src/__tests__/shared/effective-harnesses.test.ts
+++ b/cli/src/__tests__/shared/effective-harnesses.test.ts
@@ -2,7 +2,7 @@
  * Tests for getEffectiveHarnesses() -- harness selection filter for update/migrate.
  *
  * Regression targets:
- * - Absent [harnesses] enabled returns all detected stable (backward compat, REQ-006)
+ * - Absent [harnesses] enabled returns all detected stable (backward compat)
  * - Persisted selection filters to intersection of detected + selected
  * - Empty intersection returns empty array (no silent fallback)
  */
@@ -67,7 +67,7 @@ describe("getEffectiveHarnesses", () => {
 		return mod.getEffectiveHarnesses;
 	};
 
-	test("returns all detected stable when no selection persisted (REQ-006 backward compat)", async () => {
+	test("returns all detected stable when no selection persisted (backward compat)", async () => {
 		const getEffectiveHarnesses = await loadGetEffectiveHarnesses();
 
 		const detection: ToolDetectionResult = {

--- a/cli/src/__tests__/shared/harness-selection-sync.test.ts
+++ b/cli/src/__tests__/shared/harness-selection-sync.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Tests for harness selection sync (install/uninstall <-> settings.toml).
+ *
+ * Regression targets:
+ * - syncHarnessSelectionAdd adds new harness to existing enabled list
+ * - syncHarnessSelectionAdd creates [harnesses] section when absent
+ * - syncHarnessSelectionAdd is idempotent (no duplicate on re-add)
+ * - syncHarnessSelectionRemove removes harness from enabled list
+ * - syncHarnessSelectionRemove is no-op when section absent
+ * - syncHarnessSelectionRemove is no-op when harness not in list
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { resetSettingsCache } from "../../settings/loader.js";
+import {
+	syncHarnessSelectionAdd,
+	syncHarnessSelectionRemove,
+} from "../../shared/install-core.js";
+
+describe("syncHarnessSelectionAdd", () => {
+	let tempDir: string;
+	let settingsPath: string;
+
+	beforeEach(() => {
+		tempDir = join(tmpdir(), `rp1-harness-sync-test-${Date.now()}`);
+		mkdirSync(tempDir, { recursive: true });
+		settingsPath = join(tempDir, "settings.toml");
+		resetSettingsCache();
+	});
+
+	afterEach(() => {
+		rmSync(tempDir, { recursive: true, force: true });
+		resetSettingsCache();
+	});
+
+	test("creates [harnesses] section with the tool when no section exists", () => {
+		writeFileSync(settingsPath, '[models]\npreset = "standard"\n');
+
+		syncHarnessSelectionAdd("codex", settingsPath);
+
+		const content = readFileSync(settingsPath, "utf-8");
+		expect(content).toContain("[harnesses]");
+		expect(content).toContain('enabled = ["codex"]');
+		// Original content preserved
+		expect(content).toContain('[models]\npreset = "standard"');
+	});
+
+	test("creates settings file with [harnesses] section when file does not exist", () => {
+		const nonExistentPath = join(tempDir, "sub", "settings.toml");
+
+		syncHarnessSelectionAdd("claude-code", nonExistentPath);
+
+		const content = readFileSync(nonExistentPath, "utf-8");
+		expect(content).toContain("[harnesses]");
+		expect(content).toContain('enabled = ["claude-code"]');
+	});
+
+	test("adds harness to existing enabled list", () => {
+		writeFileSync(settingsPath, '[harnesses]\nenabled = ["claude-code"]\n');
+
+		syncHarnessSelectionAdd("codex", settingsPath);
+
+		const content = readFileSync(settingsPath, "utf-8");
+		expect(content).toContain('enabled = ["claude-code", "codex"]');
+	});
+
+	test("is idempotent -- does not duplicate existing harness", () => {
+		writeFileSync(
+			settingsPath,
+			'[harnesses]\nenabled = ["claude-code", "codex"]\n',
+		);
+
+		syncHarnessSelectionAdd("codex", settingsPath);
+
+		const content = readFileSync(settingsPath, "utf-8");
+		expect(content).toContain('enabled = ["claude-code", "codex"]');
+	});
+
+	test("adds to empty enabled array", () => {
+		writeFileSync(settingsPath, "[harnesses]\nenabled = []\n");
+
+		syncHarnessSelectionAdd("opencode", settingsPath);
+
+		const content = readFileSync(settingsPath, "utf-8");
+		expect(content).toContain('enabled = ["opencode"]');
+	});
+});
+
+describe("syncHarnessSelectionRemove", () => {
+	let tempDir: string;
+	let settingsPath: string;
+
+	beforeEach(() => {
+		tempDir = join(tmpdir(), `rp1-harness-sync-test-${Date.now()}`);
+		mkdirSync(tempDir, { recursive: true });
+		settingsPath = join(tempDir, "settings.toml");
+		resetSettingsCache();
+	});
+
+	afterEach(() => {
+		rmSync(tempDir, { recursive: true, force: true });
+		resetSettingsCache();
+	});
+
+	test("removes harness from enabled list", () => {
+		writeFileSync(
+			settingsPath,
+			'[harnesses]\nenabled = ["claude-code", "codex", "opencode"]\n',
+		);
+
+		syncHarnessSelectionRemove("codex", settingsPath);
+
+		const content = readFileSync(settingsPath, "utf-8");
+		expect(content).toContain('enabled = ["claude-code", "opencode"]');
+	});
+
+	test("is no-op when no [harnesses] section exists", () => {
+		writeFileSync(settingsPath, '[models]\npreset = "standard"\n');
+		const originalContent = readFileSync(settingsPath, "utf-8");
+
+		syncHarnessSelectionRemove("codex", settingsPath);
+
+		const content = readFileSync(settingsPath, "utf-8");
+		expect(content).toBe(originalContent);
+	});
+
+	test("is no-op when harness not in enabled list", () => {
+		writeFileSync(
+			settingsPath,
+			'[harnesses]\nenabled = ["claude-code", "opencode"]\n',
+		);
+
+		syncHarnessSelectionRemove("codex", settingsPath);
+
+		const content = readFileSync(settingsPath, "utf-8");
+		expect(content).toContain('enabled = ["claude-code", "opencode"]');
+	});
+
+	test("produces empty array when last harness removed", () => {
+		writeFileSync(settingsPath, '[harnesses]\nenabled = ["codex"]\n');
+
+		syncHarnessSelectionRemove("codex", settingsPath);
+
+		const content = readFileSync(settingsPath, "utf-8");
+		expect(content).toContain("enabled = []");
+	});
+
+	test("is no-op when settings file does not exist", () => {
+		const nonExistentPath = join(tempDir, "nonexistent", "settings.toml");
+
+		// Should not throw
+		syncHarnessSelectionRemove("codex", nonExistentPath);
+	});
+});

--- a/cli/src/commands/install/all.ts
+++ b/cli/src/commands/install/all.ts
@@ -8,8 +8,12 @@ import * as E from "fp-ts/lib/Either.js";
 import { formatError, getExitCode } from "../../../shared/errors.js";
 import type { Logger } from "../../../shared/logger.js";
 import { createSpinner } from "../../../shared/spinner.js";
-import { loadToolsRegistry } from "../../config/supported-tools.js";
+import {
+	getToolSupportLevel,
+	loadToolsRegistry,
+} from "../../config/supported-tools.js";
 import { colorFns } from "../../lib/colors.js";
+import { writeHarnessSelection } from "../../settings/harness-writer.js";
 import {
 	type InstallContext,
 	installAllDetectedTools,
@@ -69,6 +73,13 @@ Examples:
 		}
 
 		const installResult = result.right;
+
+		if (!ctx.dryRun) {
+			const stableIds = installResult.detected
+				.filter((d) => getToolSupportLevel(d.tool) === "stable")
+				.map((d) => d.tool.id);
+			writeHarnessSelection(stableIds);
+		}
 
 		// Display results
 		console.log("");

--- a/cli/src/commands/uninstall-antigravity.ts
+++ b/cli/src/commands/uninstall-antigravity.ts
@@ -8,6 +8,7 @@ import {
 	uninstallAntigravityPackageAssets,
 } from "../install/antigravity/index.js";
 import { colorFns } from "../lib/colors.js";
+import { syncHarnessSelectionRemove } from "../shared/install-core.js";
 
 const { bold, cyan, dim, green, yellow } = colorFns;
 
@@ -121,6 +122,10 @@ Examples:
 		if (E.isLeft(result)) {
 			console.error(formatError(result.left, process.stderr.isTTY ?? false));
 			process.exit(getExitCode(result.left));
+		}
+
+		if (!dryRun) {
+			syncHarnessSelectionRemove("antigravity");
 		}
 
 		printAntigravityUninstallResult(result.right, logger);

--- a/cli/src/commands/uninstall-codex.ts
+++ b/cli/src/commands/uninstall-codex.ts
@@ -10,6 +10,7 @@ import type { Logger } from "../../shared/logger.js";
 import { confirmAction } from "../../shared/prompts.js";
 import { getCodexPaths, uninstallCodex } from "../install/codex/index.js";
 import { colorFns } from "../lib/colors.js";
+import { syncHarnessSelectionRemove } from "../shared/install-core.js";
 
 const { bold, dim } = colorFns;
 
@@ -73,6 +74,10 @@ Examples:
 		}
 
 		const { skillsRemoved, agentsRemoved, configCleaned } = result.right;
+
+		if (!dryRun) {
+			syncHarnessSelectionRemove("codex");
+		}
 
 		if (dryRun) {
 			console.log("");

--- a/cli/src/commands/uninstall-copilot.ts
+++ b/cli/src/commands/uninstall-copilot.ts
@@ -10,6 +10,7 @@ import type { Logger } from "../../shared/logger.js";
 import { confirmAction } from "../../shared/prompts.js";
 import { getCopilotPaths, uninstallCopilot } from "../install/copilot/index.js";
 import { colorFns } from "../lib/colors.js";
+import { syncHarnessSelectionRemove } from "../shared/install-core.js";
 
 const { bold, dim } = colorFns;
 
@@ -80,6 +81,10 @@ Examples:
 			agentsRemoved,
 			legacyConfigRemoved,
 		} = result.right;
+
+		if (!dryRun) {
+			syncHarnessSelectionRemove("copilot");
+		}
 
 		if (dryRun) {
 			console.log("");

--- a/cli/src/commands/update/__tests__/soft-refresh.test.ts
+++ b/cli/src/commands/update/__tests__/soft-refresh.test.ts
@@ -54,6 +54,7 @@ describe("standard update plugin refresh", () => {
 				}),
 		}));
 		mock.module("../../../shared/install-core.js", () => ({
+			getEffectiveHarnesses: () => [detectedCopilot],
 			installAllDetectedTools: () =>
 				TE.right({
 					installed: 0,
@@ -75,6 +76,21 @@ describe("standard update plugin refresh", () => {
 							},
 						},
 					],
+				}),
+			updateForSpecificTool: () =>
+				TE.right({
+					toolId: "copilot",
+					toolName: "GitHub Copilot CLI",
+					success: false,
+					pluginsInstalled: [],
+					warnings: [],
+					error: {
+						_tag: "PrerequisiteError",
+						check: "copilot-plugin-support",
+						message: "GitHub Copilot plugin lifecycle commands are unavailable",
+						suggestion:
+							"Install or update GitHub Copilot CLI, then verify with `copilot version` and `copilot plugin --help`.",
+					},
 				}),
 			installForSpecificTool: () =>
 				TE.left({

--- a/cli/src/commands/update/index.ts
+++ b/cli/src/commands/update/index.ts
@@ -37,8 +37,11 @@ import {
 import { executeMigrate, formatMigrateSummary } from "../../migrate/index.js";
 import { applyTierRemappingsIfConfigured } from "../../settings/apply.js";
 import {
+	getEffectiveHarnesses,
+	type InstallAllResult,
 	type InstallContext,
-	installAllDetectedTools,
+	type ToolInstallResult,
+	updateForSpecificTool,
 } from "../../shared/install-core.js";
 import { formatUpdateAllResult, pluginsSubcommand } from "./plugins.js";
 import {
@@ -453,6 +456,22 @@ export const updateDetectedPlugins = async (
 		return { success: true, exitCode: 0 };
 	}
 
+	if (E.isLeft(detection)) {
+		console.log(dim("Tool detection failed. Skipping plugin refresh."));
+		return { success: true, exitCode: 0 };
+	}
+
+	const effective = getEffectiveHarnesses(detection.right);
+
+	if (effective.length === 0) {
+		console.log(
+			dim(
+				"No enabled harnesses among detected tools. Skipping plugin refresh.",
+			),
+		);
+		return { success: true, exitCode: 0 };
+	}
+
 	const ctx: InstallContext = {
 		logger,
 		isTTY,
@@ -460,24 +479,36 @@ export const updateDetectedPlugins = async (
 		skipPrompt: options.yes || !isTTY,
 	};
 
-	const result = await installAllDetectedTools(registry, ctx)();
-	if (E.isLeft(result)) {
-		console.error(formatError(result.left, isTTY));
-		console.log("");
-		console.log(
-			yellow(
-				bold("Plugin refresh failed, but the core rp1 update will continue."),
-			),
-		);
-		console.log(
-			dim("Repair the host tool, then run `rp1 update plugins` to retry."),
-		);
-		return { success: true, exitCode: 0 };
+	const results: ToolInstallResult[] = [];
+	for (const tool of effective) {
+		const toolResult = await updateForSpecificTool(
+			tool.tool.id,
+			registry,
+			ctx,
+		)();
+		if (E.isRight(toolResult)) {
+			results.push(toolResult.right);
+		} else {
+			results.push({
+				toolId: tool.tool.id,
+				toolName: tool.tool.name,
+				success: false,
+				pluginsInstalled: [],
+				warnings: [],
+				error: toolResult.left,
+			});
+		}
 	}
 
-	formatUpdateAllResult(result.right, isTTY);
+	const installAllResult: InstallAllResult = {
+		installed: results.filter((r) => r.success).length,
+		results,
+		detected: effective,
+	};
 
-	const failedResults = result.right.results.filter((tool) => !tool.success);
+	formatUpdateAllResult(installAllResult, isTTY);
+
+	const failedResults = results.filter((tool) => !tool.success);
 	if (failedResults.length > 0) {
 		console.log("");
 		console.log(

--- a/cli/src/commands/update/plugins.ts
+++ b/cli/src/commands/update/plugins.ts
@@ -8,8 +8,10 @@ import * as E from "fp-ts/lib/Either.js";
 import { formatError, getExitCode } from "../../../shared/errors.js";
 import type { Logger } from "../../../shared/logger.js";
 import { loadToolsRegistry } from "../../config/supported-tools.js";
+import { detectTools } from "../../init/tool-detector.js";
 import { getColorFns } from "../../lib/colors.js";
 import {
+	getEffectiveHarnesses,
 	type InstallAllResult,
 	type InstallContext,
 	installAllDetectedTools,
@@ -242,17 +244,55 @@ Examples:
 			let restartTargets: string[] = [];
 
 			if (targetTool === "all") {
-				// Update all detected tools
+				// Detect tools and filter to effective harnesses
 				console.log("Detecting installed tools...");
-				const result = await deps.installAllDetectedTools(registry, ctx)();
+				const detection = await detectTools(registry)();
 
-				if (E.isLeft(result)) {
-					console.error(formatError(result.left, isTTY));
-					process.exit(getExitCode(result.left));
+				if (E.isLeft(detection) || detection.right.detected.length === 0) {
+					console.log(
+						"No installed agentic tools detected. Nothing to update.",
+					);
+					process.exit(0);
 				}
 
-				formatUpdateAllResult(result.right, isTTY);
-				restartTargets = result.right.results
+				const effective = getEffectiveHarnesses(detection.right);
+
+				if (effective.length === 0) {
+					console.log(
+						"No enabled harnesses among detected tools. Nothing to update.",
+					);
+					process.exit(0);
+				}
+
+				const results: ToolInstallResult[] = [];
+				for (const tool of effective) {
+					const toolResult = await deps.updateForSpecificTool(
+						tool.tool.id,
+						registry,
+						ctx,
+					)();
+					if (E.isRight(toolResult)) {
+						results.push(toolResult.right);
+					} else {
+						results.push({
+							toolId: tool.tool.id,
+							toolName: tool.tool.name,
+							success: false,
+							pluginsInstalled: [],
+							warnings: [],
+							error: toolResult.left,
+						});
+					}
+				}
+
+				const allResult: InstallAllResult = {
+					installed: results.filter((r) => r.success).length,
+					results,
+					detected: effective,
+				};
+
+				formatUpdateAllResult(allResult, isTTY);
+				restartTargets = results
 					.filter(
 						(toolResult) =>
 							toolResult.success && toolResult.restartRequired !== false,
@@ -261,7 +301,7 @@ Examples:
 
 				// Exit with error if any failed
 				if (
-					result.right.results.some(
+					results.some(
 						(toolResult) => !toolResult.success && !toolResult.skipped,
 					)
 				) {

--- a/cli/src/commands/update/plugins.ts
+++ b/cli/src/commands/update/plugins.ts
@@ -23,12 +23,16 @@ interface PluginsSubcommandDeps {
 	readonly loadToolsRegistry: typeof loadToolsRegistry;
 	readonly installAllDetectedTools: typeof installAllDetectedTools;
 	readonly updateForSpecificTool: typeof updateForSpecificTool;
+	readonly detectTools: typeof detectTools;
+	readonly getEffectiveHarnesses: typeof getEffectiveHarnesses;
 }
 
 const defaultPluginsSubcommandDeps: PluginsSubcommandDeps = {
 	loadToolsRegistry,
 	installAllDetectedTools,
 	updateForSpecificTool,
+	detectTools,
+	getEffectiveHarnesses,
 };
 
 /**
@@ -246,7 +250,7 @@ Examples:
 			if (targetTool === "all") {
 				// Detect tools and filter to effective harnesses
 				console.log("Detecting installed tools...");
-				const detection = await detectTools(registry)();
+				const detection = await deps.detectTools(registry)();
 
 				if (E.isLeft(detection) || detection.right.detected.length === 0) {
 					console.log(
@@ -255,7 +259,7 @@ Examples:
 					process.exit(0);
 				}
 
-				const effective = getEffectiveHarnesses(detection.right);
+				const effective = deps.getEffectiveHarnesses(detection.right);
 
 				if (effective.length === 0) {
 					console.log(

--- a/cli/src/init/models.ts
+++ b/cli/src/init/models.ts
@@ -244,6 +244,7 @@ export type StepId =
 	| "directory-setup"
 	| "settings-setup"
 	| "tool-detection"
+	| "harness-selection"
 	| "instruction-injection"
 	| "gitignore-config"
 	| "install-check"
@@ -271,6 +272,8 @@ export interface UserChoices {
 	readonly reinitChoice?: ReinitChoice;
 	/** Selected gitignore preset */
 	readonly gitignorePreset?: GitignorePreset;
+	/** Selected harnesses from the harness-selection wizard step */
+	readonly enabledHarnesses?: readonly string[];
 }
 
 /**

--- a/cli/src/init/steps/harness-selection.ts
+++ b/cli/src/init/steps/harness-selection.ts
@@ -1,0 +1,72 @@
+/**
+ * Business logic for the harness-selection wizard step.
+ *
+ * Builds the multi-select items from detected tools, resolves default
+ * selections (from persisted settings or stable-harness defaults), and
+ * delegates persistence to the harness-writer.
+ */
+
+import { getToolSupportLevel } from "../../config/supported-tools.js";
+import { loadEnabledHarnesses } from "../../settings/loader.js";
+import type { DetectedTool } from "../tool-detector.js";
+import type { MultiSelectItem } from "../ui/components/MultiSelectPrompt.js";
+
+/**
+ * Extended multi-select item carrying stability metadata.
+ */
+export interface HarnessItem extends MultiSelectItem {
+	readonly isStable: boolean;
+}
+
+/**
+ * Build the multi-select items list from detected tools.
+ * Each item maps to one detected harness; stable harnesses are flagged.
+ */
+export function buildHarnessItems(
+	detected: readonly DetectedTool[],
+): readonly HarnessItem[] {
+	return detected
+		.filter((d) => d.tool.enabled !== false)
+		.map((d) => {
+			const supportLevel = getToolSupportLevel(d.tool);
+			const isStable = supportLevel === "stable";
+			const parts: string[] = [];
+			if (d.version !== "unknown") parts.push(`v${d.version}`);
+			if (!isStable) parts.push(`(${supportLevel})`);
+			const description = parts.join(" ") || undefined;
+
+			return {
+				value: d.tool.id,
+				label: d.tool.name,
+				description,
+				isStable,
+			};
+		});
+}
+
+/**
+ * Resolve which harnesses should be pre-checked in the multi-select.
+ *
+ * On re-init: returns previously persisted selection, filtered to currently
+ * detected harnesses. On fresh init: returns all stable-level harnesses.
+ */
+export function resolveDefaultSelection(
+	items: readonly HarnessItem[],
+	globalSettingsPath?: string,
+): string[] {
+	const persisted = loadEnabledHarnesses(globalSettingsPath);
+	if (persisted !== undefined) {
+		const detectedIds = new Set(items.map((i) => i.value));
+		return persisted.filter((h) => detectedIds.has(h));
+	}
+	return getStableDefaults(items);
+}
+
+/**
+ * Return all stable harness IDs from the items list.
+ */
+export function getStableDefaults(items: readonly HarnessItem[]): string[] {
+	return items.filter((i) => i.isStable).map((i) => i.value);
+}
+
+export { writeHarnessSelection } from "../../settings/harness-writer.js";

--- a/cli/src/init/ui/InitWizard.tsx
+++ b/cli/src/init/ui/InitWizard.tsx
@@ -16,7 +16,12 @@ import type {
 	StepId,
 	UserChoices,
 } from "../models.js";
+import {
+	buildHarnessItems,
+	resolveDefaultSelection,
+} from "../steps/harness-selection.js";
 import { FinalSummary } from "./components/FinalSummary.js";
+import { MultiSelectPrompt } from "./components/MultiSelectPrompt.js";
 import {
 	ancestorProjectOptions,
 	gitignorePresetOptions,
@@ -52,6 +57,7 @@ type PromptType =
 	| "reinit"
 	| "gitignore"
 	| "ancestor-project"
+	| "harness-selection"
 	| null;
 
 /**
@@ -70,6 +76,7 @@ const PROMPTABLE_STEPS: Record<StepId, PromptType> = {
 	"directory-setup": null,
 	"settings-setup": null, // Settings files are created automatically, no prompt needed
 	"tool-detection": null,
+	"harness-selection": null, // Handled by step execution via onPromptRequest
 	"instruction-injection": null,
 	"gitignore-config": "gitignore", // Conditionally shown - see needsPrompt
 	"install-check": null,
@@ -114,7 +121,12 @@ export const InitWizard: React.FC<InitWizardProps> = ({
 
 	const handlePromptRequest = useCallback(
 		(request: {
-			type: "git-root" | "reinit" | "gitignore" | "ancestor-project";
+			type:
+				| "git-root"
+				| "reinit"
+				| "gitignore"
+				| "ancestor-project"
+				| "harness-selection";
 			cwd?: string;
 			ancestorRoot?: string;
 		}) => {
@@ -169,6 +181,22 @@ export const InitWizard: React.FC<InitWizardProps> = ({
 			}
 		},
 		[options.yes, state.userChoices],
+	);
+
+	/**
+	 * Handle multi-select submission from harness selection.
+	 */
+	const handleHarnessChoice = useCallback(
+		(selected: string[]) => {
+			dispatch({
+				type: "SET_USER_CHOICE",
+				key: "enabledHarnesses",
+				value: selected,
+			});
+			setActivePrompt(null);
+			dispatch({ type: "SET_PHASE", phase: "running" });
+		},
+		[dispatch],
 	);
 
 	/**
@@ -478,6 +506,18 @@ export const InitWizard: React.FC<InitWizardProps> = ({
 						}
 					/>
 				);
+			case "harness-selection": {
+				const items = buildHarnessItems(state.detectedTools);
+				const defaults = resolveDefaultSelection(items);
+				return (
+					<MultiSelectPrompt
+						message="Which harnesses should receive rp1 support?"
+						items={items}
+						defaultSelected={defaults}
+						onSubmit={handleHarnessChoice}
+					/>
+				);
+			}
 			default:
 				return null;
 		}

--- a/cli/src/init/ui/InitWizard.tsx
+++ b/cli/src/init/ui/InitWizard.tsx
@@ -7,7 +7,7 @@
 
 import { Box, Text, useApp } from "ink";
 import type React from "react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { CLIError } from "../../../shared/errors.js";
 import type { ToolsRegistry } from "../../config/supported-tools.js";
 import type {
@@ -233,6 +233,16 @@ export const InitWizard: React.FC<InitWizardProps> = ({
 			dispatch({ type: "SET_PHASE", phase: "running" });
 		},
 		[activePrompt, dispatch],
+	);
+
+	const harnessItems = useMemo(
+		() => buildHarnessItems(state.detectedTools),
+		[state.detectedTools],
+	);
+
+	const harnessDefaults = useMemo(
+		() => resolveDefaultSelection(harnessItems),
+		[harnessItems],
 	);
 
 	/**
@@ -506,18 +516,15 @@ export const InitWizard: React.FC<InitWizardProps> = ({
 						}
 					/>
 				);
-			case "harness-selection": {
-				const items = buildHarnessItems(state.detectedTools);
-				const defaults = resolveDefaultSelection(items);
+			case "harness-selection":
 				return (
 					<MultiSelectPrompt
 						message="Which harnesses should receive rp1 support?"
-						items={items}
-						defaultSelected={defaults}
+						items={harnessItems}
+						defaultSelected={harnessDefaults}
 						onSubmit={handleHarnessChoice}
 					/>
 				);
-			}
 			default:
 				return null;
 		}

--- a/cli/src/init/ui/components/MultiSelectPrompt.tsx
+++ b/cli/src/init/ui/components/MultiSelectPrompt.tsx
@@ -1,7 +1,7 @@
 import figures from "figures";
 import { Box, Text, useInput } from "ink";
 import type React from "react";
-import { useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import { colors, spacing } from "../styles/theme.js";
 
 /**
@@ -33,6 +33,10 @@ interface MultiSelectPromptProps<T extends string = string> {
 /**
  * Renders an interactive multi-select prompt with checkbox-style toggling.
  * Supports arrow keys for navigation, space to toggle, and enter to confirm.
+ *
+ * The input handler uses a ref-stable callback pattern to prevent Ink's
+ * useInput useEffect from tearing down and re-registering the stdin event
+ * listener on every re-render, which causes an event loop freeze under Bun.
  */
 export function MultiSelectPrompt<T extends string = string>({
 	message,
@@ -45,32 +49,54 @@ export function MultiSelectPrompt<T extends string = string>({
 		() => new Set(defaultSelected),
 	);
 
-	useInput((input, key) => {
-		if (key.upArrow) {
-			setFocusIndex((prev) => (prev > 0 ? prev - 1 : items.length - 1));
-		} else if (key.downArrow) {
-			setFocusIndex((prev) => (prev < items.length - 1 ? prev + 1 : 0));
-		} else if (input === " ") {
-			const item = items[focusIndex];
-			if (item) {
-				setSelected((prev) => {
-					const next = new Set(prev);
-					if (next.has(item.value)) {
-						next.delete(item.value);
-					} else {
-						next.add(item.value);
-					}
-					return next;
-				});
+	const itemsRef = useRef(items);
+	itemsRef.current = items;
+	const selectedRef = useRef(selected);
+	selectedRef.current = selected;
+	const focusIndexRef = useRef(focusIndex);
+	focusIndexRef.current = focusIndex;
+	const onSubmitRef = useRef(onSubmit);
+	onSubmitRef.current = onSubmit;
+
+	const handleInput = useCallback(
+		(
+			input: string,
+			key: { upArrow: boolean; downArrow: boolean; return: boolean },
+		) => {
+			if (key.upArrow) {
+				setFocusIndex((prev) =>
+					prev > 0 ? prev - 1 : itemsRef.current.length - 1,
+				);
+			} else if (key.downArrow) {
+				setFocusIndex((prev) =>
+					prev < itemsRef.current.length - 1 ? prev + 1 : 0,
+				);
+			} else if (input === " ") {
+				const item = itemsRef.current[focusIndexRef.current];
+				if (item) {
+					setSelected((prev) => {
+						const next = new Set(prev);
+						if (next.has(item.value)) {
+							next.delete(item.value);
+						} else {
+							next.add(item.value);
+						}
+						return next;
+					});
+				}
+			} else if (key.return) {
+				const currentSelected = selectedRef.current;
+				onSubmitRef.current(
+					itemsRef.current
+						.filter((item) => currentSelected.has(item.value))
+						.map((item) => item.value),
+				);
 			}
-		} else if (key.return) {
-			onSubmit(
-				items
-					.filter((item) => selected.has(item.value))
-					.map((item) => item.value),
-			);
-		}
-	});
+		},
+		[],
+	);
+
+	useInput(handleInput);
 
 	return (
 		<Box flexDirection="column" marginTop={spacing.small}>

--- a/cli/src/init/ui/components/MultiSelectPrompt.tsx
+++ b/cli/src/init/ui/components/MultiSelectPrompt.tsx
@@ -1,0 +1,118 @@
+import figures from "figures";
+import { Box, Text, useInput } from "ink";
+import type React from "react";
+import { useState } from "react";
+import { colors, spacing } from "../styles/theme.js";
+
+/**
+ * A single item in the multi-select list.
+ */
+export interface MultiSelectItem<T extends string = string> {
+	/** The value returned when this item is selected */
+	readonly value: T;
+	/** Display label for the item */
+	readonly label: string;
+	/** Optional description shown below the label when focused */
+	readonly description?: string;
+}
+
+/**
+ * Props for the MultiSelectPrompt component.
+ */
+interface MultiSelectPromptProps<T extends string = string> {
+	/** The prompt message to display */
+	readonly message: string;
+	/** Available items to choose from */
+	readonly items: readonly MultiSelectItem<T>[];
+	/** Values that should be checked by default */
+	readonly defaultSelected?: readonly T[];
+	/** Callback when the user submits their selection */
+	readonly onSubmit: (selected: T[]) => void;
+}
+
+/**
+ * Renders an interactive multi-select prompt with checkbox-style toggling.
+ * Supports arrow keys for navigation, space to toggle, and enter to confirm.
+ */
+export function MultiSelectPrompt<T extends string = string>({
+	message,
+	items,
+	defaultSelected = [],
+	onSubmit,
+}: MultiSelectPromptProps<T>): React.ReactElement {
+	const [focusIndex, setFocusIndex] = useState(0);
+	const [selected, setSelected] = useState<ReadonlySet<T>>(
+		() => new Set(defaultSelected),
+	);
+
+	useInput((input, key) => {
+		if (key.upArrow) {
+			setFocusIndex((prev) => (prev > 0 ? prev - 1 : items.length - 1));
+		} else if (key.downArrow) {
+			setFocusIndex((prev) => (prev < items.length - 1 ? prev + 1 : 0));
+		} else if (input === " ") {
+			const item = items[focusIndex];
+			if (item) {
+				setSelected((prev) => {
+					const next = new Set(prev);
+					if (next.has(item.value)) {
+						next.delete(item.value);
+					} else {
+						next.add(item.value);
+					}
+					return next;
+				});
+			}
+		} else if (key.return) {
+			onSubmit(
+				items
+					.filter((item) => selected.has(item.value))
+					.map((item) => item.value),
+			);
+		}
+	});
+
+	return (
+		<Box flexDirection="column" marginTop={spacing.small}>
+			<Box marginBottom={spacing.small}>
+				<Text color={colors.info}>{figures.questionMarkPrefix} </Text>
+				<Text bold>{message}</Text>
+			</Box>
+			<Box flexDirection="column" marginLeft={spacing.medium}>
+				{items.map((item, index) => {
+					const isFocused = index === focusIndex;
+					const isChecked = selected.has(item.value);
+					const pointer = isFocused ? figures.pointer : " ";
+					const checkbox = isChecked ? figures.checkboxOn : figures.checkboxOff;
+
+					return (
+						<Box key={item.value} flexDirection="column">
+							<Box>
+								<Text color={isFocused ? colors.accent : colors.dim}>
+									{pointer} {checkbox}{" "}
+								</Text>
+								<Text
+									bold={isFocused}
+									color={isFocused ? undefined : colors.dim}
+								>
+									{item.label}
+								</Text>
+							</Box>
+							{item.description && isFocused && (
+								<Box marginLeft={4}>
+									<Text color={colors.dim}>{item.description}</Text>
+								</Box>
+							)}
+						</Box>
+					);
+				})}
+			</Box>
+			<Box marginTop={spacing.small} marginLeft={spacing.medium}>
+				<Text color={colors.dim}>
+					Use {figures.arrowUp}/{figures.arrowDown} to navigate, Space to
+					toggle, Enter to confirm
+				</Text>
+			</Box>
+		</Box>
+	);
+}

--- a/cli/src/init/ui/hooks/useStepExecution.ts
+++ b/cli/src/init/ui/hooks/useStepExecution.ts
@@ -62,6 +62,11 @@ import {
 	validateShellFencing,
 	wrapWithShellFence,
 } from "../../shell-fence.js";
+import {
+	buildHarnessItems,
+	getStableDefaults,
+	writeHarnessSelection,
+} from "../../steps/harness-selection.js";
 import { performHealthCheck } from "../../steps/health-check.js";
 import { checkPluginsInstalled } from "../../steps/plugin-installation.js";
 import {
@@ -153,6 +158,7 @@ interface ExecutionContext {
 		ancestorProjectChoice?: "use-existing" | "create-nested";
 		reinitChoice?: ReinitChoice;
 		gitignorePreset?: GitignorePreset;
+		enabledHarnesses?: readonly string[];
 	};
 }
 
@@ -161,7 +167,12 @@ interface ExecutionContext {
  * When a step needs user input, it sets this in the context.
  */
 export interface PromptRequest {
-	readonly type: "git-root" | "reinit" | "gitignore" | "ancestor-project";
+	readonly type:
+		| "git-root"
+		| "reinit"
+		| "gitignore"
+		| "ancestor-project"
+		| "harness-selection";
 	readonly resolve: (value: string) => void;
 	/** Current working directory (for git-root and ancestor-project prompts) */
 	readonly cwd?: string;
@@ -652,6 +663,84 @@ export const useStepExecution = ({
 	);
 
 	/**
+	 * Execute the harness-selection step.
+	 * In interactive mode, requests a multi-select prompt. In non-interactive
+	 * mode (--yes), auto-selects all stable harnesses.
+	 */
+	const executeHarnessSelection = useCallback(
+		async (addAct: AddActivityFn): Promise<void> => {
+			const ctx = contextRef.current;
+
+			if (
+				!ctx.toolDetectionResult ||
+				ctx.toolDetectionResult.detected.length === 0
+			) {
+				addAct("harness-selection", "Skipped (no tools detected)", "info");
+				dispatch({
+					type: "SKIP_STEP",
+					stepId: "harness-selection",
+					reason: "No AI tools detected",
+				});
+				return;
+			}
+
+			const items = buildHarnessItems(ctx.toolDetectionResult.detected);
+
+			if (items.length === 0) {
+				addAct("harness-selection", "Skipped (no enabled tools)", "info");
+				dispatch({
+					type: "SKIP_STEP",
+					stepId: "harness-selection",
+					reason: "No enabled tools",
+				});
+				return;
+			}
+
+			if (options.yes) {
+				// Non-interactive: select all stable harnesses
+				const stableIds = getStableDefaults(items);
+				addAct(
+					"harness-selection",
+					`Auto-selected ${stableIds.length} stable harness${stableIds.length === 1 ? "" : "es"}`,
+					"success",
+				);
+				writeHarnessSelection(stableIds);
+				dispatch({
+					type: "SET_USER_CHOICE",
+					key: "enabledHarnesses",
+					value: stableIds,
+				});
+				return;
+			}
+
+			// Interactive mode: check if choice already made (re-execution after prompt)
+			const choice = state.userChoices.enabledHarnesses;
+			if (choice !== undefined) {
+				addAct(
+					"harness-selection",
+					`Selected ${choice.length} harness${choice.length === 1 ? "" : "es"}`,
+					"success",
+				);
+				writeHarnessSelection([...choice]);
+				return;
+			}
+
+			// Request multi-select prompt
+			promptRequestedRef.current = true;
+			onPromptRequest?.({
+				type: "harness-selection",
+				resolve: () => {},
+			});
+		},
+		[
+			dispatch,
+			options.yes,
+			state.userChoices.enabledHarnesses,
+			onPromptRequest,
+		],
+	);
+
+	/**
 	 * Inject into a single instruction file, optionally overriding the template.
 	 */
 	const injectIntoSingleFile = useCallback(
@@ -1127,6 +1216,9 @@ export const useStepExecution = ({
 					case "tool-detection":
 						await executeToolDetection(addAct);
 						break;
+					case "harness-selection":
+						await executeHarnessSelection(addAct);
+						break;
 					case "instruction-injection":
 						await executeInstructionInjection(addAct);
 						break;
@@ -1170,6 +1262,7 @@ export const useStepExecution = ({
 			executeDirectorySetup,
 			executeSettingsSetup,
 			executeToolDetection,
+			executeHarnessSelection,
 			executeInstructionInjection,
 			executeGitignoreConfig,
 			executeInstallCheck,

--- a/cli/src/init/ui/hooks/useWizardState.ts
+++ b/cli/src/init/ui/hooks/useWizardState.ts
@@ -128,6 +128,11 @@ export const WIZARD_STEPS: readonly Omit<
 		description: "Detecting AI tools",
 	},
 	{
+		id: "harness-selection",
+		name: "Harness Selection",
+		description: "Choosing harness platforms",
+	},
+	{
 		id: "install-check",
 		name: "Install Check",
 		description: "Checking plugin installation",

--- a/cli/src/settings/harness-writer.ts
+++ b/cli/src/settings/harness-writer.ts
@@ -1,0 +1,139 @@
+/**
+ * Comment-preserving writer for the [harnesses] section of settings.toml.
+ *
+ * Uses targeted line edits (find/replace/append) rather than full-file
+ * serialization, following the same pattern as arcade-writer.ts. smol-toml
+ * is parse-only, so the writer operates on raw text to preserve user
+ * comments and formatting.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+import { resolveGlobalSettingsPath } from "../../shared/settings.js";
+import { resetSettingsCache } from "./loader.js";
+
+/** Regex matching an [harnesses] table header (exact, not [harnesses.xxx]). */
+const HARNESSES_HEADER_RE = /^\[harnesses\]\s*$/;
+
+/** Regex matching any TOML table header [xxx]. */
+const ANY_TABLE_HEADER_RE = /^\[.+\]\s*$/;
+
+/** Regex matching an enabled = ... assignment. */
+const ENABLED_KEY_RE = /^enabled\s*=/;
+
+/**
+ * Serialize a harness list into the TOML `enabled` value.
+ * Produces `enabled = ["a", "b"]` or `enabled = []` for an empty array.
+ */
+function serializeEnabledLine(harnesses: readonly string[]): string {
+	if (harnesses.length === 0) {
+		return "enabled = []";
+	}
+	const quoted = harnesses.map((h) => `"${h}"`).join(", ");
+	return `enabled = [${quoted}]`;
+}
+
+/**
+ * Find the line range of a TOML table section.
+ * Returns the header line index and the index of the last content line
+ * before the next table header (or end of file).
+ */
+function findSectionRange(
+	lines: string[],
+	headerRe: RegExp,
+): { headerIndex: number; endIndex: number } | null {
+	const headerIndex = lines.findIndex((line) => headerRe.test(line));
+	if (headerIndex === -1) return null;
+
+	let endIndex = headerIndex;
+	for (let i = headerIndex + 1; i < lines.length; i++) {
+		if (ANY_TABLE_HEADER_RE.test(lines[i])) break;
+		endIndex = i;
+	}
+
+	return { headerIndex, endIndex };
+}
+
+/**
+ * Write harness selection into user-level settings.toml, preserving
+ * existing content and comments.
+ *
+ * Behavior:
+ * - If the file does not exist, creates it with the [harnesses] section.
+ * - If the file exists but has no [harnesses] section, appends it at the end.
+ * - If the file already has a [harnesses] section, replaces the `enabled` value
+ *   in place (unlike arcade-writer which never overwrites -- harness selection
+ *   is an active user choice that replaces the previous value).
+ *
+ * @param harnesses - Array of harness IDs to persist
+ * @param globalSettingsPath - Override path to user-level settings file (defaults to ~/.config/rp1/settings.toml). Exposed for test isolation.
+ */
+export function writeHarnessSelection(
+	harnesses: readonly string[],
+	globalSettingsPath?: string,
+): void {
+	const filePath = globalSettingsPath ?? resolveGlobalSettingsPath();
+	const enabledLine = serializeEnabledLine(harnesses);
+
+	// Invalidate cached settings so subsequent reads see the new value.
+	resetSettingsCache();
+
+	if (!existsSync(filePath)) {
+		const parentDir = dirname(filePath);
+		mkdirSync(parentDir, { recursive: true });
+
+		const sections = ["[harnesses]", enabledLine, ""];
+		writeFileSync(filePath, sections.join("\n"), "utf-8");
+		return;
+	}
+
+	const content = readFileSync(filePath, "utf-8");
+	const lines = content.split("\n");
+
+	const range = findSectionRange(lines, HARNESSES_HEADER_RE);
+
+	if (range === null) {
+		// No [harnesses] section -- append at end of file
+		const appendLines: string[] = [];
+
+		if (content.length > 0 && !content.endsWith("\n\n")) {
+			if (!content.endsWith("\n")) {
+				appendLines.push("");
+			}
+			appendLines.push("");
+		}
+
+		appendLines.push("[harnesses]");
+		appendLines.push(enabledLine);
+		appendLines.push("");
+
+		writeFileSync(filePath, content + appendLines.join("\n"), "utf-8");
+		return;
+	}
+
+	// [harnesses] section exists -- find and replace the enabled line,
+	// or insert it if somehow absent.
+	let replaced = false;
+	for (let i = range.headerIndex + 1; i <= range.endIndex; i++) {
+		if (ENABLED_KEY_RE.test(lines[i])) {
+			lines[i] = enabledLine;
+			replaced = true;
+			break;
+		}
+	}
+
+	if (!replaced) {
+		// Section exists but no enabled key -- insert after header
+		// (skip over any comment lines immediately after the header)
+		let insertAt = range.headerIndex + 1;
+		while (
+			insertAt <= range.endIndex &&
+			lines[insertAt].trim().startsWith("#")
+		) {
+			insertAt++;
+		}
+		lines.splice(insertAt, 0, enabledLine);
+	}
+
+	writeFileSync(filePath, lines.join("\n"), "utf-8");
+}

--- a/cli/src/settings/loader.ts
+++ b/cli/src/settings/loader.ts
@@ -10,7 +10,11 @@ import {
 } from "../../shared/storage-mode.js";
 import { VALID_MODEL_TIERS } from "../build/models.js";
 import type { BuildPlatform } from "../build/template-context.js";
-import type { PlatformTierMap, TierRemappingConfig } from "./models.js";
+import type {
+	ParsedHarnessesSection,
+	PlatformTierMap,
+	TierRemappingConfig,
+} from "./models.js";
 import {
 	type ArcadeSettings,
 	type ArcadeTheme,
@@ -46,6 +50,7 @@ type ParsedStorageSection = Readonly<{
 }>;
 
 type ParsedSettingsFile = Readonly<{
+	harnesses?: ParsedHarnessesSection;
 	arguments: SettingsArgumentDefaults;
 	storage: ParsedStorageSection;
 	models: ParsedModelsSection;
@@ -198,6 +203,31 @@ const parseStorageSection = (
 	return {};
 };
 
+/**
+ * Extract the harnesses section from parsed TOML.
+ * Returns a typed section when `[harnesses]` exists with a valid `enabled` array,
+ * or `undefined` when absent or malformed (graceful degradation).
+ */
+const parseHarnessesSection = (
+	parsed: Record<string, unknown>,
+): ParsedHarnessesSection | undefined => {
+	const harnessesSection = parsed.harnesses;
+	if (!isPlainRecord(harnessesSection)) {
+		return undefined;
+	}
+
+	const enabled = harnessesSection.enabled;
+	if (!Array.isArray(enabled)) {
+		return undefined;
+	}
+
+	const validEntries = enabled.filter(
+		(item): item is string => typeof item === "string",
+	);
+
+	return { enabled: validEntries };
+};
+
 const parseSettingsFileStrict = (filePath: string): ParsedSettingsFile => {
 	const cached = settingsCache.get(filePath);
 	if (cached) {
@@ -247,12 +277,14 @@ const parseSettingsFileStrict = (filePath: string): ParsedSettingsFile => {
 		const models = parseModelsSection(parsed);
 		const arcade = parseArcadeSection(parsed);
 		const storage = parseStorageSection(parsed);
+		const harnesses = parseHarnessesSection(parsed);
 
 		const result: ParsedSettingsFile = {
 			arguments: argumentDefaults,
 			storage,
 			models,
 			arcade,
+			harnesses,
 		};
 		settingsCache.set(filePath, result);
 		return result;
@@ -474,4 +506,25 @@ export const loadStorageMode = async (
 	globalSettingsPath?: string,
 ): Promise<StorageMode> => {
 	return readStorageMode(projectRoot, globalSettingsPath);
+};
+
+/**
+ * Load the persisted harness selection from user-level settings.toml only.
+ *
+ * Unlike other settings sections, `[harnesses]` is NOT merged with project-level
+ * settings -- harness availability is per-machine, not per-project.
+ *
+ * @param globalSettingsPath - Override path to user-level settings file (defaults to ~/.config/rp1/settings.toml). Exposed for test isolation.
+ * @returns Array of enabled harness IDs, or `undefined` when no `[harnesses]` section exists (callers should fall back to all-detected-stable)
+ */
+export const loadEnabledHarnesses = (
+	globalSettingsPath?: string,
+): string[] | undefined => {
+	const settings = parseSettingsFileStrict(
+		globalSettingsPath ?? resolveGlobalSettingsPath(),
+	);
+	if (!settings.harnesses) {
+		return undefined;
+	}
+	return [...settings.harnesses.enabled];
 };

--- a/cli/src/settings/models.ts
+++ b/cli/src/settings/models.ts
@@ -39,6 +39,14 @@ export const DEFAULT_ARCADE_SETTINGS: ArcadeSettings = {
 } as const;
 
 /**
+ * Harness selection parsed from the `[harnesses]` section of user-level settings.toml.
+ * User-level only -- harness availability is per-machine, not per-project.
+ */
+export interface ParsedHarnessesSection {
+	readonly enabled: readonly string[];
+}
+
+/**
  * Per-platform tier-to-model mapping from user settings.
  *
  * Each key is a concrete tier (excluding "inherit") and each value is

--- a/cli/src/shared/install-core.ts
+++ b/cli/src/shared/install-core.ts
@@ -57,6 +57,7 @@ import {
 import type { CopilotInstallResult } from "../install/copilot/models.js";
 import { writeVersionMarker } from "../install/version-marker.js";
 import { getInstalledVersion } from "../lib/version.js";
+import { loadEnabledHarnesses } from "../settings/loader.js";
 
 /**
  * Context for installation operations.
@@ -791,4 +792,34 @@ export const installForSpecificTool = (
 			return TE.right(result);
 		}),
 	);
+};
+
+/**
+ * Filter detected tools to only those the user has selected (persisted in settings.toml).
+ *
+ * When no `[harnesses] enabled` selection exists, falls back to all detected tools
+ * with stable support level -- preserving backward compatibility for pre-wizard users (REQ-006).
+ *
+ * When a selection exists, returns the intersection of detected tools and the
+ * enabled list (preserving detected-tools ordering). Explicitly selected experimental
+ * tools are included.
+ *
+ * @param detection - Result from detectTools()
+ * @param globalSettingsPath - Override for test isolation
+ * @returns Filtered array of DetectedTool entries
+ */
+export const getEffectiveHarnesses = (
+	detection: ToolDetectionResult,
+	globalSettingsPath?: string,
+): readonly DetectedTool[] => {
+	const enabled = loadEnabledHarnesses(globalSettingsPath);
+
+	if (enabled === undefined) {
+		return detection.detected.filter(
+			(d) => getToolSupportLevel(d.tool) === "stable",
+		);
+	}
+
+	const enabledSet = new Set(enabled);
+	return detection.detected.filter((d) => enabledSet.has(d.tool.id));
 };

--- a/cli/src/shared/install-core.ts
+++ b/cli/src/shared/install-core.ts
@@ -57,6 +57,7 @@ import {
 import type { CopilotInstallResult } from "../install/copilot/models.js";
 import { writeVersionMarker } from "../install/version-marker.js";
 import { getInstalledVersion } from "../lib/version.js";
+import { writeHarnessSelection } from "../settings/harness-writer.js";
 import { loadEnabledHarnesses } from "../settings/loader.js";
 
 /**
@@ -773,6 +774,12 @@ export const installForSpecificTool = (
 					warnings: result.warnings,
 				}),
 			),
+			TE.chainFirst((result) => {
+				if (result.success && !ctx.dryRun) {
+					syncHarnessSelectionAdd(toolId);
+				}
+				return TE.right(undefined);
+			}),
 		);
 	}
 
@@ -791,14 +798,61 @@ export const installForSpecificTool = (
 			}
 			return TE.right(result);
 		}),
+		TE.chainFirst((result) => {
+			if (result.success && !ctx.dryRun) {
+				syncHarnessSelectionAdd(toolId);
+			}
+			return TE.right(undefined);
+		}),
 	);
+};
+
+/**
+ * Sync harness selection after install: add the tool ID to [harnesses] enabled.
+ * If no [harnesses] section exists yet, creates one with just this tool.
+ * No-op when the tool is already in the enabled list.
+ *
+ * @param toolId - Harness ID to add
+ * @param globalSettingsPath - Override for test isolation
+ */
+export const syncHarnessSelectionAdd = (
+	toolId: string,
+	globalSettingsPath?: string,
+): void => {
+	const enabled = loadEnabledHarnesses(globalSettingsPath);
+	if (enabled === undefined) {
+		writeHarnessSelection([toolId], globalSettingsPath);
+		return;
+	}
+	if (!enabled.includes(toolId)) {
+		writeHarnessSelection([...enabled, toolId], globalSettingsPath);
+	}
+};
+
+/**
+ * Sync harness selection after uninstall: remove the tool ID from [harnesses] enabled.
+ * No-op when no [harnesses] section exists or the tool is not in the list.
+ *
+ * @param toolId - Harness ID to remove
+ * @param globalSettingsPath - Override for test isolation
+ */
+export const syncHarnessSelectionRemove = (
+	toolId: string,
+	globalSettingsPath?: string,
+): void => {
+	const enabled = loadEnabledHarnesses(globalSettingsPath);
+	if (enabled === undefined) return;
+	const updated = enabled.filter((id) => id !== toolId);
+	if (updated.length !== enabled.length) {
+		writeHarnessSelection(updated, globalSettingsPath);
+	}
 };
 
 /**
  * Filter detected tools to only those the user has selected (persisted in settings.toml).
  *
  * When no `[harnesses] enabled` selection exists, falls back to all detected tools
- * with stable support level -- preserving backward compatibility for pre-wizard users (REQ-006).
+ * with stable support level -- preserving backward compatibility for pre-wizard users.
  *
  * When a selection exists, returns the intersection of detected tools and the
  * enabled list (preserving detected-tools ordering). Explicitly selected experimental


### PR DESCRIPTION
## Summary

Adds an interactive harness-selection step to `rp1 init` and persists the choice to user-level `settings.toml`, so install/update/uninstall flows respect an explicit harness selection instead of always targeting every detected tool. Phase P2 of the storage-decoupling phase plan (follows #417, #418).

- **T1** — `MultiSelectPrompt` Ink component (checkbox multi-select: arrows navigate, space toggles, enter confirms), with re-render-stability regression tests
- **T2** — settings parser/loader for the `[harnesses]` section (`loadEnabledHarnesses()` with cache integration and defensive copies)
- **T3** — comment-preserving TOML writer for `[harnesses]` (targeted line edits, idempotent, coexists with `[models]`/`[arcade]`)
- **T4** — harness-selection step wired into the init wizard between tool-detection and install-check; interactive prompt with stable-tools-pre-checked defaults, re-init pre-population from persisted settings, silent auto-select in `--yes` mode
- **T5** — install/uninstall sync: per-tool install adds to `[harnesses] enabled`, uninstalls remove, install-all writes the full detected-stable set
- **T6** — `getEffectiveHarnesses()` filter for update paths: intersects detected tools with the persisted selection, falling back to all-detected-stable when absent (backward compatible)

## Verification

- 3234/3235 cli unit tests pass (1 skip); lint/format/typecheck clean
- All 15 acceptance criteria (REQ-001–REQ-006) verified — report in `.rp1/work/features/storage-decoupling-harness-wizard/`
- Interactive flow verified end-to-end in a sandboxed PTY (render, defaults, confirm, persistence) plus a manual real-terminal check of space-toggle + persisted reduced selection

## Notes for reviewers

- Piped-stdin (non-TTY) init intentionally still uses the legacy pipeline and does not write `[harnesses]`; behavior is identical via the fallback in `getEffectiveHarnesses()`. Flagged as a follow-up for consistency.
- During verification we found a suspected pre-existing Ink input freeze under synthetic PTYs (reproduces on main with the existing single-select); tracked separately, unrelated to this change.
- Docs follow-ups TD1–TD4 (configuration/CLI docs, KB updates) are queued separately.

🤖 Generated using: 🎮 [rp1.run](https://rp1.run)