### PR TITLE
feat(init): central-mode project creation with per-platform sandbox grants (storage-decoupling P2)

### DIFF
--- a/cli/src/__tests__/agent-tools/work-search/indexer.test.ts
+++ b/cli/src/__tests__/agent-tools/work-search/indexer.test.ts
@@ -1,0 +1,151 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import {
+	computeDisplayPrefix,
+	scanMarkdownWorkFiles,
+} from "../../../agent-tools/work-search/indexer.js";
+import { cleanupTempDir, createTempDir } from "../../helpers/index.js";
+
+let tempDir: string;
+
+beforeEach(async () => {
+	tempDir = await createTempDir("indexer");
+});
+
+afterEach(async () => {
+	await cleanupTempDir(tempDir);
+});
+
+describe("computeDisplayPrefix", () => {
+	test("returns project-relative prefix when workRoot is inside projectRoot", () => {
+		const projectRoot = "/home/dev/my-project";
+		const workRoot = "/home/dev/my-project/.rp1/work";
+		expect(computeDisplayPrefix(workRoot, projectRoot)).toBe(".rp1/work");
+	});
+
+	test("returns ~-prefixed path when workRoot is outside projectRoot and under homeDir", () => {
+		const homeDir = "/home/dev";
+		const projectRoot = "/home/dev/my-project";
+		const workRoot = "/home/dev/.rp1/projects/abc-123/work";
+		expect(computeDisplayPrefix(workRoot, projectRoot, homeDir)).toBe(
+			"~/.rp1/projects/abc-123/work",
+		);
+	});
+
+	test("returns absolute path when workRoot is outside projectRoot and not under homeDir", () => {
+		const homeDir = "/home/dev";
+		const projectRoot = "/home/dev/my-project";
+		const workRoot = "/var/data/rp1/projects/abc-123/work";
+		expect(computeDisplayPrefix(workRoot, projectRoot, homeDir)).toBe(
+			"/var/data/rp1/projects/abc-123/work",
+		);
+	});
+
+	test("handles nested project structures in local mode", () => {
+		const projectRoot = "/home/dev/mono/packages/app";
+		const workRoot = "/home/dev/mono/packages/app/.rp1/work";
+		expect(computeDisplayPrefix(workRoot, projectRoot)).toBe(".rp1/work");
+	});
+});
+
+describe("scanMarkdownWorkFiles with central-mode workRoot", () => {
+	test("returns displayPath using central path format when workRoot is outside projectRoot", async () => {
+		const mockHome = join(tempDir, "home");
+		const projectId = "test-proj-id";
+		const projectRoot = join(tempDir, "project");
+		const centralWorkRoot = join(
+			mockHome,
+			".rp1",
+			"projects",
+			projectId,
+			"work",
+		);
+
+		await mkdir(join(projectRoot, ".rp1"), { recursive: true });
+		await mkdir(join(centralWorkRoot, "features", "alpha"), {
+			recursive: true,
+		});
+		await writeFile(
+			join(centralWorkRoot, "features", "alpha", "design.md"),
+			"# Alpha Design\n\nContent here",
+			"utf-8",
+		);
+
+		const files = await scanMarkdownWorkFiles(
+			centralWorkRoot,
+			projectRoot,
+			mockHome,
+		);
+
+		expect(files).toHaveLength(1);
+		expect(files[0].relativePath).toBe("features/alpha/design.md");
+		expect(files[0].displayPath).toBe(
+			`~/.rp1/projects/${projectId}/work/features/alpha/design.md`,
+		);
+	});
+
+	test("returns displayPath using local format when workRoot is inside projectRoot", async () => {
+		const projectRoot = join(tempDir, "local-project");
+		const localWorkRoot = join(projectRoot, ".rp1", "work");
+
+		await mkdir(join(localWorkRoot, "features", "beta"), { recursive: true });
+		await writeFile(
+			join(localWorkRoot, "features", "beta", "tasks.md"),
+			"# Beta Tasks\n\nTask content",
+			"utf-8",
+		);
+
+		const files = await scanMarkdownWorkFiles(localWorkRoot, projectRoot);
+
+		expect(files).toHaveLength(1);
+		expect(files[0].relativePath).toBe("features/beta/tasks.md");
+		expect(files[0].displayPath).toBe(".rp1/work/features/beta/tasks.md");
+	});
+
+	test("falls back to .rp1/work prefix when projectRoot is not provided", async () => {
+		const workRoot = join(tempDir, "standalone-work");
+		await mkdir(join(workRoot, "notes"), { recursive: true });
+		await writeFile(
+			join(workRoot, "notes", "readme.md"),
+			"# Notes\n\nFallback content",
+			"utf-8",
+		);
+
+		const files = await scanMarkdownWorkFiles(workRoot);
+
+		expect(files).toHaveLength(1);
+		expect(files[0].displayPath).toBe(".rp1/work/notes/readme.md");
+	});
+
+	test("does not block indexing for central-mode paths with no symlinks", async () => {
+		const centralWorkRoot = join(
+			tempDir,
+			"central",
+			".rp1",
+			"projects",
+			"proj-1",
+			"work",
+		);
+		const projectRoot = join(tempDir, "repo");
+
+		await mkdir(join(projectRoot, ".rp1"), { recursive: true });
+		await mkdir(join(centralWorkRoot, "features"), { recursive: true });
+		await writeFile(
+			join(centralWorkRoot, "features", "design.md"),
+			"# Design\n\nCentral content",
+			"utf-8",
+		);
+
+		const files = await scanMarkdownWorkFiles(
+			centralWorkRoot,
+			projectRoot,
+			join(tempDir, "central"),
+		);
+
+		expect(files).toHaveLength(1);
+		expect(files[0].absolutePath).toBe(
+			join(centralWorkRoot, "features", "design.md"),
+		);
+	});
+});

--- a/cli/src/__tests__/init/init-install-separation.test.ts
+++ b/cli/src/__tests__/init/init-install-separation.test.ts
@@ -393,13 +393,8 @@ describe("init-install separation", () => {
 
 			expect(content).not.toContain("\ngit_worktree = false");
 			expect(content).not.toContain("\ngit_commit = false");
-			expect(content).toContain(
-				"# Directory paths are fixed from the project root:",
-			);
-			expect(content).toContain(
-				"# - Knowledge base files live in .rp1/context",
-			);
-			expect(content).toContain("# - Work artifacts live in .rp1/work");
+			expect(content).toContain("[storage]");
+			expect(content).toContain('mode = "central"');
 			expect(content).toContain('# [arguments."dev:build"]');
 			expect(content).toContain("# git_commit = false");
 		});

--- a/cli/src/__tests__/init/settings-template.test.ts
+++ b/cli/src/__tests__/init/settings-template.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "bun:test";
 import { GITIGNORE_PRESETS } from "../../init/models.js";
-import { buildSettingsTomlTemplate } from "../../init/settings-template.js";
+import {
+	buildGlobalSettingsTomlTemplate,
+	buildSettingsTomlTemplate,
+} from "../../init/settings-template.js";
 
 describe("buildSettingsTomlTemplate", () => {
 	test("output contains [storage] section with mode = central", () => {
@@ -24,6 +27,24 @@ describe("buildSettingsTomlTemplate", () => {
 
 		expect(result).toContain("dev:build");
 		expect(result).toContain("dev:build-fast");
+	});
+});
+
+describe("buildGlobalSettingsTomlTemplate", () => {
+	test("does not set an active storage mode", () => {
+		const result = buildGlobalSettingsTomlTemplate();
+		const parsed = Bun.TOML.parse(result) as Record<string, unknown>;
+
+		// An active [storage] section in the global file would flip every
+		// project on the machine without its own mode to central.
+		expect(parsed.storage).toBeUndefined();
+	});
+
+	test("mentions storage opt-in only as commented guidance", () => {
+		const result = buildGlobalSettingsTomlTemplate();
+
+		expect(result).toContain("# [storage]");
+		expect(result).toContain('# mode = "central"');
 	});
 });
 

--- a/cli/src/__tests__/init/settings-template.test.ts
+++ b/cli/src/__tests__/init/settings-template.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from "bun:test";
+import { GITIGNORE_PRESETS } from "../../init/models.js";
+import { buildSettingsTomlTemplate } from "../../init/settings-template.js";
+
+describe("buildSettingsTomlTemplate", () => {
+	test("output contains [storage] section with mode = central", () => {
+		const result = buildSettingsTomlTemplate();
+
+		expect(result).toContain("[storage]");
+		expect(result).toContain('mode = "central"');
+	});
+
+	test("output is valid TOML with storage.mode = central", () => {
+		const result = buildSettingsTomlTemplate();
+		const parsed = Bun.TOML.parse(result) as Record<string, unknown>;
+		const storage = parsed.storage as Record<string, unknown>;
+
+		expect(storage).toBeDefined();
+		expect(storage.mode).toBe("central");
+	});
+
+	test("output preserves existing command default examples", () => {
+		const result = buildSettingsTomlTemplate();
+
+		expect(result).toContain("dev:build");
+		expect(result).toContain("dev:build-fast");
+	});
+});
+
+describe("GITIGNORE_PRESETS.central", () => {
+	test("preset exists", () => {
+		expect(GITIGNORE_PRESETS.central).toBeDefined();
+	});
+
+	test("tracks project_id", () => {
+		expect(GITIGNORE_PRESETS.central).toContain("!.rp1/project_id");
+	});
+
+	test("tracks settings.toml", () => {
+		expect(GITIGNORE_PRESETS.central).toContain("!.rp1/settings.toml");
+	});
+
+	test("excludes .rp1/context/ and .rp1/work/ via .rp1/* wildcard", () => {
+		const preset = GITIGNORE_PRESETS.central;
+
+		// .rp1/* ignores all direct children including context/ and work/
+		expect(preset).toContain(".rp1/*");
+		// Should NOT un-ignore context or work
+		expect(preset).not.toContain("!.rp1/context/");
+		expect(preset).not.toContain("!.rp1/work/");
+	});
+
+	test("overrides global gitignore with !.rp1/", () => {
+		expect(GITIGNORE_PRESETS.central).toContain("!.rp1/");
+	});
+
+	test("does not include config directory un-ignores", () => {
+		const preset = GITIGNORE_PRESETS.central;
+
+		// Central mode should not track config/ or context/ directories
+		expect(preset).not.toContain("!.rp1/config/");
+		expect(preset).not.toContain("!.rp1/context/");
+	});
+});
+
+describe("existing gitignore presets unchanged", () => {
+	test("recommended preset still un-ignores context", () => {
+		expect(GITIGNORE_PRESETS.recommended).toContain("!.rp1/context/");
+		expect(GITIGNORE_PRESETS.recommended).toContain("!.rp1/context/**");
+		expect(GITIGNORE_PRESETS.recommended).toContain("!.rp1/project_id");
+	});
+
+	test("track_all preset still tracks everything except meta.json", () => {
+		expect(GITIGNORE_PRESETS.track_all).toContain("!.rp1/");
+		expect(GITIGNORE_PRESETS.track_all).toContain(".rp1/context/meta.json");
+	});
+
+	test("ignore_all preset still ignores entire .rp1/", () => {
+		expect(GITIGNORE_PRESETS.ignore_all).toBe(".rp1/");
+	});
+});

--- a/cli/src/__tests__/init/steps/init-orchestrator-grants.test.ts
+++ b/cli/src/__tests__/init/steps/init-orchestrator-grants.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Integration tests for sandbox grants wiring in the init orchestrator.
+ *
+ * Verifies: sandbox-grants step is wired into executeInit, grant files are
+ * produced for stable platforms, and generateSandboxGrants returns GrantResult[].
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import * as E from "fp-ts/lib/Either.js";
+import type { Logger } from "../../../../shared/logger.js";
+import { executeInit } from "../../../init/index.js";
+import type { InitOptions, InitResult } from "../../../init/models.js";
+import {
+	type GrantResult,
+	generateSandboxGrants,
+} from "../../../init/steps/sandbox-grants.js";
+import { cleanupTempDir, createTempDir } from "../../helpers/index.js";
+
+function createTrackingLogger(): Logger & {
+	calls: { method: string; args: unknown[] }[];
+} {
+	const calls: { method: string; args: unknown[] }[] = [];
+	return {
+		calls,
+		trace: (...args) => calls.push({ method: "trace", args }),
+		debug: (...args) => calls.push({ method: "debug", args }),
+		info: (...args) => calls.push({ method: "info", args }),
+		warn: (...args) => calls.push({ method: "warn", args }),
+		error: (...args) => calls.push({ method: "error", args }),
+		start: (...args) => calls.push({ method: "start", args }),
+		success: (...args) => calls.push({ method: "success", args }),
+		fail: (...args) => calls.push({ method: "fail", args }),
+		box: (...args) => calls.push({ method: "box", args }),
+	};
+}
+
+describe("generateSandboxGrants returns GrantResult[]", () => {
+	let tempDir: string;
+
+	beforeEach(async () => {
+		tempDir = await createTempDir("grants-return-");
+	});
+
+	afterEach(async () => {
+		await cleanupTempDir(tempDir);
+	});
+
+	test("returns array of GrantResult for each generated platform", async () => {
+		const results: GrantResult[] = await generateSandboxGrants(
+			["claude-code", "codex"],
+			tempDir,
+		);
+
+		expect(Array.isArray(results)).toBe(true);
+		expect(results).toHaveLength(2);
+
+		const platforms = results.map((r) => r.platform);
+		expect(platforms).toContain("claude-code");
+		expect(platforms).toContain("codex");
+
+		for (const result of results) {
+			expect(result.written).toBe(true);
+			expect(typeof result.path).toBe("string");
+		}
+	});
+
+	test("returns empty array when harness list is empty", async () => {
+		const results: GrantResult[] = await generateSandboxGrants([], tempDir);
+		expect(results).toEqual([]);
+	});
+});
+
+describe("integration: executeInit produces sandbox grant files", () => {
+	let tempDir: string;
+
+	beforeEach(async () => {
+		tempDir = await createTempDir("init-grants-integration-");
+	});
+
+	afterEach(async () => {
+		await cleanupTempDir(tempDir);
+	});
+
+	test(
+		"fresh init produces settings.toml with mode=central and platform grants",
+		async () => {
+			const logger = createTrackingLogger();
+			// Use non-existent globalSettingsPath so loadEnabledHarnesses returns
+			// undefined, triggering fallback to all stable platforms (hermetic test)
+			const bogusSettingsPath = join(tempDir, "nonexistent-global.toml");
+			const options: InitOptions = {
+				cwd: tempDir,
+				yes: true,
+				globalSettingsPath: bogusSettingsPath,
+			};
+
+			const result = await executeInit(options, logger)();
+
+			expect(E.isRight(result)).toBe(true);
+			if (!E.isRight(result)) return;
+
+			const initResult: InitResult = result.right;
+
+			const settingsPath = join(tempDir, ".rp1", "settings.toml");
+			expect(existsSync(settingsPath)).toBe(true);
+			const settingsContent = readFileSync(settingsPath, "utf-8");
+			expect(settingsContent).toContain("[storage]");
+			expect(settingsContent).toContain('mode = "central"');
+
+			// Grant files should exist for all stable platforms (fallback behavior)
+			const claudeSettingsPath = join(tempDir, ".claude", "settings.json");
+			expect(existsSync(claudeSettingsPath)).toBe(true);
+
+			const claudeSettings = JSON.parse(
+				readFileSync(claudeSettingsPath, "utf-8"),
+			);
+			expect(claudeSettings.permissions.additionalDirectories).toContain(
+				"~/.rp1",
+			);
+			expect(claudeSettings.permissions.allow).toContain("Read(~/.rp1/**)");
+			expect(claudeSettings.sandbox.filesystem.allowWrite).toContain("~/.rp1");
+
+			expect(existsSync(join(tempDir, "codex.toml"))).toBe(true);
+			const codexContent = readFileSync(join(tempDir, "codex.toml"), "utf-8");
+			expect(codexContent).toContain("~/.rp1");
+
+			const grantFileActions = initResult.actions.filter(
+				(a) =>
+					a.type === "created_file" &&
+					(a.path.includes(".claude") ||
+						a.path.includes("codex.toml") ||
+						a.path.includes(".opencode") ||
+						a.path.includes(".gemini") ||
+						a.path.includes("copilot-settings.json")),
+			);
+			expect(grantFileActions.length).toBeGreaterThanOrEqual(2);
+
+			const grantErrors = initResult.warnings.filter((w) =>
+				w.includes("Sandbox grants failed"),
+			);
+			expect(grantErrors).toHaveLength(0);
+		},
+		{ timeout: 30000 },
+	);
+
+	test(
+		"init summary logs sandbox grant status for each platform",
+		async () => {
+			const logger = createTrackingLogger();
+			const bogusSettingsPath = join(tempDir, "nonexistent-global.toml");
+			const options: InitOptions = {
+				cwd: tempDir,
+				yes: true,
+				globalSettingsPath: bogusSettingsPath,
+			};
+
+			const result = await executeInit(options, logger)();
+
+			expect(E.isRight(result)).toBe(true);
+			if (!E.isRight(result)) return;
+
+			const successMessages = logger.calls
+				.filter((c) => c.method === "success")
+				.map((c) => String(c.args[0]));
+
+			const grantMessages = successMessages.filter((m) =>
+				m.includes("Sandbox grant"),
+			);
+			// With fallback to all stable platforms, should have at least 2 messages
+			expect(grantMessages.length).toBeGreaterThanOrEqual(2);
+
+			expect(grantMessages.some((m) => m.includes("claude-code"))).toBe(true);
+			expect(grantMessages.some((m) => m.includes("codex"))).toBe(true);
+		},
+		{ timeout: 30000 },
+	);
+});

--- a/cli/src/__tests__/init/steps/init-orchestrator-grants.test.ts
+++ b/cli/src/__tests__/init/steps/init-orchestrator-grants.test.ts
@@ -126,6 +126,15 @@ describe("integration: executeInit produces sandbox grant files", () => {
 			const codexContent = readFileSync(join(tempDir, "codex.toml"), "utf-8");
 			expect(codexContent).toContain("~/.rp1");
 
+			// OpenCode grant must use the HYP-002 validated format:
+			// { permission: { external_directory: { "~/.rp1/**": "allow" } } }
+			const opencodePath = join(tempDir, "opencode.json");
+			expect(existsSync(opencodePath)).toBe(true);
+			const opencodeContent = JSON.parse(readFileSync(opencodePath, "utf-8"));
+			expect(opencodeContent.permission.external_directory["~/.rp1/**"]).toBe(
+				"allow",
+			);
+
 			const grantFileActions = initResult.actions.filter(
 				(a) =>
 					a.type === "created_file" &&

--- a/cli/src/__tests__/init/steps/init-orchestrator-grants.test.ts
+++ b/cli/src/__tests__/init/steps/init-orchestrator-grants.test.ts
@@ -131,7 +131,7 @@ describe("integration: executeInit produces sandbox grant files", () => {
 					a.type === "created_file" &&
 					(a.path.includes(".claude") ||
 						a.path.includes("codex.toml") ||
-						a.path.includes(".opencode") ||
+						a.path.includes("opencode.json") ||
 						a.path.includes(".gemini") ||
 						a.path.includes("copilot-settings.json")),
 			);

--- a/cli/src/__tests__/init/steps/project-setup-central.test.ts
+++ b/cli/src/__tests__/init/steps/project-setup-central.test.ts
@@ -12,10 +12,7 @@ import { existsSync } from "node:fs";
 import { mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import type { Logger } from "../../../../shared/logger.js";
-import {
-	resolveStorageDirectoryPaths,
-	type StorageDirectoryPaths,
-} from "../../../init/directory-model.js";
+import { resolveStorageDirectoryPaths } from "../../../init/directory-model.js";
 import {
 	createMinimalProjectStructure,
 	createStorageDirectories,

--- a/cli/src/__tests__/init/steps/project-setup-central.test.ts
+++ b/cli/src/__tests__/init/steps/project-setup-central.test.ts
@@ -10,8 +10,10 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { existsSync } from "node:fs";
 import { mkdir, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
 import { join } from "node:path";
 import type { Logger } from "../../../../shared/logger.js";
+import { computeDirectoryPaths } from "../../../../shared/storage-mode.js";
 import { resolveStorageDirectoryPaths } from "../../../init/directory-model.js";
 import {
 	createMinimalProjectStructure,
@@ -253,6 +255,49 @@ describe("resolveStorageDirectoryPaths", () => {
 			projectId,
 			fakeHome,
 		);
+
+		expect(result.contextDir).toBe(join(projectRoot, ".rp1", "context"));
+		expect(result.workDir).toBe(join(projectRoot, ".rp1", "work"));
+		expect(result.storageMode).toBe("local");
+	});
+
+	// Without the homeDir test seam, the function delegates to the shared
+	// computeDirectoryPaths — the branch production code actually runs. These
+	// tests only compute paths (no directories are created), so using the real
+	// home directory is safe.
+	test("central mode without homeDir delegates to computeDirectoryPaths", async () => {
+		const projectRoot = join(tempDir, "project");
+		const projectId = "central-prod-branch-id";
+		await mkdir(join(projectRoot, ".rp1"), { recursive: true });
+		await writeFile(
+			join(projectRoot, ".rp1", "settings.toml"),
+			'[storage]\nmode = "central"\n',
+		);
+		await writeFile(join(projectRoot, ".rp1", "project_id"), projectId);
+
+		const result = resolveStorageDirectoryPaths(projectRoot, projectId);
+
+		const expected = computeDirectoryPaths(projectRoot, projectId, "central");
+		expect(result.contextDir).toBe(expected.kbRoot);
+		expect(result.workDir).toBe(expected.workRoot);
+		expect(result.storageMode).toBe("central");
+
+		const centralBase = join(homedir(), ".rp1", "projects", projectId);
+		expect(result.contextDir).toBe(join(centralBase, "context"));
+		expect(result.workDir).toBe(join(centralBase, "work"));
+	});
+
+	test("local mode without homeDir delegates to computeDirectoryPaths", async () => {
+		const projectRoot = join(tempDir, "project");
+		const projectId = "local-prod-branch-id";
+		await mkdir(join(projectRoot, ".rp1"), { recursive: true });
+		await writeFile(
+			join(projectRoot, ".rp1", "settings.toml"),
+			'[storage]\nmode = "local"\n',
+		);
+		await writeFile(join(projectRoot, ".rp1", "project_id"), projectId);
+
+		const result = resolveStorageDirectoryPaths(projectRoot, projectId);
 
 		expect(result.contextDir).toBe(join(projectRoot, ".rp1", "context"));
 		expect(result.workDir).toBe(join(projectRoot, ".rp1", "work"));

--- a/cli/src/__tests__/init/steps/project-setup-central.test.ts
+++ b/cli/src/__tests__/init/steps/project-setup-central.test.ts
@@ -1,0 +1,312 @@
+/**
+ * Tests for central-mode init directory restructure (T2).
+ *
+ * Verifies: minimal project structure creation, storage directory creation
+ * for both central and local modes, storage path resolution, and the
+ * reordered init flow that establishes project_id before computing
+ * central directory paths.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync } from "node:fs";
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import type { Logger } from "../../../../shared/logger.js";
+import {
+	resolveStorageDirectoryPaths,
+	type StorageDirectoryPaths,
+} from "../../../init/directory-model.js";
+import {
+	createMinimalProjectStructure,
+	createStorageDirectories,
+} from "../../../init/steps/project-setup.js";
+import { cleanupTempDir, createTempDir } from "../../helpers/index.js";
+
+function createTrackingLogger(): Logger & {
+	calls: { method: string; args: unknown[] }[];
+} {
+	const calls: { method: string; args: unknown[] }[] = [];
+	return {
+		calls,
+		trace: (...args) => calls.push({ method: "trace", args }),
+		debug: (...args) => calls.push({ method: "debug", args }),
+		info: (...args) => calls.push({ method: "info", args }),
+		warn: (...args) => calls.push({ method: "warn", args }),
+		error: (...args) => calls.push({ method: "error", args }),
+		start: (...args) => calls.push({ method: "start", args }),
+		success: (...args) => calls.push({ method: "success", args }),
+		fail: (...args) => calls.push({ method: "fail", args }),
+		box: (...args) => calls.push({ method: "box", args }),
+	};
+}
+
+describe("createMinimalProjectStructure", () => {
+	let tempDir: string;
+	let logger: ReturnType<typeof createTrackingLogger>;
+
+	beforeEach(async () => {
+		tempDir = await createTempDir("minimal-proj-setup-");
+		logger = createTrackingLogger();
+	});
+
+	afterEach(async () => {
+		await cleanupTempDir(tempDir);
+	});
+
+	test("creates only .rp1/ directory without context/ or work/", async () => {
+		const actions = await createMinimalProjectStructure(tempDir, logger);
+
+		expect(actions).toHaveLength(1);
+		expect(actions[0].type).toBe("created_directory");
+		expect(
+			actions[0].type === "created_directory" && actions[0].path,
+		).toContain(".rp1");
+
+		expect(existsSync(join(tempDir, ".rp1"))).toBe(true);
+		expect(existsSync(join(tempDir, ".rp1", "context"))).toBe(false);
+		expect(existsSync(join(tempDir, ".rp1", "work"))).toBe(false);
+	});
+
+	test("is idempotent when .rp1/ already exists", async () => {
+		await mkdir(join(tempDir, ".rp1"), { recursive: true });
+
+		const actions = await createMinimalProjectStructure(tempDir, logger);
+
+		expect(actions).toHaveLength(0);
+		expect(existsSync(join(tempDir, ".rp1"))).toBe(true);
+	});
+});
+
+describe("createStorageDirectories", () => {
+	let tempDir: string;
+	let fakeHome: string;
+	let logger: ReturnType<typeof createTrackingLogger>;
+
+	beforeEach(async () => {
+		tempDir = await createTempDir("storage-dirs-");
+		fakeHome = join(tempDir, "fake-home");
+		await mkdir(fakeHome, { recursive: true });
+		logger = createTrackingLogger();
+	});
+
+	afterEach(async () => {
+		await cleanupTempDir(tempDir);
+	});
+
+	test("creates central dirs under ~/.rp1/projects/{id}/ for central mode", async () => {
+		const projectRoot = join(tempDir, "project");
+		const projectId = "test-uuid-1234";
+		await mkdir(join(projectRoot, ".rp1"), { recursive: true });
+		await writeFile(
+			join(projectRoot, ".rp1", "settings.toml"),
+			'[storage]\nmode = "central"\n',
+		);
+		await writeFile(join(projectRoot, ".rp1", "project_id"), projectId);
+
+		const actions = await createStorageDirectories(
+			projectRoot,
+			projectId,
+			logger,
+			fakeHome,
+		);
+
+		expect(actions).toHaveLength(2);
+		expect(actions.every((a) => a.type === "created_directory")).toBe(true);
+
+		const centralBase = join(fakeHome, ".rp1", "projects", projectId);
+		expect(existsSync(join(centralBase, "context"))).toBe(true);
+		expect(existsSync(join(centralBase, "work"))).toBe(true);
+
+		// Local context/work should NOT exist
+		expect(existsSync(join(projectRoot, ".rp1", "context"))).toBe(false);
+		expect(existsSync(join(projectRoot, ".rp1", "work"))).toBe(false);
+	});
+
+	test("creates local dirs .rp1/context/ and .rp1/work/ for local mode", async () => {
+		const projectRoot = join(tempDir, "project");
+		const projectId = "test-uuid-5678";
+		await mkdir(join(projectRoot, ".rp1"), { recursive: true });
+		await writeFile(
+			join(projectRoot, ".rp1", "settings.toml"),
+			'[storage]\nmode = "local"\n',
+		);
+		await writeFile(join(projectRoot, ".rp1", "project_id"), projectId);
+
+		const actions = await createStorageDirectories(
+			projectRoot,
+			projectId,
+			logger,
+			fakeHome,
+		);
+
+		expect(actions).toHaveLength(2);
+
+		expect(existsSync(join(projectRoot, ".rp1", "context"))).toBe(true);
+		expect(existsSync(join(projectRoot, ".rp1", "work"))).toBe(true);
+	});
+
+	test("falls back to local when no settings.toml exists", async () => {
+		const projectRoot = join(tempDir, "project");
+		const projectId = "test-uuid-fallback";
+		await mkdir(join(projectRoot, ".rp1"), { recursive: true });
+		await writeFile(join(projectRoot, ".rp1", "project_id"), projectId);
+
+		const actions = await createStorageDirectories(
+			projectRoot,
+			projectId,
+			logger,
+			fakeHome,
+		);
+
+		expect(actions).toHaveLength(2);
+		expect(existsSync(join(projectRoot, ".rp1", "context"))).toBe(true);
+		expect(existsSync(join(projectRoot, ".rp1", "work"))).toBe(true);
+	});
+
+	test("is idempotent for central mode", async () => {
+		const projectRoot = join(tempDir, "project");
+		const projectId = "test-uuid-idempotent";
+		await mkdir(join(projectRoot, ".rp1"), { recursive: true });
+		await writeFile(
+			join(projectRoot, ".rp1", "settings.toml"),
+			'[storage]\nmode = "central"\n',
+		);
+		await writeFile(join(projectRoot, ".rp1", "project_id"), projectId);
+
+		const centralBase = join(fakeHome, ".rp1", "projects", projectId);
+		await mkdir(join(centralBase, "context"), { recursive: true });
+		await mkdir(join(centralBase, "work"), { recursive: true });
+
+		const actions = await createStorageDirectories(
+			projectRoot,
+			projectId,
+			logger,
+			fakeHome,
+		);
+
+		expect(actions).toHaveLength(0);
+	});
+});
+
+describe("resolveStorageDirectoryPaths", () => {
+	let tempDir: string;
+	let fakeHome: string;
+
+	beforeEach(async () => {
+		tempDir = await createTempDir("resolve-storage-");
+		fakeHome = join(tempDir, "fake-home");
+		await mkdir(fakeHome, { recursive: true });
+	});
+
+	afterEach(async () => {
+		await cleanupTempDir(tempDir);
+	});
+
+	test("returns central paths when settings.toml has mode = central", async () => {
+		const projectRoot = join(tempDir, "project");
+		const projectId = "central-test-id";
+		await mkdir(join(projectRoot, ".rp1"), { recursive: true });
+		await writeFile(
+			join(projectRoot, ".rp1", "settings.toml"),
+			'[storage]\nmode = "central"\n',
+		);
+		await writeFile(join(projectRoot, ".rp1", "project_id"), projectId);
+
+		const result = resolveStorageDirectoryPaths(
+			projectRoot,
+			projectId,
+			fakeHome,
+		);
+
+		const expectedBase = join(fakeHome, ".rp1", "projects", projectId);
+		expect(result.contextDir).toBe(join(expectedBase, "context"));
+		expect(result.workDir).toBe(join(expectedBase, "work"));
+		expect(result.storageMode).toBe("central");
+	});
+
+	test("returns local paths when settings.toml has mode = local", async () => {
+		const projectRoot = join(tempDir, "project");
+		const projectId = "local-test-id";
+		await mkdir(join(projectRoot, ".rp1"), { recursive: true });
+		await writeFile(
+			join(projectRoot, ".rp1", "settings.toml"),
+			'[storage]\nmode = "local"\n',
+		);
+		await writeFile(join(projectRoot, ".rp1", "project_id"), projectId);
+
+		const result = resolveStorageDirectoryPaths(
+			projectRoot,
+			projectId,
+			fakeHome,
+		);
+
+		expect(result.contextDir).toBe(join(projectRoot, ".rp1", "context"));
+		expect(result.workDir).toBe(join(projectRoot, ".rp1", "work"));
+		expect(result.storageMode).toBe("local");
+	});
+
+	test("returns local paths when no settings.toml exists", async () => {
+		const projectRoot = join(tempDir, "project");
+		const projectId = "no-settings-id";
+		await mkdir(join(projectRoot, ".rp1"), { recursive: true });
+		await writeFile(join(projectRoot, ".rp1", "project_id"), projectId);
+
+		const result = resolveStorageDirectoryPaths(
+			projectRoot,
+			projectId,
+			fakeHome,
+		);
+
+		expect(result.contextDir).toBe(join(projectRoot, ".rp1", "context"));
+		expect(result.workDir).toBe(join(projectRoot, ".rp1", "work"));
+		expect(result.storageMode).toBe("local");
+	});
+});
+
+describe("init directory restructure: two repos get distinct project IDs", () => {
+	let tempDir: string;
+	let fakeHome: string;
+	let logger: ReturnType<typeof createTrackingLogger>;
+
+	beforeEach(async () => {
+		tempDir = await createTempDir("distinct-ids-");
+		fakeHome = join(tempDir, "fake-home");
+		await mkdir(fakeHome, { recursive: true });
+		logger = createTrackingLogger();
+	});
+
+	afterEach(async () => {
+		await cleanupTempDir(tempDir);
+	});
+
+	test("two repos get distinct central directories", async () => {
+		const repo1 = join(tempDir, "repo1");
+		const repo2 = join(tempDir, "repo2");
+		const id1 = "uuid-repo-1";
+		const id2 = "uuid-repo-2";
+
+		for (const [root, id] of [
+			[repo1, id1],
+			[repo2, id2],
+		] as const) {
+			await mkdir(join(root, ".rp1"), { recursive: true });
+			await writeFile(
+				join(root, ".rp1", "settings.toml"),
+				'[storage]\nmode = "central"\n',
+			);
+			await writeFile(join(root, ".rp1", "project_id"), id);
+		}
+
+		await createStorageDirectories(repo1, id1, logger, fakeHome);
+		await createStorageDirectories(repo2, id2, logger, fakeHome);
+
+		const central1 = join(fakeHome, ".rp1", "projects", id1);
+		const central2 = join(fakeHome, ".rp1", "projects", id2);
+
+		expect(existsSync(join(central1, "context"))).toBe(true);
+		expect(existsSync(join(central1, "work"))).toBe(true);
+		expect(existsSync(join(central2, "context"))).toBe(true);
+		expect(existsSync(join(central2, "work"))).toBe(true);
+		expect(central1).not.toBe(central2);
+	});
+});

--- a/cli/src/__tests__/init/steps/sandbox-grants.test.ts
+++ b/cli/src/__tests__/init/steps/sandbox-grants.test.ts
@@ -1,0 +1,224 @@
+/**
+ * Unit tests for per-platform sandbox grant generation.
+ *
+ * Tests pure grant generators (shape/content), file writers (merge/create),
+ * and the dispatch function (harness selection filtering + undefined fallback).
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+	generateAntigravityGrants,
+	generateClaudeCodeGrants,
+	generateCodexGrants,
+	generateCopilotGrants,
+	generateOpenCodeGrants,
+	generateSandboxGrants,
+	writeClaudeCodeGrants,
+	writeCodexGrants,
+} from "../../../init/steps/sandbox-grants.js";
+import {
+	cleanupTempDir,
+	createTempDir,
+	writeFixture,
+} from "../../helpers/index.js";
+
+describe("sandbox-grants", () => {
+	let tempDir: string;
+
+	beforeEach(async () => {
+		tempDir = await createTempDir("sandbox-grants-test");
+	});
+
+	afterEach(async () => {
+		await cleanupTempDir(tempDir);
+	});
+
+	// ─── Claude Code ──────────────────────────────────────────────
+
+	describe("generateClaudeCodeGrants", () => {
+		test("returns object with additionalDirectories including ~/.rp1", () => {
+			const grants = generateClaudeCodeGrants();
+			expect(grants.permissions.additionalDirectories).toContain("~/.rp1");
+		});
+
+		test("returns allow rules for Read and Edit on ~/.rp1/**", () => {
+			const grants = generateClaudeCodeGrants();
+			expect(grants.permissions.allow).toContain("Read(~/.rp1/**)");
+			expect(grants.permissions.allow).toContain("Edit(~/.rp1/**)");
+		});
+
+		test("returns sandbox.filesystem.allowWrite including ~/.rp1", () => {
+			const grants = generateClaudeCodeGrants();
+			expect(grants.sandbox.filesystem.allowWrite).toContain("~/.rp1");
+		});
+	});
+
+	describe("writeClaudeCodeGrants", () => {
+		test("merges grants into existing .claude/settings.json without overwriting user content", async () => {
+			const existing = {
+				permissions: {
+					allow: ["Bash(npm *)"],
+					deny: ["Bash(rm -rf *)"],
+				},
+				customKey: "preserved",
+			};
+			await writeFixture(
+				tempDir,
+				".claude/settings.json",
+				JSON.stringify(existing, null, 2),
+			);
+
+			await writeClaudeCodeGrants(tempDir);
+
+			const content = JSON.parse(
+				readFileSync(join(tempDir, ".claude", "settings.json"), "utf-8"),
+			);
+
+			expect(content.customKey).toBe("preserved");
+			expect(content.permissions.deny).toEqual(["Bash(rm -rf *)"]);
+			expect(content.permissions.allow).toContain("Bash(npm *)");
+			expect(content.permissions.additionalDirectories).toContain("~/.rp1");
+			expect(content.permissions.allow).toContain("Read(~/.rp1/**)");
+			expect(content.permissions.allow).toContain("Edit(~/.rp1/**)");
+			expect(content.sandbox.filesystem.allowWrite).toContain("~/.rp1");
+		});
+
+		test("creates .claude/settings.json when file does not exist", async () => {
+			await writeClaudeCodeGrants(tempDir);
+
+			const path = join(tempDir, ".claude", "settings.json");
+			expect(existsSync(path)).toBe(true);
+
+			const content = JSON.parse(readFileSync(path, "utf-8"));
+			expect(content.permissions.additionalDirectories).toContain("~/.rp1");
+			expect(content.permissions.allow).toContain("Read(~/.rp1/**)");
+			expect(content.sandbox.filesystem.allowWrite).toContain("~/.rp1");
+		});
+
+		test("does not duplicate grants on repeated writes", async () => {
+			await writeClaudeCodeGrants(tempDir);
+			await writeClaudeCodeGrants(tempDir);
+
+			const content = JSON.parse(
+				readFileSync(join(tempDir, ".claude", "settings.json"), "utf-8"),
+			);
+
+			const dirCount = (
+				content.permissions.additionalDirectories as string[]
+			).filter((d: string) => d === "~/.rp1").length;
+			expect(dirCount).toBe(1);
+		});
+	});
+
+	// ─── Codex ────────────────────────────────────────────────────
+
+	describe("generateCodexGrants", () => {
+		test("produces writable_roots config including ~/.rp1", () => {
+			const grants = generateCodexGrants();
+			expect(grants.sandbox_workspace_write.writable_roots).toContain("~/.rp1");
+		});
+	});
+
+	describe("writeCodexGrants", () => {
+		test("creates codex.toml with writable_roots section", async () => {
+			await writeCodexGrants(tempDir);
+
+			const content = readFileSync(join(tempDir, "codex.toml"), "utf-8");
+			expect(content).toContain("[sandbox_workspace_write]");
+			expect(content).toContain("~/.rp1");
+		});
+
+		test("preserves existing content when appending sandbox section", async () => {
+			await writeFixture(
+				tempDir,
+				"codex.toml",
+				"[features]\nmulti_agent = true\n",
+			);
+			await writeCodexGrants(tempDir);
+
+			const content = readFileSync(join(tempDir, "codex.toml"), "utf-8");
+			expect(content).toContain("[features]");
+			expect(content).toContain("multi_agent = true");
+			expect(content).toContain("[sandbox_workspace_write]");
+			expect(content).toContain("~/.rp1");
+		});
+	});
+
+	// ─── OpenCode ─────────────────────────────────────────────────
+
+	describe("generateOpenCodeGrants", () => {
+		test("produces external_directory config including ~/.rp1", () => {
+			const grants = generateOpenCodeGrants();
+			expect(grants.sandbox.external_directories).toContain("~/.rp1");
+		});
+	});
+
+	// ─── Antigravity ──────────────────────────────────────────────
+
+	describe("generateAntigravityGrants", () => {
+		test("produces sandbox config granting ~/.rp1 access", () => {
+			const grants = generateAntigravityGrants();
+			expect(grants.sandbox.allowed_paths).toContain("~/.rp1");
+		});
+	});
+
+	// ─── Copilot ──────────────────────────────────────────────────
+
+	describe("generateCopilotGrants", () => {
+		test("produces sandbox allowlist including ~/.rp1", () => {
+			const grants = generateCopilotGrants();
+			expect(grants.sandbox.allowlist).toContain("~/.rp1");
+		});
+	});
+
+	// ─── Dispatch ─────────────────────────────────────────────────
+
+	describe("generateSandboxGrants dispatch", () => {
+		test("given harness selection ['claude-code', 'codex'], only those two platform grants are generated", async () => {
+			await generateSandboxGrants(["claude-code", "codex"], tempDir);
+
+			expect(existsSync(join(tempDir, ".claude", "settings.json"))).toBe(true);
+			expect(existsSync(join(tempDir, "codex.toml"))).toBe(true);
+
+			expect(existsSync(join(tempDir, ".opencode", "settings.json"))).toBe(
+				false,
+			);
+			expect(existsSync(join(tempDir, ".gemini", "settings.json"))).toBe(false);
+			expect(
+				existsSync(join(tempDir, ".github", "copilot-settings.json")),
+			).toBe(false);
+		});
+
+		test("given undefined harness selection, grants are generated for all detected stable harnesses", async () => {
+			// Pass non-existent globalSettingsPath so loadEnabledHarnesses returns undefined,
+			// triggering fallback to all stable platforms from the tool registry.
+			const bogusSettingsPath = join(tempDir, "nonexistent-settings.toml");
+			await generateSandboxGrants(undefined, tempDir, bogusSettingsPath);
+
+			expect(existsSync(join(tempDir, ".claude", "settings.json"))).toBe(true);
+			expect(existsSync(join(tempDir, "codex.toml"))).toBe(true);
+			expect(existsSync(join(tempDir, ".opencode", "settings.json"))).toBe(
+				true,
+			);
+			expect(existsSync(join(tempDir, ".gemini", "settings.json"))).toBe(true);
+			expect(
+				existsSync(join(tempDir, ".github", "copilot-settings.json")),
+			).toBe(true);
+		});
+
+		test("skips unknown harness IDs without error", async () => {
+			await generateSandboxGrants(["claude-code", "unknown-tool"], tempDir);
+
+			expect(existsSync(join(tempDir, ".claude", "settings.json"))).toBe(true);
+		});
+
+		test("generates no files when harness list is empty", async () => {
+			await generateSandboxGrants([], tempDir);
+
+			expect(existsSync(join(tempDir, ".claude", "settings.json"))).toBe(false);
+			expect(existsSync(join(tempDir, "codex.toml"))).toBe(false);
+		});
+	});
+});

--- a/cli/src/__tests__/init/steps/sandbox-grants.test.ts
+++ b/cli/src/__tests__/init/steps/sandbox-grants.test.ts
@@ -17,6 +17,7 @@ import {
 	generateSandboxGrants,
 	writeClaudeCodeGrants,
 	writeCodexGrants,
+	writeOpenCodeGrants,
 } from "../../../init/steps/sandbox-grants.js";
 import {
 	cleanupTempDir,
@@ -149,9 +150,59 @@ describe("sandbox-grants", () => {
 	// ─── OpenCode ─────────────────────────────────────────────────
 
 	describe("generateOpenCodeGrants", () => {
-		test("produces external_directory config including ~/.rp1", () => {
+		test("produces permission.external_directory map with ~/.rp1/** allow rule", () => {
 			const grants = generateOpenCodeGrants();
-			expect(grants.sandbox.external_directories).toContain("~/.rp1");
+			expect(grants.permission.external_directory).toEqual({
+				"~/.rp1/**": "allow",
+			});
+		});
+	});
+
+	describe("writeOpenCodeGrants", () => {
+		test("creates opencode.json with permission.external_directory grant", async () => {
+			await writeOpenCodeGrants(tempDir);
+
+			const path = join(tempDir, "opencode.json");
+			expect(existsSync(path)).toBe(true);
+
+			const content = JSON.parse(readFileSync(path, "utf-8"));
+			expect(content.permission.external_directory["~/.rp1/**"]).toBe("allow");
+		});
+
+		test("merges grants into existing opencode.json without overwriting user content", async () => {
+			const existing = {
+				plugin: ["file:///some/plugin/index.ts"],
+				permission: {
+					external_directory: { "/other/path/**": "allow" },
+				},
+			};
+			await writeFixture(
+				tempDir,
+				"opencode.json",
+				JSON.stringify(existing, null, 2),
+			);
+
+			await writeOpenCodeGrants(tempDir);
+
+			const content = JSON.parse(
+				readFileSync(join(tempDir, "opencode.json"), "utf-8"),
+			);
+			expect(content.plugin).toEqual(["file:///some/plugin/index.ts"]);
+			expect(content.permission.external_directory["/other/path/**"]).toBe(
+				"allow",
+			);
+			expect(content.permission.external_directory["~/.rp1/**"]).toBe("allow");
+		});
+
+		test("does not duplicate grants on repeated writes", async () => {
+			await writeOpenCodeGrants(tempDir);
+			await writeOpenCodeGrants(tempDir);
+
+			const content = JSON.parse(
+				readFileSync(join(tempDir, "opencode.json"), "utf-8"),
+			);
+			const keys = Object.keys(content.permission.external_directory);
+			expect(keys.filter((k) => k === "~/.rp1/**")).toHaveLength(1);
 		});
 	});
 
@@ -182,9 +233,7 @@ describe("sandbox-grants", () => {
 			expect(existsSync(join(tempDir, ".claude", "settings.json"))).toBe(true);
 			expect(existsSync(join(tempDir, "codex.toml"))).toBe(true);
 
-			expect(existsSync(join(tempDir, ".opencode", "settings.json"))).toBe(
-				false,
-			);
+			expect(existsSync(join(tempDir, "opencode.json"))).toBe(false);
 			expect(existsSync(join(tempDir, ".gemini", "settings.json"))).toBe(false);
 			expect(
 				existsSync(join(tempDir, ".github", "copilot-settings.json")),
@@ -199,9 +248,7 @@ describe("sandbox-grants", () => {
 
 			expect(existsSync(join(tempDir, ".claude", "settings.json"))).toBe(true);
 			expect(existsSync(join(tempDir, "codex.toml"))).toBe(true);
-			expect(existsSync(join(tempDir, ".opencode", "settings.json"))).toBe(
-				true,
-			);
+			expect(existsSync(join(tempDir, "opencode.json"))).toBe(true);
 			expect(existsSync(join(tempDir, ".gemini", "settings.json"))).toBe(true);
 			expect(
 				existsSync(join(tempDir, ".github", "copilot-settings.json")),

--- a/cli/src/__tests__/init/ui/hooks/useStepExecution.test.tsx
+++ b/cli/src/__tests__/init/ui/hooks/useStepExecution.test.tsx
@@ -1,0 +1,126 @@
+/**
+ * Tests for the wizard's directory/settings step executors.
+ *
+ * Guards the wizard/headless parity for central-mode init: directory-setup
+ * must create only the minimal .rp1/ + project_id, and settings-setup must
+ * create the storage directories AFTER settings.toml exists so the storage
+ * mode is honored (mirroring the headless three-phase flow in executeInit).
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, readFileSync } from "node:fs";
+import { rm } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { Text } from "ink";
+import { render } from "ink-testing-library";
+import type React from "react";
+import { useEffect } from "react";
+import type { InitOptions } from "../../../../init/models.js";
+import {
+	type StepExecutor,
+	useStepExecution,
+} from "../../../../init/ui/hooks/useStepExecution.js";
+import { useWizardState } from "../../../../init/ui/hooks/useWizardState.js";
+import { cleanupTempDir, createTempDir } from "../../../helpers/index.js";
+
+interface HarnessProps {
+	readonly options: InitOptions;
+	readonly onReady: (executor: StepExecutor) => void;
+}
+
+const Harness: React.FC<HarnessProps> = ({ options, onReady }) => {
+	const [state, dispatch] = useWizardState();
+	const executor = useStepExecution({ state, dispatch, options });
+
+	useEffect(() => {
+		onReady(executor);
+	}, [executor, onReady]);
+
+	return <Text>harness</Text>;
+};
+
+async function mountExecutor(options: InitOptions): Promise<StepExecutor> {
+	let executor: StepExecutor | undefined;
+	render(<Harness options={options} onReady={(e) => (executor = e)} />);
+
+	for (let i = 0; i < 50 && executor === undefined; i++) {
+		await new Promise((resolve) => setTimeout(resolve, 10));
+	}
+	if (executor === undefined) {
+		throw new Error("Harness never provided a step executor");
+	}
+	return executor;
+}
+
+function readProjectId(projectRoot: string): string {
+	return readFileSync(join(projectRoot, ".rp1", "project_id"), "utf-8").trim();
+}
+
+describe("wizard directory-setup and settings-setup steps", () => {
+	let tempDir: string;
+	let centralProjectDir: string | undefined;
+
+	beforeEach(async () => {
+		tempDir = await createTempDir("wizard-step-exec-");
+		centralProjectDir = undefined;
+	});
+
+	afterEach(async () => {
+		// The wizard resolves the real home directory for central storage, so
+		// remove the central store entry created for this test's project id.
+		if (centralProjectDir !== undefined) {
+			await rm(centralProjectDir, { recursive: true, force: true });
+		}
+		await cleanupTempDir(tempDir);
+	});
+
+	test("directory-setup creates only minimal .rp1/ + project_id; settings-setup creates central storage dirs", async () => {
+		const executor = await mountExecutor({ cwd: tempDir });
+
+		await executor("directory-setup");
+
+		expect(existsSync(join(tempDir, ".rp1"))).toBe(true);
+		expect(existsSync(join(tempDir, ".rp1", "project_id"))).toBe(true);
+		// Storage directories must NOT be created before settings.toml exists —
+		// their location depends on the storage mode written there.
+		expect(existsSync(join(tempDir, ".rp1", "context"))).toBe(false);
+		expect(existsSync(join(tempDir, ".rp1", "work"))).toBe(false);
+
+		await executor("settings-setup");
+
+		const settingsPath = join(tempDir, ".rp1", "settings.toml");
+		expect(existsSync(settingsPath)).toBe(true);
+		const settings = readFileSync(settingsPath, "utf-8");
+		expect(settings).toContain('mode = "central"');
+
+		// Central mode: storage lives under ~/.rp1/projects/<id>/, not the repo.
+		const projectId = readProjectId(tempDir);
+		centralProjectDir = join(homedir(), ".rp1", "projects", projectId);
+		expect(existsSync(join(centralProjectDir, "context"))).toBe(true);
+		expect(existsSync(join(centralProjectDir, "work"))).toBe(true);
+		expect(existsSync(join(tempDir, ".rp1", "context"))).toBe(false);
+		expect(existsSync(join(tempDir, ".rp1", "work"))).toBe(false);
+	});
+
+	test("settings-setup honors an existing local-mode settings.toml", async () => {
+		const executor = await mountExecutor({ cwd: tempDir });
+
+		await executor("directory-setup");
+
+		const settingsPath = join(tempDir, ".rp1", "settings.toml");
+		await Bun.write(settingsPath, '[storage]\nmode = "local"\n');
+
+		await executor("settings-setup");
+
+		// Existing settings are preserved and local-mode dirs are created in-repo.
+		expect(readFileSync(settingsPath, "utf-8")).toContain('mode = "local"');
+		expect(existsSync(join(tempDir, ".rp1", "context"))).toBe(true);
+		expect(existsSync(join(tempDir, ".rp1", "work"))).toBe(true);
+
+		const projectId = readProjectId(tempDir);
+		expect(existsSync(join(homedir(), ".rp1", "projects", projectId))).toBe(
+			false,
+		);
+	});
+});

--- a/cli/src/__tests__/init/ui/hooks/useWizardState.test.ts
+++ b/cli/src/__tests__/init/ui/hooks/useWizardState.test.ts
@@ -108,6 +108,7 @@ describe("useWizardState", () => {
 				"install-check",
 				"directory-setup",
 				"settings-setup",
+				"sandbox-grants",
 				"instruction-injection",
 				"gitignore-config",
 				"health-check",
@@ -147,7 +148,7 @@ describe("useWizardState", () => {
 		});
 
 		test("returns last step for final index", () => {
-			const state = createTestState({ currentStepIndex: 11 });
+			const state = createTestState({ currentStepIndex: 12 });
 			const current = getCurrentStep(state);
 
 			expect(current?.id).toBe("summary");

--- a/cli/src/agent-tools/work-search/indexer.ts
+++ b/cli/src/agent-tools/work-search/indexer.ts
@@ -1,6 +1,7 @@
 import type { Database } from "bun:sqlite";
 import { createHash } from "node:crypto";
 import { lstat, readdir, readFile } from "node:fs/promises";
+import { homedir } from "node:os";
 import { extname, isAbsolute, join, relative, resolve, sep } from "node:path";
 import * as E from "fp-ts/lib/Either.js";
 import { pipe } from "fp-ts/lib/function.js";
@@ -89,10 +90,41 @@ export const resolveWorkSearchProjectScope = (
 		),
 	);
 
+/**
+ * Computes a human-readable display prefix for work artifact paths.
+ *
+ * Local mode (workRoot inside projectRoot): returns the project-relative path (e.g. `.rp1/work`).
+ * Central mode (workRoot outside projectRoot): returns a `~`-prefixed home-relative path
+ * (e.g. `~/.rp1/projects/{id}/work`), falling back to the absolute path when workRoot
+ * is not under the home directory.
+ */
+export const computeDisplayPrefix = (
+	workRoot: string,
+	projectRoot: string,
+	homeDir?: string,
+): string => {
+	const resolvedWorkRoot = resolve(workRoot);
+	const resolvedProjectRoot = resolve(projectRoot);
+
+	if (isWithinRoot(resolvedWorkRoot, resolvedProjectRoot)) {
+		return normalizeRelativePath(
+			relative(resolvedProjectRoot, resolvedWorkRoot),
+		);
+	}
+
+	const home = homeDir ?? homedir();
+	if (resolvedWorkRoot.startsWith(home + sep) || resolvedWorkRoot === home) {
+		return `~${normalizeRelativePath(resolvedWorkRoot.slice(home.length))}`;
+	}
+
+	return normalizeRelativePath(resolvedWorkRoot);
+};
+
 const collectMarkdownFiles = async (
 	workRoot: string,
 	currentDir: string,
 	files: MarkdownWorkFile[],
+	displayPrefix: string,
 ): Promise<void> => {
 	let entries: string[];
 	try {
@@ -119,7 +151,7 @@ const collectMarkdownFiles = async (
 		}
 
 		if (stat.isDirectory()) {
-			await collectMarkdownFiles(workRoot, absolutePath, files);
+			await collectMarkdownFiles(workRoot, absolutePath, files, displayPrefix);
 			continue;
 		}
 
@@ -137,7 +169,7 @@ const collectMarkdownFiles = async (
 		files.push({
 			absolutePath,
 			relativePath,
-			displayPath: `.rp1/work/${relativePath}`,
+			displayPath: `${displayPrefix}/${relativePath}`,
 			sizeBytes: stat.size,
 			mtimeMs: Math.round(stat.mtimeMs),
 		});
@@ -146,6 +178,8 @@ const collectMarkdownFiles = async (
 
 export const scanMarkdownWorkFiles = async (
 	workRoot: string,
+	projectRoot?: string,
+	homeDir?: string,
 ): Promise<readonly MarkdownWorkFile[]> => {
 	let rootStat: Awaited<ReturnType<typeof lstat>>;
 	try {
@@ -158,8 +192,12 @@ export const scanMarkdownWorkFiles = async (
 		return [];
 	}
 
+	const displayPrefix = projectRoot
+		? computeDisplayPrefix(workRoot, projectRoot, homeDir)
+		: ".rp1/work";
+
 	const files: MarkdownWorkFile[] = [];
-	await collectMarkdownFiles(workRoot, workRoot, files);
+	await collectMarkdownFiles(workRoot, workRoot, files, displayPrefix);
 	return files.sort((left, right) =>
 		left.relativePath.localeCompare(right.relativePath),
 	);
@@ -339,7 +377,7 @@ export const refreshWorkSearchIndex = (
 		TE.chain((project) =>
 			pipe(
 				TE.tryCatch(
-					() => scanMarkdownWorkFiles(project.workRoot),
+					() => scanMarkdownWorkFiles(project.workRoot, project.projectRoot),
 					(error) =>
 						runtimeError(
 							`Failed to scan work-search markdown files: ${error instanceof Error ? error.message : String(error)}`,

--- a/cli/src/init/directory-model.ts
+++ b/cli/src/init/directory-model.ts
@@ -2,6 +2,11 @@ import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import * as E from "fp-ts/lib/Either.js";
 import { resolveDirectorySet } from "../../shared/directory-resolution.js";
+import type { StorageMode } from "../../shared/storage-mode.js";
+import {
+	computeDirectoryPaths,
+	readStorageMode,
+} from "../../shared/storage-mode.js";
 import { hasFencedContent } from "./comment-fence.js";
 import type { ReinitState } from "./models.js";
 import type { DetectedTool } from "./tool-detector.js";
@@ -99,6 +104,55 @@ export const chooseInitDirectoryModel = (
 	forceLocalProject
 		? defaultInitDirectoryModel(cwd)
 		: resolveInitDirectoryModel(cwd);
+
+/**
+ * Resolved storage directory paths based on the project's storage mode.
+ * Used after project_id and settings.toml are established to determine
+ * where KB and work artifacts should be stored.
+ */
+export interface StorageDirectoryPaths {
+	readonly contextDir: string;
+	readonly workDir: string;
+	readonly storageMode: StorageMode;
+}
+
+/**
+ * Compute storage directories using the resolver's path computation.
+ * Reads the storage mode from the project's settings.toml and delegates
+ * to computeDirectoryPaths for central vs local path resolution.
+ *
+ * Must be called after settings.toml is written and project_id exists.
+ *
+ * @param homeDir - Override home directory for central path computation
+ *   (test isolation seam; Bun's homedir() does not respect HOME env var)
+ */
+export const resolveStorageDirectoryPaths = (
+	projectRoot: string,
+	projectId: string,
+	homeDir?: string,
+): StorageDirectoryPaths => {
+	const mode = readStorageMode(projectRoot);
+
+	if (mode === "central" && homeDir !== undefined) {
+		const centralBase = path.join(homeDir, ".rp1", "projects", projectId);
+		return {
+			contextDir: path.join(centralBase, "context"),
+			workDir: path.join(centralBase, "work"),
+			storageMode: "central",
+		};
+	}
+
+	const { kbRoot, workRoot, effectiveMode } = computeDirectoryPaths(
+		projectRoot,
+		projectId,
+		mode,
+	);
+	return {
+		contextDir: kbRoot,
+		workDir: workRoot,
+		storageMode: effectiveMode,
+	};
+};
 
 async function fileExists(filePath: string): Promise<boolean> {
 	try {

--- a/cli/src/init/index.ts
+++ b/cli/src/init/index.ts
@@ -45,7 +45,6 @@ import { performHealthCheck } from "./steps/health-check.js";
 import { checkPluginsInstalled } from "./steps/plugin-installation.js";
 import {
 	configureGitignore,
-	createDirectoryStructure,
 	createMinimalProjectStructure,
 	createSettingsFiles,
 	createStorageDirectories,

--- a/cli/src/init/index.ts
+++ b/cli/src/init/index.ts
@@ -51,6 +51,7 @@ import {
 	injectInstructions,
 } from "./steps/project-setup.js";
 import { checkRp1Readiness } from "./steps/readiness.js";
+import { generateSandboxGrants } from "./steps/sandbox-grants.js";
 import { displaySummary, generateNextSteps } from "./steps/summary.js";
 import {
 	verifyClaudeCodePlugins,
@@ -103,6 +104,10 @@ const INIT_STEPS = [
 	{ name: "install-check", description: "Checking plugin installation..." },
 	{ name: "directory-setup", description: "Setting up directory structure..." },
 	{ name: "settings-setup", description: "Creating settings files..." },
+	{
+		name: "sandbox-grants",
+		description: "Configuring sandbox grants...",
+	},
 	{
 		name: "instruction-injection",
 		description: "Configuring instruction file...",
@@ -824,6 +829,32 @@ export function executeInit(
 				);
 				allActions.push(...storageDirActions);
 				progress.completeStep();
+
+				// Phase 3: Generate sandbox grants for selected harnesses
+				// so AI coding platforms can access the central store at ~/.rp1/
+				progress.startStep("sandbox-grants");
+				try {
+					const grantResults = await generateSandboxGrants(
+						undefined,
+						cwd,
+						options.globalSettingsPath,
+					);
+					for (const grant of grantResults) {
+						if (grant.written) {
+							allActions.push({ type: "created_file", path: grant.path });
+							logger.success(
+								`Sandbox grant: ${grant.platform} → ${grant.path}`,
+							);
+						}
+					}
+					progress.completeStep();
+				} catch (error) {
+					const errorMessage =
+						error instanceof Error ? error.message : String(error);
+					logger.warn(`Sandbox grant error: ${errorMessage}`);
+					allWarnings.push(`Sandbox grants failed: ${errorMessage}`);
+					progress.failStep();
+				}
 
 				progress.startStep("instruction-injection");
 				const { actions: instrActions } = await injectInstructions(

--- a/cli/src/init/index.ts
+++ b/cli/src/init/index.ts
@@ -46,7 +46,9 @@ import { checkPluginsInstalled } from "./steps/plugin-installation.js";
 import {
 	configureGitignore,
 	createDirectoryStructure,
+	createMinimalProjectStructure,
 	createSettingsFiles,
+	createStorageDirectories,
 	injectInstructions,
 } from "./steps/project-setup.js";
 import { checkRp1Readiness } from "./steps/readiness.js";
@@ -795,16 +797,20 @@ export function executeInit(
 				}
 
 				// --- Project setup ---
+				// Phase 1: Create minimal .rp1/ + project_id (required before
+				// central path computation and settings.toml write)
 				progress.startStep("directory-setup");
-				const dirActions = await createDirectoryStructure(
+				const minimalDirActions = await createMinimalProjectStructure(
 					cwd,
 					logger,
 					directories,
 				);
-				allActions.push(...dirActions);
-				await ensureProjectId(directories.projectRoot);
+				allActions.push(...minimalDirActions);
+				const projectId = await ensureProjectId(directories.projectRoot);
 				progress.completeStep();
 
+				// Phase 2: Write settings.toml, then create storage directories
+				// based on the resolved storage mode
 				progress.startStep("settings-setup");
 				const settingsActions = await createSettingsFiles(
 					cwd,
@@ -812,6 +818,12 @@ export function executeInit(
 					directories,
 				);
 				allActions.push(...settingsActions);
+				const storageDirActions = await createStorageDirectories(
+					directories.projectRoot,
+					projectId,
+					logger,
+				);
+				allActions.push(...storageDirActions);
 				progress.completeStep();
 
 				progress.startStep("instruction-injection");

--- a/cli/src/init/models.ts
+++ b/cli/src/init/models.ts
@@ -4,8 +4,11 @@
  * next steps guidance, and progress tracking.
  */
 
+import type { StorageMode } from "../../shared/storage-mode.js";
 import type { GitRootResult } from "./git-root.js";
 import type { DetectedTool } from "./tool-detector.js";
+
+export type { StorageMode };
 
 /**
  * Project context classification for greenfield/brownfield detection.
@@ -210,6 +213,15 @@ export const GITIGNORE_PRESETS = {
 
 	/** Option C: Ignore entire .rp1/ */
 	ignore_all: `.rp1/`,
+
+	/**
+	 * Central mode: KB and work artifacts live under ~/.rp1/projects/<id>/,
+	 * so only project_id and settings.toml need tracking in the repo.
+	 */
+	central: `!.rp1/
+.rp1/*
+!.rp1/project_id
+!.rp1/settings.toml`,
 } as const;
 
 export type GitignorePreset = keyof typeof GITIGNORE_PRESETS;

--- a/cli/src/init/models.ts
+++ b/cli/src/init/models.ts
@@ -184,6 +184,8 @@ export interface InitOptions {
 	readonly interactive?: boolean;
 	/** Force creating a nested project even when an ancestor project exists */
 	readonly forceNested?: boolean;
+	/** Override path to global settings file (test isolation seam) */
+	readonly globalSettingsPath?: string;
 }
 
 /**
@@ -257,6 +259,7 @@ export type StepId =
 	| "settings-setup"
 	| "tool-detection"
 	| "harness-selection"
+	| "sandbox-grants"
 	| "instruction-injection"
 	| "gitignore-config"
 	| "install-check"

--- a/cli/src/init/settings-template.ts
+++ b/cli/src/init/settings-template.ts
@@ -18,3 +18,32 @@ mode = "central"
 # afk = false
 `;
 }
+
+/**
+ * Template for the user-global settings file (~/.config/rp1/settings.toml).
+ *
+ * Deliberately does NOT set an active [storage] section: the global file is a
+ * fallback for every project on the machine, so an active mode here would
+ * silently flip existing local-mode projects to central. Central mode is a
+ * per-project opt-in written into the project's .rp1/settings.toml.
+ */
+export function buildGlobalSettingsTomlTemplate(): string {
+	return `# rp1 Global Settings
+# Documentation: https://rp1.run/configuration/settings
+
+# Storage mode is a per-project setting written to <project>/.rp1/settings.toml
+# during init. Setting it here would apply to every project on this machine
+# that does not set its own mode, so leave it commented unless that is intended.
+# [storage]
+# mode = "central"
+
+# Command default examples:
+# [arguments."dev:build"]
+# afk = false
+# git_commit = false
+# git_push = false
+
+# [arguments."dev:build-fast"]
+# afk = false
+`;
+}

--- a/cli/src/init/settings-template.ts
+++ b/cli/src/init/settings-template.ts
@@ -2,13 +2,11 @@ export function buildSettingsTomlTemplate(): string {
 	return `# rp1 Settings
 # Documentation: https://rp1.run/configuration/settings
 
-# Project-level settings are optional.
-# Most projects can leave this file with commented examples only.
-#
-# Directory paths are fixed from the project root:
-# - Knowledge base files live in .rp1/context
-# - Work artifacts live in .rp1/work
-# Use this file for command defaults only.
+# Storage mode: "central" stores KB and work artifacts under ~/.rp1/projects/<id>/
+# instead of inside the repo tree, eliminating git churn from rp1-generated files.
+# "local" keeps artifacts under .rp1/ in the project directory (legacy default).
+[storage]
+mode = "central"
 
 # Command default examples:
 # [arguments."dev:build"]

--- a/cli/src/init/steps/project-setup.ts
+++ b/cli/src/init/steps/project-setup.ts
@@ -27,6 +27,7 @@ import {
 import {
 	type InitDirectoryModel,
 	resolveInitDirectoryModel,
+	resolveStorageDirectoryPaths,
 } from "../directory-model.js";
 import { buildManagedGitignoreContent } from "../gitignore.js";
 import type { GitignorePreset, InitAction } from "../models.js";
@@ -111,6 +112,67 @@ export async function createDirectoryStructure(
 		logger.info(`Created: ${rp1Dir}`);
 		actions.push({ type: "created_directory", path: rp1Dir });
 	}
+
+	if (!(await directoryExists(contextDir))) {
+		await fs.mkdir(contextDir, { recursive: true });
+		logger.info(`Created: ${contextDir}`);
+		actions.push({ type: "created_directory", path: contextDir });
+	}
+
+	if (!(await directoryExists(workDir))) {
+		await fs.mkdir(workDir, { recursive: true });
+		logger.info(`Created: ${workDir}`);
+		actions.push({ type: "created_directory", path: workDir });
+	}
+
+	return actions;
+}
+
+/**
+ * Create only the minimal .rp1/ directory without context/ or work/ subdirs.
+ * Used in the reordered init flow where project_id and settings.toml must
+ * be established before storage directories can be computed.
+ */
+export async function createMinimalProjectStructure(
+	cwd: string,
+	logger: Logger,
+	directoriesOverride?: InitDirectoryModel,
+): Promise<InitAction[]> {
+	const actions: InitAction[] = [];
+	const directories = directoriesOverride ?? resolveInitDirectoryModel(cwd);
+	const { rp1Dir } = directories;
+
+	if (!(await directoryExists(rp1Dir))) {
+		await fs.mkdir(rp1Dir, { recursive: true });
+		logger.info(`Created: ${rp1Dir}`);
+		actions.push({ type: "created_directory", path: rp1Dir });
+	}
+
+	return actions;
+}
+
+/**
+ * Create storage directories (context + work) based on the resolved storage mode.
+ * For central mode, creates dirs under ~/.rp1/projects/{projectId}/.
+ * For local mode, creates dirs under {projectRoot}/.rp1/.
+ *
+ * Must be called after settings.toml is written and project_id exists,
+ * because the storage mode is read from the project's settings.
+ *
+ * @param homeDir - Override home directory for test isolation
+ */
+export async function createStorageDirectories(
+	projectRoot: string,
+	projectId: string,
+	logger: Logger,
+	homeDir?: string,
+): Promise<InitAction[]> {
+	const actions: InitAction[] = [];
+	const { contextDir, workDir } = resolveStorageDirectoryPaths(
+		projectRoot,
+		projectId,
+		homeDir,
+	);
 
 	if (!(await directoryExists(contextDir))) {
 		await fs.mkdir(contextDir, { recursive: true });

--- a/cli/src/init/steps/project-setup.ts
+++ b/cli/src/init/steps/project-setup.ts
@@ -32,7 +32,10 @@ import {
 import { buildManagedGitignoreContent } from "../gitignore.js";
 import type { GitignorePreset, InitAction } from "../models.js";
 import type { InitProgress } from "../progress.js";
-import { buildSettingsTomlTemplate } from "../settings-template.js";
+import {
+	buildGlobalSettingsTomlTemplate,
+	buildSettingsTomlTemplate,
+} from "../settings-template.js";
 import {
 	appendShellFencedContent,
 	hasShellFencedContent,
@@ -218,6 +221,7 @@ function resolveLocalSettingsPath(
  */
 async function createOrUpdateSettingsFile(
 	filePath: string,
+	template: string,
 ): Promise<{ action: InitAction; isNew: boolean; addedFields: string[] }> {
 	if (await fileExists(filePath)) {
 		return {
@@ -227,8 +231,7 @@ async function createOrUpdateSettingsFile(
 		};
 	}
 
-	const content = buildSettingsTomlTemplate();
-	await writeFileContent(filePath, content);
+	await writeFileContent(filePath, template);
 
 	return {
 		action: { type: "created_file", path: filePath },
@@ -254,7 +257,10 @@ export async function createSettingsFiles(
 
 	// Process global settings file
 	const globalPath = resolveGlobalSettingsPath();
-	const globalResult = await createOrUpdateSettingsFile(globalPath);
+	const globalResult = await createOrUpdateSettingsFile(
+		globalPath,
+		buildGlobalSettingsTomlTemplate(),
+	);
 	actions.push(globalResult.action);
 
 	if (globalResult.isNew) {
@@ -269,7 +275,10 @@ export async function createSettingsFiles(
 
 	// Process local settings file
 	const localPath = resolveLocalSettingsPath(cwd, directoriesOverride);
-	const localResult = await createOrUpdateSettingsFile(localPath);
+	const localResult = await createOrUpdateSettingsFile(
+		localPath,
+		buildSettingsTomlTemplate(),
+	);
 	actions.push(localResult.action);
 
 	if (localResult.isNew) {

--- a/cli/src/init/steps/project-setup.ts
+++ b/cli/src/init/steps/project-setup.ts
@@ -162,12 +162,15 @@ export async function createMinimalProjectStructure(
  * Must be called after settings.toml is written and project_id exists,
  * because the storage mode is read from the project's settings.
  *
+ * The logger is narrowed to `info` so non-Logger callers (the init wizard,
+ * which reports through per-step activity callbacks) can share this logic.
+ *
  * @param homeDir - Override home directory for test isolation
  */
 export async function createStorageDirectories(
 	projectRoot: string,
 	projectId: string,
-	logger: Logger,
+	logger: Pick<Logger, "info">,
 	homeDir?: string,
 ): Promise<InitAction[]> {
 	const actions: InitAction[] = [];

--- a/cli/src/init/steps/sandbox-grants.ts
+++ b/cli/src/init/steps/sandbox-grants.ts
@@ -381,13 +381,17 @@ export async function generateSandboxGrants(
 	harnesses: string[] | undefined,
 	projectRoot: string,
 	globalSettingsPath?: string,
-): Promise<void> {
+): Promise<GrantResult[]> {
 	const resolved = await resolveHarnesses(harnesses, globalSettingsPath);
+	const results: GrantResult[] = [];
 
 	for (const platformId of resolved) {
 		const writer = PLATFORM_WRITERS[platformId];
 		if (writer) {
-			await writer(projectRoot);
+			const result = await writer(projectRoot);
+			results.push(result);
 		}
 	}
+
+	return results;
 }

--- a/cli/src/init/steps/sandbox-grants.ts
+++ b/cli/src/init/steps/sandbox-grants.ts
@@ -1,0 +1,393 @@
+/**
+ * Per-platform sandbox grant generators for central-mode rp1 projects.
+ *
+ * Each AI coding harness enforces a filesystem sandbox that blocks access
+ * outside the project directory by default. Central-mode stores KB and work
+ * artifacts under ~/.rp1/projects/<id>/, so each platform needs an explicit
+ * grant to read and write that path.
+ *
+ * Pure generator functions produce typed config objects; writer functions
+ * persist them to the platform-specific config file in the project root.
+ * The dispatcher resolves which platforms need grants from the persisted
+ * harness selection or falls back to all stable platforms.
+ */
+
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import {
+	getDefaultInstallTools,
+	loadToolsRegistry,
+} from "../../config/supported-tools.js";
+import { loadEnabledHarnesses } from "../../settings/loader.js";
+
+const CENTRAL_STORE_PATH = "~/.rp1";
+const CENTRAL_STORE_GLOB = "~/.rp1/**";
+
+// ─── Grant result ─────────────────────────────────────────────────────────
+
+export interface GrantResult {
+	readonly platform: string;
+	readonly written: boolean;
+	readonly path: string;
+}
+
+// ─── Claude Code ──────────────────────────────────────────────────────────
+
+export interface ClaudeCodeGrants {
+	readonly permissions: {
+		readonly additionalDirectories: readonly string[];
+		readonly allow: readonly string[];
+	};
+	readonly sandbox: {
+		readonly filesystem: {
+			readonly allowWrite: readonly string[];
+		};
+	};
+}
+
+export function generateClaudeCodeGrants(): ClaudeCodeGrants {
+	return {
+		permissions: {
+			additionalDirectories: [CENTRAL_STORE_PATH],
+			allow: [`Read(${CENTRAL_STORE_GLOB})`, `Edit(${CENTRAL_STORE_GLOB})`],
+		},
+		sandbox: {
+			filesystem: {
+				allowWrite: [CENTRAL_STORE_PATH],
+			},
+		},
+	};
+}
+
+/**
+ * Deduplicate a string array while preserving insertion order.
+ */
+function dedupeArray(arr: readonly string[]): string[] {
+	return [...new Set(arr)];
+}
+
+/**
+ * Deep-merge rp1 grants into an existing Claude Code settings.json object.
+ * Arrays are union-merged (deduped). Existing user keys are preserved.
+ */
+function mergeClaudeCodeSettings(
+	existing: Record<string, unknown>,
+	grants: ClaudeCodeGrants,
+): Record<string, unknown> {
+	const result = { ...existing };
+
+	const existingPerms = (result.permissions ?? {}) as Record<string, unknown>;
+	const mergedPerms = { ...existingPerms };
+
+	mergedPerms.additionalDirectories = dedupeArray([
+		...((existingPerms.additionalDirectories as string[]) ?? []),
+		...(grants.permissions.additionalDirectories as string[]),
+	]);
+
+	mergedPerms.allow = dedupeArray([
+		...((existingPerms.allow as string[]) ?? []),
+		...(grants.permissions.allow as string[]),
+	]);
+
+	result.permissions = mergedPerms;
+
+	const existingSandbox = (result.sandbox ?? {}) as Record<string, unknown>;
+	const existingFs = (existingSandbox.filesystem ?? {}) as Record<
+		string,
+		unknown
+	>;
+
+	const mergedFs = { ...existingFs };
+	mergedFs.allowWrite = dedupeArray([
+		...((existingFs.allowWrite as string[]) ?? []),
+		...(grants.sandbox.filesystem.allowWrite as string[]),
+	]);
+
+	result.sandbox = { ...existingSandbox, filesystem: mergedFs };
+
+	return result;
+}
+
+export async function writeClaudeCodeGrants(
+	projectRoot: string,
+): Promise<GrantResult> {
+	const grants = generateClaudeCodeGrants();
+	const settingsDir = join(projectRoot, ".claude");
+	const settingsPath = join(settingsDir, "settings.json");
+
+	let existing: Record<string, unknown> = {};
+	try {
+		const content = await readFile(settingsPath, "utf-8");
+		existing = JSON.parse(content) as Record<string, unknown>;
+	} catch {
+		// File absent or invalid — start fresh
+	}
+
+	const merged = mergeClaudeCodeSettings(existing, grants);
+	await mkdir(settingsDir, { recursive: true });
+	await writeFile(
+		settingsPath,
+		`${JSON.stringify(merged, null, 2)}\n`,
+		"utf-8",
+	);
+
+	return { platform: "claude-code", written: true, path: settingsPath };
+}
+
+// ─── Codex ────────────────────────────────────────────────────────────────
+
+export interface CodexGrants {
+	readonly sandbox_workspace_write: {
+		readonly writable_roots: readonly string[];
+	};
+}
+
+export function generateCodexGrants(): CodexGrants {
+	return {
+		sandbox_workspace_write: {
+			writable_roots: [CENTRAL_STORE_PATH],
+		},
+	};
+}
+
+export async function writeCodexGrants(
+	projectRoot: string,
+): Promise<GrantResult> {
+	const grants = generateCodexGrants();
+	const configPath = join(projectRoot, "codex.toml");
+
+	const entries = grants.sandbox_workspace_write.writable_roots
+		.map((r) => `"${r}"`)
+		.join(", ");
+	const section = `[sandbox_workspace_write]\nwritable_roots = [${entries}]`;
+
+	let existing = "";
+	try {
+		existing = await readFile(configPath, "utf-8");
+	} catch {
+		// File absent
+	}
+
+	let content: string;
+	if (existing.includes("[sandbox_workspace_write]")) {
+		// Section already exists — leave it as-is to avoid overwriting user entries
+		content = existing;
+	} else {
+		content = existing.trim()
+			? `${existing.trim()}\n\n${section}\n`
+			: `${section}\n`;
+	}
+
+	await writeFile(configPath, content, "utf-8");
+	return { platform: "codex", written: true, path: configPath };
+}
+
+// ─── OpenCode ─────────────────────────────────────────────────────────────
+
+export interface OpenCodeGrants {
+	readonly sandbox: {
+		readonly external_directories: readonly string[];
+	};
+}
+
+export function generateOpenCodeGrants(): OpenCodeGrants {
+	return {
+		sandbox: {
+			external_directories: [CENTRAL_STORE_PATH],
+		},
+	};
+}
+
+export async function writeOpenCodeGrants(
+	projectRoot: string,
+): Promise<GrantResult> {
+	const grants = generateOpenCodeGrants();
+	const settingsDir = join(projectRoot, ".opencode");
+	const settingsPath = join(settingsDir, "settings.json");
+
+	let existing: Record<string, unknown> = {};
+	try {
+		const content = await readFile(settingsPath, "utf-8");
+		existing = JSON.parse(content) as Record<string, unknown>;
+	} catch {
+		// File absent or invalid
+	}
+
+	const existingSandbox = (existing.sandbox ?? {}) as Record<string, unknown>;
+	const mergedSandbox = { ...existingSandbox };
+	mergedSandbox.external_directories = dedupeArray([
+		...((existingSandbox.external_directories as string[]) ?? []),
+		...(grants.sandbox.external_directories as string[]),
+	]);
+
+	const merged = { ...existing, sandbox: mergedSandbox };
+	await mkdir(settingsDir, { recursive: true });
+	await writeFile(
+		settingsPath,
+		`${JSON.stringify(merged, null, 2)}\n`,
+		"utf-8",
+	);
+
+	return { platform: "opencode", written: true, path: settingsPath };
+}
+
+// ─── Antigravity ──────────────────────────────────────────────────────────
+
+export interface AntigravityGrants {
+	readonly sandbox: {
+		readonly allowed_paths: readonly string[];
+	};
+}
+
+export function generateAntigravityGrants(): AntigravityGrants {
+	return {
+		sandbox: {
+			allowed_paths: [CENTRAL_STORE_PATH],
+		},
+	};
+}
+
+export async function writeAntigravityGrants(
+	projectRoot: string,
+): Promise<GrantResult> {
+	const grants = generateAntigravityGrants();
+	const settingsDir = join(projectRoot, ".gemini");
+	const settingsPath = join(settingsDir, "settings.json");
+
+	let existing: Record<string, unknown> = {};
+	try {
+		const content = await readFile(settingsPath, "utf-8");
+		existing = JSON.parse(content) as Record<string, unknown>;
+	} catch {
+		// File absent or invalid
+	}
+
+	const existingSandbox = (existing.sandbox ?? {}) as Record<string, unknown>;
+	const mergedSandbox = { ...existingSandbox };
+	mergedSandbox.allowed_paths = dedupeArray([
+		...((existingSandbox.allowed_paths as string[]) ?? []),
+		...(grants.sandbox.allowed_paths as string[]),
+	]);
+
+	const merged = { ...existing, sandbox: mergedSandbox };
+	await mkdir(settingsDir, { recursive: true });
+	await writeFile(
+		settingsPath,
+		`${JSON.stringify(merged, null, 2)}\n`,
+		"utf-8",
+	);
+
+	return { platform: "antigravity", written: true, path: settingsPath };
+}
+
+// ─── Copilot ──────────────────────────────────────────────────────────────
+
+export interface CopilotGrants {
+	readonly sandbox: {
+		readonly allowlist: readonly string[];
+	};
+}
+
+export function generateCopilotGrants(): CopilotGrants {
+	return {
+		sandbox: {
+			allowlist: [CENTRAL_STORE_PATH],
+		},
+	};
+}
+
+export async function writeCopilotGrants(
+	projectRoot: string,
+): Promise<GrantResult> {
+	const grants = generateCopilotGrants();
+	const settingsDir = join(projectRoot, ".github");
+	const settingsPath = join(settingsDir, "copilot-settings.json");
+
+	let existing: Record<string, unknown> = {};
+	try {
+		const content = await readFile(settingsPath, "utf-8");
+		existing = JSON.parse(content) as Record<string, unknown>;
+	} catch {
+		// File absent or invalid
+	}
+
+	const existingSandbox = (existing.sandbox ?? {}) as Record<string, unknown>;
+	const mergedSandbox = { ...existingSandbox };
+	mergedSandbox.allowlist = dedupeArray([
+		...((existingSandbox.allowlist as string[]) ?? []),
+		...(grants.sandbox.allowlist as string[]),
+	]);
+
+	const merged = { ...existing, sandbox: mergedSandbox };
+	await mkdir(settingsDir, { recursive: true });
+	await writeFile(
+		settingsPath,
+		`${JSON.stringify(merged, null, 2)}\n`,
+		"utf-8",
+	);
+
+	return { platform: "copilot", written: true, path: settingsPath };
+}
+
+// ─── Platform writer dispatch table ───────────────────────────────────────
+
+const PLATFORM_WRITERS: Readonly<
+	Record<string, (projectRoot: string) => Promise<GrantResult>>
+> = {
+	"claude-code": writeClaudeCodeGrants,
+	codex: writeCodexGrants,
+	opencode: writeOpenCodeGrants,
+	antigravity: writeAntigravityGrants,
+	copilot: writeCopilotGrants,
+};
+
+// ─── Dispatch ─────────────────────────────────────────────────────────────
+
+/**
+ * Resolve the effective harness list.
+ *
+ * 1. If an explicit list is provided, use it.
+ * 2. Otherwise read persisted selection via loadEnabledHarnesses.
+ * 3. If nothing is persisted, fall back to all stable platforms in the registry.
+ */
+async function resolveHarnesses(
+	harnesses: string[] | undefined,
+	globalSettingsPath?: string,
+): Promise<readonly string[]> {
+	if (harnesses !== undefined) {
+		return harnesses;
+	}
+
+	const persisted = loadEnabledHarnesses(globalSettingsPath);
+	if (persisted !== undefined) {
+		return persisted;
+	}
+
+	const registry = await loadToolsRegistry();
+	return getDefaultInstallTools(registry).map((t) => t.id);
+}
+
+/**
+ * Generate sandbox grants for selected platforms.
+ *
+ * Dispatches to per-platform writers based on the resolved harness list.
+ * Unknown platform IDs are silently skipped.
+ *
+ * @param harnesses - Explicit list, or undefined to resolve from settings/registry
+ * @param projectRoot - Project root directory where grant files are written
+ * @param globalSettingsPath - Override path for test isolation (passed through to loadEnabledHarnesses)
+ */
+export async function generateSandboxGrants(
+	harnesses: string[] | undefined,
+	projectRoot: string,
+	globalSettingsPath?: string,
+): Promise<void> {
+	const resolved = await resolveHarnesses(harnesses, globalSettingsPath);
+
+	for (const platformId of resolved) {
+		const writer = PLATFORM_WRITERS[platformId];
+		if (writer) {
+			await writer(projectRoot);
+		}
+	}
+}

--- a/cli/src/init/steps/sandbox-grants.ts
+++ b/cli/src/init/steps/sandbox-grants.ts
@@ -184,16 +184,23 @@ export async function writeCodexGrants(
 
 // ─── OpenCode ─────────────────────────────────────────────────────────────
 
+/**
+ * OpenCode enforces an `external_directory` permission that defaults to "ask"
+ * for paths outside the working directory. The grant writes allow rules into
+ * the project-level `opencode.json` as a path-pattern-to-mode map.
+ *
+ * Validated format per HYP-002: `{ permission: { external_directory: { "~/.rp1/**": "allow" } } }`
+ */
 export interface OpenCodeGrants {
-	readonly sandbox: {
-		readonly external_directories: readonly string[];
+	readonly permission: {
+		readonly external_directory: Readonly<Record<string, string>>;
 	};
 }
 
 export function generateOpenCodeGrants(): OpenCodeGrants {
 	return {
-		sandbox: {
-			external_directories: [CENTRAL_STORE_PATH],
+		permission: {
+			external_directory: { [CENTRAL_STORE_GLOB]: "allow" },
 		},
 	};
 }
@@ -202,33 +209,35 @@ export async function writeOpenCodeGrants(
 	projectRoot: string,
 ): Promise<GrantResult> {
 	const grants = generateOpenCodeGrants();
-	const settingsDir = join(projectRoot, ".opencode");
-	const settingsPath = join(settingsDir, "settings.json");
+	const configPath = join(projectRoot, "opencode.json");
 
 	let existing: Record<string, unknown> = {};
 	try {
-		const content = await readFile(settingsPath, "utf-8");
+		const content = await readFile(configPath, "utf-8");
 		existing = JSON.parse(content) as Record<string, unknown>;
 	} catch {
 		// File absent or invalid
 	}
 
-	const existingSandbox = (existing.sandbox ?? {}) as Record<string, unknown>;
-	const mergedSandbox = { ...existingSandbox };
-	mergedSandbox.external_directories = dedupeArray([
-		...((existingSandbox.external_directories as string[]) ?? []),
-		...(grants.sandbox.external_directories as string[]),
-	]);
+	const existingPermission = (existing.permission ?? {}) as Record<
+		string,
+		unknown
+	>;
+	const existingExtDir = (existingPermission.external_directory ??
+		{}) as Record<string, string>;
 
-	const merged = { ...existing, sandbox: mergedSandbox };
-	await mkdir(settingsDir, { recursive: true });
-	await writeFile(
-		settingsPath,
-		`${JSON.stringify(merged, null, 2)}\n`,
-		"utf-8",
-	);
+	const mergedPermission = {
+		...existingPermission,
+		external_directory: {
+			...existingExtDir,
+			...grants.permission.external_directory,
+		},
+	};
 
-	return { platform: "opencode", written: true, path: settingsPath };
+	const merged = { ...existing, permission: mergedPermission };
+	await writeFile(configPath, `${JSON.stringify(merged, null, 2)}\n`, "utf-8");
+
+	return { platform: "opencode", written: true, path: configPath };
 }
 
 // ─── Antigravity ──────────────────────────────────────────────────────────

--- a/cli/src/init/ui/InitWizard.tsx
+++ b/cli/src/init/ui/InitWizard.tsx
@@ -77,6 +77,7 @@ const PROMPTABLE_STEPS: Record<StepId, PromptType> = {
 	"settings-setup": null, // Settings files are created automatically, no prompt needed
 	"tool-detection": null,
 	"harness-selection": null, // Handled by step execution via onPromptRequest
+	"sandbox-grants": null,
 	"instruction-injection": null,
 	"gitignore-config": "gitignore", // Conditionally shown - see needsPrompt
 	"install-check": null,

--- a/cli/src/init/ui/hooks/useStepExecution.ts
+++ b/cli/src/init/ui/hooks/useStepExecution.ts
@@ -72,6 +72,7 @@ import {
 } from "../../steps/harness-selection.js";
 import { performHealthCheck } from "../../steps/health-check.js";
 import { checkPluginsInstalled } from "../../steps/plugin-installation.js";
+import { createStorageDirectories } from "../../steps/project-setup.js";
 import {
 	checkRp1Readiness,
 	type ReadinessResult,
@@ -528,8 +529,10 @@ export const useStepExecution = ({
 				chooseInitDirectoryModel(ctx.cwd, ctx.forceLocalProject);
 			ctx.directories = directories;
 
-			let created = 0;
-
+			// Only the minimal .rp1/ + project_id are created here. Context and
+			// work directories depend on the storage mode in settings.toml, so
+			// they are created by the settings-setup step after that file is
+			// written (mirroring the headless three-phase init flow).
 			if (!(await directoryExists(directories.rp1Dir))) {
 				await fs.mkdir(directories.rp1Dir, { recursive: true });
 				addAct(
@@ -537,35 +540,12 @@ export const useStepExecution = ({
 					`Created ${formatDirectoryForDisplay(ctx.cwd, directories.rp1Dir)}`,
 					"success",
 				);
-				created++;
-			}
-
-			if (!(await directoryExists(directories.contextDir))) {
-				await fs.mkdir(directories.contextDir, { recursive: true });
-				addAct(
-					"directory-setup",
-					`Created ${formatDirectoryForDisplay(ctx.cwd, directories.contextDir)}`,
-					"success",
-				);
-				created++;
-			}
-
-			if (!(await directoryExists(directories.workDir))) {
-				await fs.mkdir(directories.workDir, { recursive: true });
-				addAct(
-					"directory-setup",
-					`Created ${formatDirectoryForDisplay(ctx.cwd, directories.workDir)}`,
-					"success",
-				);
-				created++;
+			} else {
+				addAct("directory-setup", "Directory structure exists", "success");
 			}
 
 			await ensureProjectId(directories.projectRoot);
 			addAct("directory-setup", "Project ID ensured", "success");
-
-			if (created === 0) {
-				addAct("directory-setup", "Directory structure exists", "success");
-			}
 		},
 		[],
 	);
@@ -607,6 +587,26 @@ export const useStepExecution = ({
 					"Local settings file exists (user values preserved)",
 					"info",
 				);
+			}
+
+			// Create storage directories now that settings.toml determines the
+			// mode: central mode places context/work under ~/.rp1/projects/<id>/,
+			// local mode under <projectRoot>/.rp1/.
+			const directories =
+				ctx.directories ??
+				chooseInitDirectoryModel(ctx.cwd, ctx.forceLocalProject);
+			ctx.directories = directories;
+			const projectId = await ensureProjectId(directories.projectRoot);
+			const storageActions = await createStorageDirectories(
+				directories.projectRoot,
+				projectId,
+				{
+					info: (message: string) =>
+						addAct("settings-setup", message, "success"),
+				},
+			);
+			if (storageActions.length === 0) {
+				addAct("settings-setup", "Storage directories exist", "info");
 			}
 		},
 		[],

--- a/cli/src/init/ui/hooks/useStepExecution.ts
+++ b/cli/src/init/ui/hooks/useStepExecution.ts
@@ -54,7 +54,10 @@ import type {
 	ReinitState,
 	StepId,
 } from "../../models.js";
-import { buildSettingsTomlTemplate } from "../../settings-template.js";
+import {
+	buildGlobalSettingsTomlTemplate,
+	buildSettingsTomlTemplate,
+} from "../../settings-template.js";
 import {
 	appendShellFencedContent,
 	hasShellFencedContent,
@@ -98,6 +101,7 @@ import {
 import type { WizardAction, WizardState } from "./useWizardState.js";
 
 const DEFAULT_SETTINGS_TEMPLATE = buildSettingsTomlTemplate();
+const GLOBAL_SETTINGS_TEMPLATE = buildGlobalSettingsTomlTemplate();
 
 /**
  * Resolve the global settings file path.
@@ -579,7 +583,7 @@ export const useStepExecution = ({
 			const globalDir = path.dirname(globalPath);
 			if (!(await fileExists(globalPath))) {
 				await fs.mkdir(globalDir, { recursive: true });
-				await writeFileContent(globalPath, DEFAULT_SETTINGS_TEMPLATE);
+				await writeFileContent(globalPath, GLOBAL_SETTINGS_TEMPLATE);
 				addAct("settings-setup", "Created global settings file", "success");
 			} else {
 				addAct(

--- a/cli/src/init/ui/hooks/useStepExecution.ts
+++ b/cli/src/init/ui/hooks/useStepExecution.ts
@@ -73,6 +73,7 @@ import {
 	checkRp1Readiness,
 	type ReadinessResult,
 } from "../../steps/readiness.js";
+import { generateSandboxGrants } from "../../steps/sandbox-grants.js";
 import { generateNextSteps } from "../../steps/summary.js";
 import {
 	verifyClaudeCodePlugins,
@@ -602,6 +603,38 @@ export const useStepExecution = ({
 					"Local settings file exists (user values preserved)",
 					"info",
 				);
+			}
+		},
+		[],
+	);
+
+	/**
+	 * Execute the sandbox grants step.
+	 * Generates per-platform filesystem grants so AI coding harnesses
+	 * can access centrally-stored artifacts under ~/.rp1/.
+	 */
+	const executeSandboxGrants = useCallback(
+		async (addAct: AddActivityFn): Promise<void> => {
+			const ctx = contextRef.current;
+			try {
+				const grantResults = await generateSandboxGrants(undefined, ctx.cwd);
+				let granted = 0;
+				for (const grant of grantResults) {
+					if (grant.written) {
+						addAct(
+							"sandbox-grants",
+							`${grant.platform} → ${grant.path}`,
+							"success",
+						);
+						granted++;
+					}
+				}
+				if (granted === 0) {
+					addAct("sandbox-grants", "No sandbox grants needed", "info");
+				}
+			} catch (error) {
+				const msg = error instanceof Error ? error.message : String(error);
+				addAct("sandbox-grants", `Grant error: ${msg}`, "warning");
 			}
 		},
 		[],
@@ -1219,6 +1252,9 @@ export const useStepExecution = ({
 					case "harness-selection":
 						await executeHarnessSelection(addAct);
 						break;
+					case "sandbox-grants":
+						await executeSandboxGrants(addAct);
+						break;
 					case "instruction-injection":
 						await executeInstructionInjection(addAct);
 						break;
@@ -1263,6 +1299,7 @@ export const useStepExecution = ({
 			executeSettingsSetup,
 			executeToolDetection,
 			executeHarnessSelection,
+			executeSandboxGrants,
 			executeInstructionInjection,
 			executeGitignoreConfig,
 			executeInstallCheck,

--- a/cli/src/init/ui/hooks/useWizardState.ts
+++ b/cli/src/init/ui/hooks/useWizardState.ts
@@ -148,6 +148,11 @@ export const WIZARD_STEPS: readonly Omit<
 		description: "Creating settings files",
 	},
 	{
+		id: "sandbox-grants",
+		name: "Sandbox Grants",
+		description: "Configuring sandbox grants",
+	},
+	{
 		id: "instruction-injection",
 		name: "Instruction File",
 		description: "Configuring instruction file",


### PR DESCRIPTION
## Summary

Completes the third and final child feature of storage-decoupling Phase 2 (`storage-decoupling-central-init`, plan: `.rp1/work/prds/storage-decoupling-phase-plan.md`). `rp1 init` now creates projects in **central mode** by default: KB and work artifacts resolve to `~/.rp1/projects/<project_id>/`, the repo keeps only `.rp1/project_id` + `settings.toml`, and per-platform sandbox grants are generated for the harnesses selected via the `[harnesses] enabled` wizard (#419).

## Changes

- **Settings template + gitignore** (`93d51708`): template emits an active `[storage] mode = "central"` section; new `central` gitignore preset tracks only `project_id` and `settings.toml`. Existing projects without a `[storage]` section stay in local mode.
- **Sandbox grant generator** (`cebd6d68`, `7fe04c67`): new `cli/src/init/steps/sandbox-grants.ts` with pure per-platform generators + merge-preserving writers for Claude Code (`additionalDirectories`), Codex (`writable_roots`), OpenCode (`permission.external_directory` in `opencode.json`), Antigravity, and Copilot; dispatch scoped to `[harnesses] enabled` with all-detected-stable fallback.
- **Init reorder** (`c806acef`, `c281c22d`): `executeInit` phase 1 creates `.rp1/` + `project_id` only; phase 2 writes settings then creates mode-appropriate storage directories (central or local).
- **Orchestrator wiring** (`59db55f3`): sandbox-grants step wired into both headless `executeInit` and the Ink wizard (`StepId`, `WIZARD_STEPS`, `PROMPTABLE_STEPS`, `useStepExecution`).
- **Work-search indexer** (`f429628d`): hardcoded `.rp1/work/` display prefix replaced with mode-aware `computeDisplayPrefix()` (`~/.rp1/projects/<id>/work` in central mode).

## Hypothesis validation (empirical)

- **HYP-001 CONFIRMED**: Claude Code sandbox bug #29013 does not reproduce on v2.1.204 — `~/.rp1/` reads/writes succeed; `additionalDirectories` grant kept as defensive measure (REQ-010).
- **HYP-002 REJECTED → fixed**: OpenCode enforces `permission.external_directory` (default `ask`); grant implemented in the validated format, not the design's original sketch.
- **HYP-003 CONFIRMED**: Gemini CLI/Antigravity sandbox is opt-in; defensive grant only.

## Verification

- Feature verification: **PASS** — all 23 applicable acceptance criteria across REQ-001..REQ-011 satisfied (`feature_verification_002.md`).
- Code checks: CLI biome lint/format clean (892 files), `tsc --noEmit` clean, unit tests **3288/3288** pass.
- Build readiness: WARN/proceed — the only warnings are pre-existing (evals `attestation.json` formatting drift; 1 integration test failure in the full coverage run — diff is confined to `cli/`).

## Follow-ups (non-blocking)

Docs tasks TD1–TD4 tracked in the feature task plan: settings reference ([storage] section), architecture KB persistence layer, patterns KB I/O, and a new sandbox-grants reference page.

🤖 Generated using: 🎮 [rp1.run](https://rp1.run)