### PR TITLE
feat(init): global instruction stanzas for central-mode projects (storage-decoupling P3)

### DIFF
--- a/cli/src/__tests__/commands/update/update-stanza-phase.test.ts
+++ b/cli/src/__tests__/commands/update/update-stanza-phase.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+	manageGlobalStanzaPhase,
+	resolveStanzaHarnesses,
+} from "../../../commands/update/index.js";
+import { hasFencedContent } from "../../../init/comment-fence.js";
+import { writeGlobalStanza } from "../../../init/global-stanza-writer.js";
+import { resetSettingsCache } from "../../../settings/loader.js";
+import { cleanupTempDir, createTempDir } from "../../helpers/index.js";
+
+function writeSettingsToml(dir: string, content: string): string {
+	mkdirSync(dir, { recursive: true });
+	const filePath = join(dir, "settings.toml");
+	writeFileSync(filePath, content, "utf-8");
+	return filePath;
+}
+
+describe("resolveStanzaHarnesses", () => {
+	let tempDir: string;
+
+	beforeEach(async () => {
+		tempDir = await createTempDir("update-stanza-resolve-");
+		resetSettingsCache();
+	});
+
+	afterEach(async () => {
+		resetSettingsCache();
+		await cleanupTempDir(tempDir);
+	});
+
+	test("returns persisted source for existing [harnesses] section", async () => {
+		const settingsPath = writeSettingsToml(
+			join(tempDir, ".config", "rp1"),
+			'[harnesses]\nenabled = ["claude-code", "opencode"]\n',
+		);
+
+		const result = await resolveStanzaHarnesses(settingsPath);
+
+		expect(result.source).toBe("persisted");
+		expect(result.selection).toEqual(["claude-code", "opencode"]);
+	});
+
+	test("returns persisted source even when enabled is empty", async () => {
+		const settingsPath = writeSettingsToml(
+			join(tempDir, ".config", "rp1"),
+			"[harnesses]\nenabled = []\n",
+		);
+
+		const result = await resolveStanzaHarnesses(settingsPath);
+
+		expect(result.source).toBe("persisted");
+		expect(result.selection).toEqual([]);
+	});
+
+	test("returns none when settings file does not exist", async () => {
+		const settingsPath = join(tempDir, "nonexistent", "settings.toml");
+
+		const result = await resolveStanzaHarnesses(settingsPath);
+
+		expect(result.source).not.toBe("persisted");
+	});
+});
+
+describe("manageGlobalStanzaPhase integration", () => {
+	let tempDir: string;
+
+	beforeEach(async () => {
+		tempDir = await createTempDir("update-stanza-phase-");
+		resetSettingsCache();
+	});
+
+	afterEach(async () => {
+		resetSettingsCache();
+		await cleanupTempDir(tempDir);
+	});
+
+	test("persisted selection writes stanzas to temp homeDir", async () => {
+		writeSettingsToml(
+			join(tempDir, ".config", "rp1"),
+			'[harnesses]\nenabled = ["claude-code"]\n',
+		);
+
+		const homeDir = join(tempDir, "home");
+		mkdirSync(homeDir, { recursive: true });
+
+		await writeGlobalStanza("claude-code", homeDir);
+
+		const claudeMdPath = join(homeDir, ".claude", "CLAUDE.md");
+		expect(existsSync(claudeMdPath)).toBe(true);
+		const content = readFileSync(claudeMdPath, "utf-8");
+		expect(hasFencedContent(content)).toBe(true);
+	});
+
+	test("dry-run makes no writes", async () => {
+		const settingsPath = writeSettingsToml(
+			join(tempDir, ".config", "rp1"),
+			'[harnesses]\nenabled = ["claude-code"]\n',
+		);
+
+		const result = await manageGlobalStanzaPhase(
+			{ dryRun: true, globalSettingsPath: settingsPath },
+			false,
+		);
+
+		expect(result.success).toBe(true);
+
+		const claudeMdPath = join(tempDir, ".claude", "CLAUDE.md");
+		expect(existsSync(claudeMdPath)).toBe(false);
+	});
+
+	test("persisted empty selection removes previously written stanza", async () => {
+		const homeDir = join(tempDir, "home");
+
+		await writeGlobalStanza("claude-code", homeDir);
+		const claudeMdPath = join(homeDir, ".claude", "CLAUDE.md");
+		expect(existsSync(claudeMdPath)).toBe(true);
+		expect(hasFencedContent(readFileSync(claudeMdPath, "utf-8"))).toBe(true);
+
+		const settingsPath = writeSettingsToml(
+			join(tempDir, ".config", "rp1"),
+			"[harnesses]\nenabled = []\n",
+		);
+
+		resetSettingsCache();
+
+		const resolved = await resolveStanzaHarnesses(settingsPath);
+		expect(resolved.source).toBe("persisted");
+		expect(resolved.selection).toEqual([]);
+
+		const { manageGlobalStanzas } = await import(
+			"../../../init/global-stanza-writer.js"
+		);
+		const result = await manageGlobalStanzas(resolved.selection, {
+			homeDir,
+		});
+
+		expect(result.removed).toContain("claude-code");
+
+		const updatedContent = readFileSync(claudeMdPath, "utf-8");
+		expect(hasFencedContent(updatedContent)).toBe(false);
+	});
+});

--- a/cli/src/__tests__/init/comment-fence.test.ts
+++ b/cli/src/__tests__/init/comment-fence.test.ts
@@ -10,6 +10,7 @@ import {
 	extractFenceVersion,
 	findFencedContent,
 	hasFencedContent,
+	removeFencedContent,
 	replaceFencedContent,
 	validateFencing,
 	wrapWithFence,
@@ -311,6 +312,77 @@ after`;
 			const result = validateFencing(content);
 
 			expect(result.valid).toBe(true);
+		});
+	});
+
+	describe("removeFencedContent", () => {
+		test("returns content unchanged when no fence exists", () => {
+			const content = "Just plain content without any fence markers.";
+			expect(removeFencedContent(content)).toBe(content);
+		});
+
+		test("returns empty string when file is fence-only", () => {
+			const content = "<!-- rp1:start -->\nmanaged content\n<!-- rp1:end -->";
+			expect(removeFencedContent(content)).toBe("");
+		});
+
+		test("returns empty string for fence-only with trailing newline", () => {
+			const content = "<!-- rp1:start -->\nmanaged content\n<!-- rp1:end -->\n";
+			expect(removeFencedContent(content)).toBe("");
+		});
+
+		test("removes fence and preserves content before", () => {
+			const content =
+				"# Header\n\nSome text.\n\n<!-- rp1:start -->\nmanaged\n<!-- rp1:end -->";
+			const result = removeFencedContent(content);
+
+			expect(result).toContain("# Header");
+			expect(result).toContain("Some text.");
+			expect(result).not.toContain("<!-- rp1:start");
+			expect(result).not.toContain("managed");
+		});
+
+		test("removes fence and preserves content after", () => {
+			const content =
+				"<!-- rp1:start -->\nmanaged\n<!-- rp1:end -->\n\n## Footer\n\nMore text.";
+			const result = removeFencedContent(content);
+
+			expect(result).toContain("## Footer");
+			expect(result).toContain("More text.");
+			expect(result).not.toContain("<!-- rp1:start");
+			expect(result).not.toContain("managed");
+		});
+
+		test("removes fence and preserves content before and after", () => {
+			const content =
+				"# Header\n\nBefore.\n\n<!-- rp1:start -->\nmanaged\n<!-- rp1:end -->\n\nAfter.\n\n## Footer";
+			const result = removeFencedContent(content);
+
+			expect(result).toContain("# Header");
+			expect(result).toContain("Before.");
+			expect(result).toContain("After.");
+			expect(result).toContain("## Footer");
+			expect(result).not.toContain("managed");
+		});
+
+		test("handles versioned fence markers", () => {
+			const content =
+				"Keep this.\n\n<!-- rp1:start:v0.7.1 -->\nversioned managed\n<!-- rp1:end:v0.7.1 -->\n\nAlso keep.";
+			const result = removeFencedContent(content);
+
+			expect(result).toContain("Keep this.");
+			expect(result).toContain("Also keep.");
+			expect(result).not.toContain("versioned managed");
+			expect(result).not.toContain("<!-- rp1:start:v0.7.1 -->");
+		});
+
+		test("result ends with trailing newline when non-empty content remains", () => {
+			const content =
+				"Keep this.\n\n<!-- rp1:start -->\nmanaged\n<!-- rp1:end -->";
+			const result = removeFencedContent(content);
+
+			expect(result.length).toBeGreaterThan(0);
+			expect(result.endsWith("\n")).toBe(true);
 		});
 	});
 });

--- a/cli/src/__tests__/init/global-path-map.test.ts
+++ b/cli/src/__tests__/init/global-path-map.test.ts
@@ -1,9 +1,3 @@
-/**
- * Unit tests for the global instruction file path mapping.
- * Verifies correct path resolution for all supported harnesses
- * and forward-compatible null return for unknown harness IDs.
- */
-
 import { describe, expect, test } from "bun:test";
 import { join } from "node:path";
 import {

--- a/cli/src/__tests__/init/global-path-map.test.ts
+++ b/cli/src/__tests__/init/global-path-map.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Unit tests for the global instruction file path mapping.
+ * Verifies correct path resolution for all supported harnesses
+ * and forward-compatible null return for unknown harness IDs.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { join } from "node:path";
+import {
+	GLOBAL_INSTRUCTION_PATH_MAP,
+	resolveGlobalInstructionPath,
+} from "../../init/global-path-map.js";
+
+describe("GLOBAL_INSTRUCTION_PATH_MAP", () => {
+	test("contains entries for all five supported harnesses", () => {
+		const expected = [
+			"claude-code",
+			"codex",
+			"opencode",
+			"copilot",
+			"antigravity",
+		];
+		expect(Object.keys(GLOBAL_INSTRUCTION_PATH_MAP).sort()).toEqual(
+			expected.sort(),
+		);
+	});
+
+	test("each entry is a function accepting a home directory string", () => {
+		for (const [_id, resolver] of Object.entries(GLOBAL_INSTRUCTION_PATH_MAP)) {
+			expect(typeof resolver).toBe("function");
+			expect(typeof resolver("/home/test")).toBe("string");
+		}
+	});
+});
+
+describe("resolveGlobalInstructionPath", () => {
+	const home = "/fake/home";
+
+	test("claude-code resolves to ~/.claude/CLAUDE.md", () => {
+		const result = resolveGlobalInstructionPath("claude-code", home);
+		expect(result).toBe(join(home, ".claude", "CLAUDE.md"));
+	});
+
+	test("codex resolves to ~/.codex/AGENTS.md", () => {
+		const result = resolveGlobalInstructionPath("codex", home);
+		expect(result).toBe(join(home, ".codex", "AGENTS.md"));
+	});
+
+	test("opencode resolves to ~/.config/opencode/AGENTS.md", () => {
+		const result = resolveGlobalInstructionPath("opencode", home);
+		expect(result).toBe(join(home, ".config", "opencode", "AGENTS.md"));
+	});
+
+	test("copilot resolves to ~/.copilot/copilot-instructions.md", () => {
+		const result = resolveGlobalInstructionPath("copilot", home);
+		expect(result).toBe(join(home, ".copilot", "copilot-instructions.md"));
+	});
+
+	test("antigravity resolves to ~/.gemini/AGENTS.md", () => {
+		const result = resolveGlobalInstructionPath("antigravity", home);
+		expect(result).toBe(join(home, ".gemini", "AGENTS.md"));
+	});
+
+	test("returns null for unknown harness ID", () => {
+		expect(resolveGlobalInstructionPath("unknown-harness", home)).toBeNull();
+	});
+
+	test("returns null for empty string harness ID", () => {
+		expect(resolveGlobalInstructionPath("", home)).toBeNull();
+	});
+
+	test("homeDir override changes the base path for all harnesses", () => {
+		const customHome = "/custom/home/dir";
+		const result = resolveGlobalInstructionPath("claude-code", customHome);
+		expect(result).toBe(join(customHome, ".claude", "CLAUDE.md"));
+		expect(result).not.toContain("/fake/home");
+	});
+
+	test("uses os.homedir() when no homeDir provided", () => {
+		const result = resolveGlobalInstructionPath("claude-code");
+		expect(result).not.toBeNull();
+		expect(result!.endsWith(join(".claude", "CLAUDE.md"))).toBe(true);
+	});
+});

--- a/cli/src/__tests__/init/global-stanza-template.test.ts
+++ b/cli/src/__tests__/init/global-stanza-template.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Unit tests for the global stanza template content generator.
+ * Verifies platform-specific stanza content and cross-project path discovery.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+	buildGlobalStanzaContent,
+	LATEST_FENCE_VERSION,
+} from "../../init/global-stanza-template.js";
+
+describe("LATEST_FENCE_VERSION", () => {
+	test("is a semver string without v prefix", () => {
+		expect(LATEST_FENCE_VERSION).toMatch(/^\d+\.\d+\.\d+$/);
+	});
+});
+
+describe("buildGlobalStanzaContent", () => {
+	describe("shared KB section (all platforms)", () => {
+		const platforms = [
+			"claude-code",
+			"codex",
+			"opencode",
+			"copilot",
+			"antigravity",
+		];
+
+		for (const platform of platforms) {
+			test(`${platform} includes KB progressive disclosure pattern`, () => {
+				const content = buildGlobalStanzaContent(platform);
+				expect(content).toContain("## rp1 Knowledge Base");
+				expect(content).toContain("Progressive Disclosure Pattern");
+			});
+
+			test(`${platform} uses rp1-root-dir for path discovery`, () => {
+				const content = buildGlobalStanzaContent(platform);
+				expect(content).toContain("rp1 agent-tools rp1-root-dir");
+			});
+
+			test(`${platform} does not contain hardcoded .rp1/context/ paths`, () => {
+				const content = buildGlobalStanzaContent(platform);
+				expect(content).not.toContain("`.rp1/context/`");
+				expect(content).not.toContain("'.rp1/context/'");
+			});
+
+			test(`${platform} lists all five KB files`, () => {
+				const content = buildGlobalStanzaContent(platform);
+				expect(content).toContain("index.md");
+				expect(content).toContain("architecture.md");
+				expect(content).toContain("modules.md");
+				expect(content).toContain("patterns.md");
+				expect(content).toContain("concept_map.md");
+			});
+
+			test(`${platform} includes loading rules`, () => {
+				const content = buildGlobalStanzaContent(platform);
+				expect(content).toContain("Code review: patterns.md");
+				expect(content).toContain(
+					"Bug investigation: architecture.md, modules.md",
+				);
+				expect(content).toContain("Feature work: modules.md, patterns.md");
+			});
+		}
+	});
+
+	describe("claude-code platform", () => {
+		test("includes skill awareness section", () => {
+			const content = buildGlobalStanzaContent("claude-code");
+			expect(content).toContain("## rp1 Skill Awareness");
+			expect(content).toContain("/guide");
+		});
+
+		test("does not include codex conventions", () => {
+			const content = buildGlobalStanzaContent("claude-code");
+			expect(content).not.toContain("Task shorthand");
+			expect(content).not.toContain("Subagent waiting");
+		});
+	});
+
+	describe("codex platform", () => {
+		test("includes codex conventions section", () => {
+			const content = buildGlobalStanzaContent("codex");
+			expect(content).toContain("Codex agent conventions");
+			expect(content).toContain("Task shorthand");
+			expect(content).toContain("Subagent waiting");
+		});
+
+		test("does not include skill awareness section", () => {
+			const content = buildGlobalStanzaContent("codex");
+			expect(content).not.toContain("## rp1 Skill Awareness");
+		});
+	});
+
+	describe("default platform (opencode, copilot, antigravity, unknown)", () => {
+		test("opencode gets skill awareness, not codex conventions", () => {
+			const content = buildGlobalStanzaContent("opencode");
+			expect(content).toContain("## rp1 Skill Awareness");
+			expect(content).not.toContain("Codex agent conventions");
+		});
+
+		test("copilot gets skill awareness, not codex conventions", () => {
+			const content = buildGlobalStanzaContent("copilot");
+			expect(content).toContain("## rp1 Skill Awareness");
+			expect(content).not.toContain("Codex agent conventions");
+		});
+
+		test("antigravity gets skill awareness, not codex conventions", () => {
+			const content = buildGlobalStanzaContent("antigravity");
+			expect(content).toContain("## rp1 Skill Awareness");
+			expect(content).not.toContain("Codex agent conventions");
+		});
+
+		test("unknown platform falls through to default (skill awareness)", () => {
+			const content = buildGlobalStanzaContent("future-platform");
+			expect(content).toContain("## rp1 Knowledge Base");
+			expect(content).toContain("## rp1 Skill Awareness");
+		});
+	});
+});

--- a/cli/src/__tests__/init/global-stanza-template.test.ts
+++ b/cli/src/__tests__/init/global-stanza-template.test.ts
@@ -1,8 +1,3 @@
-/**
- * Unit tests for the global stanza template content generator.
- * Verifies platform-specific stanza content and cross-project path discovery.
- */
-
 import { describe, expect, test } from "bun:test";
 import {
 	buildGlobalStanzaContent,

--- a/cli/src/__tests__/init/global-stanza-writer.test.ts
+++ b/cli/src/__tests__/init/global-stanza-writer.test.ts
@@ -1,0 +1,362 @@
+/**
+ * Unit tests for the global stanza writer module.
+ * Tests write, replace, remove, and orchestration of fenced stanza blocks
+ * in user-global instruction files with filesystem isolation via temp dirs.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync } from "node:fs";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import {
+	manageGlobalStanzas,
+	removeGlobalStanza,
+	writeGlobalStanza,
+} from "../../init/global-stanza-writer.js";
+import { cleanupTempDir, createTempDir } from "../helpers/index.js";
+
+let tempDir: string;
+
+beforeEach(async () => {
+	tempDir = await createTempDir("global-stanza-writer-");
+});
+
+afterEach(async () => {
+	await cleanupTempDir(tempDir);
+});
+
+async function readIfExists(filePath: string): Promise<string | null> {
+	try {
+		return await readFile(filePath, "utf-8");
+	} catch {
+		return null;
+	}
+}
+
+describe("writeGlobalStanza", () => {
+	test("creates file and parent directory when file does not exist", async () => {
+		const result = await writeGlobalStanza("claude-code", tempDir);
+
+		expect(result.action).toBe("written");
+		expect(result.filePath).toBe(join(tempDir, ".claude", "CLAUDE.md"));
+
+		const content = await readFile(result.filePath, "utf-8");
+		expect(content).toContain("<!-- rp1:start");
+		expect(content).toContain("<!-- rp1:end");
+		expect(content).toContain("rp1 Knowledge Base");
+	});
+
+	test("appends fenced block when file exists without fence", async () => {
+		const filePath = join(tempDir, ".claude", "CLAUDE.md");
+		await mkdir(join(tempDir, ".claude"), { recursive: true });
+		await writeFile(
+			filePath,
+			"# My custom instructions\n\nKeep this.\n",
+			"utf-8",
+		);
+
+		const result = await writeGlobalStanza("claude-code", tempDir);
+
+		expect(result.action).toBe("written");
+
+		const content = await readFile(filePath, "utf-8");
+		expect(content).toContain("# My custom instructions");
+		expect(content).toContain("Keep this.");
+		expect(content).toContain("<!-- rp1:start");
+		expect(content).toContain("rp1 Knowledge Base");
+	});
+
+	test("replaces fenced block when file has existing fence", async () => {
+		const filePath = join(tempDir, ".claude", "CLAUDE.md");
+		await mkdir(join(tempDir, ".claude"), { recursive: true });
+		await writeFile(
+			filePath,
+			"User content\n\n<!-- rp1:start -->\nold stanza\n<!-- rp1:end -->\n\nMore user content\n",
+			"utf-8",
+		);
+
+		const result = await writeGlobalStanza("claude-code", tempDir);
+
+		expect(result.action).toBe("updated");
+
+		const content = await readFile(filePath, "utf-8");
+		expect(content).toContain("User content");
+		expect(content).toContain("More user content");
+		expect(content).not.toContain("old stanza");
+		expect(content).toContain("rp1 Knowledge Base");
+	});
+
+	test("preserves user content outside fence on replace", async () => {
+		const filePath = join(tempDir, ".codex", "AGENTS.md");
+		await mkdir(join(tempDir, ".codex"), { recursive: true });
+		await writeFile(
+			filePath,
+			"# Header\n\nCustom rules here.\n\n<!-- rp1:start:v0.6.0 -->\nold\n<!-- rp1:end:v0.6.0 -->\n\n## Footer\n",
+			"utf-8",
+		);
+
+		await writeGlobalStanza("codex", tempDir);
+
+		const content = await readFile(filePath, "utf-8");
+		expect(content).toContain("# Header");
+		expect(content).toContain("Custom rules here.");
+		expect(content).toContain("## Footer");
+		expect(content).toContain("Codex agent conventions");
+	});
+
+	test("throws for unknown harness ID", async () => {
+		await expect(
+			writeGlobalStanza("nonexistent-harness", tempDir),
+		).rejects.toThrow("Unknown harness ID");
+	});
+
+	test("throws for invalid fencing in existing file", async () => {
+		const filePath = join(tempDir, ".claude", "CLAUDE.md");
+		await mkdir(join(tempDir, ".claude"), { recursive: true });
+		await writeFile(
+			filePath,
+			"<!-- rp1:start -->\ncontent\n<!-- rp1:start -->\nmore\n<!-- rp1:end -->\n<!-- rp1:end -->\n",
+			"utf-8",
+		);
+
+		await expect(writeGlobalStanza("claude-code", tempDir)).rejects.toThrow(
+			"Invalid fencing",
+		);
+	});
+
+	test("writes versioned fence markers", async () => {
+		const result = await writeGlobalStanza("claude-code", tempDir);
+
+		const content = await readFile(result.filePath, "utf-8");
+		expect(content).toMatch(/<!-- rp1:start:v\d+\.\d+\.\d+ -->/);
+		expect(content).toMatch(/<!-- rp1:end:v\d+\.\d+\.\d+ -->/);
+	});
+
+	test("codex platform gets codex-specific stanza content", async () => {
+		const result = await writeGlobalStanza("codex", tempDir);
+
+		const content = await readFile(result.filePath, "utf-8");
+		expect(content).toContain("Task shorthand");
+		expect(content).toContain("Subagent waiting");
+	});
+
+	test("creates correct path for each harness", async () => {
+		const expected: Record<string, string> = {
+			"claude-code": join(tempDir, ".claude", "CLAUDE.md"),
+			codex: join(tempDir, ".codex", "AGENTS.md"),
+			opencode: join(tempDir, ".config", "opencode", "AGENTS.md"),
+			copilot: join(tempDir, ".copilot", "copilot-instructions.md"),
+			antigravity: join(tempDir, ".gemini", "AGENTS.md"),
+		};
+
+		for (const [harnessId, expectedPath] of Object.entries(expected)) {
+			const result = await writeGlobalStanza(harnessId, tempDir);
+			expect(result.filePath).toBe(expectedPath);
+			expect(existsSync(expectedPath)).toBe(true);
+		}
+	});
+});
+
+describe("removeGlobalStanza", () => {
+	test("removes fenced block from existing file", async () => {
+		const filePath = join(tempDir, ".claude", "CLAUDE.md");
+		await mkdir(join(tempDir, ".claude"), { recursive: true });
+		await writeFile(
+			filePath,
+			"User content\n\n<!-- rp1:start -->\nmanaged\n<!-- rp1:end -->\n\nMore content\n",
+			"utf-8",
+		);
+
+		const result = await removeGlobalStanza("claude-code", tempDir);
+
+		expect(result.action).toBe("removed");
+		expect(result.filePath).toBe(filePath);
+
+		const content = await readFile(filePath, "utf-8");
+		expect(content).toContain("User content");
+		expect(content).toContain("More content");
+		expect(content).not.toContain("<!-- rp1:start");
+		expect(content).not.toContain("managed");
+	});
+
+	test("skips when file does not exist", async () => {
+		const result = await removeGlobalStanza("claude-code", tempDir);
+
+		expect(result.action).toBe("skipped");
+		expect(result.filePath).toBe(join(tempDir, ".claude", "CLAUDE.md"));
+	});
+
+	test("skips when file has no fenced block", async () => {
+		const filePath = join(tempDir, ".claude", "CLAUDE.md");
+		await mkdir(join(tempDir, ".claude"), { recursive: true });
+		await writeFile(filePath, "Just user content, no rp1 fence.\n", "utf-8");
+
+		const result = await removeGlobalStanza("claude-code", tempDir);
+
+		expect(result.action).toBe("skipped");
+	});
+
+	test("returns skipped with null filePath for unknown harness", async () => {
+		const result = await removeGlobalStanza("nonexistent-harness", tempDir);
+
+		expect(result.action).toBe("skipped");
+		expect(result.filePath).toBeNull();
+	});
+
+	test("preserves user content when removing fence", async () => {
+		const filePath = join(tempDir, ".codex", "AGENTS.md");
+		await mkdir(join(tempDir, ".codex"), { recursive: true });
+		await writeFile(
+			filePath,
+			"# My Rules\n\nKeep this.\n\n<!-- rp1:start:v0.7.1 -->\nmanaged stuff\n<!-- rp1:end:v0.7.1 -->\n\n## Also keep\n",
+			"utf-8",
+		);
+
+		await removeGlobalStanza("codex", tempDir);
+
+		const content = await readFile(filePath, "utf-8");
+		expect(content).toContain("# My Rules");
+		expect(content).toContain("Keep this.");
+		expect(content).toContain("## Also keep");
+		expect(content).not.toContain("managed stuff");
+	});
+});
+
+describe("manageGlobalStanzas", () => {
+	test("writes stanzas to enabled harnesses", async () => {
+		const result = await manageGlobalStanzas(["claude-code", "codex"], {
+			homeDir: tempDir,
+		});
+
+		expect(result.written).toContain("claude-code");
+		expect(result.written).toContain("codex");
+		expect(result.errors).toHaveLength(0);
+
+		const claudeContent = await readIfExists(
+			join(tempDir, ".claude", "CLAUDE.md"),
+		);
+		const codexContent = await readIfExists(
+			join(tempDir, ".codex", "AGENTS.md"),
+		);
+		expect(claudeContent).toContain("rp1 Knowledge Base");
+		expect(codexContent).toContain("rp1 Knowledge Base");
+	});
+
+	test("removes stanzas from disabled harnesses", async () => {
+		await writeGlobalStanza("copilot", tempDir);
+		await writeGlobalStanza("antigravity", tempDir);
+
+		const result = await manageGlobalStanzas(["claude-code"], {
+			homeDir: tempDir,
+		});
+
+		expect(result.written).toContain("claude-code");
+		expect(result.removed).toContain("copilot");
+		expect(result.removed).toContain("antigravity");
+	});
+
+	test("skips disabled harnesses that have no existing stanza", async () => {
+		const result = await manageGlobalStanzas(["claude-code"], {
+			homeDir: tempDir,
+		});
+
+		expect(result.written).toContain("claude-code");
+		expect(result.skipped.length).toBeGreaterThan(0);
+	});
+
+	test("reports updated when replacing existing stanzas", async () => {
+		await writeGlobalStanza("claude-code", tempDir);
+
+		const result = await manageGlobalStanzas(["claude-code"], {
+			homeDir: tempDir,
+		});
+
+		expect(result.updated).toContain("claude-code");
+		expect(result.written).not.toContain("claude-code");
+	});
+
+	test("dryRun mode reports what would happen without writing", async () => {
+		const result = await manageGlobalStanzas(["claude-code", "codex"], {
+			homeDir: tempDir,
+			dryRun: true,
+		});
+
+		expect(result.written).toContain("claude-code");
+		expect(result.written).toContain("codex");
+
+		const claudeFile = await readIfExists(
+			join(tempDir, ".claude", "CLAUDE.md"),
+		);
+		expect(claudeFile).toBeNull();
+	});
+
+	test("dryRun reports updated for harnesses with existing stanzas", async () => {
+		await writeGlobalStanza("claude-code", tempDir);
+
+		const result = await manageGlobalStanzas(["claude-code"], {
+			homeDir: tempDir,
+			dryRun: true,
+		});
+
+		expect(result.updated).toContain("claude-code");
+	});
+
+	test("dryRun reports removed for disabled harnesses with existing stanzas", async () => {
+		await writeGlobalStanza("codex", tempDir);
+
+		const result = await manageGlobalStanzas(["claude-code"], {
+			homeDir: tempDir,
+			dryRun: true,
+		});
+
+		expect(result.removed).toContain("codex");
+	});
+
+	test("empty enabled list removes all existing stanzas", async () => {
+		await writeGlobalStanza("claude-code", tempDir);
+		await writeGlobalStanza("codex", tempDir);
+
+		const result = await manageGlobalStanzas([], { homeDir: tempDir });
+
+		expect(result.removed).toContain("claude-code");
+		expect(result.removed).toContain("codex");
+		expect(result.written).toHaveLength(0);
+	});
+
+	test("collects errors non-blocking", async () => {
+		const filePath = join(tempDir, ".claude", "CLAUDE.md");
+		await mkdir(join(tempDir, ".claude"), { recursive: true });
+		await writeFile(
+			filePath,
+			"<!-- rp1:start -->\na\n<!-- rp1:start -->\nb\n<!-- rp1:end -->\n<!-- rp1:end -->\n",
+			"utf-8",
+		);
+
+		const result = await manageGlobalStanzas(["claude-code"], {
+			homeDir: tempDir,
+		});
+
+		expect(result.errors.length).toBeGreaterThan(0);
+		expect(result.errors[0].platform).toBe("claude-code");
+		expect(result.errors[0].error).toContain("Invalid fencing");
+	});
+
+	test("manages all five harnesses simultaneously", async () => {
+		const allHarnesses = [
+			"claude-code",
+			"codex",
+			"opencode",
+			"copilot",
+			"antigravity",
+		];
+
+		const result = await manageGlobalStanzas(allHarnesses, {
+			homeDir: tempDir,
+		});
+
+		expect(result.written.sort()).toEqual(allHarnesses.sort());
+		expect(result.errors).toHaveLength(0);
+		expect(result.removed).toHaveLength(0);
+		expect(result.skipped).toHaveLength(0);
+	});
+});

--- a/cli/src/__tests__/init/global-stanza-writer.test.ts
+++ b/cli/src/__tests__/init/global-stanza-writer.test.ts
@@ -1,9 +1,3 @@
-/**
- * Unit tests for the global stanza writer module.
- * Tests write, replace, remove, and orchestration of fenced stanza blocks
- * in user-global instruction files with filesystem isolation via temp dirs.
- */
-
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { existsSync } from "node:fs";
 import { mkdir, readFile, writeFile } from "node:fs/promises";

--- a/cli/src/__tests__/init/init-install-separation.test.ts
+++ b/cli/src/__tests__/init/init-install-separation.test.ts
@@ -70,6 +70,16 @@ async function readFileIfExists(filePath: string): Promise<string | null> {
 	}
 }
 
+async function setupLocalStorageMode(cwd: string): Promise<void> {
+	const rp1Dir = join(cwd, ".rp1");
+	await mkdir(rp1Dir, { recursive: true });
+	await writeFile(
+		join(rp1Dir, "settings.toml"),
+		'[storage]\nmode = "local"\n',
+		"utf-8",
+	);
+}
+
 function createDetectedTool(
 	id: "claude-code" | "opencode" | "codex",
 	instructionFile: "CLAUDE.md" | "AGENTS.md",
@@ -205,6 +215,7 @@ describe("init-install separation", () => {
 		test(
 			"install failure does not prevent project setup from completing",
 			async () => {
+				await setupLocalStorageMode(tempDir);
 				const logger = createTrackingLogger();
 				const options: InitOptions = { cwd: tempDir, yes: true };
 

--- a/cli/src/__tests__/init/init.integration.test.ts
+++ b/cli/src/__tests__/init/init.integration.test.ts
@@ -59,10 +59,12 @@ async function readFileIfExists(filePath: string): Promise<string | null> {
 
 describe("integration: init workflow", () => {
 	let tempDir: string;
+	let globalSettingsPath: string;
 	const originalEnv = process.env.RP1_ROOT;
 
 	beforeEach(async () => {
 		tempDir = await createTempDir("init-integration-");
+		globalSettingsPath = join(tempDir, "global-settings.toml");
 		// Clear RP1_ROOT env var to use default ".rp1"
 		delete process.env.RP1_ROOT;
 	});
@@ -85,6 +87,7 @@ describe("integration: init workflow", () => {
 				const options: InitOptions = {
 					cwd: tempDir,
 					yes: true, // Non-interactive mode
+					globalSettingsPath,
 				};
 
 				const result = await executeInit(options, logger)();
@@ -142,6 +145,7 @@ describe("integration: init workflow", () => {
 				const options: InitOptions = {
 					cwd: tempDir,
 					yes: true,
+					globalSettingsPath,
 				};
 
 				const result = await executeInit(options, logger)();
@@ -207,6 +211,7 @@ More custom content below.
 				const options: InitOptions = {
 					cwd: tempDir,
 					yes: true, // Non-interactive mode defaults to skip re-init
+					globalSettingsPath,
 				};
 
 				// First verify the reinit state detection
@@ -278,6 +283,7 @@ This is an existing feature document.
 				const options: InitOptions = {
 					cwd: tempDir,
 					yes: true,
+					globalSettingsPath,
 				};
 
 				// Verify reinit state detection
@@ -310,6 +316,7 @@ This is an existing feature document.
 				const options: InitOptions = {
 					cwd: tempDir,
 					yes: true,
+					globalSettingsPath,
 				};
 
 				const result = await executeInit(options, logger)();
@@ -339,6 +346,7 @@ This is an existing feature document.
 				const options: InitOptions = {
 					cwd: tempDir,
 					yes: true,
+					globalSettingsPath,
 				};
 
 				const result = await executeInit(options, logger)();
@@ -382,6 +390,7 @@ This is an existing feature document.
 				const options: InitOptions = {
 					cwd: tempDir,
 					yes: true,
+					globalSettingsPath,
 				};
 
 				// Note: In the real workflow, plugin installation is attempted
@@ -436,6 +445,7 @@ This is an existing feature document.
 				const options: InitOptions = {
 					cwd: tempDir,
 					yes: true,
+					globalSettingsPath,
 				};
 
 				const result = await executeInit(options, logger)();
@@ -482,7 +492,10 @@ This is an existing feature document.
 				);
 
 				const logger = createTrackingLogger();
-				const result = await executeInit({ cwd: tempDir, yes: true }, logger)();
+				const result = await executeInit(
+					{ cwd: tempDir, yes: true, globalSettingsPath },
+					logger,
+				)();
 
 				expect(E.isRight(result)).toBe(true);
 				if (!E.isRight(result)) return;
@@ -513,7 +526,10 @@ This is an existing feature document.
 				await writeFile(join(tempDir, "CLAUDE.md"), "# My Project\n", "utf-8");
 
 				const logger = createTrackingLogger();
-				const result = await executeInit({ cwd: tempDir, yes: true }, logger)();
+				const result = await executeInit(
+					{ cwd: tempDir, yes: true, globalSettingsPath },
+					logger,
+				)();
 
 				expect(E.isRight(result)).toBe(true);
 				if (!E.isRight(result)) return;
@@ -538,7 +554,10 @@ This is an existing feature document.
 				await writeFile(join(tempDir, "AGENTS.md"), "# Agents\n", "utf-8");
 
 				const logger = createTrackingLogger();
-				const result = await executeInit({ cwd: tempDir, yes: true }, logger)();
+				const result = await executeInit(
+					{ cwd: tempDir, yes: true, globalSettingsPath },
+					logger,
+				)();
 
 				expect(E.isRight(result)).toBe(true);
 				if (!E.isRight(result)) return;
@@ -555,7 +574,10 @@ This is an existing feature document.
 			"neither file: creates default instruction file with full stanza",
 			async () => {
 				const logger = createTrackingLogger();
-				const result = await executeInit({ cwd: tempDir, yes: true }, logger)();
+				const result = await executeInit(
+					{ cwd: tempDir, yes: true, globalSettingsPath },
+					logger,
+				)();
 
 				expect(E.isRight(result)).toBe(true);
 				if (!E.isRight(result)) return;
@@ -594,6 +616,7 @@ Existing agent instructions.
 				const options: InitOptions = {
 					cwd: tempDir,
 					yes: true,
+					globalSettingsPath,
 				};
 
 				const result = await executeInit(options, logger)();
@@ -623,6 +646,7 @@ Existing agent instructions.
 				const options: InitOptions = {
 					cwd: tempDir,
 					yes: true,
+					globalSettingsPath,
 				};
 
 				const result = await executeInit(options, logger)();

--- a/cli/src/__tests__/init/init.integration.test.ts
+++ b/cli/src/__tests__/init/init.integration.test.ts
@@ -53,6 +53,20 @@ async function readFileIfExists(filePath: string): Promise<string | null> {
 	}
 }
 
+/**
+ * Pre-create .rp1/settings.toml with local storage mode so that
+ * init takes the per-project stanza injection path instead of central mode.
+ */
+async function setupLocalStorageMode(cwd: string): Promise<void> {
+	const rp1Dir = join(cwd, ".rp1");
+	await mkdir(rp1Dir, { recursive: true });
+	await writeFile(
+		join(rp1Dir, "settings.toml"),
+		'[storage]\nmode = "local"\n',
+		"utf-8",
+	);
+}
+
 // ============================================================================
 // Integration Tests
 // ============================================================================
@@ -83,6 +97,7 @@ describe("integration: init workflow", () => {
 		test(
 			"creates complete setup with directories and instruction file",
 			async () => {
+				await setupLocalStorageMode(tempDir);
 				const logger = createTrackingLogger();
 				const options: InitOptions = {
 					cwd: tempDir,
@@ -480,6 +495,7 @@ This is an existing feature document.
 		test(
 			"both files: CLAUDE.md gets @AGENTS.md reference, AGENTS.md gets full stanza",
 			async () => {
+				await setupLocalStorageMode(tempDir);
 				await writeFile(
 					join(tempDir, "CLAUDE.md"),
 					"# My Project\n\nProject-level instructions.\n",
@@ -523,6 +539,7 @@ This is an existing feature document.
 		test(
 			"CLAUDE.md only: gets full stanza without reference",
 			async () => {
+				await setupLocalStorageMode(tempDir);
 				await writeFile(join(tempDir, "CLAUDE.md"), "# My Project\n", "utf-8");
 
 				const logger = createTrackingLogger();
@@ -551,6 +568,7 @@ This is an existing feature document.
 		test(
 			"AGENTS.md only: gets full stanza",
 			async () => {
+				await setupLocalStorageMode(tempDir);
 				await writeFile(join(tempDir, "AGENTS.md"), "# Agents\n", "utf-8");
 
 				const logger = createTrackingLogger();
@@ -573,6 +591,7 @@ This is an existing feature document.
 		test(
 			"neither file: creates default instruction file with full stanza",
 			async () => {
+				await setupLocalStorageMode(tempDir);
 				const logger = createTrackingLogger();
 				const result = await executeInit(
 					{ cwd: tempDir, yes: true, globalSettingsPath },
@@ -602,6 +621,7 @@ This is an existing feature document.
 		test(
 			"handles existing AGENTS.md file",
 			async () => {
+				await setupLocalStorageMode(tempDir);
 				// Create existing AGENTS.md (OpenCode style)
 				await writeFile(
 					join(tempDir, "AGENTS.md"),

--- a/cli/src/__tests__/init/steps/init-orchestrator-grants.test.ts
+++ b/cli/src/__tests__/init/steps/init-orchestrator-grants.test.ts
@@ -87,13 +87,12 @@ describe("integration: executeInit produces sandbox grant files", () => {
 		"fresh init produces settings.toml with mode=central and platform grants",
 		async () => {
 			const logger = createTrackingLogger();
-			// Use non-existent globalSettingsPath so loadEnabledHarnesses returns
-			// undefined, triggering fallback to all stable platforms (hermetic test)
 			const bogusSettingsPath = join(tempDir, "nonexistent-global.toml");
 			const options: InitOptions = {
 				cwd: tempDir,
 				yes: true,
 				globalSettingsPath: bogusSettingsPath,
+				homeDir: tempDir,
 			};
 
 			const result = await executeInit(options, logger)();
@@ -109,31 +108,20 @@ describe("integration: executeInit produces sandbox grant files", () => {
 			expect(settingsContent).toContain("[storage]");
 			expect(settingsContent).toContain('mode = "central"');
 
-			// Grant files should exist for all stable platforms (fallback behavior)
+			// Grant files should exist for detected stable platforms
 			const claudeSettingsPath = join(tempDir, ".claude", "settings.json");
-			expect(existsSync(claudeSettingsPath)).toBe(true);
-
-			const claudeSettings = JSON.parse(
-				readFileSync(claudeSettingsPath, "utf-8"),
-			);
-			expect(claudeSettings.permissions.additionalDirectories).toContain(
-				"~/.rp1",
-			);
-			expect(claudeSettings.permissions.allow).toContain("Read(~/.rp1/**)");
-			expect(claudeSettings.sandbox.filesystem.allowWrite).toContain("~/.rp1");
-
-			expect(existsSync(join(tempDir, "codex.toml"))).toBe(true);
-			const codexContent = readFileSync(join(tempDir, "codex.toml"), "utf-8");
-			expect(codexContent).toContain("~/.rp1");
-
-			// OpenCode grant must use the HYP-002 validated format:
-			// { permission: { external_directory: { "~/.rp1/**": "allow" } } }
-			const opencodePath = join(tempDir, "opencode.json");
-			expect(existsSync(opencodePath)).toBe(true);
-			const opencodeContent = JSON.parse(readFileSync(opencodePath, "utf-8"));
-			expect(opencodeContent.permission.external_directory["~/.rp1/**"]).toBe(
-				"allow",
-			);
+			if (existsSync(claudeSettingsPath)) {
+				const claudeSettings = JSON.parse(
+					readFileSync(claudeSettingsPath, "utf-8"),
+				);
+				expect(claudeSettings.permissions.additionalDirectories).toContain(
+					"~/.rp1",
+				);
+				expect(claudeSettings.permissions.allow).toContain("Read(~/.rp1/**)");
+				expect(claudeSettings.sandbox.filesystem.allowWrite).toContain(
+					"~/.rp1",
+				);
+			}
 
 			const grantFileActions = initResult.actions.filter(
 				(a) =>
@@ -144,7 +132,7 @@ describe("integration: executeInit produces sandbox grant files", () => {
 						a.path.includes(".gemini") ||
 						a.path.includes("copilot-settings.json")),
 			);
-			expect(grantFileActions.length).toBeGreaterThanOrEqual(2);
+			expect(grantFileActions.length).toBeGreaterThanOrEqual(1);
 
 			const grantErrors = initResult.warnings.filter((w) =>
 				w.includes("Sandbox grants failed"),
@@ -163,6 +151,7 @@ describe("integration: executeInit produces sandbox grant files", () => {
 				cwd: tempDir,
 				yes: true,
 				globalSettingsPath: bogusSettingsPath,
+				homeDir: tempDir,
 			};
 
 			const result = await executeInit(options, logger)();
@@ -177,11 +166,7 @@ describe("integration: executeInit produces sandbox grant files", () => {
 			const grantMessages = successMessages.filter((m) =>
 				m.includes("Sandbox grant"),
 			);
-			// With fallback to all stable platforms, should have at least 2 messages
-			expect(grantMessages.length).toBeGreaterThanOrEqual(2);
-
-			expect(grantMessages.some((m) => m.includes("claude-code"))).toBe(true);
-			expect(grantMessages.some((m) => m.includes("codex"))).toBe(true);
+			expect(grantMessages.length).toBeGreaterThanOrEqual(1);
 		},
 		{ timeout: 30000 },
 	);

--- a/cli/src/__tests__/init/steps/init-orchestrator-grants.test.ts
+++ b/cli/src/__tests__/init/steps/init-orchestrator-grants.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import * as E from "fp-ts/lib/Either.js";
 import type { Logger } from "../../../../shared/logger.js";
@@ -16,6 +16,7 @@ import {
 	type GrantResult,
 	generateSandboxGrants,
 } from "../../../init/steps/sandbox-grants.js";
+import { resetSettingsCache } from "../../../settings/loader.js";
 import { cleanupTempDir, createTempDir } from "../../helpers/index.js";
 
 function createTrackingLogger(): Logger & {
@@ -72,14 +73,25 @@ describe("generateSandboxGrants returns GrantResult[]", () => {
 	});
 });
 
+function preWriteHarnessSettings(dir: string, harnesses: string[]): string {
+	const settingsDir = join(dir, ".config", "rp1");
+	mkdirSync(settingsDir, { recursive: true });
+	const settingsPath = join(settingsDir, "settings.toml");
+	const quoted = harnesses.map((h) => `"${h}"`).join(", ");
+	writeFileSync(settingsPath, `[harnesses]\nenabled = [${quoted}]\n`, "utf-8");
+	return settingsPath;
+}
+
 describe("integration: executeInit produces sandbox grant files", () => {
 	let tempDir: string;
 
 	beforeEach(async () => {
 		tempDir = await createTempDir("init-grants-integration-");
+		resetSettingsCache();
 	});
 
 	afterEach(async () => {
+		resetSettingsCache();
 		await cleanupTempDir(tempDir);
 	});
 
@@ -87,11 +99,15 @@ describe("integration: executeInit produces sandbox grant files", () => {
 		"fresh init produces settings.toml with mode=central and platform grants",
 		async () => {
 			const logger = createTrackingLogger();
-			const bogusSettingsPath = join(tempDir, "nonexistent-global.toml");
+			const globalSettingsPath = preWriteHarnessSettings(tempDir, [
+				"claude-code",
+				"codex",
+				"opencode",
+			]);
 			const options: InitOptions = {
 				cwd: tempDir,
 				yes: true,
-				globalSettingsPath: bogusSettingsPath,
+				globalSettingsPath,
 				homeDir: tempDir,
 			};
 
@@ -108,20 +124,28 @@ describe("integration: executeInit produces sandbox grant files", () => {
 			expect(settingsContent).toContain("[storage]");
 			expect(settingsContent).toContain('mode = "central"');
 
-			// Grant files should exist for detected stable platforms
 			const claudeSettingsPath = join(tempDir, ".claude", "settings.json");
-			if (existsSync(claudeSettingsPath)) {
-				const claudeSettings = JSON.parse(
-					readFileSync(claudeSettingsPath, "utf-8"),
-				);
-				expect(claudeSettings.permissions.additionalDirectories).toContain(
-					"~/.rp1",
-				);
-				expect(claudeSettings.permissions.allow).toContain("Read(~/.rp1/**)");
-				expect(claudeSettings.sandbox.filesystem.allowWrite).toContain(
-					"~/.rp1",
-				);
-			}
+			expect(existsSync(claudeSettingsPath)).toBe(true);
+
+			const claudeSettings = JSON.parse(
+				readFileSync(claudeSettingsPath, "utf-8"),
+			);
+			expect(claudeSettings.permissions.additionalDirectories).toContain(
+				"~/.rp1",
+			);
+			expect(claudeSettings.permissions.allow).toContain("Read(~/.rp1/**)");
+			expect(claudeSettings.sandbox.filesystem.allowWrite).toContain("~/.rp1");
+
+			expect(existsSync(join(tempDir, "codex.toml"))).toBe(true);
+			const codexContent = readFileSync(join(tempDir, "codex.toml"), "utf-8");
+			expect(codexContent).toContain("~/.rp1");
+
+			const opencodePath = join(tempDir, "opencode.json");
+			expect(existsSync(opencodePath)).toBe(true);
+			const opencodeContent = JSON.parse(readFileSync(opencodePath, "utf-8"));
+			expect(opencodeContent.permission.external_directory["~/.rp1/**"]).toBe(
+				"allow",
+			);
 
 			const grantFileActions = initResult.actions.filter(
 				(a) =>
@@ -132,7 +156,7 @@ describe("integration: executeInit produces sandbox grant files", () => {
 						a.path.includes(".gemini") ||
 						a.path.includes("copilot-settings.json")),
 			);
-			expect(grantFileActions.length).toBeGreaterThanOrEqual(1);
+			expect(grantFileActions.length).toBeGreaterThanOrEqual(2);
 
 			const grantErrors = initResult.warnings.filter((w) =>
 				w.includes("Sandbox grants failed"),
@@ -146,11 +170,15 @@ describe("integration: executeInit produces sandbox grant files", () => {
 		"init summary logs sandbox grant status for each platform",
 		async () => {
 			const logger = createTrackingLogger();
-			const bogusSettingsPath = join(tempDir, "nonexistent-global.toml");
+			const globalSettingsPath = preWriteHarnessSettings(tempDir, [
+				"claude-code",
+				"codex",
+				"opencode",
+			]);
 			const options: InitOptions = {
 				cwd: tempDir,
 				yes: true,
-				globalSettingsPath: bogusSettingsPath,
+				globalSettingsPath,
 				homeDir: tempDir,
 			};
 
@@ -166,7 +194,10 @@ describe("integration: executeInit produces sandbox grant files", () => {
 			const grantMessages = successMessages.filter((m) =>
 				m.includes("Sandbox grant"),
 			);
-			expect(grantMessages.length).toBeGreaterThanOrEqual(1);
+			expect(grantMessages.length).toBeGreaterThanOrEqual(2);
+
+			expect(grantMessages.some((m) => m.includes("claude-code"))).toBe(true);
+			expect(grantMessages.some((m) => m.includes("codex"))).toBe(true);
 		},
 		{ timeout: 30000 },
 	);

--- a/cli/src/commands/update/index.ts
+++ b/cli/src/commands/update/index.ts
@@ -535,18 +535,28 @@ export const updateDetectedPlugins = async (
 	return { success: true, exitCode: 0 };
 };
 
-const resolveStanzaHarnesses = async (): Promise<readonly string[]> => {
-	const persisted = loadEnabledHarnesses();
+export interface StanzaHarnessResolution {
+	readonly selection: readonly string[];
+	readonly source: "persisted" | "detected" | "none";
+}
+
+export const resolveStanzaHarnesses = async (
+	globalSettingsPath?: string,
+): Promise<StanzaHarnessResolution> => {
+	const persisted = loadEnabledHarnesses(globalSettingsPath);
 	if (persisted !== undefined) {
-		return persisted;
+		return { selection: persisted, source: "persisted" };
 	}
 
 	const registry = await loadToolsRegistry();
 	const detection = await detectTools(registry)();
 	if (E.isLeft(detection) || detection.right.detected.length === 0) {
-		return [];
+		return { selection: [], source: "none" };
 	}
-	return getEffectiveHarnesses(detection.right).map((d) => d.tool.id);
+	return {
+		selection: getEffectiveHarnesses(detection.right).map((d) => d.tool.id),
+		source: "detected",
+	};
 };
 
 const formatStanzaResult = (
@@ -581,8 +591,8 @@ const formatStanzaResult = (
 	}
 };
 
-const manageGlobalStanzaPhase = async (
-	options: { dryRun: boolean },
+export const manageGlobalStanzaPhase = async (
+	options: { dryRun: boolean; globalSettingsPath?: string },
 	isTTY: boolean,
 ): Promise<PostUpdatePhaseResult> => {
 	const { bold, dim } = getColorFns(isTTY);
@@ -596,15 +606,15 @@ const manageGlobalStanzaPhase = async (
 		),
 	);
 
-	const enabledHarnesses = await resolveStanzaHarnesses();
-	if (enabledHarnesses.length === 0) {
+	const resolved = await resolveStanzaHarnesses(options.globalSettingsPath);
+	if (resolved.source === "none") {
 		console.log(
 			dim("No enabled harnesses. Skipping global stanza management."),
 		);
 		return { success: true, exitCode: 0 };
 	}
 
-	const result = await manageGlobalStanzas(enabledHarnesses, {
+	const result = await manageGlobalStanzas(resolved.selection, {
 		dryRun: options.dryRun,
 	});
 

--- a/cli/src/commands/update/index.ts
+++ b/cli/src/commands/update/index.ts
@@ -535,11 +535,6 @@ export const updateDetectedPlugins = async (
 	return { success: true, exitCode: 0 };
 };
 
-/**
- * Resolve the list of harness IDs that should have global stanzas.
- * Prefers the persisted `[harnesses] enabled` selection; falls back to
- * all-detected-stable when absent, matching P2 backward-compatibility.
- */
 const resolveStanzaHarnesses = async (): Promise<readonly string[]> => {
 	const persisted = loadEnabledHarnesses();
 	if (persisted !== undefined) {
@@ -554,9 +549,6 @@ const resolveStanzaHarnesses = async (): Promise<readonly string[]> => {
 	return getEffectiveHarnesses(detection.right).map((d) => d.tool.id);
 };
 
-/**
- * Format the global stanza phase result for console output.
- */
 const formatStanzaResult = (
 	result: GlobalStanzaResult,
 	isTTY: boolean,
@@ -589,11 +581,6 @@ const formatStanzaResult = (
 	}
 };
 
-/**
- * Manage global instruction stanzas for all known harnesses.
- * Writes stanzas for enabled harnesses and removes stanzas from disabled ones.
- * Failures are non-blocking warnings.
- */
 const manageGlobalStanzaPhase = async (
 	options: { dryRun: boolean },
 	isTTY: boolean,

--- a/cli/src/commands/update/index.ts
+++ b/cli/src/commands/update/index.ts
@@ -16,6 +16,10 @@ import { resolveDirectorySet } from "../../../shared/directory-resolution.js";
 import { formatError } from "../../../shared/errors.js";
 import type { Logger } from "../../../shared/logger.js";
 import { loadToolsRegistry } from "../../config/supported-tools.js";
+import {
+	type GlobalStanzaResult,
+	manageGlobalStanzas,
+} from "../../init/global-stanza-writer.js";
 import { detectTools } from "../../init/tool-detector.js";
 import { DEFAULT_TTL_HOURS, writeCache } from "../../lib/cache.js";
 import { getColorFns } from "../../lib/colors.js";
@@ -36,6 +40,7 @@ import {
 } from "../../lib/version.js";
 import { executeMigrate, formatMigrateSummary } from "../../migrate/index.js";
 import { applyTierRemappingsIfConfigured } from "../../settings/apply.js";
+import { loadEnabledHarnesses } from "../../settings/loader.js";
 import {
 	getEffectiveHarnesses,
 	type InstallAllResult,
@@ -531,6 +536,96 @@ export const updateDetectedPlugins = async (
 };
 
 /**
+ * Resolve the list of harness IDs that should have global stanzas.
+ * Prefers the persisted `[harnesses] enabled` selection; falls back to
+ * all-detected-stable when absent, matching P2 backward-compatibility.
+ */
+const resolveStanzaHarnesses = async (): Promise<readonly string[]> => {
+	const persisted = loadEnabledHarnesses();
+	if (persisted !== undefined) {
+		return persisted;
+	}
+
+	const registry = await loadToolsRegistry();
+	const detection = await detectTools(registry)();
+	if (E.isLeft(detection) || detection.right.detected.length === 0) {
+		return [];
+	}
+	return getEffectiveHarnesses(detection.right).map((d) => d.tool.id);
+};
+
+/**
+ * Format the global stanza phase result for console output.
+ */
+const formatStanzaResult = (
+	result: GlobalStanzaResult,
+	isTTY: boolean,
+): void => {
+	const { green, yellow, dim } = getColorFns(isTTY);
+
+	const parts: string[] = [];
+	if (result.written.length > 0) {
+		parts.push(green(`${result.written.length} written`));
+	}
+	if (result.updated.length > 0) {
+		parts.push(green(`${result.updated.length} updated`));
+	}
+	if (result.removed.length > 0) {
+		parts.push(`${result.removed.length} removed`);
+	}
+	if (result.skipped.length > 0) {
+		parts.push(dim(`${result.skipped.length} skipped`));
+	}
+	if (result.errors.length > 0) {
+		parts.push(yellow(`${result.errors.length} errors`));
+	}
+
+	if (parts.length > 0) {
+		console.log(`  Global stanzas: ${parts.join(", ")}`);
+	}
+
+	for (const err of result.errors) {
+		console.log(yellow(`  ${err.platform}: ${err.error}`));
+	}
+};
+
+/**
+ * Manage global instruction stanzas for all known harnesses.
+ * Writes stanzas for enabled harnesses and removes stanzas from disabled ones.
+ * Failures are non-blocking warnings.
+ */
+const manageGlobalStanzaPhase = async (
+	options: { dryRun: boolean },
+	isTTY: boolean,
+): Promise<PostUpdatePhaseResult> => {
+	const { bold, dim } = getColorFns(isTTY);
+
+	console.log("");
+	console.log(
+		bold(
+			options.dryRun
+				? "Checking global instruction stanzas..."
+				: "Updating global instruction stanzas...",
+		),
+	);
+
+	const enabledHarnesses = await resolveStanzaHarnesses();
+	if (enabledHarnesses.length === 0) {
+		console.log(
+			dim("No enabled harnesses. Skipping global stanza management."),
+		);
+		return { success: true, exitCode: 0 };
+	}
+
+	const result = await manageGlobalStanzas(enabledHarnesses, {
+		dryRun: options.dryRun,
+	});
+
+	formatStanzaResult(result, isTTY);
+	return { success: true, exitCode: 0 };
+};
+
+/**
  * Run project migrations after plugin refresh. This is best-effort when the
  * current working directory is not an rp1 project.
  */
@@ -779,6 +874,18 @@ export const executeUpdateAction = async (
 			const { yellow } = getColorFns(isTTY);
 			const message = error instanceof Error ? error.message : String(error);
 			console.log(yellow(`Tier remapping failed (non-blocking): ${message}`));
+		}
+	}
+
+	if (pluginResult.success) {
+		try {
+			await manageGlobalStanzaPhase({ dryRun: options.dryRun }, isTTY);
+		} catch (error) {
+			const { yellow } = getColorFns(isTTY);
+			const message = error instanceof Error ? error.message : String(error);
+			console.log(
+				yellow(`Global stanza management failed (non-blocking): ${message}`),
+			);
 		}
 	}
 

--- a/cli/src/init/comment-fence.ts
+++ b/cli/src/init/comment-fence.ts
@@ -101,6 +101,17 @@ export function hasFencedContent(content: string): boolean {
 	return findFencedContent(content) !== null;
 }
 
+export function removeFencedContent(content: string): string {
+	const position = findFencedContent(content);
+	if (!position) return content;
+
+	const before = content.slice(0, position.start);
+	const after = content.slice(position.end);
+
+	const result = (before.trimEnd() + after.trimStart()).trim();
+	return result.length > 0 ? `${result}\n` : "";
+}
+
 export function validateFencing(content: string): {
 	valid: boolean;
 	error?: string;

--- a/cli/src/init/global-path-map.ts
+++ b/cli/src/init/global-path-map.ts
@@ -1,0 +1,30 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+/**
+ * Maps each harness ID to a function that resolves its user-global instruction
+ * file path from a given home directory.
+ */
+export const GLOBAL_INSTRUCTION_PATH_MAP: Record<
+	string,
+	(homeDir: string) => string
+> = {
+	"claude-code": (home) => join(home, ".claude", "CLAUDE.md"),
+	codex: (home) => join(home, ".codex", "AGENTS.md"),
+	opencode: (home) => join(home, ".config", "opencode", "AGENTS.md"),
+	copilot: (home) => join(home, ".copilot", "copilot-instructions.md"),
+	antigravity: (home) => join(home, ".gemini", "AGENTS.md"),
+};
+
+/**
+ * Resolve the absolute path to a harness's global instruction file.
+ * Returns null for unknown harness IDs so callers can skip with a warning
+ * (forward-compatible with future platforms).
+ */
+export function resolveGlobalInstructionPath(
+	harnessId: string,
+	homeDir: string = homedir(),
+): string | null {
+	const resolver = GLOBAL_INSTRUCTION_PATH_MAP[harnessId];
+	return resolver ? resolver(homeDir) : null;
+}

--- a/cli/src/init/global-path-map.ts
+++ b/cli/src/init/global-path-map.ts
@@ -1,10 +1,6 @@
 import { homedir } from "node:os";
 import { join } from "node:path";
 
-/**
- * Maps each harness ID to a function that resolves its user-global instruction
- * file path from a given home directory.
- */
 export const GLOBAL_INSTRUCTION_PATH_MAP: Record<
 	string,
 	(homeDir: string) => string
@@ -16,11 +12,6 @@ export const GLOBAL_INSTRUCTION_PATH_MAP: Record<
 	antigravity: (home) => join(home, ".gemini", "AGENTS.md"),
 };
 
-/**
- * Resolve the absolute path to a harness's global instruction file.
- * Returns null for unknown harness IDs so callers can skip with a warning
- * (forward-compatible with future platforms).
- */
 export function resolveGlobalInstructionPath(
 	harnessId: string,
 	homeDir: string = homedir(),

--- a/cli/src/init/global-stanza-template.ts
+++ b/cli/src/init/global-stanza-template.ts
@@ -1,0 +1,50 @@
+import { LATEST_FENCE_VERSION } from "../lib/fence-version.js";
+
+export { LATEST_FENCE_VERSION };
+
+const KB_SECTION = `## rp1 Knowledge Base
+
+**Use Progressive Disclosure Pattern**
+
+Run \`rp1 agent-tools rp1-root-dir\` to discover the project's \`kbRoot\` directory, then load KB files from that location.
+
+Files:
+- index.md (always load first)
+- architecture.md
+- modules.md
+- patterns.md
+- concept_map.md
+
+Loading rules:
+1. Run \`rp1 agent-tools rp1-root-dir\` to resolve the \`kbRoot\` path.
+2. Read \`index.md\` first from the resolved kbRoot.
+3. Then load based on task type:
+   - Code review: patterns.md
+   - Bug investigation: architecture.md, modules.md
+   - Feature work: modules.md, patterns.md
+   - Strategic or system-wide analysis: all files`;
+
+const SKILL_AWARENESS_SECTION = `## rp1 Skill Awareness
+
+Installed plugins: rp1-base, rp1-dev. Run \`/guide\` to discover skills by task.
+
+- Suggest at most 1 skill per turn: name, one-line reason, offer to run.
+- Skip if the user declined this session or a workflow is already running.
+- Only suggest when there is a clear match to the user's current activity.`;
+
+const CODEX_CONVENTIONS_SECTION = `## Codex agent conventions
+
+**Task shorthand**: \`Task: <sub-agent-name>\` means spawn that sub-agent. Treat it as an execution directive, not descriptive text.
+
+**Subagent waiting**: Do not assume a subagent failed because it is slow. Wait for completion before declaring it stalled. Check for expected side effects (artifact files, DB writes) before concluding it is stuck. Prefer patient polling over short timeouts for critical-path subagents.`;
+
+export function buildGlobalStanzaContent(platform: string): string {
+	switch (platform) {
+		case "claude-code":
+			return `${KB_SECTION}\n\n${SKILL_AWARENESS_SECTION}`;
+		case "codex":
+			return `${KB_SECTION}\n\n${CODEX_CONVENTIONS_SECTION}`;
+		default:
+			return `${KB_SECTION}\n\n${SKILL_AWARENESS_SECTION}`;
+	}
+}

--- a/cli/src/init/global-stanza-writer.ts
+++ b/cli/src/init/global-stanza-writer.ts
@@ -1,0 +1,188 @@
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import {
+	appendFencedContent,
+	hasFencedContent,
+	removeFencedContent,
+	replaceFencedContent,
+	validateFencing,
+} from "./comment-fence.js";
+import {
+	GLOBAL_INSTRUCTION_PATH_MAP,
+	resolveGlobalInstructionPath,
+} from "./global-path-map.js";
+import {
+	buildGlobalStanzaContent,
+	LATEST_FENCE_VERSION,
+} from "./global-stanza-template.js";
+
+export interface GlobalStanzaResult {
+	readonly written: string[];
+	readonly updated: string[];
+	readonly removed: string[];
+	readonly skipped: string[];
+	readonly errors: Array<{ platform: string; error: string }>;
+}
+
+export interface ManageGlobalStanzasOptions {
+	readonly homeDir?: string;
+	readonly dryRun?: boolean;
+}
+
+async function readFileContent(filePath: string): Promise<string | null> {
+	try {
+		return await fs.readFile(filePath, "utf-8");
+	} catch {
+		return null;
+	}
+}
+
+async function writeFileContent(
+	filePath: string,
+	content: string,
+): Promise<void> {
+	const dir = path.dirname(filePath);
+	await fs.mkdir(dir, { recursive: true });
+	await fs.writeFile(filePath, content, "utf-8");
+}
+
+export async function writeGlobalStanza(
+	harnessId: string,
+	homeDir?: string,
+): Promise<{ action: "written" | "updated"; filePath: string }> {
+	const filePath = resolveGlobalInstructionPath(harnessId, homeDir);
+	if (!filePath) {
+		throw new Error(`Unknown harness ID: ${harnessId}`);
+	}
+
+	const stanzaContent = buildGlobalStanzaContent(harnessId);
+	const existing = await readFileContent(filePath);
+
+	if (existing === null) {
+		const fenced = `${appendFencedContent("", stanzaContent, LATEST_FENCE_VERSION)}`;
+		await writeFileContent(filePath, fenced);
+		return { action: "written", filePath };
+	}
+
+	const fencingResult = validateFencing(existing);
+	if (!fencingResult.valid) {
+		throw new Error(
+			`Invalid fencing in ${filePath}: ${fencingResult.error}. ` +
+				"Manually fix or remove the rp1 fence markers before retrying.",
+		);
+	}
+
+	if (hasFencedContent(existing)) {
+		const updated = replaceFencedContent(
+			existing,
+			stanzaContent,
+			LATEST_FENCE_VERSION,
+		);
+		await writeFileContent(filePath, updated);
+		return { action: "updated", filePath };
+	}
+
+	const appended = appendFencedContent(
+		existing,
+		stanzaContent,
+		LATEST_FENCE_VERSION,
+	);
+	await writeFileContent(filePath, appended);
+	return { action: "written", filePath };
+}
+
+export async function removeGlobalStanza(
+	harnessId: string,
+	homeDir?: string,
+): Promise<{ action: "removed" | "skipped"; filePath: string | null }> {
+	const filePath = resolveGlobalInstructionPath(harnessId, homeDir);
+	if (!filePath) {
+		return { action: "skipped", filePath: null };
+	}
+
+	const existing = await readFileContent(filePath);
+	if (existing === null || !hasFencedContent(existing)) {
+		return { action: "skipped", filePath };
+	}
+
+	const cleaned = removeFencedContent(existing);
+	await writeFileContent(filePath, cleaned);
+	return { action: "removed", filePath };
+}
+
+export async function manageGlobalStanzas(
+	enabledHarnesses: readonly string[],
+	options: ManageGlobalStanzasOptions = {},
+): Promise<GlobalStanzaResult> {
+	const { homeDir, dryRun = false } = options;
+	const enabledSet = new Set(enabledHarnesses);
+	const allPlatforms = Object.keys(GLOBAL_INSTRUCTION_PATH_MAP);
+
+	const result: {
+		written: string[];
+		updated: string[];
+		removed: string[];
+		skipped: string[];
+		errors: Array<{ platform: string; error: string }>;
+	} = { written: [], updated: [], removed: [], skipped: [], errors: [] };
+
+	for (const platform of allPlatforms) {
+		if (enabledSet.has(platform)) {
+			try {
+				if (dryRun) {
+					const filePath = resolveGlobalInstructionPath(platform, homeDir);
+					if (!filePath) {
+						result.skipped.push(platform);
+						continue;
+					}
+					const existing = await readFileContent(filePath);
+					if (existing === null || !hasFencedContent(existing)) {
+						result.written.push(platform);
+					} else {
+						result.updated.push(platform);
+					}
+				} else {
+					const { action } = await writeGlobalStanza(platform, homeDir);
+					if (action === "written") {
+						result.written.push(platform);
+					} else {
+						result.updated.push(platform);
+					}
+				}
+			} catch (err) {
+				result.errors.push({
+					platform,
+					error: err instanceof Error ? err.message : String(err),
+				});
+			}
+		} else {
+			const filePath = resolveGlobalInstructionPath(platform, homeDir);
+			if (!filePath) {
+				result.skipped.push(platform);
+				continue;
+			}
+
+			try {
+				const existing = await readFileContent(filePath);
+				if (existing === null || !hasFencedContent(existing)) {
+					result.skipped.push(platform);
+					continue;
+				}
+
+				if (dryRun) {
+					result.removed.push(platform);
+				} else {
+					await removeGlobalStanza(platform, homeDir);
+					result.removed.push(platform);
+				}
+			} catch (err) {
+				result.errors.push({
+					platform,
+					error: err instanceof Error ? err.message : String(err),
+				});
+			}
+		}
+	}
+
+	return result;
+}

--- a/cli/src/init/global-stanza-writer.ts
+++ b/cli/src/init/global-stanza-writer.ts
@@ -22,6 +22,7 @@ export interface GlobalStanzaResult {
 	readonly removed: string[];
 	readonly skipped: string[];
 	readonly errors: Array<{ platform: string; error: string }>;
+	readonly paths: ReadonlyMap<string, string>;
 }
 
 export interface ManageGlobalStanzasOptions {
@@ -124,7 +125,15 @@ export async function manageGlobalStanzas(
 		removed: string[];
 		skipped: string[];
 		errors: Array<{ platform: string; error: string }>;
-	} = { written: [], updated: [], removed: [], skipped: [], errors: [] };
+		paths: Map<string, string>;
+	} = {
+		written: [],
+		updated: [],
+		removed: [],
+		skipped: [],
+		errors: [],
+		paths: new Map(),
+	};
 
 	for (const platform of allPlatforms) {
 		if (enabledSet.has(platform)) {
@@ -135,6 +144,7 @@ export async function manageGlobalStanzas(
 						result.skipped.push(platform);
 						continue;
 					}
+					result.paths.set(platform, filePath);
 					const existing = await readFileContent(filePath);
 					if (existing === null || !hasFencedContent(existing)) {
 						result.written.push(platform);
@@ -142,7 +152,11 @@ export async function manageGlobalStanzas(
 						result.updated.push(platform);
 					}
 				} else {
-					const { action } = await writeGlobalStanza(platform, homeDir);
+					const { action, filePath } = await writeGlobalStanza(
+						platform,
+						homeDir,
+					);
+					result.paths.set(platform, filePath);
 					if (action === "written") {
 						result.written.push(platform);
 					} else {
@@ -169,6 +183,7 @@ export async function manageGlobalStanzas(
 					continue;
 				}
 
+				result.paths.set(platform, filePath);
 				if (dryRun) {
 					result.removed.push(platform);
 				} else {

--- a/cli/src/init/index.ts
+++ b/cli/src/init/index.ts
@@ -3,6 +3,8 @@
  * Orchestrates all initialization steps with TTY-aware interactivity.
  */
 
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
 import * as E from "fp-ts/lib/Either.js";
 import { pipe } from "fp-ts/lib/function.js";
 import * as TE from "fp-ts/lib/TaskEither.js";
@@ -14,10 +16,12 @@ import {
 	loadToolsRegistry,
 	type ToolsRegistry,
 } from "../config/supported-tools.js";
+import { readStorageMode } from "../../shared/storage-mode.js";
 import {
 	type InstallContext,
 	installAllDetectedTools,
 } from "../shared/install-core.js";
+import { hasFencedContent, removeFencedContent } from "./comment-fence.js";
 import {
 	type ContextDetectionResult,
 	detectProjectContext,
@@ -28,6 +32,7 @@ import {
 	detectReinitState as detectSharedReinitState,
 	type InitDirectoryModel,
 } from "./directory-model.js";
+import { manageGlobalStanzas } from "./global-stanza-writer.js";
 import { detectGitRoot, type GitRootResult } from "./git-root.js";
 import type {
 	HealthReport,
@@ -870,12 +875,66 @@ export function executeInit(
 				}
 
 				progress.startStep("instruction-injection");
-				const { actions: instrActions } = await injectInstructions(
-					cwd,
-					primaryTool || null,
-					logger,
+				const storageMode = readStorageMode(
+					directories.projectRoot,
+					options.globalSettingsPath,
 				);
-				allActions.push(...instrActions);
+
+				if (storageMode === "central") {
+					for (const file of ["CLAUDE.md", "AGENTS.md"] as const) {
+						const filePath = path.resolve(cwd, file);
+						try {
+							const content = await fs.readFile(filePath, "utf-8");
+							if (hasFencedContent(content)) {
+								const cleaned = removeFencedContent(content);
+								await fs.writeFile(filePath, cleaned, "utf-8");
+								allActions.push({ type: "updated_file", path: filePath });
+								logger.info(
+									`Removed per-project rp1 stanza from ${file} (central mode)`,
+								);
+							}
+						} catch {
+							// File does not exist — nothing to clean up
+						}
+					}
+
+					const stanzaResult = await manageGlobalStanzas(stableIds, {
+						homeDir: undefined,
+					});
+
+					for (const platform of stanzaResult.written) {
+						allActions.push({
+							type: "created_file",
+							path: `global stanza: ${platform}`,
+						});
+						logger.success(`Wrote global stanza for ${platform}`);
+					}
+					for (const platform of stanzaResult.updated) {
+						allActions.push({
+							type: "updated_file",
+							path: `global stanza: ${platform}`,
+						});
+						logger.success(`Updated global stanza for ${platform}`);
+					}
+					for (const platform of stanzaResult.removed) {
+						logger.info(
+							`Removed global stanza for deselected platform: ${platform}`,
+						);
+					}
+					for (const { platform, error } of stanzaResult.errors) {
+						logger.warn(`Global stanza error for ${platform}: ${error}`);
+						allWarnings.push(
+							`Global stanza write failed for ${platform}: ${error}`,
+						);
+					}
+				} else {
+					const { actions: instrActions } = await injectInstructions(
+						cwd,
+						primaryTool || null,
+						logger,
+					);
+					allActions.push(...instrActions);
+				}
 				progress.completeStep();
 
 				progress.startStep("gitignore-config");

--- a/cli/src/init/index.ts
+++ b/cli/src/init/index.ts
@@ -3,8 +3,6 @@
  * Orchestrates all initialization steps with TTY-aware interactivity.
  */
 
-import * as fs from "node:fs/promises";
-import * as path from "node:path";
 import * as E from "fp-ts/lib/Either.js";
 import { pipe } from "fp-ts/lib/function.js";
 import * as TE from "fp-ts/lib/TaskEither.js";
@@ -12,16 +10,15 @@ import { type CLIError, runtimeError } from "../../shared/errors.js";
 import type { Logger } from "../../shared/logger.js";
 import { ensureProjectId } from "../../shared/project-id.js";
 import { type PromptOptions, selectOption } from "../../shared/prompts.js";
-import { readStorageMode } from "../../shared/storage-mode.js";
 import {
 	loadToolsRegistry,
 	type ToolsRegistry,
 } from "../config/supported-tools.js";
+import { loadEnabledHarnesses } from "../settings/loader.js";
 import {
 	type InstallContext,
 	installAllDetectedTools,
 } from "../shared/install-core.js";
-import { hasFencedContent, removeFencedContent } from "./comment-fence.js";
 import {
 	type ContextDetectionResult,
 	detectProjectContext,
@@ -33,7 +30,6 @@ import {
 	type InitDirectoryModel,
 } from "./directory-model.js";
 import { detectGitRoot, type GitRootResult } from "./git-root.js";
-import { manageGlobalStanzas } from "./global-stanza-writer.js";
 import type {
 	HealthReport,
 	InitAction,
@@ -58,7 +54,7 @@ import {
 	createMinimalProjectStructure,
 	createSettingsFiles,
 	createStorageDirectories,
-	injectInstructions,
+	injectInstructionsForStorageMode,
 } from "./steps/project-setup.js";
 import { checkRp1Readiness } from "./steps/readiness.js";
 import { generateSandboxGrants } from "./steps/sandbox-grants.js";
@@ -646,7 +642,11 @@ export function executeInit(
 
 				const harnessItems = buildHarnessItems(toolDetectionResult.detected);
 				const stableIds = getStableDefaults(harnessItems);
-				writeHarnessSelection(stableIds, options.globalSettingsPath);
+				const persisted = loadEnabledHarnesses(options.globalSettingsPath);
+				const selection = persisted ?? stableIds;
+				if (persisted === undefined) {
+					writeHarnessSelection(stableIds, options.globalSettingsPath);
+				}
 
 				// --- Install check and delegation ---
 				progress.startStep("install-check");
@@ -849,7 +849,7 @@ export function executeInit(
 				progress.startStep("sandbox-grants");
 				try {
 					const grantResults = await generateSandboxGrants(
-						[...stableIds],
+						[...selection],
 						cwd,
 						options.globalSettingsPath,
 					);
@@ -871,66 +871,21 @@ export function executeInit(
 				}
 
 				progress.startStep("instruction-injection");
-				const storageMode = readStorageMode(
-					directories.projectRoot,
-					options.globalSettingsPath,
-				);
-
-				if (storageMode === "central") {
-					for (const file of ["CLAUDE.md", "AGENTS.md"] as const) {
-						const filePath = path.resolve(cwd, file);
-						try {
-							const content = await fs.readFile(filePath, "utf-8");
-							if (hasFencedContent(content)) {
-								const cleaned = removeFencedContent(content);
-								await fs.writeFile(filePath, cleaned, "utf-8");
-								allActions.push({ type: "updated_file", path: filePath });
-								logger.info(
-									`Removed per-project rp1 stanza from ${file} (central mode)`,
-								);
-							}
-						} catch {
-							// File does not exist — nothing to clean up
-						}
-					}
-
-					const stanzaResult = await manageGlobalStanzas(stableIds, {
-						homeDir: options.homeDir,
-					});
-
-					for (const platform of stanzaResult.written) {
-						allActions.push({
-							type: "created_file",
-							path: `global stanza: ${platform}`,
-						});
-						logger.success(`Wrote global stanza for ${platform}`);
-					}
-					for (const platform of stanzaResult.updated) {
-						allActions.push({
-							type: "updated_file",
-							path: `global stanza: ${platform}`,
-						});
-						logger.success(`Updated global stanza for ${platform}`);
-					}
-					for (const platform of stanzaResult.removed) {
-						logger.info(
-							`Removed global stanza for deselected platform: ${platform}`,
-						);
-					}
-					for (const { platform, error } of stanzaResult.errors) {
-						logger.warn(`Global stanza error for ${platform}: ${error}`);
-						allWarnings.push(
-							`Global stanza write failed for ${platform}: ${error}`,
-						);
-					}
-				} else {
-					const { actions: instrActions } = await injectInstructions(
-						cwd,
-						primaryTool || null,
-						logger,
-					);
-					allActions.push(...instrActions);
-				}
+				const instrResult = await injectInstructionsForStorageMode({
+					cwd,
+					projectRoot: directories.projectRoot,
+					harnessSelection: selection,
+					detectedTool: primaryTool || null,
+					homeDir: options.homeDir,
+					globalSettingsPath: options.globalSettingsPath,
+					onProgress: (msg, type) => {
+						if (type === "success") logger.success(msg);
+						else if (type === "warning") logger.warn(msg);
+						else logger.info(msg);
+					},
+				});
+				allActions.push(...instrResult.actions);
+				allWarnings.push(...instrResult.warnings);
 				progress.completeStep();
 
 				progress.startStep("gitignore-config");

--- a/cli/src/init/index.ts
+++ b/cli/src/init/index.ts
@@ -41,6 +41,11 @@ import type {
 	ReinitState,
 } from "./models.js";
 import { createProgress, type InitProgress } from "./progress.js";
+import {
+	buildHarnessItems,
+	getStableDefaults,
+	writeHarnessSelection,
+} from "./steps/harness-selection.js";
 import { performHealthCheck } from "./steps/health-check.js";
 import { checkPluginsInstalled } from "./steps/plugin-installation.js";
 import {
@@ -633,6 +638,14 @@ export function executeInit(
 				allWarnings.push(...toolWarnings);
 				const primaryTool = getPrimaryTool(toolDetectionResult);
 				progress.completeStep();
+
+				// --- Harness persistence (non-TTY) ---
+				// Persist [harnesses] enabled to settings.toml so that
+				// rp1 update can scope global stanza writes correctly.
+				// Matches the TTY --yes path in useStepExecution.ts.
+				const harnessItems = buildHarnessItems(toolDetectionResult.detected);
+				const stableIds = getStableDefaults(harnessItems);
+				writeHarnessSelection(stableIds, options.globalSettingsPath);
 
 				// --- Install check and delegation ---
 				progress.startStep("install-check");

--- a/cli/src/init/index.ts
+++ b/cli/src/init/index.ts
@@ -12,11 +12,11 @@ import { type CLIError, runtimeError } from "../../shared/errors.js";
 import type { Logger } from "../../shared/logger.js";
 import { ensureProjectId } from "../../shared/project-id.js";
 import { type PromptOptions, selectOption } from "../../shared/prompts.js";
+import { readStorageMode } from "../../shared/storage-mode.js";
 import {
 	loadToolsRegistry,
 	type ToolsRegistry,
 } from "../config/supported-tools.js";
-import { readStorageMode } from "../../shared/storage-mode.js";
 import {
 	type InstallContext,
 	installAllDetectedTools,
@@ -32,8 +32,8 @@ import {
 	detectReinitState as detectSharedReinitState,
 	type InitDirectoryModel,
 } from "./directory-model.js";
-import { manageGlobalStanzas } from "./global-stanza-writer.js";
 import { detectGitRoot, type GitRootResult } from "./git-root.js";
+import { manageGlobalStanzas } from "./global-stanza-writer.js";
 import type {
 	HealthReport,
 	InitAction,

--- a/cli/src/init/index.ts
+++ b/cli/src/init/index.ts
@@ -644,10 +644,6 @@ export function executeInit(
 				const primaryTool = getPrimaryTool(toolDetectionResult);
 				progress.completeStep();
 
-				// --- Harness persistence (non-TTY) ---
-				// Persist [harnesses] enabled to settings.toml so that
-				// rp1 update can scope global stanza writes correctly.
-				// Matches the TTY --yes path in useStepExecution.ts.
 				const harnessItems = buildHarnessItems(toolDetectionResult.detected);
 				const stableIds = getStableDefaults(harnessItems);
 				writeHarnessSelection(stableIds, options.globalSettingsPath);
@@ -853,7 +849,7 @@ export function executeInit(
 				progress.startStep("sandbox-grants");
 				try {
 					const grantResults = await generateSandboxGrants(
-						undefined,
+						[...stableIds],
 						cwd,
 						options.globalSettingsPath,
 					);
@@ -899,7 +895,7 @@ export function executeInit(
 					}
 
 					const stanzaResult = await manageGlobalStanzas(stableIds, {
-						homeDir: undefined,
+						homeDir: options.homeDir,
 					});
 
 					for (const platform of stanzaResult.written) {

--- a/cli/src/init/models.ts
+++ b/cli/src/init/models.ts
@@ -186,6 +186,8 @@ export interface InitOptions {
 	readonly forceNested?: boolean;
 	/** Override path to global settings file (test isolation seam) */
 	readonly globalSettingsPath?: string;
+	/** Override home directory for global stanza writes (test isolation seam) */
+	readonly homeDir?: string;
 }
 
 /**

--- a/cli/src/init/steps/project-setup.ts
+++ b/cli/src/init/steps/project-setup.ts
@@ -16,10 +16,12 @@ import { formatError } from "../../../shared/errors.js";
 import type { Logger } from "../../../shared/logger.js";
 import type { PromptOptions } from "../../../shared/prompts.js";
 import { selectOption } from "../../../shared/prompts.js";
+import { readStorageMode } from "../../../shared/storage-mode.js";
 import { LATEST_FENCE_VERSION } from "../../lib/fence-version.js";
 import {
 	appendFencedContent,
 	hasFencedContent,
+	removeFencedContent,
 	replaceFencedContent,
 	validateFencing,
 	wrapWithFence,
@@ -30,6 +32,10 @@ import {
 	resolveStorageDirectoryPaths,
 } from "../directory-model.js";
 import { buildManagedGitignoreContent } from "../gitignore.js";
+import {
+	type GlobalStanzaResult,
+	manageGlobalStanzas,
+} from "../global-stanza-writer.js";
 import type { GitignorePreset, InitAction } from "../models.js";
 import type { InitProgress } from "../progress.js";
 import {
@@ -446,6 +452,122 @@ export async function injectInstructions(
 	}
 
 	return { actions, instructionFile: primaryFile };
+}
+
+// ============================================================================
+// Storage-Mode-Aware Instruction Injection
+// ============================================================================
+
+export interface InstructionInjectionOptions {
+	readonly cwd: string;
+	readonly projectRoot: string;
+	readonly harnessSelection: readonly string[];
+	readonly detectedTool: DetectedTool | null;
+	readonly homeDir?: string;
+	readonly globalSettingsPath?: string;
+	readonly onProgress?: (
+		message: string,
+		type: "info" | "success" | "warning",
+	) => void;
+}
+
+export interface InstructionInjectionResult {
+	readonly actions: InitAction[];
+	readonly stanzaResult: GlobalStanzaResult | null;
+	readonly warnings: string[];
+}
+
+export async function injectInstructionsForStorageMode(
+	options: InstructionInjectionOptions,
+): Promise<InstructionInjectionResult> {
+	const {
+		cwd,
+		projectRoot,
+		harnessSelection,
+		detectedTool,
+		homeDir,
+		globalSettingsPath,
+		onProgress,
+	} = options;
+
+	const actions: InitAction[] = [];
+	const warnings: string[] = [];
+	const storageMode = readStorageMode(projectRoot, globalSettingsPath);
+
+	if (storageMode === "central") {
+		for (const file of ["CLAUDE.md", "AGENTS.md"] as const) {
+			const filePath = path.resolve(cwd, file);
+			try {
+				const content = await readFileContent(filePath);
+				if (content !== null && hasFencedContent(content)) {
+					const cleaned = removeFencedContent(content);
+					await writeFileContent(filePath, cleaned);
+					actions.push({ type: "updated_file", path: filePath });
+					onProgress?.(
+						`Removed per-project rp1 stanza from ${file} (central mode)`,
+						"info",
+					);
+				}
+			} catch {
+				// File does not exist
+			}
+		}
+
+		const stanzaResult = await manageGlobalStanzas(harnessSelection, {
+			homeDir,
+		});
+
+		for (const platform of stanzaResult.written) {
+			const stanzaPath =
+				stanzaResult.paths.get(platform) ?? `global stanza: ${platform}`;
+			actions.push({
+				type: "created_file",
+				path: stanzaPath,
+			});
+			onProgress?.(`Wrote global stanza for ${platform}`, "success");
+		}
+		for (const platform of stanzaResult.updated) {
+			const stanzaPath =
+				stanzaResult.paths.get(platform) ?? `global stanza: ${platform}`;
+			actions.push({
+				type: "updated_file",
+				path: stanzaPath,
+			});
+			onProgress?.(`Updated global stanza for ${platform}`, "success");
+		}
+		for (const platform of stanzaResult.removed) {
+			onProgress?.(
+				`Removed global stanza for deselected platform: ${platform}`,
+				"info",
+			);
+		}
+		for (const { platform, error } of stanzaResult.errors) {
+			onProgress?.(`Global stanza error for ${platform}: ${error}`, "warning");
+			warnings.push(`Global stanza write failed for ${platform}: ${error}`);
+		}
+
+		return { actions, stanzaResult, warnings };
+	}
+
+	const proxyLogger: Logger = {
+		info: (msg: string) => onProgress?.(msg, "info"),
+		success: (msg: string) => onProgress?.(msg, "success"),
+		warn: (msg: string) => onProgress?.(msg, "warning"),
+		fail: (msg: string) => onProgress?.(msg, "warning"),
+		error: (msg: string) => onProgress?.(msg, "warning"),
+		debug: () => {},
+		trace: () => {},
+		start: () => {},
+		box: () => {},
+	};
+	const { actions: instrActions } = await injectInstructions(
+		cwd,
+		detectedTool,
+		proxyLogger,
+	);
+	actions.push(...instrActions);
+
+	return { actions, stanzaResult: null, warnings };
 }
 
 // ============================================================================

--- a/cli/src/init/steps/sandbox-grants.ts
+++ b/cli/src/init/steps/sandbox-grants.ts
@@ -359,7 +359,7 @@ const PLATFORM_WRITERS: Readonly<
  * 2. Otherwise read persisted selection via loadEnabledHarnesses.
  * 3. If nothing is persisted, fall back to all stable platforms in the registry.
  */
-async function resolveHarnesses(
+export async function resolveHarnesses(
 	harnesses: string[] | undefined,
 	globalSettingsPath?: string,
 ): Promise<readonly string[]> {

--- a/cli/src/init/ui/hooks/useStepExecution.ts
+++ b/cli/src/init/ui/hooks/useStepExecution.ts
@@ -19,17 +19,11 @@ import {
 	type ToolsRegistry,
 } from "../../../config/supported-tools.js";
 import { LATEST_FENCE_VERSION } from "../../../lib/fence-version.js";
+import { loadEnabledHarnesses } from "../../../settings/loader.js";
 import {
 	type InstallContext,
 	installAllDetectedTools,
 } from "../../../shared/install-core.js";
-import {
-	appendFencedContent,
-	hasFencedContent,
-	replaceFencedContent,
-	validateFencing,
-	wrapWithFence,
-} from "../../comment-fence.js";
 import {
 	detectProjectContext,
 	type ProjectContext,
@@ -72,7 +66,10 @@ import {
 } from "../../steps/harness-selection.js";
 import { performHealthCheck } from "../../steps/health-check.js";
 import { checkPluginsInstalled } from "../../steps/plugin-installation.js";
-import { createStorageDirectories } from "../../steps/project-setup.js";
+import {
+	createStorageDirectories,
+	injectInstructionsForStorageMode,
+} from "../../steps/project-setup.js";
 import {
 	checkRp1Readiness,
 	type ReadinessResult,
@@ -84,12 +81,6 @@ import {
 	verifyCopilotPlugins,
 	verifyOpenCodePlugins,
 } from "../../steps/verification.js";
-import {
-	AGENTS_REFERENCE_TEMPLATE,
-	getInstructionFiles,
-	getPrimaryInstructionTemplateTarget,
-	resolveInstructionTemplate,
-} from "../../templates/index.js";
 import {
 	type DetectedTool,
 	detectTools,
@@ -620,8 +611,16 @@ export const useStepExecution = ({
 	const executeSandboxGrants = useCallback(
 		async (addAct: AddActivityFn): Promise<void> => {
 			const ctx = contextRef.current;
+			const wizardSelection = state.userChoices.enabledHarnesses;
+			const selection = wizardSelection
+				? [...wizardSelection]
+				: (loadEnabledHarnesses(options.globalSettingsPath) ?? undefined);
 			try {
-				const grantResults = await generateSandboxGrants(undefined, ctx.cwd);
+				const grantResults = await generateSandboxGrants(
+					selection,
+					ctx.cwd,
+					options.globalSettingsPath,
+				);
 				let granted = 0;
 				for (const grant of grantResults) {
 					if (grant.written) {
@@ -641,7 +640,7 @@ export const useStepExecution = ({
 				addAct("sandbox-grants", `Grant error: ${msg}`, "warning");
 			}
 		},
-		[],
+		[state.userChoices.enabledHarnesses, options.globalSettingsPath],
 	);
 
 	/**
@@ -778,121 +777,54 @@ export const useStepExecution = ({
 	);
 
 	/**
-	 * Inject into a single instruction file, optionally overriding the template.
-	 */
-	const injectIntoSingleFile = useCallback(
-		async (
-			addAct: AddActivityFn,
-			file: string,
-			detectedTool: DetectedTool | null,
-			templateOverride?: string,
-		): Promise<void> => {
-			const ctx = contextRef.current;
-			const filePath = path.resolve(ctx.cwd, file);
-			const exists = await fileExists(filePath);
-
-			if (!exists) return;
-
-			addAct("instruction-injection", `Configuring ${file}...`, "info");
-
-			const existingContent = await readFileContent(filePath);
-			if (existingContent === null) {
-				throw new Error(`Failed to read file: ${filePath}`);
-			}
-
-			const validation = validateFencing(existingContent);
-			if (!validation.valid) {
-				throw new Error(`Invalid fencing in ${file}: ${validation.error}`);
-			}
-
-			const template =
-				templateOverride ??
-				resolveInstructionTemplate(file as "CLAUDE.md" | "AGENTS.md", {
-					detectedTool,
-					existingContent,
-				});
-
-			if (hasFencedContent(existingContent)) {
-				const newContent = replaceFencedContent(
-					existingContent,
-					template,
-					LATEST_FENCE_VERSION,
-				);
-				await writeFileContent(filePath, newContent);
-				addAct("instruction-injection", `Updated ${file}`, "success");
-			} else {
-				const newContent = appendFencedContent(
-					existingContent,
-					template,
-					LATEST_FENCE_VERSION,
-				);
-				await writeFileContent(filePath, newContent);
-				addAct("instruction-injection", `Appended to ${file}`, "success");
-			}
-		},
-		[],
-	);
-
-	/**
 	 * Execute the instruction injection step.
 	 *
-	 * When both CLAUDE.md and AGENTS.md exist, the full stanza goes into
-	 * AGENTS.md only and CLAUDE.md receives a single-line `@AGENTS.md`
-	 * import reference inside its fence.
+	 * Delegates to the shared injectInstructionsForStorageMode function so
+	 * both the wizard and headless paths handle central/local modes identically.
 	 */
 	const executeInstructionInjection = useCallback(
 		async (addAct: AddActivityFn): Promise<void> => {
 			const ctx = contextRef.current;
+			const directories =
+				ctx.directories ??
+				chooseInitDirectoryModel(ctx.cwd, ctx.forceLocalProject);
 
-			const claudePath = path.resolve(ctx.cwd, "CLAUDE.md");
-			const agentsPath = path.resolve(ctx.cwd, "AGENTS.md");
+			const wizardSelection = state.userChoices.enabledHarnesses;
+			const selection = wizardSelection
+				? [...wizardSelection]
+				: (loadEnabledHarnesses(options.globalSettingsPath) ?? []);
 
-			const claudeExists = await fileExists(claudePath);
-			const agentsExists = await fileExists(agentsPath);
-
-			// If neither exists, create the primary tool's file or default to CLAUDE.md
-			if (!claudeExists && !agentsExists) {
-				const { file: primaryFile, template } =
-					getPrimaryInstructionTemplateTarget(ctx.primaryTool);
-				const filePath = path.resolve(ctx.cwd, primaryFile);
-
-				addAct("instruction-injection", `Creating ${primaryFile}...`, "info");
-				const content = `${wrapWithFence(template, LATEST_FENCE_VERSION)}\n`;
-				await writeFileContent(filePath, content);
-				addAct("instruction-injection", `Created ${primaryFile}`, "success");
-				return;
-			}
-
-			if (claudeExists && agentsExists) {
-				await injectIntoSingleFile(addAct, "AGENTS.md", ctx.primaryTool);
-				// Skip CLAUDE.md when it already imports AGENTS.md outside any rp1
-				// fence — injecting the reference fence would duplicate the import.
-				const claudeContent = (await readFileContent(claudePath)) ?? "";
-				if (
-					/^@AGENTS\.md\s*$/m.test(claudeContent) &&
-					!hasFencedContent(claudeContent)
-				) {
+			const result = await injectInstructionsForStorageMode({
+				cwd: ctx.cwd,
+				projectRoot: directories.projectRoot,
+				harnessSelection: selection,
+				detectedTool: ctx.primaryTool,
+				homeDir: options.homeDir,
+				globalSettingsPath: options.globalSettingsPath,
+				onProgress: (msg, type) => {
 					addAct(
 						"instruction-injection",
-						"CLAUDE.md already references AGENTS.md; skipping",
-						"info",
+						msg,
+						type === "warning"
+							? "warning"
+							: type === "success"
+								? "success"
+								: "info",
 					);
-				} else {
-					await injectIntoSingleFile(
-						addAct,
-						"CLAUDE.md",
-						ctx.primaryTool,
-						AGENTS_REFERENCE_TEMPLATE,
-					);
-				}
-				return;
-			}
+				},
+			});
 
-			for (const file of getInstructionFiles()) {
-				await injectIntoSingleFile(addAct, file, ctx.primaryTool);
+			if (result.warnings.length > 0) {
+				for (const warning of result.warnings) {
+					addAct("instruction-injection", warning, "warning");
+				}
 			}
 		},
-		[injectIntoSingleFile],
+		[
+			state.userChoices.enabledHarnesses,
+			options.globalSettingsPath,
+			options.homeDir,
+		],
 	);
 
 	/**

--- a/cli/src/init/ui/hooks/useStepExecution.ts
+++ b/cli/src/init/ui/hooks/useStepExecution.ts
@@ -74,7 +74,10 @@ import {
 	checkRp1Readiness,
 	type ReadinessResult,
 } from "../../steps/readiness.js";
-import { generateSandboxGrants } from "../../steps/sandbox-grants.js";
+import {
+	generateSandboxGrants,
+	resolveHarnesses,
+} from "../../steps/sandbox-grants.js";
 import { generateNextSteps } from "../../steps/summary.js";
 import {
 	verifyClaudeCodePlugins,
@@ -790,9 +793,12 @@ export const useStepExecution = ({
 				chooseInitDirectoryModel(ctx.cwd, ctx.forceLocalProject);
 
 			const wizardSelection = state.userChoices.enabledHarnesses;
+			// Unknown selection must not collapse to [] — manageGlobalStanzas([])
+			// removes every global stanza. Resolve like the sandbox-grants step:
+			// persisted selection first, then stable registry defaults.
 			const selection = wizardSelection
 				? [...wizardSelection]
-				: (loadEnabledHarnesses(options.globalSettingsPath) ?? []);
+				: await resolveHarnesses(undefined, options.globalSettingsPath);
 
 			const result = await injectInstructionsForStorageMode({
 				cwd: ctx.cwd,

--- a/cli/src/uninstall/index.ts
+++ b/cli/src/uninstall/index.ts
@@ -13,7 +13,10 @@ import * as TE from "fp-ts/lib/TaskEither.js";
 import { type CLIError, runtimeError } from "../../shared/errors.js";
 import type { Logger } from "../../shared/logger.js";
 import { confirmAction, type PromptOptions } from "../../shared/prompts.js";
-import { findFencedContent, hasFencedContent } from "../init/comment-fence.js";
+import {
+	hasFencedContent,
+	removeFencedContent,
+} from "../init/comment-fence.js";
 import { resolveInitDirectoryModel } from "../init/directory-model.js";
 import {
 	findShellFencedContent,
@@ -87,22 +90,6 @@ async function writeFileContent(
 	content: string,
 ): Promise<void> {
 	await fs.writeFile(filePath, content, "utf-8");
-}
-
-/**
- * Remove fenced content from a markdown file (CLAUDE.md, AGENTS.md).
- * Uses HTML comment markers: <!-- rp1:start --> and <!-- rp1:end -->
- */
-function removeFencedContent(content: string): string {
-	const position = findFencedContent(content);
-	if (!position) return content;
-
-	const before = content.slice(0, position.start);
-	const after = content.slice(position.end);
-
-	// Clean up extra newlines around the removed section
-	const result = (before.trimEnd() + after.trimStart()).trim();
-	return result.length > 0 ? `${result}\n` : "";
 }
 
 /**


### PR DESCRIPTION
## Summary

P3 of the storage-decoupling phase plan: central-mode projects now receive rp1 instructions via **user-global instruction files** instead of per-project stanzas. When a project uses central storage, `rp1 init` and `rp1 update` write fenced rp1 stanzas to the global instruction file of each enabled harness:

- `~/.claude/CLAUDE.md` (Claude Code)
- `~/.codex/AGENTS.md` (Codex)
- `~/.config/opencode/AGENTS.md` (OpenCode)
- `~/.copilot/copilot-instructions.md` (GitHub Copilot)
- `~/.gemini/AGENTS.md` (Gemini / Antigravity)

Global stanza content is cross-project: it directs agents to resolve project directories at runtime via `rp1 agent-tools rp1-root-dir` rather than hardcoding `.rp1/` paths.

## Key changes

- **`global-path-map.ts`** — per-harness global instruction file map with `homeDir` seam; `comment-fence.ts` extracts `removeFencedContent` as a shared export
- **`global-stanza-template.ts`** — platform-specific stanza content (KB + Skill Awareness for Claude Code; KB + conventions for Codex; generic default)
- **`global-stanza-writer.ts`** — `writeGlobalStanza` / `removeGlobalStanza` / `manageGlobalStanzas` with merge-safe fenced writes, dry-run, and fence validation
- **`rp1 update`** — global stanza phase wired in after tier remapping (non-blocking)
- **`rp1 init`** — central-mode projects get per-project fence cleanup + global stanza writes; local mode unchanged; non-TTY init persists harness selection
- **Repair (T8)** — passes `stableIds` explicitly to `generateSandboxGrants` (fixes a detected-platform double-resolution regression) and adds a `homeDir?: string` seam to `InitOptions` so `executeInit` integration tests stay isolated from the real user home

## Testing

- 111 new unit tests (path map, template, writer, comment fence), all isolated via temp `homeDir`
- Init-focused suite 549/549; `tsc --noEmit` clean; biome/format clean
- Build readiness: PASS (report archived at `.rp1/work/archives/features/storage-decoupling-global-stanza/build-readiness.md`)

## Known follow-ups (non-blocking)

- Codex global stanza omits the Skill Awareness section (REQ-003 gap)
- Docs: configuration.md `[harnesses]` section, CLI reference, KB entries (TD1–TD3)
- REQ-008 manual fence-rendering verification across the 5 platforms
- Pre-existing (P2-era): `executeInit` integration tests still write real sandbox-grant/settings files when run without an isolated `$HOME`

🤖 Generated using: 🎮 [rp1.run](https://rp1.run)