### PR TITLE
chore: update core capabilities matrix and browser mapping baseline

### DIFF
--- a/.rp1/context/core-capabilties-matrix.md
+++ b/.rp1/context/core-capabilties-matrix.md
@@ -1,474 +1,682 @@
 # Core Capabilities Required for RP1 Platform Support
 
 **Generated**: 2026-03-14
+**Last Updated**: 2026-05-11
+**Current Baseline**: `/Users/prem/Development/rp1` at `v0.7.7` / `da8446bc`
 **Scope**: strategic-analysis
 **Purpose**: Reference document for evaluating whether a new AI agentic tool can serve as an RP1 harness
-**Derived From**: 15+ internal research documents spanning Dec 2025 - Mar 2026
+**Derived From**: Original Dec 2025 - Mar 2026 internal research plus current repo evidence through May 2026
 
 ## Executive Summary
 
-RP1 is a plugin-driven workflow system that delivers markdown-authored skills and agents to AI coding tools via a build pipeline. After supporting Claude Code (primary), OpenCode (second harness), and attempting Codex (abandoned due to capability gaps), we now have empirical data on what capabilities an agentic tool **must** provide before RP1 can target it.
+RP1 is a plugin-driven workflow system that delivers markdown-authored skills and agents to AI coding tools through a platform-aware build pipeline. The original report was written when Claude Code and OpenCode were supported, Codex had been judged too costly, and GitHub Copilot CLI support did not yet exist.
 
-This document distills those findings into a tiered capability checklist: **Must Have** (blocking -- RP1 fundamentally cannot work without these), **Should Have** (significant degradation without, but workarounds exist), and **Nice to Have** (enhances UX but not required for core functionality).
+That posture is now stale. The current repository has first-class build/install/verify/documentation paths for **Claude Code**, **OpenCode**, **Codex CLI**, and **GitHub Copilot CLI**. Codex is no longer merely an abandoned experiment: current code emits Codex skills, per-agent TOML, `openai.yaml`, managed `config.toml` sections, and Codex session hooks. Copilot is now a fourth generated target with native plugin-marketplace install support.
 
-The decision to drop Codex support validates this framework -- Codex failed on multiple Must Have and Should Have capabilities simultaneously, making the integration cost exceed the value.
+The original capability framework still holds, but the decision rule needs one refinement: a harness can be viable when RP1 can compensate for missing native behavior through generated prompts, installer configuration, and runtime tools. Those compensations are not free. They become permanent build, install, verification, and support obligations.
 
----
+The most important new blocking requirement is **workflow bootstrap compatibility**. Since the original report, tracked workflows now rely on generated `rp1 agent-tools workflow-bootstrap` stanzas for argument resolution, run identity, directory resolution, `codeRoot`, and harness attribution. A new harness that cannot reliably execute that bootstrap, parse the result, and preserve the returned variables cannot support current RP1 workflows with Arcade parity.
+
+## Current Support Snapshot
+
+| Harness                    | Current repo support                                         | Invocation shape             | Integration path                                             | Current posture                                   |
+| -------------------------- | ------------------------------------------------------------ | ---------------------------- | ------------------------------------------------------------ | ------------------------------------------------- |
+| Claude Code                | Build, install, verify, hooks, docs                          | `/knowledge-build`, `/build` | Native Claude plugin artifacts                               | Primary / high confidence                         |
+| OpenCode                   | Build, install, verify, docs                                 | `/rp1-base-knowledge-build`  | OpenCode config and generated skills/agents                  | Supported / high confidence                       |
+| Codex CLI                  | Build, install, verify, hooks, docs                          | `$rp1-base-knowledge-build`  | `.codex/skills`, `.codex/agents/rp1`, managed `config.toml`  | Supported with compensations                      |
+| GitHub Copilot CLI         | Build, install, verify, docs                                 | `/rp1-base-knowledge-build`  | Native Copilot plugin marketplace via `gh copilot -- plugin` | Supported, but tracked-workflow parity is partial |
+| Goose and other candidates | No `supported-tools` entry, no `BuildPlatform`, no templates | N/A                          | N/A                                                          | Unevaluated                                       |
+
+Copilot deserves a specific caveat: `cli/src/build/templates/copilot/skill.liquid` currently injects `resolve-args` guidance for parameterized skills, but it does not inject the tracked `workflow-bootstrap` section that Claude Code, OpenCode, and Codex templates inject. Treat Copilot as supported for generated skills/agents/install, but not yet proven equivalent for current tracked workflow state semantics until that gap is closed or intentionally accepted.
+
+## Change Evidence Since 2026-03-14
+
+| Evidence | What changed | Matrix impact |
+|----------|--------------|---------------|
+| `c4c7f3f4 feat!: support codex (#295)` | Codex artifacts, config management, validators, install/verify paths, parameter transforms, and docs were added or hardened. | Codex status changes from "dropped" to "supported with compensations." |
+| `5c97bf41 feat: add GitHub Copilot CLI support (#311)` | Copilot registry, templates, tags, install/verify commands, marketplace lifecycle, docs, and tests were added. | Add Copilot as a fourth evaluated harness. |
+| `490cb761 feat(cli): implement deterministic workflow bootstrap (#318)` | Tracked workflows now bootstrap run identity, arguments, directories, and run policy through a single agent tool. | Add workflow bootstrap as a Tier 1 capability. |
+| `d208e63d feat: add codeRoot to bootstrap for worktree-aware code edits (#343)` | Source edits now use `codeRoot` while artifacts stay in canonical `workRoot`/`kbRoot`. | Worktree awareness is now a runtime contract, not only a convenience. |
+| `cli/src/config/supported-tools.yaml` | Authoritative tool registry lists Claude Code, OpenCode, Codex, and Copilot with minimum versions and instruction files. | Current support snapshot must include four supported tools. |
+| `cli/src/build/template-context.ts` | `BuildPlatform` now includes `opencode`, `codex`, `claude-code`, and `copilot`. | New harnesses require an explicit build target. |
+| `cli/src/build/platform-definitions.ts` | Platform definitions centralize templates, registries, naming, hooks, and bundle behavior. | Build-pipeline compatibility is now data-driven but still requires per-harness definitions. |
+| `cli/src/build/tags/dispatch-agent.ts` | `dispatch_agent` renders Claude `Task`, OpenCode `task`, Codex `Spawn agent`, and Copilot `create_agent`. | Sub-agent capability is now compiled per harness through semantic tags. |
+| `cli/src/build/filters/param-transform.ts` | Codex and Copilot replace `$ARGUMENTS` / `$1` with model-extraction prose. | Native parameter passing remains degraded but no longer blocks generated support by itself. |
+| `plugins/base/hooks/codex-hooks.json` and Codex config patching | Codex hook support is enabled with `codex_hooks = true` and a generated hook file. | Codex hook status changes from "No" to "Yes, through managed config." |
+| `docs/getting-started/installation.md` and `docs/reference/platforms/copilot.md` | Public docs describe Codex and Copilot setup, invocation, install, and verification. | Support claims are user-facing, not only internal build code. |
 
 ## Tier 1: Must Have (Blocking)
 
-These capabilities are non-negotiable. If an agentic tool lacks **any** of these, RP1 cannot support it as a harness.
+These capabilities are non-negotiable. If a harness lacks any of these and RP1 cannot supply a reliable generated/configuration workaround, RP1 should not claim support.
 
 ### 1. Sub-Agent Spawning (Single Level)
 
-**What**: The ability for a running skill/prompt to spawn at least one sub-agent that executes independently and returns results.
+**What**: The ability for a running skill/prompt to spawn at least one bounded worker and receive or retrieve its result.
 
-**Why**: RP1's architecture is built on skill-to-agent delegation. 27 of 31 workflows spawn sub-agents. The build workflow spawns 14 agents; PR review spawns 7; knowledge-build spawns 5. Without sub-agent spawning, RP1 reduces to a collection of single-file prompts -- losing all orchestration, map-reduce, and builder-reviewer loop capabilities.
+**Why**: Current RP1 still depends heavily on skill-to-agent delegation. In the current tree, 31 of 44 skills contain dispatch patterns, 16 skills are tracked workflows, and there are 52 agent files. Build, PR review, knowledge build, deep research, docs generation, prompt build, and strategy workflows all depend on delegation.
 
 **Minimum Requirements**:
-- Spawn at least one sub-agent from within a skill/prompt context
-- Pass a prompt/instructions to the sub-agent
-- Receive structured results back from the sub-agent
-- Support parallel spawning (multiple sub-agents in a single turn)
-- Depth of 1 is sufficient -- RP1 sub-agents never spawn other sub-agents
 
-**How Each Platform Delivers This**:
-| Platform | Mechanism | Status |
-|----------|-----------|--------|
-| Claude Code | `Task` tool with `subagent_type` parameter | Working |
-| OpenCode | `@mention` pattern with `mode: subagent` | Working |
-| Codex | `spawn_agent` / `wait` pattern | Untested -- Codex dropped before validation |
+* Spawn at least one sub-agent from a skill/prompt context.
 
-**Evidence**: Codex gap analysis F-002, templating differences F-003, sub-agent extraction research
+* Pass a prompt/instructions payload to the sub-agent.
 
----
+* Retrieve a result through the harness response or a durable file-backed contract.
+
+* Support parallel/background spawning for map-reduce workflows.
+
+* Depth of 1 is sufficient. RP1 sub-agents should not spawn other sub-agents.
+
+**How Current Platforms Deliver This**:
+
+| Platform           | Mechanism                                                                                                                | Status                                                             |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------ |
+| Claude Code        | `Task` tool with `subagent_type`                                                                                         | Working                                                            |
+| OpenCode           | `task` tool with `subagent_type` / `@rp1-*` names                                                                        | Working                                                            |
+| Codex              | Generated `Spawn agent` / wait instructions with managed TOML agents and `multi_agent = true`                            | Supported with Codex-specific flow                                 |
+| GitHub Copilot CLI | Generated `create_agent` instructions and `.agent.md` definitions; result handoff points to `.rp1/work/agent-output/...` | Supported in generated prompts, runtime parity should be validated |
+
+**Evidence**: `cli/src/build/tags/dispatch-agent.ts`, `cli/src/build/codex/*`, `cli/src/build/copilot/registry.ts`, `cli/src/__tests__/build/tags/dispatch-agent.test.ts`
+
+***
 
 ### 2. Custom Prompt / Skill Loading
 
-**What**: The ability to load and execute user-authored markdown-based prompts (skills) with at minimum `name` and `description` metadata.
+**What**: The ability to load and execute markdown-based RP1 skills with frontmatter metadata.
 
-**Why**: RP1's entire delivery mechanism is SKILL.md files following the Agent Skills open standard. Skills are the interface layer through which users access all RP1 workflows. Without skill loading, there is no way to deliver RP1 functionality to the tool.
+**Why**: Skills are RP1's user-facing interface. Without skill loading, RP1 can only ship ad hoc prompt text, not a discoverable workflow suite.
 
 **Minimum Requirements**:
-- Load SKILL.md files with YAML frontmatter (`name`, `description`)
-- Execute the markdown body as instructions for the model
-- Support a discovery mechanism (directory-based, marketplace, or config registration)
-- Gracefully ignore unknown frontmatter fields (RP1 uses a `metadata` map for extensions)
 
-**How Each Platform Delivers This**:
-| Platform | Mechanism | Status |
-|----------|-----------|--------|
-| Claude Code | Plugin marketplace + `.claude/skills/` directory | Working |
-| OpenCode | `.opencode/skills/` + `.claude/skills/` compat | Working |
-| Codex | `~/.agents/skills/` + `$skillname` invocation | Tested -- skill loading works |
+* Load `SKILL.md` or equivalent markdown prompt files.
 
-**Evidence**: Codex gap analysis F-001 (agentskills.io compatibility), commands-to-skills migration F-001
+* Preserve at least `name` and `description`.
 
----
+* Support a discovery or install mechanism.
+
+* Gracefully ignore or preserve unknown metadata fields used by RP1.
+
+* Prefer structured argument metadata, even if runtime argument passing is degraded.
+
+**How Current Platforms Deliver This**:
+
+| Platform           | Mechanism                                                            | Status  |
+| ------------------ | -------------------------------------------------------------------- | ------- |
+| Claude Code        | Native plugin skills and `.claude` plugin packaging                  | Working |
+| OpenCode           | Generated OpenCode skills under config-managed install paths         | Working |
+| Codex              | `.codex/skills/{rp1-*}/SKILL.md` plus `$rp1-*` invocation            | Working |
+| GitHub Copilot CLI | Native plugin `skills/` directory through Copilot plugin marketplace | Working |
+
+**Evidence**: `cli/src/build/templates/*/skill.liquid`, `cli/src/install/*`, `docs/getting-started/installation.md`
+
+***
 
 ### 3. Shell Command Execution
 
-**What**: The ability to run arbitrary shell/bash commands from within a skill or agent context.
+**What**: The ability to run shell commands from skill and agent contexts.
 
-**Why**: RP1's runtime services are CLI tools invoked via `rp1 agent-tools ...` commands. State tracking (`emit`), artifact registration (`work artifact`), root directory resolution (`rp1-root-dir`), and mermaid validation (`mmd-validate`) all depend on shell execution. Without Bash, agents cannot interact with RP1's runtime layer.
+**Why**: RP1's runtime is exposed through CLI calls such as `rp1 agent-tools emit`, `workflow-bootstrap`, `resolve-args`, `feedback`, `mmd-validate`, and `rp1-root-dir`. Without shell execution, workflows cannot update state, register artifacts, validate diagrams, or resolve project directories.
 
 **Minimum Requirements**:
-- Execute shell commands and capture stdout/stderr
-- Support long-running commands (some agent-tools operations take 10+ seconds)
-- Allow pre-authorized command patterns to avoid per-invocation approval prompts
 
-**How Each Platform Delivers This**:
-| Platform | Mechanism | Status |
-|----------|-----------|--------|
-| Claude Code | `Bash` tool with pattern-based `allowed-tools` | Working |
-| OpenCode | `bash_run` with glob permissions | Working |
-| Codex | `functions.exec_command` with sandbox policy | Working (sandbox limitations apply) |
+* Execute shell commands and capture stdout/stderr.
 
-**Evidence**: All research documents reference Bash tool usage; Codex gap analysis F-003
+* Support commands that take 10+ seconds.
 
----
+* Allow `rp1` storage writes outside the source tree, especially `~/.rp1` and platform config directories.
+
+* Provide a way to reduce approval fatigue for repeated `rp1`, `git`, `gh`, and filesystem commands.
+
+**How Current Platforms Deliver This**:
+
+| Platform           | Mechanism                                                             | Status                             |
+| ------------------ | --------------------------------------------------------------------- | ---------------------------------- |
+| Claude Code        | `Bash` with `allowed-tools`                                           | Working                            |
+| OpenCode           | Bash/tool permission map                                              | Working                            |
+| Codex              | `functions.exec_command` plus managed writable roots in `config.toml` | Working with sandbox configuration |
+| GitHub Copilot CLI | `run_terminal_command` / skill `shell(...)` permissions               | Working in generated artifacts     |
+
+**Evidence**: `cli/src/build/filters/allowed-tools.ts`, `cli/src/install/codex/config.ts`, `cli/src/build/templates/copilot/skill.liquid`
+
+***
 
 ### 4. File System Read and Write
 
-**What**: The ability to read files from and write files to the local filesystem.
+**What**: The ability to read, write, edit, and search local files.
 
-**Why**: Agents read knowledge base files (`index.md`, `architecture.md`, etc.), read/write feature artifacts (`requirements.md`, `design.md`, `tasks.md`), and produce research reports. File I/O is fundamental to every RP1 workflow.
+**Why**: RP1 workflows read KB files, write `.rp1/work` artifacts, inspect source code, and edit user projects. Current workflows also separate source-code edits (`codeRoot`) from canonical KB/work artifacts (`kbRoot`, `workRoot`).
 
 **Minimum Requirements**:
-- Read file contents given a path
-- Write/create files at specified paths
-- Edit existing files (string replacement or diff-based)
-- Search files by name pattern (glob) and content (grep)
 
-**How Each Platform Delivers This**:
-| Platform | Read | Write | Edit | Search |
-|----------|------|-------|------|--------|
-| Claude Code | `Read` | `Write` | `Edit` (exact string replacement) | `Glob`, `Grep` |
-| OpenCode | `read_file` | `write_file` | `edit_file` | `glob_pattern`, `grep_file` |
-| Codex | `cat` via exec_command | `apply_patch` | `apply_patch` (unified diff) | `grep` via exec_command |
+* Read file contents by path.
 
-**Note**: Codex's file I/O is more limited -- no dedicated read tool (uses `cat` via shell), no dedicated search tools. This works but is less ergonomic. The minimum bar is having file read/write capability, even if through shell commands.
+* Write/create files at specified paths.
 
-**Evidence**: Templating differences F-002, all workflow research documents
+* Edit existing files with a precise method.
 
----
+* Search file names and contents.
+
+* Respect `codeRoot`, `kbRoot`, and `workRoot` rather than assuming all files live under one root.
+
+**How Current Platforms Deliver This**:
+
+| Platform           | Read                             | Write                      | Edit                    | Search                       |
+| ------------------ | -------------------------------- | -------------------------- | ----------------------- | ---------------------------- |
+| Claude Code        | `Read`                           | `Write`                    | `Edit`                  | `Glob`, `Grep`               |
+| OpenCode           | `read_file`                      | `write_file`               | `edit_file`             | `glob_pattern`, `grep_file`  |
+| Codex              | Shell reads (`sed`, `cat`, `rg`) | Shell writes where allowed | `functions.apply_patch` | Shell search (`rg`)          |
+| GitHub Copilot CLI | `read_file`                      | `write_file`               | `edit_file`             | `grep_search`, `file_search` |
+
+**Evidence**: `cli/src/build/*/registry.ts`, `cli/src/build/filters/tool-prose.ts`, `docs/reference/platforms/copilot.md`
+
+***
 
 ### 5. Project-Level Instruction File
 
-**What**: A mechanism to inject persistent instructions that are loaded at the start of every session (CLAUDE.md, AGENTS.md, or equivalent).
+**What**: A persistent instruction file loaded at session start.
 
-**Why**: RP1 injects knowledge base loading instructions into this file during `rp1 init`. These instructions tell the model to read `index.md` first and then load task-specific KB files. Without this, agents don't know about the project's knowledge base and cannot follow RP1's progressive disclosure pattern.
+**Why**: `rp1 init` injects KB loading rules, skill awareness, host guidance, and managed fence markers into host instruction files. Without an instruction file, a harness does not reliably know to load `.rp1/context/index.md` first or how to follow RP1 conventions.
 
 **Minimum Requirements**:
-- A file (or set of files) automatically loaded at session start
-- Support for content fencing so RP1 can manage its section (`<!-- rp1:start/end -->` or equivalent)
-- Sufficient size limit (RP1's injection is small, typically <1KB)
 
-**How Each Platform Delivers This**:
-| Platform | File | Discovery | Limit |
-|----------|------|-----------|-------|
-| Claude Code | `CLAUDE.md` | Git root + parent dirs | No documented limit |
-| OpenCode | `CLAUDE.md` (compat) + `AGENTS.md` | Git root | No documented limit |
-| Codex | `AGENTS.md` | Git root to CWD, cascading | 32 KiB combined (configurable) |
+* A project-level file automatically loaded by the harness.
 
-**Evidence**: Codex gap analysis F-010, OpenCode compatibility F-012
+* Versioned/fenced managed sections so RP1 can migrate stale content without overwriting user text.
 
----
+* Enough capacity for KB instructions and host-specific guidance.
 
----
+* Compatibility with `CURRENT_HOST` self-identification guidance.
+
+**How Current Platforms Deliver This**:
+
+| Platform           | File        | Status  |
+| ------------------ | ----------- | ------- |
+| Claude Code        | `CLAUDE.md` | Working |
+| OpenCode           | `AGENTS.md` | Working |
+| Codex              | `AGENTS.md` | Working |
+| GitHub Copilot CLI | `AGENTS.md` | Working |
+
+**Evidence**: `cli/src/init/templates/*`, `cli/src/config/supported-tools.yaml`, `docs/getting-started/installation.md`
+
+***
+
+### 6. Workflow Bootstrap and Harness Identity
+
+**What**: The ability to execute a generated bootstrap command at the start of tracked workflows, parse its JSON, and carry the returned values through the workflow.
+
+**Why**: Since `490cb761`, tracked workflows should not hand-generate `RUN_ID`s or manually call `resolve-args`/`rp1-root-dir`. The generated `workflow-bootstrap` section returns the canonical argument values, run identity, directories, `codeRoot`, run policy, and harness identity. Arcade tracking, resumability, worktree correctness, and artifact routing depend on those values.
+
+**Minimum Requirements**:
+
+* Run `rp1 agent-tools workflow-bootstrap`.
+
+* Pass the workflow name, schema path, raw user arguments, project root, and `CURRENT_HOST`.
+
+* Parse the JSON response.
+
+* Preserve `RUN_ID`, `projectRoot`, `kbRoot`, `workRoot`, `codeRoot`, workflow metadata, and run decision values for later steps.
+
+* Pass `--harness $CURRENT_HOST` on subsequent `rp1 agent-tools emit` calls.
+
+**How Current Platforms Deliver This**:
+
+| Platform           | Status                                                                                  |
+| ------------------ | --------------------------------------------------------------------------------------- |
+| Claude Code        | Template injects workflow bootstrap for tracked workflows                               |
+| OpenCode           | Template injects workflow bootstrap for tracked workflows                               |
+| Codex              | Template injects workflow bootstrap for tracked workflows, with argument prose fallback |
+| GitHub Copilot CLI | Partial: current template injects `resolve-args`, not full `workflow-bootstrap`         |
+
+**Evidence**: `cli/src/build/templates/claude-code/skill.liquid`, `cli/src/build/templates/opencode/skill.liquid`, `cli/src/build/templates/codex/skill.liquid`, `cli/src/build/templates/copilot/skill.liquid`, `cli/src/build/lint/rules/tracked-workflow-bootstrap.ts`, `cli/src/agent-tools/workflow-bootstrap/*`
+
+***
 
 ## Tier 2: Should Have (Significant Degradation Without)
 
-These capabilities are important for a good experience. Missing any one is manageable; missing several makes the platform significantly less capable.
+These capabilities are important for a complete experience. Missing one can be handled through generated prompt workarounds; missing several usually makes support fragile.
 
-### 6. Agent Definition Files
+### 7. Agent Definition Files
 
-**What**: The ability to define reusable agent personas with specific instructions, tool access, and model configuration -- separate from skill files.
+**What**: Reusable agent personas with specific instructions, tool access, and optional model/configuration.
 
-**Why**: RP1 has 45+ agent files that define specialized roles (task-builder, code-checker, feature-verifier, etc.). Each agent has tailored instructions, anti-loop directives, output contracts, and tool lists. Without agent definition files, all agent instructions must be inlined into skill prompts, making skills massive and unmaintainable.
+**Why**: RP1 currently has 52 agent files. Inlining those instructions into every skill would make workflow prompts too large and hard to maintain.
 
-**How Each Platform Delivers This**:
-| Platform | Format | Discovery |
-|----------|--------|-----------|
-| Claude Code | Bare `.md` files in plugin `agents/` directory | Via `Task` tool `subagent_type` parameter |
-| OpenCode | `.md` with YAML frontmatter (`mode: subagent`, `tools: {}`) | Via `@mention` or Task tool |
-| Codex | TOML sections in `config.toml` with `developer_instructions` | Via `[agents.<name>]` config |
+| Platform           | Format                                             | Status  |
+| ------------------ | -------------------------------------------------- | ------- |
+| Claude Code        | Bare `.md` agents in plugin `agents/`              | Working |
+| OpenCode           | `.md` with subagent frontmatter                    | Working |
+| Codex              | Per-agent `.toml` plus aggregate `rp1-agents.toml` | Working |
+| GitHub Copilot CLI | `.agent.md` files in plugin `agents/`              | Working |
 
-**Evidence**: Codex gap analysis F-013, templating differences F-006
+**Evidence**: `plugins/*/agents/*.md`, `cli/src/build/templates/*/agent*`, `cli/src/build/platform-definitions.ts`
 
----
+***
 
-### 7. Parameter Passing to Skills
+### 8. Parameter Passing to Skills
 
-**What**: The ability to pass arguments from the user's invocation to the skill content (`$ARGUMENTS`, `$1`, `$2`).
+**What**: The ability to pass invocation arguments into skill content.
 
-**Why**: Most RP1 skills accept parameters -- feature IDs, PR numbers, file paths, freeform context. Without parameter substitution, users must type the full context into a natural language prompt and the model must parse it -- less reliable and more error-prone.
+**Why**: RP1 skills accept feature IDs, PR numbers, file paths, topics, and mode flags. Weak argument handling causes workflows to start with the wrong target.
 
-**Workaround**: Model-driven argument parsing where the skill prompt instructs the model to extract named parameters from the user's natural language input. This is platform-agnostic but less precise.
+**Current Rule**: Native substitution is best. Model-extracted arguments are acceptable only when paired with `resolve-args`/`workflow-bootstrap` and clear generated instructions.
 
-**How Each Platform Delivers This**:
-| Platform | Mechanism | Status |
-|----------|-----------|--------|
-| Claude Code | `$ARGUMENTS`, `$1`, `$2` substitution | Working |
-| OpenCode | Parameter substitution (limited) | Partial |
-| Codex | NOT supported -- `$ARGUMENTS` stays as literal string | Missing (model-driven fallback) |
+| Platform           | Mechanism                                                                                         | Status                                       |
+| ------------------ | ------------------------------------------------------------------------------------------------- | -------------------------------------------- |
+| Claude Code        | `$ARGUMENTS`, `$1`, `$2`                                                                          | Working                                      |
+| OpenCode           | Argument forwarding to generated skill                                                            | Partial/working enough for current templates |
+| Codex              | No native `$ARGUMENTS`; generated prose says "the arguments provided by the user in their prompt" | Supported fallback, lower reliability        |
+| GitHub Copilot CLI | Same generated prose fallback as Codex                                                            | Supported fallback, lower reliability        |
 
-**Evidence**: Commands-to-skills migration F-004 (live Codex test confirmed `$ARGUMENTS` does NOT resolve)
+**Evidence**: `cli/src/build/filters/param-transform.ts`, `cli/src/build/arguments.ts`, `cli/src/agent-tools/resolve-args/*`
 
----
+***
 
-### 8. Explicit Skill Invocation Syntax
+### 9. Explicit Skill Invocation Syntax
 
-**What**: A mechanism for users to explicitly invoke a specific skill by name (slash commands, `$` mentions, or equivalent).
+**What**: A way for users to invoke one exact RP1 skill by name.
 
-**Why**: Users need to be able to say "run the build workflow" unambiguously. Implicit invocation (description matching) is unreliable for complex multi-step workflows where the wrong skill could be triggered.
+**Why**: RP1 workflows are too stateful and intent-specific to rely only on ambient matching.
 
-**How Each Platform Delivers This**:
-| Platform | Syntax | Example |
-|----------|--------|---------|
-| Claude Code | `/skill-name` | `/rp1-dev:build-fast feature-123` |
-| OpenCode | `/user:rp1-dev:skill-name` | `/user:rp1-dev:build-fast` |
-| Codex | `$skill-name` | `$rp1-dev-build-fast` |
+| Platform           | Syntax        | Example                     |
+| ------------------ | ------------- | --------------------------- |
+| Claude Code        | `/skill-name` | `/build my-feature`         |
+| OpenCode           | `/rp1-*`      | `/rp1-dev-build my-feature` |
+| Codex              | `$rp1-*`      | `$rp1-dev-build my-feature` |
+| GitHub Copilot CLI | `/rp1-*`      | `/rp1-dev-build my-feature` |
 
-**Evidence**: Codex gap analysis F-005, OpenCode compatibility F-012
+**Evidence**: `docs/getting-started/installation.md`, `cli/src/build/filters/slash-commands.ts`
 
----
+***
 
-### 9. Structured Output from Sub-Agents
+### 10. Structured Output from Sub-Agents
 
-**What**: Sub-agents can return structured data (JSON) to the orchestrator.
+**What**: Sub-agents return data that the orchestrator can consume reliably.
 
-**Why**: RP1's map-reduce workflows depend on agents returning JSON output contracts. The PR review splitter returns review units as JSON. Knowledge build agents return findings as JSON. The orchestrator merges these structured results. Without structured output, orchestrators must parse free-text agent responses, which is unreliable.
+**Why**: PR review, knowledge build, prompt build, and verification workflows expect JSON or schema-like sections from worker agents.
 
 **Minimum Requirements**:
-- Sub-agent can write structured output (JSON or similar)
-- Orchestrator can read the sub-agent's output programmatically
-- Output survives context window boundaries (not truncated)
 
-**Evidence**: Sub-agent extraction research F-001--F-005 (all propose JSON output contracts), all map-reduce workflow research
+* Sub-agent can produce JSON or a tightly constrained markdown section.
 
----
+* Parent can retrieve the output without context truncation.
 
-### 10. Concurrent Sub-Agent Execution
+* For background work, durable file-backed handoff is acceptable.
 
-**What**: The ability to spawn multiple sub-agents in parallel (not just sequentially).
+**Current Platform Notes**:
 
-**Why**: RP1's map-reduce workflows spawn 4-14 agents simultaneously. PR review spawns all sub-reviewers in a single message. Knowledge build spawns 4 analysis agents in parallel. Sequential execution would make these workflows 4-14x slower.
+* Claude Code and OpenCode generally return sub-agent output through native task results.
 
-**How Each Platform Delivers This**:
-| Platform | Mechanism | Status |
-|----------|-----------|--------|
-| Claude Code | Multiple `Task` calls in a single message | Working |
-| OpenCode | Multiple `task` calls in a single message | Working |
-| Codex | `spawn_agent` + `wait` pattern (async) | Supported but different pattern |
+* Codex uses generated wait/check instructions around spawned agents.
 
-**Evidence**: Task system migration F-002 (3 distinct map-reduce patterns), PR review and knowledge-build workflows
+* Copilot generated prompts currently direct the parent to read `.rp1/work/agent-output/{run-id}/...json`; that convention needs runtime validation and producer discipline.
 
----
+**Evidence**: `cli/src/build/tags/dispatch-agent.ts`, `plugins/*/agents/*.md`, `plugins/base/skills/artifact-templates/*`
+
+***
+
+### 11. Concurrent Sub-Agent Execution
+
+**What**: Multiple sub-agents can run concurrently or in the background.
+
+**Why**: RP1 map-reduce workflows spawn 4-14 workers in a single phase. Sequential fallback can make workflows several times slower.
+
+| Platform           | Mechanism                                                  | Status                                                   |
+| ------------------ | ---------------------------------------------------------- | -------------------------------------------------------- |
+| Claude Code        | Multiple `Task` calls in one turn                          | Working                                                  |
+| OpenCode           | Multiple `task` calls                                      | Working                                                  |
+| Codex              | `Spawn agent (background)` plus later result check         | Supported with different flow                            |
+| GitHub Copilot CLI | `create_agent (background)` plus file-backed result lookup | Supported in generated prompts, needs runtime validation |
+
+**Evidence**: `plugins/base/skills/knowledge-build/SKILL.md`, `plugins/dev/skills/pr-review/SKILL.md`, `cli/src/build/tags/dispatch-agent.ts`
+
+***
+
+### 12. Interactive User Input Gates
+
+**What**: The harness can pause a workflow, ask the user a bounded question, and resume with the answer.
+
+**Why**: Current workflows use human gates for stale KB decisions, dirty worktree handling, requirements approval, implementation readiness, and review posting.
+
+**Minimum Requirements**:
+
+* Ask a question with optional choices.
+
+* Stop the workflow at the gate.
+
+* Preserve enough state to resume after the user's answer.
+
+| Platform           | Mechanism                                                                         | Status                    |
+| ------------------ | --------------------------------------------------------------------------------- | ------------------------- |
+| Claude Code        | `AskUserQuestion`                                                                 | Working                   |
+| OpenCode           | `ask_user`                                                                        | Working                   |
+| Codex              | `request_user_input` when available plus generated plain-text checkpoint fallback | Partial                   |
+| GitHub Copilot CLI | `ask_user`                                                                        | Working in generated tags |
+
+**Evidence**: `cli/src/build/tags/ask-user.ts`, `plugins/dev/skills/build/SKILL.md`, `plugins/dev/skills/pr-review/SKILL.md`
+
+***
 
 ## Tier 3: Nice to Have (Enhances UX)
 
-These capabilities improve the developer experience but are not required for core functionality.
+These capabilities improve support quality but are not required for core RP1 functionality when the Tier 1 and Tier 2 contracts are satisfied.
 
-### 11. Dynamic Context / Shell Expansion in Prompts
+### 13. Dynamic Context / Shell Expansion in Prompts
 
-**What**: The ability to execute shell commands at prompt-load time and inject the results into the skill content (`` !`command` `` syntax).
+**What**: Prompt-load shell expansion such as injecting command output before model execution.
 
-**Why**: Used in 17 skills exclusively for `rp1 agent-tools rp1-root-dir`. However, this is syntactic sugar -- the model can simply run the same command as a regular Bash call at the start of skill execution. Not a hard requirement of the platform.
+**Current Assessment**: This is less important than in the original report. Current generated templates should call `workflow-bootstrap` or `resolve-args` at runtime instead of relying on prompt-load shell expansion.
 
-**Current Coverage**: Claude Code (working), Codex (working), OpenCode (unknown)
+**Impact of Absence**: Low, as long as shell execution and bootstrap work.
 
-**Evidence**: Commands-to-skills migration F-004
+***
 
----
+### 14. Tool Permission Pre-Authorization
 
-### 12. Tool Permission Pre-Authorization
+**What**: A way to pre-authorize common tool patterns.
 
-**What**: A mechanism to pre-approve specific tool usage patterns so that workflows can run without constant human approval prompts.
+**Why**: RP1 workflows make many shell and file operations. Without pre-authorization, approval prompts make workflows tedious.
 
-**Why**: RP1 workflows make dozens of shell calls per run. Without pre-authorization, every call triggers an approval prompt. Tedious but functional -- users can approve manually.
+| Platform           | Current coverage                                                 |
+| ------------------ | ---------------------------------------------------------------- |
+| Claude Code        | Per-skill `allowed-tools`                                        |
+| OpenCode           | Generated tool permission map                                    |
+| Codex              | Managed `config.toml`, writable roots, and allowed tool prose    |
+| GitHub Copilot CLI | Skill `allowed-tools` permission patterns such as `shell(rp1:*)` |
 
-**Current Coverage**: Claude Code (per-skill `allowed-tools`), OpenCode (per-agent permission map), Codex (session-wide `[[shell.approved]]`)
+**Evidence**: `cli/src/build/filters/allowed-tools.ts`, `cli/src/build/templates/copilot/skill.liquid`, `cli/src/install/codex/config.ts`
 
-**Evidence**: Codex gap analysis F-003, templating differences F-008
+***
 
----
+### 15. Lifecycle Hooks
 
-### 13. Lifecycle Hooks
+**What**: Hooks that run on session start or other host events.
 
-**What**: Event-driven hooks that fire on session start, tool execution, task completion, etc.
+**Why**: RP1 uses hooks to start Arcade and check for updates. Workflows still function if the user starts Arcade manually.
 
-**Why**: RP1 uses hooks for update checks and arcade daemon startup. These are convenience features, not core functionality.
+| Platform           | Current coverage                                                                                              |
+| ------------------ | ------------------------------------------------------------------------------------------------------------- |
+| Claude Code        | Session hooks shipped under plugin hooks                                                                      |
+| OpenCode           | Host hook support exists; RP1 coverage depends on generated install path                                      |
+| Codex              | `codex_hooks = true` and `plugins/base/hooks/codex-hooks.json`                                                |
+| GitHub Copilot CLI | Template supports plugin hook path if `copilot-hooks.json` exists; no shipped hook file found in current tree |
 
-**Current Coverage**:
-| Platform | Session Start | Tool Events | Task Events |
-|----------|---------------|-------------|-------------|
-| Claude Code | Yes (hooks.json) | No | No |
-| OpenCode | Yes (30+ event types) | Yes | Yes |
-| Codex | No hook system | No | No |
+**Impact of Absence**: Medium UX degradation, not a core workflow blocker.
 
-**Impact of Absence**: Users must manually run `rp1 check-update` and `rp1 arcade`. Minor inconvenience.
+***
 
-**Evidence**: Hook system compatibility research
-
----
-
-### 14. Web Search and Fetch
+### 16. Web Search and Fetch
 
 **What**: Tools for searching the web and fetching URL content.
 
-**Why**: Research workflows (deep-research, requirements gathering) benefit from web access. Without it, research is limited to codebase analysis.
+**Why**: Research workflows benefit from external evidence, but most RP1 workflows can operate on local repo and KB evidence.
 
-**Current Coverage**: Claude Code (WebFetch + WebSearch), OpenCode (web_fetch + web_search), Codex (web_search only, via Responses API)
+| Platform           | Current coverage                                                          |
+| ------------------ | ------------------------------------------------------------------------- |
+| Claude Code        | Web search and fetch                                                      |
+| OpenCode           | Web search and fetch                                                      |
+| Codex              | Partial: generated `web_access` degrades toward search; fetch unavailable |
+| GitHub Copilot CLI | Partial: `fetch_url`; web search unavailable                              |
 
-**Evidence**: Templating differences F-008
+**Evidence**: `cli/src/build/tags/web-access.ts`, `cli/src/build/filters/tool-prose.ts`
 
----
+***
 
-### 15. Planning / Task Tracking Tools
+### 17. Planning / Task Tracking Tools
 
-**What**: Built-in tools for creating task lists, tracking progress, managing dependencies (TaskCreate, TodoWrite, update_plan).
+**What**: Built-in plan/todo tools.
 
-**Why**: Enables real-time progress visibility in the RP1 web UI dashboard. Without it, workflow progress is only visible via state machine status updates (which work via shell commands).
+**Why**: Helps users see work breakdown in the host UI. RP1's durable workflow state still lives in emitted events and artifacts.
 
-**Evidence**: Task system migration research, state management overhaul research
+| Platform           | Current coverage                                                       |
+| ------------------ | ---------------------------------------------------------------------- |
+| Claude Code        | `TodoWrite`, plan-mode tools                                           |
+| OpenCode           | `manage_todos`                                                         |
+| Codex              | `update_plan`                                                          |
+| GitHub Copilot CLI | No dedicated tool; generated fallback says to write status to markdown |
 
----
+**Evidence**: `cli/src/build/tags/plan-tool.ts`
 
-### 16. LSP Integration
+***
 
-**What**: Language Server Protocol tools for code intelligence (go-to-definition, find-references, diagnostics).
+### 18. LSP Integration
 
-**Why**: Improves code navigation accuracy for agents working on large codebases. Not required -- agents can use grep/glob as fallback.
+**What**: Language Server Protocol tools for go-to-definition, references, and diagnostics.
 
-**Current Coverage**: Claude Code (LSP tool), OpenCode (lsp tool), Codex (not available)
+**Why**: Improves code navigation quality in large repositories.
 
-**Evidence**: Templating differences F-008
+**Current Assessment**: Helpful, not required. File search, semantic search, and shell tooling are acceptable fallbacks.
 
----
+| Platform           | Current coverage                                  |
+| ------------------ | ------------------------------------------------- |
+| Claude Code        | Yes                                               |
+| OpenCode           | Yes                                               |
+| Codex              | No dedicated LSP surface in RP1 mapping           |
+| GitHub Copilot CLI | Unknown / not represented in current RP1 registry |
 
-### 17. MCP Server Support
+***
 
-**What**: Model Context Protocol for connecting external services as tool providers.
+### 19. MCP Server Support
 
-**Why**: Enables integration with external systems (Slack, GitHub, databases). Useful but not part of RP1's core workflow.
+**What**: Model Context Protocol support for external service tools.
 
-**Current Coverage**: Claude Code (full), OpenCode (limited), Codex (full -- both consumer and provider)
+**Why**: Useful for Slack, GitHub, databases, and internal systems, but RP1 core workflows use the local `rp1` CLI and filesystem.
 
-**Evidence**: Codex gap analysis F-008
+**Current Assessment**: MCP is not a Tier 1 support requirement. It should influence prioritization only when a planned workflow depends on external services that cannot be reached through shell or host-native tools.
 
----
+***
 
-### 18. Implicit Skill Invocation
+### 20. Implicit Skill Invocation
 
-**What**: Automatic skill activation based on description matching (Codex-specific feature).
+**What**: Automatic skill activation by description matching.
 
-**Why**: Could improve discoverability -- users describe a task and the right skill auto-triggers. Risk of mis-triggering for complex workflows.
+**Why**: Improves discoverability but risks invoking the wrong stateful workflow.
 
-**Evidence**: Codex gap analysis F-011
+**Current Assessment**: Do not require this. Explicit invocation is safer for RP1. Codex generation now writes `allow_implicit_invocation: false` in `openai.yaml`, which is the right default for stateful RP1 workflows.
 
----
+**Evidence**: `cli/src/build/templates/codex/openai-yaml.liquid`
 
-### 19. Git Worktree Awareness
+***
 
-**What**: Proper handling of git worktrees for parallel development (resolving shared config, .rp1 directory discovery).
+### 21. Git Worktree Awareness
 
-**Why**: Enables parallel feature development with isolated working directories. RP1 has its own workaround via `rp1 agent-tools rp1-root-dir`.
+**What**: Correct behavior when the user invokes RP1 from a linked worktree while `.rp1/` lives in a canonical project root.
 
-**Evidence**: Worktree research (3 documents)
+**Why**: RP1 users often work in multiple linked worktrees. Current code separates:
 
----
+* `codeRoot`: source reads and writes
+
+* `kbRoot`: project knowledge base
+
+* `workRoot`: durable workflow artifacts
+
+**Current Assessment**: This is no longer just a convenience. The harness must preserve generated `codeRoot`/`workRoot` values through delegated work, especially for code-writing agents.
+
+**Evidence**: `cli/src/agent-tools/workflow-bootstrap/*`, `cli/src/agent-tools/rp1-root-dir/*`, `docs/concepts/skill-format.md`
+
+***
 
 ## Quick Reference: Evaluation Checklist
 
 Use this checklist when evaluating a new agentic tool for RP1 support.
 
-### Must Have (all required)
+### Must Have (All Required)
 
 | # | Capability | Test |
-|---|-----------|------|
-| 1 | Sub-agent spawning | Can a skill spawn an agent and get results back? |
-| 2 | Custom prompt / skill loading | Can SKILL.md files be loaded and executed? |
-| 3 | Shell command execution | Can `rp1 agent-tools emit ...` run from within a skill? |
-| 4 | File system read/write | Can agents read KB files and write artifacts? |
-| 5 | Project instruction file | Is there a CLAUDE.md/AGENTS.md equivalent auto-loaded at session start? |
+|---|------------|------|
+| 1 | Sub-agent spawning                      | Can a skill spawn a named worker and retrieve its result?                             |
+| 2 | Custom prompt / skill loading           | Can generated RP1 skill files be loaded and invoked?                                  |
+| 3 | Shell command execution                 | Can `rp1 agent-tools workflow-bootstrap` and `emit` run successfully?                 |
+| 4 | File read/write/search/edit             | Can agents read KB, write artifacts, search code, and edit `codeRoot`?                |
+| 5 | Project instruction file                | Is there a loaded `CLAUDE.md`/`AGENTS.md` equivalent with managed fences?             |
+| 6 | Workflow bootstrap and harness identity | Can the prompt parse bootstrap JSON and preserve `RUN_ID`, roots, and `CURRENT_HOST`? |
 
-### Should Have (degraded without)
-
-| # | Capability | Test |
-|---|-----------|------|
-| 6 | Agent definition files | Can reusable agent personas be defined separately from skills? |
-| 7 | Parameter passing | Does `/skill arg1 arg2` deliver args to the skill content? |
-| 8 | Explicit invocation syntax | Can users invoke a skill by exact name? |
-| 9 | Structured sub-agent output | Can sub-agents return JSON that the orchestrator can parse? |
-| 10 | Concurrent sub-agents | Can 4+ sub-agents run in parallel? |
-
-### Nice to Have (enhances UX)
+### Should Have (Degraded Without)
 
 | # | Capability | Test |
-|---|-----------|------|
-| 11 | Dynamic context in prompts | Does `` !`rp1 agent-tools rp1-root-dir` `` resolve at load time? |
-| 12 | Tool permission pre-auth | Can `rp1 *` and `echo *` be pre-approved to avoid approval fatigue? |
-| 13 | Lifecycle hooks | Session start hooks for update checks? |
-| 14 | Web search/fetch | Can research agents search the web? |
-| 15 | Planning tools | Built-in task/todo tracking? |
-| 16 | LSP integration | Code intelligence tools? |
-| 17 | MCP support | External service integration? |
-| 18 | Implicit invocation | Auto-trigger skills by description? |
-| 19 | Worktree awareness | Handles git worktrees correctly? |
+|---|------------|------|
+| 7  | Agent definition files      | Can reusable RP1 agents be defined separately from skills?                  |
+| 8  | Parameter passing           | Does invocation context reach `resolve-args`/`workflow-bootstrap` reliably? |
+| 9  | Explicit invocation syntax  | Can users invoke one exact RP1 skill?                                       |
+| 10 | Structured sub-agent output | Can the parent parse JSON or read a durable result file?                    |
+| 11 | Concurrent sub-agents       | Can 4+ workers run concurrently or in background?                           |
+| 12 | Interactive user gates      | Can a workflow ask a bounded question and resume later?                     |
 
----
+### Nice to Have (Enhances UX)
+
+| # | Capability | Test |
+|---|------------|------|
+| 13 | Dynamic context in prompts | Can prompt-load shell expansion work, or is runtime bootstrap enough?           |
+| 14 | Tool permission pre-auth   | Can common `rp1`, `git`, `gh`, file, and shell patterns avoid repeated prompts? |
+| 15 | Lifecycle hooks            | Can Arcade/update hooks run on session start?                                   |
+| 16 | Web search/fetch           | Can research workflows gather external evidence?                                |
+| 17 | Planning tools             | Is there a native todo/plan surface?                                            |
+| 18 | LSP integration            | Are code intelligence tools available?                                          |
+| 19 | MCP support                | Are external service tools available if needed?                                 |
+| 20 | Implicit invocation        | Can it be disabled or made safe for stateful workflows?                         |
+| 21 | Worktree awareness         | Does generated context keep `codeRoot`, `kbRoot`, and `workRoot` distinct?      |
+
+***
 
 ## Platform Scorecard
 
-Current platform support status as of 2026-03-14:
+Current support status as of 2026-05-11:
 
-| Capability | Claude Code | OpenCode | Codex |
-|-----------|:-----------:|:--------:|:-----:|
-| **Must Have** | | | |
-| 1. Sub-agent spawning | Yes | Yes | Yes (different API) |
-| 2. Skill loading | Yes | Yes | Yes |
-| 3. Shell execution | Yes | Yes | Yes (sandboxed) |
-| 4. File read/write | Yes | Yes | Partial (via shell) |
-| 5. Instruction file | Yes | Yes | Yes |
-| **Should Have** | | | |
-| 6. Agent definitions | Yes | Yes | Yes (TOML format) |
-| 7. Parameter passing | Yes | Partial | No |
-| 8. Explicit invocation | Yes (`/`) | Yes (`/user:`) | Yes (`$`) |
-| 9. Structured output | Yes | Yes | Untested |
-| 10. Concurrent sub-agents | Yes | Yes | Yes |
-| **Nice to Have** | | | |
-| 11. Dynamic context | Yes | Unknown | Yes |
-| 12. Permission pre-auth | Yes (per-skill) | Yes (per-agent) | Yes (session-wide) |
-| 13. Hooks | Yes | Yes (30+ events) | No |
-| 14. Web search/fetch | Yes | Yes | Partial |
-| 15. Planning tools | Yes | Partial | Yes |
-| 16. LSP | Yes | Yes | No |
-| 17. MCP | Yes | Limited | Yes |
-| 18. Implicit invocation | No | No | Yes |
-| 19. Worktree awareness | Via rp1 tooling | Via rp1 tooling | Via rp1 tooling |
+| Capability                                 |  Claude Code |    OpenCode    |      Codex     | GitHub Copilot CLI |
+| ------------------------------------------ | :----------: | :------------: | :------------: | :----------------: |
+| **Must Have**                              |      -       |       -        |       -        |         -          |
+| 1. Sub-agent spawning                      |      Yes     |       Yes      |       Yes      |       Partial      |
+| 2. Skill loading                           |      Yes     |       Yes      |       Yes      |         Yes        |
+| 3. Shell execution                         |      Yes     |       Yes      |       Yes      |         Yes        |
+| 4. File read/write/search/edit             |      Yes     |       Yes      |     Partial    |         Yes        |
+| 5. Instruction file                        |      Yes     |       Yes      |       Yes      |         Yes        |
+| 6. Workflow bootstrap and harness identity |      Yes     |       Yes      |       Yes      |       Partial      |
+| **Should Have**                            |      -       |       -        |       -        |         -          |
+| 7. Agent definitions                       |      Yes     |       Yes      |       Yes      |         Yes        |
+| 8. Parameter passing                       |      Yes     |     Partial    |     Partial    |       Partial      |
+| 9. Explicit invocation                     |   Yes (`/`)  | Yes (`/rp1-*`) | Yes (`$rp1-*`) |   Yes (`/rp1-*`)   |
+| 10. Structured sub-agent output            |      Yes     |       Yes      |     Partial    |       Partial      |
+| 11. Concurrent sub-agents                  |      Yes     |       Yes      |       Yes      |       Partial      |
+| 12. Interactive user gates                 |      Yes     |       Yes      |     Partial    |         Yes        |
+| **Nice to Have**                           |      -       |       -        |       -        |         -          |
+| 13. Dynamic context                        | Not required |  Not required  |  Not required  |    Not required    |
+| 14. Permission pre-auth                    |      Yes     |       Yes      |       Yes      |         Yes        |
+| 15. Hooks                                  |      Yes     |       Yes      |       Yes      |       Partial      |
+| 16. Web search/fetch                       |      Yes     |       Yes      |     Partial    |       Partial      |
+| 17. Planning tools                         |      Yes     |       Yes      |       Yes      |         No         |
+| 18. LSP                                    |      Yes     |       Yes      |       No       |       Unknown      |
+| 19. MCP                                    |      Yes     |     Limited    |       Yes      |       Unknown      |
+| 20. Implicit invocation                    |      No      |       No       |    Disabled    |         No         |
+| 21. Worktree awareness                     |      Yes     |       Yes      |       Yes      |       Partial      |
 
----
+Interpretation:
+
+* **Claude Code** remains the canonical/highest-confidence target.
+
+* **OpenCode** remains a strong supported target.
+
+* **Codex** is supported, but its support is compensation-heavy: no native parameter substitution, file I/O mostly through shell/apply-patch, managed config changes, and a different multi-agent flow.
+
+* **Copilot** has real support infrastructure, but should not be treated as fully parity-equivalent until tracked workflow bootstrap and file-backed sub-agent output are validated end-to-end.
+
+***
 
 ## Build Pipeline Compatibility
 
-Beyond runtime capabilities, RP1 also needs to **generate** platform-specific artifacts. The build pipeline transforms Claude Code-canonical SKILL.md and agent `.md` files into platform-specific formats. A new harness requires:
+Beyond target-harness runtime capabilities, RP1 must generate installable artifacts. A new harness now requires more than the original five implementation items.
 
-1. **PlatformRegistry** -- Tool name mappings (e.g., `Read` -> platform equivalent)
-2. **Content transformations** -- Namespace syntax, slash commands, agent references
-3. **Artifact generator** -- Produce platform-specific file formats (frontmatter, TOML, etc.)
-4. **Installer** -- Copy artifacts to the correct platform directories
-5. **Validator** -- Verify generated artifacts are well-formed
+### Required RP1 Build Work for a New Harness
 
-This is implementation work, not a capability requirement of the target platform. But it scales with how different the platform's formats are from Claude Code's canonical format. Codex required the most transformation work due to TOML agent configs, `$` invocation syntax, and `[[shell.approved]]` config injection.
+1. **Supported tool registry**: Add the tool to `cli/src/config/supported-tools.yaml` with binary, minimum version, instruction file, and capabilities.
+2. **Build platform type**: Add the platform to `BuildPlatform` in `cli/src/build/template-context.ts`.
+3. **Platform registry**: Map canonical RP1/Claude-style tool names to target-harness tool names.
+4. **Platform definition**: Add a `PlatformDefinition` with templates, naming, lifecycle hooks, bundle behavior, and platform config.
+5. **Skill template**: Render frontmatter, arguments, host context, `workflow-bootstrap` for tracked workflows, parameter fallback, and semantic-tag output.
+6. **Agent template**: Render standalone agent definitions in the harness format.
+7. **Semantic tags and filters**: Support `dispatch_agent`, `ask_user`, `plan_tool`, `edit_model`, `web_access`, namespace references, slash commands, parameters, and tool prose.
+8. **Installer**: Install or register generated artifacts without clobbering user-owned configuration.
+9. **Verifier**: Detect healthy, partial, legacy, and missing installs.
+10. **Uninstaller/update path**: Remove only RP1-managed content and preserve user content.
+11. **Docs**: Add setup, invocation, troubleshooting, and platform caveats.
+12. **Tests**: Add template golden tests, tag/filter tests, install/verify tests, and lint coverage.
 
----
+The generic build loop is now data-driven, but adding a harness still requires per-harness product work. The work is cheapest when the new harness resembles Claude Code or OpenCode. It becomes more expensive when RP1 must generate config patches, role mappings, file-backed handoffs, or prose fallbacks for missing native tools.
 
-## Lessons from the Codex Experience
+***
 
-Codex was dropped not because of a single missing capability, but because of **compounding friction**:
+## Revised Lessons from Codex
 
-1. **Parameter passing doesn't work** -- `$ARGUMENTS` stays literal (Should Have #9)
-2. **Sub-agent spawning untested at scale** -- spawn/wait API pattern is fundamentally different (Must Have #1 -- technically present but unvalidated)
-3. **No hooks** -- Can't auto-start arcade or check updates (Nice to Have #13)
-4. **Session-wide permissions only** -- Requires modifying user config files (Must Have #6 -- present but invasive)
-5. **API instability** -- Rust rewrite in progress, interfaces may change (external risk)
-6. **Sandbox restrictions** -- Limits on filesystem and network access (compounds with #3, #4)
+The original report concluded that Codex should be dropped. The current codebase proves a narrower lesson: Codex became supportable only after RP1 absorbed the incompatibilities into first-class build and install machinery.
 
-The key insight: even when individual capabilities are technically present, **the integration quality matters**. A capability that exists but works differently from the canonical format (Claude Code) incurs ongoing build pipeline maintenance cost.
+Current Codex compensations:
 
----
+1. **No native `$ARGUMENTS`**: RP1 rewrites parameter references into prose and relies on `resolve-args`/`workflow-bootstrap`.
+2. **Different agent model**: RP1 emits per-agent TOML, an aggregate `rp1-agents.toml`, role heuristics, and sub-agent validation.
+3. **Different tool names**: RP1 rewrites tool prose and filters unsupported tools.
+4. **Sandbox/write restrictions**: RP1 patches writable roots into Codex config.
+5. **Hooks require config**: RP1 enables `codex_hooks = true` and ships `codex-hooks.json`.
+6. **Different invocation syntax**: RP1 emits `$rp1-*` commands and disables implicit invocation.
+
+The lesson is not "never support a harness with gaps." The lesson is: support a gappy harness only when the workarounds are explicit, tested, installed safely, documented, and worth the maintenance burden.
+
+***
 
 ## Decision Framework
 
 When evaluating a new tool:
 
-1. **Check all 5 Must Haves** -- If any are missing, stop. RP1 cannot support this tool.
-2. **Count Should Haves** -- If fewer than 3 of 5 are present, the degraded experience may not be worth the build pipeline investment.
-3. **Assess integration quality** -- Even if capabilities exist, how different are they from Claude Code? More difference = more build pipeline work = more maintenance burden.
-4. **Evaluate platform maturity** -- Is the platform stable or actively being rewritten? Unstable APIs mean rework.
-5. **Consider user base** -- Is there sufficient demand for this platform to justify the investment?
+1. **Check all Tier 1 capabilities**. If any are missing and cannot be reliably generated or configured by RP1, stop.
+2. **Identify required compensations**. For every non-native behavior, name the exact RP1 build/install/runtime workaround.
+3. **Validate workflow bootstrap first**. Run a tracked workflow that exercises `workflow-bootstrap`, `emit`, artifact registration, and a user gate.
+4. **Validate sub-agent scale**. Run a workflow with multiple background workers, not only a single toy agent.
+5. **Validate codeRoot/workRoot behavior**. Test from a linked worktree and confirm source edits land in the worktree while artifacts land in canonical `.rp1/work`.
+6. **Assess integration quality**. More transformation means more ongoing maintenance.
+7. **Assess platform maturity**. Unstable APIs and config formats increase support cost.
+8. **Assess demand**. A compensation-heavy target needs a clear user base.
+9. **Document caveats honestly**. Do not list a harness as parity-equivalent when it only has build/install support.
 
----
+***
+
+## Known Gaps and Follow-Up
+
+1. **Copilot tracked workflow parity**: `copilot/skill.liquid` should either inject full `workflow-bootstrap` for tracked workflows or the docs/scorecard should keep Copilot marked partial for Arcade-tracked workflows.
+2. **Copilot file-backed sub-agent outputs**: Generated prompts reference `.rp1/work/agent-output/{run-id}/...json`; this needs end-to-end validation and a producer convention that actually writes those files.
+3. **Codex/Copilot multi-agent scale**: Current build tests verify generated instructions. Runtime scale validation should run representative map-reduce workflows.
+4. **`rp1 run` overlay**: Memory and prior research discuss a coalesced overlay launch model, but no `rp1 run` command exists in the current source tree. Do not treat it as current support evidence.
+5. **New harnesses such as Goose**: No current registry/template/install evidence exists. Evaluate from Tier 1 rather than assuming support from branch names or adjacent experiments.
+
+***
 
 ## Sources
 
-This document synthesizes findings from the following research reports:
+### Original Research Inputs
 
-| Document | Key Contributions |
-|----------|-------------------|
-| `2026-03-08-codex-cli-support-for-rp1-gap-analysis.md` | Must Haves 1-6, Codex capability mapping |
-| `2026-03-09-codex-integration-issues-gap-analysis-and-fix-plan.md` | Agent definition formats, content transformation gaps |
-| `2026-01-31-opencode-compatibility-gaps.md` | OpenCode capability mapping, directory conventions |
-| `2026-03-09-hook-system-compatibility-across-claude-code.md` | Hook capability comparison across platforms |
-| `2026-03-12-templating-differences-across-claude-code-opencode.md` | Tool name mappings, behavioral differences matrix |
-| `2026-03-13-codex-support-changes-regression-check.md` | Build pipeline validation, platform artifact formats |
-| `2026-02-20-migrating-rp1-task-system-to-claudes-agent-teams.md` | Agent teams, task coordination capabilities |
-| `2026-02-26-migrating-rp1-custom-prompts-commands-to-skills.md` | Skill loading, parameter passing, platform constraints |
-| `2026-03-01-state-management-overhaul-declarative-state-machines.md` | State tracking, workflow visibility requirements |
-| `2026-03-10-templating-system-for-rp1-multi-harness-artifact.md` | Build pipeline architecture, template system |
-| `2026-02-22-claude-code-tasks-vs-teams-separate-features.md` | Agent teams vs task list distinction |
-| `2025-12-29-git-worktrees-for-parallel-ai-agent-development.md` | Worktree support, path resolution |
-| `2026-01-01-extracting-more-sub-agents-from-build-md-command.md` | Sub-agent architecture, JSON output contracts |
-| `2026-03-04-is-the-dedicated-work-status-skill-still-needed.md` | State machine integration, status reporting |
-| `2026-03-09-rp1-meta-skill-a-self-aware-system-guide.md` | Skill discovery, documentation patterns |
+| Document                                                             | Key Contributions                                     |
+| -------------------------------------------------------------------- | ----------------------------------------------------- |
+| `2026-03-08-codex-cli-support-for-rp1-gap-analysis.md`               | Original Codex capability mapping                     |
+| `2026-03-09-codex-integration-issues-gap-analysis-and-fix-plan.md`   | Agent definition formats, content transformation gaps |
+| `2026-01-31-opencode-compatibility-gaps.md`                          | OpenCode capability mapping and directory conventions |
+| `2026-03-09-hook-system-compatibility-across-claude-code.md`         | Hook capability comparison                            |
+| `2026-03-12-templating-differences-across-claude-code-opencode.md`   | Tool name mappings and behavioral differences         |
+| `2026-03-13-codex-support-changes-regression-check.md`               | Build pipeline validation and artifact formats        |
+| `2026-02-20-migrating-rp1-task-system-to-claudes-agent-teams.md`     | Agent teams and task coordination                     |
+| `2026-02-26-migrating-rp1-custom-prompts-commands-to-skills.md`      | Skill loading and parameter passing                   |
+| `2026-03-01-state-management-overhaul-declarative-state-machines.md` | Workflow visibility and state tracking                |
+| `2026-03-10-templating-system-for-rp1-multi-harness-artifact.md`     | Multi-harness template architecture                   |
+| `2025-12-29-git-worktrees-for-parallel-ai-agent-development.md`      | Worktree support and path resolution                  |
+
+### Current Repo Evidence
+
+| Source                                     | Evidence Used                                            |
+| ------------------------------------------ | -------------------------------------------------------- |
+| `cli/src/config/supported-tools.yaml`      | Current supported tool registry                          |
+| `cli/src/build/template-context.ts`        | Current `BuildPlatform` union                            |
+| `cli/src/build/platform-definitions.ts`    | Platform definitions and hooks for all generated targets |
+| `cli/src/build/tags/*.ts`                  | Semantic tag rendering by platform                       |
+| `cli/src/build/filters/*.ts`               | Tool, parameter, namespace, and prose transformations    |
+| `cli/src/build/templates/*`                | Generated skill/agent/manifest shapes                    |
+| `cli/src/install/codex/*`                  | Codex install, config patching, prerequisites            |
+| `cli/src/install/copilot/*`                | Copilot marketplace install and verification             |
+| `cli/src/agent-tools/workflow-bootstrap/*` | Tracked workflow bootstrap runtime contract              |
+| `cli/src/agent-tools/rp1-root-dir/*`       | Directory and `codeRoot` resolution                      |
+| `docs/getting-started/installation.md`     | User-facing platform setup and invocation docs           |
+| `docs/reference/platforms/copilot.md`      | Copilot support, verification, and troubleshooting docs  |

--- a/cli/bun.lock
+++ b/cli/bun.lock
@@ -7,8 +7,8 @@
       "dependencies": {
         "@inquirer/prompts": "^8.0.2",
         "@octokit/rest": "^22.0.1",
-        "baseline-browser-mapping": "^2.10.27",
-        "caniuse-lite": "^1.0.30001791",
+        "baseline-browser-mapping": "^2.10.29",
+        "caniuse-lite": "^1.0.30001792",
         "chalk": "^5.6.2",
         "commander": "^14.0.2",
         "consola": "^3.4.2",
@@ -273,7 +273,7 @@
 
     "bare-url": ["bare-url@2.3.2", "", { "dependencies": { "bare-path": "^3.0.0" } }, "sha512-ZMq4gd9ngV5aTMa5p9+UfY0b3skwhHELaDkhEHetMdX0LRkW9kzaym4oo/Eh+Ghm0CCDuMTsRIGM/ytUc1ZYmw=="],
 
-    "baseline-browser-mapping": ["baseline-browser-mapping@2.10.27", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-zEs/ufmZoUd7WftKpKyXaT6RFxpQ5Qm9xytKRHvJfxFV9DFJkZph9RvJ1LcOUi0Z1ZVijMte65JbILeV+8QQEA=="],
+    "baseline-browser-mapping": ["baseline-browser-mapping@2.10.43", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-AjYpR78kDWAY3Efj+cDTFH9t9SCoL7OoTp1BOb0mQV7S+6CiLwnWM3FyxhJtdPufDFKzmCSFoUncKjWgJEZTCQ=="],
 
     "basic-ftp": ["basic-ftp@5.0.5", "", {}, "sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg=="],
 
@@ -285,7 +285,7 @@
 
     "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
 
-    "caniuse-lite": ["caniuse-lite@1.0.30001791", "", {}, "sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ=="],
+    "caniuse-lite": ["caniuse-lite@1.0.30001805", "", {}, "sha512-52noaS3DubycKSXaU30TwPGIp+POyQSUVa5jBEq3vkRkY0kjyb3LQgvhU6WGyCcyXqVLWO0Cw0Q6BSdD0kUfVA=="],
 
     "ccount": ["ccount@2.0.1", "", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -64,8 +64,8 @@
 	"dependencies": {
 		"@inquirer/prompts": "^8.0.2",
 		"@octokit/rest": "^22.0.1",
-		"baseline-browser-mapping": "^2.10.27",
-		"caniuse-lite": "^1.0.30001791",
+		"baseline-browser-mapping": "^2.10.29",
+		"caniuse-lite": "^1.0.30001792",
 		"chalk": "^5.6.2",
 		"commander": "^14.0.2",
 		"consola": "^3.4.2",


### PR DESCRIPTION
## Summary

Ports the mergeable commits from the local `bug-fix` branch onto current main:

- **Core capabilities matrix** — refresh of `.rp1/context/core-capabilties-matrix.md` (+495/−287).
- **Browser mapping baseline** — bump `baseline-browser-mapping` ^2.10.27→^2.10.29 and `caniuse-lite` ^1.0.30001791→^1.0.30001792, lockfile regenerated against current main.

Two commits from the original branch were dropped as already covered by main:
- `chore: add light mark logo` — asset already present on main (empty cherry-pick).
- `chore: have a utility to clean local bin` — superseded by the `rm-stable` script refactor (`rm-stable-impl.sh` removes `bin/rp1`) and the existing `rm-local` recipe.

## Testing

- Pre-push hooks green: typecheck (cli + web-ui), catalog, eval-verify, no-artifactory.

🤖 Generated using: 🎮 [rp1.run](https://rp1.run)