### PR TITLE
fix(emit): reuse existing artifact doc_id when file identity is lost

### DIFF
--- a/cli/src/__tests__/agent-tools/emit/database.test.ts
+++ b/cli/src/__tests__/agent-tools/emit/database.test.ts
@@ -20,6 +20,7 @@ import { dirname, join } from "node:path";
 import {
 	closeDatabase,
 	countEventsSince,
+	dedupeArtifactLocations,
 	deleteActivitySearchRun,
 	deleteAnnotation,
 	deriveRunStatus,
@@ -57,6 +58,7 @@ import {
 	reclassifyInactiveRuns,
 	resetInstance,
 	resolveArtifactPathForRun,
+	setArtifactBaseline,
 	updateAnnotation,
 	upsertActivitySearchRun,
 	upsertAnnotation,
@@ -390,7 +392,7 @@ describe("emit database", () => {
 			const versionRow = db
 				.prepare("SELECT version FROM schema_version")
 				.get() as { version: number };
-			expect(versionRow.version).toBe(18);
+			expect(versionRow.version).toBe(LATEST_SCHEMA_VERSION);
 
 			const runRow = db
 				.prepare(
@@ -503,7 +505,7 @@ describe("emit database", () => {
 			const versionRow = db
 				.prepare("SELECT version FROM schema_version")
 				.get() as { version: number };
-			expect(versionRow.version).toBe(18);
+			expect(versionRow.version).toBe(LATEST_SCHEMA_VERSION);
 
 			const duelColumns = db
 				.prepare("PRAGMA table_info(socratic_duels)")
@@ -621,7 +623,7 @@ describe("emit database", () => {
 			const versionRow = db
 				.prepare("SELECT version FROM schema_version")
 				.get() as { version: number };
-			expect(versionRow.version).toBe(18);
+			expect(versionRow.version).toBe(LATEST_SCHEMA_VERSION);
 
 			const migratedDuel = db
 				.prepare(
@@ -762,7 +764,7 @@ describe("emit database", () => {
 			const versionRow = db
 				.prepare("SELECT version FROM schema_version")
 				.get() as { version: number };
-			expect(versionRow.version).toBe(18);
+			expect(versionRow.version).toBe(LATEST_SCHEMA_VERSION);
 			expect(
 				db
 					.prepare(
@@ -906,7 +908,7 @@ describe("emit database", () => {
 			const versionRow = db
 				.prepare("SELECT version FROM schema_version")
 				.get() as { version: number };
-			expect(versionRow.version).toBe(18);
+			expect(versionRow.version).toBe(LATEST_SCHEMA_VERSION);
 		});
 
 		test("migrates v2 schema to add subflow column to artifacts", async () => {
@@ -997,7 +999,7 @@ describe("emit database", () => {
 			const versionRow = db
 				.prepare("SELECT version FROM schema_version")
 				.get() as { version: number };
-			expect(versionRow.version).toBe(18);
+			expect(versionRow.version).toBe(LATEST_SCHEMA_VERSION);
 		});
 
 		test("v3 to v4 migration adds baseline column and cleans orphaned edit-diff annotations", async () => {
@@ -1084,7 +1086,7 @@ describe("emit database", () => {
 			const versionRow = db
 				.prepare("SELECT version FROM schema_version")
 				.get() as { version: number };
-			expect(versionRow.version).toBe(18);
+			expect(versionRow.version).toBe(LATEST_SCHEMA_VERSION);
 
 			const annotations = db.prepare("SELECT * FROM annotations").all() as {
 				content: string;
@@ -1204,7 +1206,7 @@ describe("emit database", () => {
 			const versionRow = db
 				.prepare("SELECT version FROM schema_version")
 				.get() as { version: number };
-			expect(versionRow.version).toBe(18);
+			expect(versionRow.version).toBe(LATEST_SCHEMA_VERSION);
 
 			const indexes = db.prepare("PRAGMA index_list(runs)").all() as {
 				name: string;
@@ -1411,7 +1413,7 @@ describe("emit database", () => {
 			const versionRow = db
 				.prepare("SELECT version FROM schema_version")
 				.get() as { version: number };
-			expect(versionRow.version).toBe(18);
+			expect(versionRow.version).toBe(LATEST_SCHEMA_VERSION);
 		});
 
 		test("foreign key constraints are enforced", async () => {
@@ -2117,6 +2119,129 @@ describe("emit database", () => {
 
 			expect(artifact.storageRoot).toBe("work_dir");
 			expect(artifact.path).toBe("features/feat/design.md");
+		});
+	});
+
+	describe("dedupeArtifactLocations", () => {
+		test("merges duplicate rows keeping the most recently registered doc_id", async () => {
+			const dbPath = join(tempDir, "artifact-dedupe.db");
+			const db = await expectTaskRight(getEmitDatabase(dbPath));
+
+			insertRun(db, {
+				id: "run-dedupe",
+				flow: "build",
+				featureId: "feat",
+				projectPath: "/p",
+			});
+
+			// Three churned rows for one location. doc-a has the lowest row id
+			// but the most recent artifact_registered event, so it is the
+			// authoritative identity despite doc-c having the highest row id.
+			for (const docId of ["doc-a", "doc-b", "doc-c"]) {
+				upsertArtifact(db, {
+					docId,
+					runId: "run-dedupe",
+					path: "features/feat/tasks.md",
+					type: "markdown",
+					storageRoot: "work_dir",
+					projectPath: "/p",
+					feature: "feat",
+				});
+			}
+			insertEvent(db, {
+				runId: "run-dedupe",
+				type: "artifact_registered",
+				data: JSON.stringify({
+					docId: "doc-b",
+					path: "features/feat/tasks.md",
+				}),
+			});
+			insertEvent(db, {
+				runId: "run-dedupe",
+				type: "artifact_registered",
+				data: JSON.stringify({
+					docId: "doc-a",
+					path: "features/feat/tasks.md",
+				}),
+			});
+
+			// Attachments on rows that will be merged away must survive.
+			upsertAnnotation(db, {
+				docId: "doc-b",
+				runId: "run-dedupe",
+				content: "note on stale row",
+			});
+			setArtifactBaseline(db, "doc-c", "baseline content");
+
+			dedupeArtifactLocations(db);
+
+			const rows = db
+				.prepare(
+					"SELECT doc_id, baseline FROM artifacts WHERE path = 'features/feat/tasks.md'",
+				)
+				.all() as { doc_id: string; baseline: string | null }[];
+			expect(rows).toHaveLength(1);
+			expect(rows[0].doc_id).toBe("doc-a");
+			expect(rows[0].baseline).toBe("baseline content");
+
+			const annotations = db
+				.prepare("SELECT doc_id, content FROM annotations")
+				.all() as { doc_id: string; content: string }[];
+			expect(annotations).toHaveLength(1);
+			expect(annotations[0].doc_id).toBe("doc-a");
+			expect(annotations[0].content).toBe("note on stale row");
+		});
+
+		test("leaves distinct locations and url artifacts untouched", async () => {
+			const dbPath = join(tempDir, "artifact-dedupe-noop.db");
+			const db = await expectTaskRight(getEmitDatabase(dbPath));
+
+			insertRun(db, {
+				id: "run-dedupe-noop",
+				flow: "build",
+				featureId: "feat",
+				projectPath: "/p",
+			});
+
+			upsertArtifact(db, {
+				docId: "doc-one",
+				runId: "run-dedupe-noop",
+				path: "features/feat/design.md",
+				type: "markdown",
+				storageRoot: "work_dir",
+				projectPath: "/p",
+				feature: "feat",
+			});
+			upsertArtifact(db, {
+				docId: "doc-two",
+				runId: "run-dedupe-noop",
+				path: "features/feat/tasks.md",
+				type: "markdown",
+				storageRoot: "work_dir",
+				projectPath: "/p",
+				feature: "feat",
+			});
+			// Two url artifacts sharing a path must not be merged.
+			for (const docId of ["link-one", "link-two"]) {
+				upsertArtifact(db, {
+					docId,
+					runId: "run-dedupe-noop",
+					locationKind: "url",
+					path: "https://example.com/pr/1",
+					url: "https://example.com/pr/1",
+					type: "link",
+					storageRoot: "work_dir",
+					projectPath: "/p",
+					feature: "feat",
+				});
+			}
+
+			dedupeArtifactLocations(db);
+
+			const count = db.prepare("SELECT COUNT(*) AS n FROM artifacts").get() as {
+				n: number;
+			};
+			expect(count.n).toBe(4);
 		});
 	});
 

--- a/cli/src/__tests__/agent-tools/emit/doc-id.test.ts
+++ b/cli/src/__tests__/agent-tools/emit/doc-id.test.ts
@@ -6,18 +6,16 @@
 
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { readFile, rm } from "node:fs/promises";
+import { join } from "node:path";
 import {
 	generateDocId,
 	injectFrontmatter,
 	isMarkdownFile,
+	overwriteDocIdFrontmatter,
 	parseFrontmatter,
-	resolveDocId,
+	readFrontmatterDocId,
 } from "../../../agent-tools/emit/doc-id.js";
-import {
-	createTempDir,
-	expectTaskRight,
-	writeFixture,
-} from "../../helpers/index.js";
+import { createTempDir, writeFixture } from "../../helpers/index.js";
 
 const UUID_V4_REGEX =
 	/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
@@ -126,86 +124,133 @@ describe("doc-id utility", () => {
 		});
 	});
 
-	describe("resolveDocId", () => {
-		test("creates frontmatter for markdown with no frontmatter", async () => {
+	describe("readFrontmatterDocId", () => {
+		test("returns the rp1_doc_id from markdown frontmatter without modifying the file", async () => {
+			const existingId = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee";
+			const originalContent = `---\nrp1_doc_id: ${existingId}\ntitle: Existing\n---\n# Content`;
 			const filePath = await writeFixture(
 				tempDir,
-				"no-frontmatter.md",
+				"peek-has-doc-id.md",
+				originalContent,
+			);
+
+			expect(await readFrontmatterDocId(filePath)).toBe(existingId);
+
+			const fileContent = await readFile(filePath, "utf-8");
+			expect(fileContent).toBe(originalContent);
+		});
+
+		test("returns null for markdown without frontmatter and never writes", async () => {
+			const originalContent = "# My Document\n\nSome content here.";
+			const filePath = await writeFixture(
+				tempDir,
+				"peek-no-frontmatter.md",
+				originalContent,
+			);
+
+			expect(await readFrontmatterDocId(filePath)).toBeNull();
+
+			const fileContent = await readFile(filePath, "utf-8");
+			expect(fileContent).toBe(originalContent);
+		});
+
+		test("returns null for frontmatter without rp1_doc_id", async () => {
+			const filePath = await writeFixture(
+				tempDir,
+				"peek-other-frontmatter.md",
+				"---\ntitle: Design Doc\n---\n# Design",
+			);
+
+			expect(await readFrontmatterDocId(filePath)).toBeNull();
+		});
+
+		test("returns null for non-markdown files", async () => {
+			const filePath = await writeFixture(
+				tempDir,
+				"peek-script.ts",
+				"const x = 42;\n",
+			);
+
+			expect(await readFrontmatterDocId(filePath)).toBeNull();
+		});
+
+		test("returns null for missing files", async () => {
+			expect(
+				await readFrontmatterDocId(join(tempDir, "does-not-exist.md")),
+			).toBeNull();
+		});
+	});
+
+	describe("overwriteDocIdFrontmatter", () => {
+		test("prepends frontmatter to markdown without any", async () => {
+			const filePath = await writeFixture(
+				tempDir,
+				"stamp-no-frontmatter.md",
 				"# My Document\n\nSome content here.",
 			);
 
-			const result = await expectTaskRight(resolveDocId(filePath));
+			await overwriteDocIdFrontmatter(filePath, "doc-stamped");
 
-			expect(result.isNew).toBe(true);
-			expect(result.docId).toMatch(UUID_V4_REGEX);
-
-			const updatedContent = await readFile(filePath, "utf-8");
-			expect(updatedContent).toContain("rp1_doc_id:");
-			expect(updatedContent).toContain(result.docId);
-			expect(updatedContent).toContain("# My Document");
+			const content = await readFile(filePath, "utf-8");
+			expect(content).toContain("rp1_doc_id: doc-stamped");
+			expect(content).toContain("# My Document");
 		});
 
 		test("adds rp1_doc_id to existing frontmatter", async () => {
 			const filePath = await writeFixture(
 				tempDir,
-				"existing-frontmatter.md",
-				"---\ntitle: Design Doc\nauthor: Test\n---\n# Design\n\nDetails here.",
+				"stamp-existing-frontmatter.md",
+				"---\ntitle: Design Doc\n---\n# Design\n",
 			);
 
-			const result = await expectTaskRight(resolveDocId(filePath));
+			await overwriteDocIdFrontmatter(filePath, "doc-added");
 
-			expect(result.isNew).toBe(true);
-			expect(result.docId).toMatch(UUID_V4_REGEX);
-
-			const updatedContent = await readFile(filePath, "utf-8");
-			expect(updatedContent).toContain("rp1_doc_id:");
-			expect(updatedContent).toContain("title: Design Doc");
+			const content = await readFile(filePath, "utf-8");
+			expect(content).toContain("rp1_doc_id: doc-added");
+			expect(content).toContain("title: Design Doc");
 		});
 
-		test("returns existing rp1_doc_id without modifying file", async () => {
-			const existingId = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee";
-			const originalContent = `---\nrp1_doc_id: ${existingId}\ntitle: Existing\n---\n# Content`;
+		test("replaces a mismatched rp1_doc_id", async () => {
 			const filePath = await writeFixture(
 				tempDir,
-				"has-doc-id.md",
+				"stamp-mismatch.md",
+				"---\nrp1_doc_id: doc-loser\ntitle: Kept\n---\n# Body\n",
+			);
+
+			await overwriteDocIdFrontmatter(filePath, "doc-winner");
+
+			const content = await readFile(filePath, "utf-8");
+			expect(content).toContain("rp1_doc_id: doc-winner");
+			expect(content).not.toContain("doc-loser");
+			expect(content).toContain("title: Kept");
+		});
+
+		test("leaves a matching rp1_doc_id untouched", async () => {
+			const originalContent = "---\nrp1_doc_id: doc-same\n---\n# Body\n";
+			const filePath = await writeFixture(
+				tempDir,
+				"stamp-same.md",
 				originalContent,
 			);
 
-			const result = await expectTaskRight(resolveDocId(filePath));
+			await overwriteDocIdFrontmatter(filePath, "doc-same");
 
-			expect(result.isNew).toBe(false);
-			expect(result.docId).toBe(existingId);
-
-			const fileContent = await readFile(filePath, "utf-8");
-			expect(fileContent).toBe(originalContent);
+			const content = await readFile(filePath, "utf-8");
+			expect(content).toBe(originalContent);
 		});
 
-		test("generates doc_id for non-markdown without file modification", async () => {
-			const originalContent = "const x = 42;\nexport { x };\n";
+		test("never touches non-markdown files", async () => {
+			const originalContent = "const x = 42;\n";
 			const filePath = await writeFixture(
 				tempDir,
-				"script.ts",
+				"stamp-script.ts",
 				originalContent,
 			);
 
-			const result = await expectTaskRight(resolveDocId(filePath));
+			await overwriteDocIdFrontmatter(filePath, "doc-ignored");
 
-			expect(result.isNew).toBe(true);
-			expect(result.docId).toMatch(UUID_V4_REGEX);
-
-			const fileContent = await readFile(filePath, "utf-8");
-			expect(fileContent).toBe(originalContent);
-		});
-
-		test("generated doc_id is a valid UUID v4", async () => {
-			const filePath = await writeFixture(
-				tempDir,
-				"uuid-test.md",
-				"# UUID Test",
-			);
-
-			const result = await expectTaskRight(resolveDocId(filePath));
-			expect(result.docId).toMatch(UUID_V4_REGEX);
+			const content = await readFile(filePath, "utf-8");
+			expect(content).toBe(originalContent);
 		});
 	});
 });

--- a/cli/src/__tests__/agent-tools/emit/emit.test.ts
+++ b/cli/src/__tests__/agent-tools/emit/emit.test.ts
@@ -497,13 +497,18 @@ describe("emit end-to-end", () => {
 					),
 				);
 
+			// Three concurrent callers cover the third-reader interleaving:
+			// identity is only ever written to the file after the transaction
+			// picks the winner, so no caller can observe a transient losing id.
 			const stamp = Date.now();
-			const [first, second] = await Promise.all([
+			const [first, second, third] = await Promise.all([
 				emitFor(`run-race-a-${stamp}`),
 				emitFor(`run-race-b-${stamp}`),
+				emitFor(`run-race-c-${stamp}`),
 			]);
 
 			expect(second.data.docId).toBe(first.data.docId);
+			expect(third.data.docId).toBe(first.data.docId);
 
 			const db = await expectTaskRight(getEmitDatabase(dbPath));
 			const rowCount = db

--- a/cli/src/__tests__/agent-tools/emit/emit.test.ts
+++ b/cli/src/__tests__/agent-tools/emit/emit.test.ts
@@ -9,7 +9,7 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { createHash } from "node:crypto";
 import { mkdirSync, writeFileSync } from "node:fs";
-import { rm } from "node:fs/promises";
+import { readFile, rm } from "node:fs/promises";
 import { join } from "node:path";
 import {
 	closeDatabase,
@@ -318,6 +318,106 @@ describe("emit end-to-end", () => {
 
 			expect(artifact?.storageRoot).toBe("work_dir");
 			expect(artifact?.path).toBe("features/test-feat/design.md");
+		});
+
+		test("reuses the existing doc_id when markdown frontmatter is stripped by a rewrite", async () => {
+			const projectRoot = join(tempDir, "project-docid-heal");
+			await writeFixture(
+				projectRoot,
+				".rp1/project_id",
+				"test-docid-heal-uuid",
+			);
+			const filePath = await writeFixture(
+				join(projectRoot, ".rp1", "work"),
+				"features/heal-feat/tasks.md",
+				"# Tasks\n",
+			);
+			const runId = `run-docid-heal-${Date.now()}`;
+
+			const register = () =>
+				expectTaskRight(
+					executeEmit(
+						makeInput({
+							type: "artifact_registered",
+							runId,
+							step: "planning",
+							projectPath: projectRoot,
+							data: {
+								path: "features/heal-feat/tasks.md",
+								feature: "heal-feat",
+								storageRoot: "work_dir",
+								type: "markdown",
+								workflow: "build",
+							},
+						}),
+					),
+				);
+
+			const first = await register();
+
+			// Simulate an agent rewriting the file without preserving frontmatter.
+			writeFileSync(filePath, "# Tasks rewritten\n");
+
+			const second = await register();
+
+			expect(second.data.docId).toBe(first.data.docId);
+
+			const healed = await readFile(filePath, "utf-8");
+			expect(healed).toContain(`rp1_doc_id: ${first.data.docId}`);
+
+			const db = await expectTaskRight(getEmitDatabase(dbPath));
+			const rowCount = db
+				.prepare(
+					"SELECT COUNT(*) AS n FROM artifacts WHERE path = 'features/heal-feat/tasks.md'",
+				)
+				.get() as { n: number };
+			expect(rowCount.n).toBe(1);
+		});
+
+		test("reuses the existing doc_id for non-markdown artifacts across re-registrations", async () => {
+			const projectRoot = join(tempDir, "project-docid-json");
+			await writeFixture(
+				projectRoot,
+				".rp1/project_id",
+				"test-docid-json-uuid",
+			);
+			await writeFixture(
+				join(projectRoot, ".rp1", "work"),
+				"features/json-feat/tasks.json",
+				'{"tasks": []}',
+			);
+			const runId = `run-docid-json-${Date.now()}`;
+
+			const register = () =>
+				expectTaskRight(
+					executeEmit(
+						makeInput({
+							type: "artifact_registered",
+							runId,
+							step: "planning",
+							projectPath: projectRoot,
+							data: {
+								path: "features/json-feat/tasks.json",
+								feature: "json-feat",
+								storageRoot: "work_dir",
+								workflow: "build",
+							},
+						}),
+					),
+				);
+
+			const first = await register();
+			const second = await register();
+
+			expect(second.data.docId).toBe(first.data.docId);
+
+			const db = await expectTaskRight(getEmitDatabase(dbPath));
+			const rowCount = db
+				.prepare(
+					"SELECT COUNT(*) AS n FROM artifacts WHERE path = 'features/json-feat/tasks.json'",
+				)
+				.get() as { n: number };
+			expect(rowCount.n).toBe(1);
 		});
 
 		test("uses frontmatter doc_id for relative work-dir artifacts when storageRoot is explicit", async () => {

--- a/cli/src/__tests__/agent-tools/emit/emit.test.ts
+++ b/cli/src/__tests__/agent-tools/emit/emit.test.ts
@@ -420,6 +420,103 @@ describe("emit end-to-end", () => {
 			expect(rowCount.n).toBe(1);
 		});
 
+		test("keeps frontmatter identity when a stale duplicate row has a higher id", async () => {
+			const projectRoot = join(tempDir, "project-frontmatter-auth");
+			await writeFixture(
+				projectRoot,
+				".rp1/project_id",
+				"test-frontmatter-auth-uuid",
+			);
+			const filePath = await writeFixture(
+				join(projectRoot, ".rp1", "work"),
+				"features/auth-feat/design.md",
+				"---\nrp1_doc_id: doc-auth\n---\n# Design\n",
+			);
+
+			// Legacy doc-id churn: a stale duplicate row at the same location
+			// with a higher row id than the authoritative one.
+			const db = await expectTaskRight(getEmitDatabase(dbPath));
+			for (const docId of ["doc-auth", "doc-stale"]) {
+				upsertArtifact(db, {
+					docId,
+					path: "features/auth-feat/design.md",
+					type: "markdown",
+					storageRoot: "work_dir",
+					projectPath: projectRoot,
+					feature: "auth-feat",
+				});
+			}
+
+			const result = await expectTaskRight(
+				executeEmit(
+					makeInput({
+						type: "artifact_registered",
+						step: "planning",
+						projectPath: projectRoot,
+						data: {
+							path: "features/auth-feat/design.md",
+							feature: "auth-feat",
+							storageRoot: "work_dir",
+							type: "markdown",
+							workflow: "build",
+						},
+					}),
+				),
+			);
+
+			expect(result.data.docId).toBe("doc-auth");
+			const content = await readFile(filePath, "utf-8");
+			expect(content).toContain("rp1_doc_id: doc-auth");
+		});
+
+		test("converges concurrent first registrations on a single artifact row", async () => {
+			const projectRoot = join(tempDir, "project-race");
+			await writeFixture(projectRoot, ".rp1/project_id", "test-race-uuid");
+			const filePath = await writeFixture(
+				join(projectRoot, ".rp1", "work"),
+				"features/race-feat/notes.md",
+				"# Notes\n",
+			);
+
+			const emitFor = (runId: string) =>
+				expectTaskRight(
+					executeEmit(
+						makeInput({
+							type: "artifact_registered",
+							runId,
+							step: "planning",
+							projectPath: projectRoot,
+							data: {
+								path: "features/race-feat/notes.md",
+								feature: "race-feat",
+								storageRoot: "work_dir",
+								type: "markdown",
+								workflow: "build",
+							},
+						}),
+					),
+				);
+
+			const stamp = Date.now();
+			const [first, second] = await Promise.all([
+				emitFor(`run-race-a-${stamp}`),
+				emitFor(`run-race-b-${stamp}`),
+			]);
+
+			expect(second.data.docId).toBe(first.data.docId);
+
+			const db = await expectTaskRight(getEmitDatabase(dbPath));
+			const rowCount = db
+				.prepare(
+					"SELECT COUNT(*) AS n FROM artifacts WHERE path = 'features/race-feat/notes.md'",
+				)
+				.get() as { n: number };
+			expect(rowCount.n).toBe(1);
+
+			const content = await readFile(filePath, "utf-8");
+			expect(content).toContain(`rp1_doc_id: ${first.data.docId}`);
+		});
+
 		test("uses frontmatter doc_id for relative work-dir artifacts when storageRoot is explicit", async () => {
 			const projectRoot = join(tempDir, "project-relative-doc-id");
 			await writeFixture(

--- a/cli/src/agent-tools/emit/database.ts
+++ b/cli/src/agent-tools/emit/database.ts
@@ -35,7 +35,7 @@ import { readProjectId } from "../../../shared/project-id.js";
 import { computeDirectoryPaths } from "../../../shared/storage-mode.js";
 
 /** Current schema version. Bump when adding migrations. */
-export const LATEST_SCHEMA_VERSION = 18;
+export const LATEST_SCHEMA_VERSION = 19;
 
 /** Default database file location. Override with RP1_DB env var. */
 const getDefaultDbPath = (): string =>
@@ -190,6 +190,7 @@ CREATE INDEX IF NOT EXISTS idx_artifacts_doc_id ON artifacts(doc_id);
 CREATE INDEX IF NOT EXISTS idx_artifacts_run ON artifacts(run_id);
 CREATE INDEX IF NOT EXISTS idx_artifacts_project_feature ON artifacts(project_path, feature);
 CREATE INDEX IF NOT EXISTS idx_artifacts_project_id ON artifacts(project_id);
+CREATE INDEX IF NOT EXISTS idx_artifacts_location ON artifacts(project_path, path, storage_root);
 
 CREATE TABLE IF NOT EXISTS annotations (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -922,6 +923,78 @@ const migrateSocraticDuelLockSchema = (db: Database): void => {
 };
 
 /**
+ * Merge duplicate file-artifact rows that share one on-disk location.
+ *
+ * Doc-id churn (pre-v19 registration minted a fresh doc_id whenever
+ * markdown lost its frontmatter, and on every non-markdown registration)
+ * left multiple artifact rows per (project_path, path, storage_root).
+ * The keeper is the doc_id with the most recent artifact_registered
+ * event — true registration recency, which for markdown matches the
+ * doc_id last injected into the file — falling back to the highest row
+ * id. Annotations are re-pointed to the keeper, the newest surviving
+ * baseline is preserved, and the stale rows are deleted.
+ */
+export const dedupeArtifactLocations = (db: Database): void => {
+	const groups = db
+		.prepare(
+			`SELECT project_path, path, storage_root
+			 FROM artifacts
+			 WHERE location_kind = 'file'
+			 GROUP BY project_path, path, storage_root
+			 HAVING COUNT(*) > 1`,
+		)
+		.all() as { project_path: string; path: string; storage_root: string }[];
+
+	const mergeGroup = db.transaction(
+		(group: { project_path: string; path: string; storage_root: string }) => {
+			const rows = db
+				.prepare(
+					`SELECT a.id, a.doc_id, a.baseline,
+					        (SELECT MAX(e.id) FROM events e
+					          WHERE e.type = 'artifact_registered'
+					            AND json_extract(e.data, '$.docId') = a.doc_id) AS last_event_id
+					 FROM artifacts a
+					 WHERE a.project_path = $projectPath
+					   AND a.path = $path
+					   AND a.storage_root = $storageRoot
+					   AND a.location_kind = 'file'
+					 ORDER BY COALESCE(last_event_id, -1) DESC, a.id DESC`,
+				)
+				.all({
+					$projectPath: group.project_path,
+					$path: group.path,
+					$storageRoot: group.storage_root,
+				}) as { id: number; doc_id: string; baseline: string | null }[];
+
+			const [keeper, ...stale] = rows;
+			if (!keeper) return;
+
+			let keeperBaseline = keeper.baseline;
+			for (const row of stale) {
+				db.prepare(
+					"UPDATE annotations SET doc_id = $keeperDocId WHERE doc_id = $staleDocId",
+				).run({ $keeperDocId: keeper.doc_id, $staleDocId: row.doc_id });
+
+				if (keeperBaseline == null && row.baseline != null) {
+					db.prepare(
+						"UPDATE artifacts SET baseline = $baseline WHERE doc_id = $docId",
+					).run({ $baseline: row.baseline, $docId: keeper.doc_id });
+					keeperBaseline = row.baseline;
+				}
+
+				db.prepare("DELETE FROM artifacts WHERE id = $id").run({
+					$id: row.id,
+				});
+			}
+		},
+	);
+
+	for (const group of groups) {
+		mergeGroup(group);
+	}
+};
+
+/**
  * Apply schema migrations based on the current schema version.
  * Each migration bumps the version to prevent re-application.
  */
@@ -1414,6 +1487,14 @@ const applyMigrations = (db: Database): void => {
 		.get() as { version: number } | null;
 
 	if ((postV17Version?.version ?? 17) < 18) {
+		applyV18Migration(db);
+	}
+
+	const postV18Version = db
+		.prepare("SELECT version FROM schema_version LIMIT 1")
+		.get() as { version: number } | null;
+
+	if ((postV18Version?.version ?? 18) < 19) {
 		const artifactsTable = db
 			.prepare(
 				"SELECT name FROM sqlite_master WHERE type='table' AND name='artifacts'",
@@ -1421,44 +1502,61 @@ const applyMigrations = (db: Database): void => {
 			.get() as { name: string } | null;
 
 		if (artifactsTable) {
-			const artifactCols = db.prepare("PRAGMA table_info(artifacts)").all() as {
-				name: string;
-			}[];
-			const artifactColNames = new Set(artifactCols.map((c) => c.name));
-
-			if (!artifactColNames.has("location_kind")) {
-				db.exec(
-					"ALTER TABLE artifacts ADD COLUMN location_kind TEXT NOT NULL DEFAULT 'file' CHECK(location_kind IN ('file', 'url'))",
-				);
-			}
-			if (!artifactColNames.has("url")) {
-				db.exec("ALTER TABLE artifacts ADD COLUMN url TEXT DEFAULT NULL");
-			}
-			if (!artifactColNames.has("label")) {
-				db.exec("ALTER TABLE artifacts ADD COLUMN label TEXT DEFAULT NULL");
-			}
-			if (!artifactColNames.has("relationship")) {
-				db.exec(
-					"ALTER TABLE artifacts ADD COLUMN relationship TEXT DEFAULT NULL",
-				);
-			}
-			if (!artifactColNames.has("source_context")) {
-				db.exec(
-					"ALTER TABLE artifacts ADD COLUMN source_context TEXT DEFAULT NULL",
-				);
-			}
-			if (!artifactColNames.has("source_artifact_path")) {
-				db.exec(
-					"ALTER TABLE artifacts ADD COLUMN source_artifact_path TEXT DEFAULT NULL",
-				);
-			}
-			if (!artifactColNames.has("metadata")) {
-				db.exec("ALTER TABLE artifacts ADD COLUMN metadata TEXT DEFAULT NULL");
-			}
+			dedupeArtifactLocations(db);
+			db.exec(
+				"CREATE INDEX IF NOT EXISTS idx_artifacts_location ON artifacts(project_path, path, storage_root)",
+			);
 		}
 
-		db.prepare("UPDATE schema_version SET version = 18").run();
+		db.prepare("UPDATE schema_version SET version = 19").run();
 	}
+};
+
+const applyV18Migration = (db: Database): void => {
+	const artifactsTable = db
+		.prepare(
+			"SELECT name FROM sqlite_master WHERE type='table' AND name='artifacts'",
+		)
+		.get() as { name: string } | null;
+
+	if (artifactsTable) {
+		const artifactCols = db.prepare("PRAGMA table_info(artifacts)").all() as {
+			name: string;
+		}[];
+		const artifactColNames = new Set(artifactCols.map((c) => c.name));
+
+		if (!artifactColNames.has("location_kind")) {
+			db.exec(
+				"ALTER TABLE artifacts ADD COLUMN location_kind TEXT NOT NULL DEFAULT 'file' CHECK(location_kind IN ('file', 'url'))",
+			);
+		}
+		if (!artifactColNames.has("url")) {
+			db.exec("ALTER TABLE artifacts ADD COLUMN url TEXT DEFAULT NULL");
+		}
+		if (!artifactColNames.has("label")) {
+			db.exec("ALTER TABLE artifacts ADD COLUMN label TEXT DEFAULT NULL");
+		}
+		if (!artifactColNames.has("relationship")) {
+			db.exec(
+				"ALTER TABLE artifacts ADD COLUMN relationship TEXT DEFAULT NULL",
+			);
+		}
+		if (!artifactColNames.has("source_context")) {
+			db.exec(
+				"ALTER TABLE artifacts ADD COLUMN source_context TEXT DEFAULT NULL",
+			);
+		}
+		if (!artifactColNames.has("source_artifact_path")) {
+			db.exec(
+				"ALTER TABLE artifacts ADD COLUMN source_artifact_path TEXT DEFAULT NULL",
+			);
+		}
+		if (!artifactColNames.has("metadata")) {
+			db.exec("ALTER TABLE artifacts ADD COLUMN metadata TEXT DEFAULT NULL");
+		}
+	}
+
+	db.prepare("UPDATE schema_version SET version = 18").run();
 };
 
 /**

--- a/cli/src/agent-tools/emit/database.ts
+++ b/cli/src/agent-tools/emit/database.ts
@@ -3053,6 +3053,39 @@ export const getArtifactByDocId = (
 };
 
 /**
+ * Get the most recently registered file artifact at a given location.
+ * Used at registration time to reuse the existing doc_id when the file
+ * itself no longer carries one (frontmatter stripped by a rewrite) or
+ * cannot carry one (non-markdown), instead of minting a duplicate row.
+ */
+export const getLatestArtifactByLocation = (
+	db: Database,
+	location: {
+		readonly projectPath: string;
+		readonly path: string;
+		readonly storageRoot: ArtifactStorageRoot;
+	},
+): ArtifactRecord | null => {
+	const row = db
+		.prepare(
+			`SELECT * FROM artifacts
+			 WHERE project_path = $projectPath
+			   AND path = $path
+			   AND storage_root = $storageRoot
+			   AND location_kind = 'file'
+			 ORDER BY id DESC
+			 LIMIT 1`,
+		)
+		.get({
+			$projectPath: location.projectPath,
+			$path: location.path,
+			$storageRoot: location.storageRoot,
+		}) as ArtifactRow | null;
+
+	return row ? artifactRowToRecord(row) : null;
+};
+
+/**
  * Get the baseline content and path info for an artifact by doc_id.
  */
 export const getArtifactBaseline = (

--- a/cli/src/agent-tools/emit/doc-id.ts
+++ b/cli/src/agent-tools/emit/doc-id.ts
@@ -83,23 +83,34 @@ export const injectFrontmatter = (
  * For markdown files (.md, .mdx):
  * - Reads the file and parses frontmatter
  * - If rp1_doc_id exists in frontmatter, returns it (idempotent)
- * - If no rp1_doc_id, generates one and injects it into frontmatter
+ * - If no rp1_doc_id, reuses `existingDocId` when provided (healing a
+ *   rewrite that stripped frontmatter) or generates one, then injects it
  * - Writes the updated content back to the file
  *
- * For non-markdown files:
- * - Generates a UUID and returns it without modifying the file
+ * For non-markdown files (which cannot carry frontmatter):
+ * - Reuses `existingDocId` when provided, otherwise generates a UUID;
+ *   the file is never modified
+ *
+ * `existingDocId` is the doc_id of the artifact row already registered at
+ * this location, so re-registering the same file keeps a stable identity
+ * instead of minting a duplicate artifact row per emit.
  */
 export const resolveDocId = (
 	filePath: string,
+	existingDocId?: string,
 ): TE.TaskEither<CLIError, DocIdResult> => {
 	if (!isMarkdownFile(filePath)) {
-		return TE.right({ docId: generateDocId(), isNew: true });
+		return TE.right(
+			existingDocId
+				? { docId: existingDocId, isNew: false }
+				: { docId: generateDocId(), isNew: true },
+		);
 	}
 
 	return TE.tryCatch(
 		async () => {
 			const content = await readFile(filePath, "utf-8");
-			const docId = generateDocId();
+			const docId = existingDocId ?? generateDocId();
 			const result = injectFrontmatter(content, docId);
 
 			if (!result.isNew) {
@@ -111,7 +122,7 @@ export const resolveDocId = (
 			}
 
 			await writeFile(filePath, result.content, "utf-8");
-			return { docId, isNew: true };
+			return { docId, isNew: existingDocId === undefined };
 		},
 		(error) =>
 			runtimeError(

--- a/cli/src/agent-tools/emit/doc-id.ts
+++ b/cli/src/agent-tools/emit/doc-id.ts
@@ -5,22 +5,7 @@
 
 import { readFile, writeFile } from "node:fs/promises";
 import { extname } from "node:path";
-import * as TE from "fp-ts/lib/TaskEither.js";
 import { parse, stringify } from "yaml";
-import type { CLIError } from "../../../shared/errors.js";
-import { runtimeError } from "../../../shared/errors.js";
-
-/** Result of resolving a doc_id for a file */
-export interface DocIdResult {
-	readonly docId: string;
-	readonly isNew: boolean;
-	/**
-	 * Where the doc_id came from. "frontmatter" is authoritative (the file
-	 * itself carries the identity); "existing" reuses a previously registered
-	 * artifact row; "generated" is a freshly minted UUID.
-	 */
-	readonly source: "frontmatter" | "existing" | "generated";
-}
 
 const MARKDOWN_EXTENSIONS = new Set([".md", ".mdx"]);
 const FRONTMATTER_REGEX = /^---\r?\n([\s\S]*?)\r?\n---/;
@@ -84,10 +69,34 @@ export const injectFrontmatter = (
 };
 
 /**
+ * Read the rp1_doc_id carried in a markdown file's frontmatter without
+ * modifying the file. Returns null for non-markdown files, files without
+ * an rp1_doc_id, and unreadable files. This is the only pre-registration
+ * identity probe: a speculative doc_id must never be written to the file
+ * before the registration transaction picks the winning identity, or a
+ * concurrent registration could adopt a transient losing id as
+ * authoritative.
+ */
+export const readFrontmatterDocId = async (
+	filePath: string,
+): Promise<string | null> => {
+	if (!isMarkdownFile(filePath)) return null;
+
+	let content: string;
+	try {
+		content = await readFile(filePath, "utf-8");
+	} catch {
+		return null;
+	}
+
+	const docId = parseFrontmatter(content)?.frontmatter.rp1_doc_id;
+	return docId ? String(docId) : null;
+};
+
+/**
  * Force rp1_doc_id in a markdown file's frontmatter to the given value,
- * overwriting any existing id. Used to re-heal a file after a concurrent
- * registration race settles on a different doc_id than the one this
- * process injected.
+ * overwriting any existing id. Called after the registration transaction
+ * settles the winning identity, to stamp it into the file.
  */
 export const overwriteDocIdFrontmatter = async (
 	filePath: string,
@@ -112,63 +121,4 @@ export const overwriteDocIdFrontmatter = async (
 	parsed.frontmatter.rp1_doc_id = docId;
 	const serialized = stringify(parsed.frontmatter).trimEnd();
 	await writeFile(filePath, `---\n${serialized}\n---${parsed.body}`, "utf-8");
-};
-
-/**
- * Resolve the doc_id for a file path.
- *
- * For markdown files (.md, .mdx):
- * - Reads the file and parses frontmatter
- * - If rp1_doc_id exists in frontmatter, returns it (idempotent)
- * - If no rp1_doc_id, reuses `existingDocId` when provided (healing a
- *   rewrite that stripped frontmatter) or generates one, then injects it
- * - Writes the updated content back to the file
- *
- * For non-markdown files (which cannot carry frontmatter):
- * - Reuses `existingDocId` when provided, otherwise generates a UUID;
- *   the file is never modified
- *
- * `existingDocId` is the doc_id of the artifact row already registered at
- * this location, so re-registering the same file keeps a stable identity
- * instead of minting a duplicate artifact row per emit.
- */
-export const resolveDocId = (
-	filePath: string,
-	existingDocId?: string,
-): TE.TaskEither<CLIError, DocIdResult> => {
-	if (!isMarkdownFile(filePath)) {
-		return TE.right(
-			existingDocId
-				? { docId: existingDocId, isNew: false, source: "existing" as const }
-				: { docId: generateDocId(), isNew: true, source: "generated" as const },
-		);
-	}
-
-	return TE.tryCatch(
-		async () => {
-			const content = await readFile(filePath, "utf-8");
-			const docId = existingDocId ?? generateDocId();
-			const result = injectFrontmatter(content, docId);
-
-			if (!result.isNew) {
-				const parsed = parseFrontmatter(content);
-				return {
-					docId: String(parsed?.frontmatter.rp1_doc_id),
-					isNew: false,
-					source: "frontmatter" as const,
-				};
-			}
-
-			await writeFile(filePath, result.content, "utf-8");
-			return {
-				docId,
-				isNew: existingDocId === undefined,
-				source: existingDocId ? ("existing" as const) : ("generated" as const),
-			};
-		},
-		(error) =>
-			runtimeError(
-				`Failed to resolve doc_id for ${filePath}: ${error instanceof Error ? error.message : String(error)}`,
-			),
-	);
 };

--- a/cli/src/agent-tools/emit/doc-id.ts
+++ b/cli/src/agent-tools/emit/doc-id.ts
@@ -14,6 +14,12 @@ import { runtimeError } from "../../../shared/errors.js";
 export interface DocIdResult {
 	readonly docId: string;
 	readonly isNew: boolean;
+	/**
+	 * Where the doc_id came from. "frontmatter" is authoritative (the file
+	 * itself carries the identity); "existing" reuses a previously registered
+	 * artifact row; "generated" is a freshly minted UUID.
+	 */
+	readonly source: "frontmatter" | "existing" | "generated";
 }
 
 const MARKDOWN_EXTENSIONS = new Set([".md", ".mdx"]);
@@ -78,6 +84,37 @@ export const injectFrontmatter = (
 };
 
 /**
+ * Force rp1_doc_id in a markdown file's frontmatter to the given value,
+ * overwriting any existing id. Used to re-heal a file after a concurrent
+ * registration race settles on a different doc_id than the one this
+ * process injected.
+ */
+export const overwriteDocIdFrontmatter = async (
+	filePath: string,
+	docId: string,
+): Promise<void> => {
+	if (!isMarkdownFile(filePath)) return;
+
+	const content = await readFile(filePath, "utf-8");
+	const parsed = parseFrontmatter(content);
+
+	if (!parsed) {
+		await writeFile(
+			filePath,
+			`---\nrp1_doc_id: ${docId}\n---\n${content}`,
+			"utf-8",
+		);
+		return;
+	}
+
+	if (parsed.frontmatter.rp1_doc_id === docId) return;
+
+	parsed.frontmatter.rp1_doc_id = docId;
+	const serialized = stringify(parsed.frontmatter).trimEnd();
+	await writeFile(filePath, `---\n${serialized}\n---${parsed.body}`, "utf-8");
+};
+
+/**
  * Resolve the doc_id for a file path.
  *
  * For markdown files (.md, .mdx):
@@ -102,8 +139,8 @@ export const resolveDocId = (
 	if (!isMarkdownFile(filePath)) {
 		return TE.right(
 			existingDocId
-				? { docId: existingDocId, isNew: false }
-				: { docId: generateDocId(), isNew: true },
+				? { docId: existingDocId, isNew: false, source: "existing" as const }
+				: { docId: generateDocId(), isNew: true, source: "generated" as const },
 		);
 	}
 
@@ -118,11 +155,16 @@ export const resolveDocId = (
 				return {
 					docId: String(parsed?.frontmatter.rp1_doc_id),
 					isNew: false,
+					source: "frontmatter" as const,
 				};
 			}
 
 			await writeFile(filePath, result.content, "utf-8");
-			return { docId, isNew: existingDocId === undefined };
+			return {
+				docId,
+				isNew: existingDocId === undefined,
+				source: existingDocId ? ("existing" as const) : ("generated" as const),
+			};
 		},
 		(error) =>
 			runtimeError(

--- a/cli/src/agent-tools/emit/index.ts
+++ b/cli/src/agent-tools/emit/index.ts
@@ -35,6 +35,7 @@ import {
 	type EventInput,
 	endRun,
 	getEmitDatabase,
+	getLatestArtifactByLocation,
 	getRunById,
 	getSkippableSteps,
 	getStepStatuses,
@@ -388,19 +389,29 @@ const handleArtifactRegistration = (
 		);
 	}
 
-	const docIdTask = pipe(
-		resolveDocId(absolutePath),
-		TE.orElse(() =>
-			TE.right({ docId: generateDocId(), isNew: true } as DocIdResult),
-		),
-	);
-
 	return pipe(
-		docIdTask,
-		TE.chain((docIdResult) =>
-			pipe(
-				getEmitDatabase(),
-				TE.map((db) => {
+		getEmitDatabase(),
+		TE.chain((db) => {
+			// Reuse the doc_id already registered at this location so repeated
+			// registrations of the same file (frontmatter stripped by a rewrite,
+			// or non-markdown files that cannot carry frontmatter) refresh the
+			// existing artifact row instead of minting a duplicate per emit.
+			const existing = getLatestArtifactByLocation(db, {
+				projectPath: input.projectPath,
+				path: normalizedStorage.path,
+				storageRoot: normalizedStorage.storageRoot,
+			});
+
+			return pipe(
+				resolveDocId(absolutePath, existing?.docId),
+				TE.orElse(
+					(): TE.TaskEither<CLIError, DocIdResult> =>
+						TE.right({
+							docId: existing?.docId ?? generateDocId(),
+							isNew: existing == null,
+						}),
+				),
+				TE.map((docIdResult) => {
 					const artifactType =
 						(input.data.type as string) ?? classifyArtifactType(filePath);
 					const feature = (input.data.feature as string) ?? "unknown";
@@ -421,8 +432,8 @@ const handleArtifactRegistration = (
 					upsertArtifact(db, artifactInput);
 					return { docId: docIdResult.docId };
 				}),
-			),
-		),
+			);
+		}),
 	);
 };
 

--- a/cli/src/agent-tools/emit/index.ts
+++ b/cli/src/agent-tools/emit/index.ts
@@ -46,10 +46,9 @@ import {
 	upsertArtifact,
 } from "./database.js";
 import {
-	type DocIdResult,
 	generateDocId,
 	overwriteDocIdFrontmatter,
-	resolveDocId,
+	readFrontmatterDocId,
 } from "./doc-id.js";
 import type { EmitInput, EmitResult } from "./models.js";
 import { maybeGenerateNotification } from "./notification-generator.js";
@@ -396,85 +395,71 @@ const handleArtifactRegistration = (
 
 	return pipe(
 		getEmitDatabase(),
-		TE.chain((db) => {
-			// Reuse the doc_id already registered at this location so repeated
-			// registrations of the same file (frontmatter stripped by a rewrite,
-			// or non-markdown files that cannot carry frontmatter) refresh the
-			// existing artifact row instead of minting a duplicate per emit.
-			const location = {
-				projectPath: input.projectPath,
-				path: normalizedStorage.path,
-				storageRoot: normalizedStorage.storageRoot,
-			};
-			const existing = getLatestArtifactByLocation(db, location);
+		TE.chain((db) =>
+			TE.tryCatch(
+				async () => {
+					const artifactType =
+						(input.data.type as string) ?? classifyArtifactType(filePath);
+					const feature = (input.data.feature as string) ?? "unknown";
+					const location = {
+						projectPath: input.projectPath,
+						path: normalizedStorage.path,
+						storageRoot: normalizedStorage.storageRoot,
+					};
 
-			return pipe(
-				resolveDocId(absolutePath, existing?.docId),
-				TE.orElse(
-					(): TE.TaskEither<CLIError, DocIdResult> =>
-						TE.right({
-							docId: existing?.docId ?? generateDocId(),
-							isNew: existing == null,
-							source: existing ? "existing" : "generated",
-						}),
-				),
-				TE.chain((docIdResult) =>
-					TE.tryCatch(
-						async () => {
-							const artifactType =
-								(input.data.type as string) ?? classifyArtifactType(filePath);
-							const feature = (input.data.feature as string) ?? "unknown";
+					// Identity resolution never writes before the transaction picks
+					// the winner: a speculative doc_id written to the file first
+					// could be read as authoritative by a concurrent registration.
+					// Frontmatter is peeked read-only; when absent, the identity is
+					// established inside the write transaction (reusing the row
+					// already registered at this location — frontmatter stripped by
+					// a rewrite, non-markdown files, or a concurrent racer — and
+					// minting a UUID only when there is none) and injected after.
+					const frontmatterDocId = await readFrontmatterDocId(absolutePath);
 
-							// Re-check the location inside a write transaction so
-							// concurrent first registrations converge on one doc_id
-							// instead of inserting two rows. Frontmatter identity is
-							// authoritative and never overridden by the re-check.
-							const register = db.transaction(() => {
-								const docId =
-									docIdResult.source === "frontmatter"
-										? docIdResult.docId
-										: (getLatestArtifactByLocation(db, location)?.docId ??
-											docIdResult.docId);
+					const register = db.transaction(() => {
+						const docId =
+							frontmatterDocId ??
+							getLatestArtifactByLocation(db, location)?.docId ??
+							generateDocId();
 
-								const artifactInput: ArtifactInput = {
-									docId,
-									runId: input.runId,
-									path: normalizedStorage.path,
-									type: artifactType,
-									storageRoot: normalizedStorage.storageRoot,
-									projectPath: input.projectPath,
-									projectId: run.projectId ?? undefined,
-									feature,
-									step: input.step,
-									subflow: input.data.subflow === true,
-								};
+						const artifactInput: ArtifactInput = {
+							docId,
+							runId: input.runId,
+							path: normalizedStorage.path,
+							type: artifactType,
+							storageRoot: normalizedStorage.storageRoot,
+							projectPath: input.projectPath,
+							projectId: run.projectId ?? undefined,
+							feature,
+							step: input.step,
+							subflow: input.data.subflow === true,
+						};
 
-								upsertArtifact(db, artifactInput);
-								return docId;
-							});
-							const docId = register.immediate() as string;
+						upsertArtifact(db, artifactInput);
+						return docId;
+					});
+					const docId = register.immediate() as string;
 
-							if (docId !== docIdResult.docId) {
-								// A concurrent registration won the race; re-point the
-								// file at the winning identity. Best-effort: the row is
-								// already correct and the next emit reconverges anyway.
-								try {
-									await overwriteDocIdFrontmatter(absolutePath, docId);
-								} catch {
-									// File may be gone or unwritable; ignore.
-								}
-							}
+					if (frontmatterDocId === null) {
+						// Inject the winning identity into markdown frontmatter.
+						// Best-effort: the row is already correct, the file may be
+						// gone or unwritable, and the next emit reconverges anyway.
+						try {
+							await overwriteDocIdFrontmatter(absolutePath, docId);
+						} catch {
+							// Ignore.
+						}
+					}
 
-							return { docId };
-						},
-						(error) =>
-							runtimeError(
-								`Failed to register artifact for ${filePath}: ${error instanceof Error ? error.message : String(error)}`,
-							),
+					return { docId };
+				},
+				(error) =>
+					runtimeError(
+						`Failed to register artifact for ${filePath}: ${error instanceof Error ? error.message : String(error)}`,
 					),
-				),
-			);
-		}),
+			),
+		),
 	);
 };
 

--- a/cli/src/agent-tools/emit/index.ts
+++ b/cli/src/agent-tools/emit/index.ts
@@ -45,7 +45,12 @@ import {
 	upsertAnnotation,
 	upsertArtifact,
 } from "./database.js";
-import { type DocIdResult, generateDocId, resolveDocId } from "./doc-id.js";
+import {
+	type DocIdResult,
+	generateDocId,
+	overwriteDocIdFrontmatter,
+	resolveDocId,
+} from "./doc-id.js";
 import type { EmitInput, EmitResult } from "./models.js";
 import { maybeGenerateNotification } from "./notification-generator.js";
 import {
@@ -396,11 +401,12 @@ const handleArtifactRegistration = (
 			// registrations of the same file (frontmatter stripped by a rewrite,
 			// or non-markdown files that cannot carry frontmatter) refresh the
 			// existing artifact row instead of minting a duplicate per emit.
-			const existing = getLatestArtifactByLocation(db, {
+			const location = {
 				projectPath: input.projectPath,
 				path: normalizedStorage.path,
 				storageRoot: normalizedStorage.storageRoot,
-			});
+			};
+			const existing = getLatestArtifactByLocation(db, location);
 
 			return pipe(
 				resolveDocId(absolutePath, existing?.docId),
@@ -409,29 +415,64 @@ const handleArtifactRegistration = (
 						TE.right({
 							docId: existing?.docId ?? generateDocId(),
 							isNew: existing == null,
+							source: existing ? "existing" : "generated",
 						}),
 				),
-				TE.map((docIdResult) => {
-					const artifactType =
-						(input.data.type as string) ?? classifyArtifactType(filePath);
-					const feature = (input.data.feature as string) ?? "unknown";
+				TE.chain((docIdResult) =>
+					TE.tryCatch(
+						async () => {
+							const artifactType =
+								(input.data.type as string) ?? classifyArtifactType(filePath);
+							const feature = (input.data.feature as string) ?? "unknown";
 
-					const artifactInput: ArtifactInput = {
-						docId: docIdResult.docId,
-						runId: input.runId,
-						path: normalizedStorage.path,
-						type: artifactType,
-						storageRoot: normalizedStorage.storageRoot,
-						projectPath: input.projectPath,
-						projectId: run.projectId ?? undefined,
-						feature,
-						step: input.step,
-						subflow: input.data.subflow === true,
-					};
+							// Re-check the location inside a write transaction so
+							// concurrent first registrations converge on one doc_id
+							// instead of inserting two rows. Frontmatter identity is
+							// authoritative and never overridden by the re-check.
+							const register = db.transaction(() => {
+								const docId =
+									docIdResult.source === "frontmatter"
+										? docIdResult.docId
+										: (getLatestArtifactByLocation(db, location)?.docId ??
+											docIdResult.docId);
 
-					upsertArtifact(db, artifactInput);
-					return { docId: docIdResult.docId };
-				}),
+								const artifactInput: ArtifactInput = {
+									docId,
+									runId: input.runId,
+									path: normalizedStorage.path,
+									type: artifactType,
+									storageRoot: normalizedStorage.storageRoot,
+									projectPath: input.projectPath,
+									projectId: run.projectId ?? undefined,
+									feature,
+									step: input.step,
+									subflow: input.data.subflow === true,
+								};
+
+								upsertArtifact(db, artifactInput);
+								return docId;
+							});
+							const docId = register.immediate() as string;
+
+							if (docId !== docIdResult.docId) {
+								// A concurrent registration won the race; re-point the
+								// file at the winning identity. Best-effort: the row is
+								// already correct and the next emit reconverges anyway.
+								try {
+									await overwriteDocIdFrontmatter(absolutePath, docId);
+								} catch {
+									// File may be gone or unwritable; ignore.
+								}
+							}
+
+							return { docId };
+						},
+						(error) =>
+							runtimeError(
+								`Failed to register artifact for ${filePath}: ${error instanceof Error ? error.message : String(error)}`,
+							),
+					),
+				),
 			);
 		}),
 	);


### PR DESCRIPTION
## Problem

Artifact registration derives document identity solely from markdown frontmatter. Two paths mint a fresh `doc_id` — and therefore a **duplicate `artifacts` row for the same file** — on every registration:

1. **Non-markdown artifacts** (`tasks.json`): `resolveDocId` generates a new UUID per emit, unconditionally.
2. **Markdown rewritten without frontmatter**: agents that rewrite a file with `Write` and drop the `rp1_doc_id` frontmatter lose the identity, and the next emit mints a new one.

Observed damage in a live DB: one run accumulated **8 duplicate rows for a single `tasks.md`** (registered 8 times over 4 hours), 129 duplicate groups / 295 redundant rows overall. Stale duplicate rows also become permanently unresolvable (the file's frontmatter now carries a different doc_id), feeding slow full-tree reconciliation scans in Arcade.

This is the surviving live portion of the April `artifact-loading-metadata-drift` investigation (`.rp1/work/notes/artifact-loading-metadata-drift-20260412.md`). The original storage_root drift from that note has not recurred since April — the emit-time normalization guard makes it impossible at write time.

## Fix

`handleArtifactRegistration` now looks up the most recently registered file artifact at the same `(project_path, path, storage_root)` before resolving a doc_id:

- **Markdown with frontmatter**: unchanged — the embedded `rp1_doc_id` stays authoritative.
- **Markdown without frontmatter**: reuses the existing row's doc_id and re-injects it into the file, healing rewrites that stripped frontmatter.
- **Non-markdown files**: reuse the existing row's doc_id across emits instead of minting one per registration.
- **Unreadable-file fallback**: also prefers the existing doc_id.

Re-registering the same file now refreshes the existing artifact row (upsert by doc_id) instead of inserting a duplicate.

## Testing

- Two new regression tests: frontmatter-stripped markdown re-registration keeps the doc_id, heals the file, and leaves exactly one row; non-markdown re-registration keeps the doc_id and leaves exactly one row.
- Full CLI suite: 3581 pass / 23 skip; the single failure (`command-cli.test.ts` rp1-root-dir) fails identically on `main` in this environment (worktree vs registered project root) and is unrelated.
- Typecheck and biome clean.

🤖 Generated using: 🎮 [rp1.run](https://rp1.run)