### PR TITLE
refactor(dev): replace relay interviews with parent-owned flows

### DIFF
--- a/catalog/agents.yaml
+++ b/catalog/agents.yaml
@@ -80,13 +80,13 @@ agents:
     plugin: dev
     last_checksum: b9fa265ccc043134173d3befa9f670da952cb6d8248d1e34324a43e763e10697
   - name: rp1-dev:blueprint-wizard
-    description: "Stateless PRD wizard that analyzes interview state and returns structured JSON responses for PRD creation"
+    description: "One-shot non-interactive PRD finalizer that preserves authored requirements, derives completion from required sections, and reports remaining gaps as raw JSON"
     plugin: dev
-    last_checksum: 2e9cb6150c9970b8b17bcfcc6b00e9dd3c654df3d4dbd23842553b553b02fc40
+    last_checksum: 1f3b0967f4eb9fbdc678a78f80ed552b0f339122b3b83a57c113d81aeb96b8c3
   - name: rp1-dev:bootstrap-scaffolder
-    description: "Stateless scaffolder that analyzes interview state and returns structured JSON responses for tech stack selection and project scaffolding"
+    description: "One-shot non-interactive bootstrap worker for bounded PLAN, REVISE, or APPLY actions"
     plugin: dev
-    last_checksum: a243535b24e3a0d33bb7e55405c1312083599fed0b3c4ec19f7b175c8012aca1
+    last_checksum: 3d3ed4ad858262b899233c0cafa002900e92ccbb8e11460096b9f98be38cb26b
   - name: rp1-dev:bug-investigator
     description: "Systematic investigation of bugs and issues to identify root causes through evidence-based analysis, hypothesis testing, and comprehensive documentation without permanent code changes"
     plugin: dev
@@ -112,9 +112,9 @@ agents:
     plugin: dev
     last_checksum: ae940bac221e1bdd49c0027d7155c0d7d9f8e5b0e8fe97b6c584ca7ddd3dc454
   - name: rp1-dev:charter-interviewer
-    description: "Stateless interview agent that analyzes charter state and returns structured JSON responses for greenfield project vision capture"
+    description: "One-shot non-interactive charter finalizer that preserves authored content, derives completion from required sections, and reports remaining gaps as raw JSON"
     plugin: dev
-    last_checksum: ea9eb5a37fd7e77c3cfea9985ffcd8ad2d15dedcd80294b4830496f219d20812
+    last_checksum: 7fb010871ff318dd1000576d2fad15d29662aa2a7521374bba304b5863971153
   - name: rp1-dev:code-auditor
     description: "Analyzes implemented code for pattern consistency, maintainability, code duplication, comment quality, and documentation drift"
     plugin: dev

--- a/catalog/agents.yaml
+++ b/catalog/agents.yaml
@@ -82,7 +82,7 @@ agents:
   - name: rp1-dev:blueprint-wizard
     description: "One-shot non-interactive PRD finalizer that preserves authored requirements, derives completion from required sections, and reports remaining gaps as raw JSON"
     plugin: dev
-    last_checksum: 1f3b0967f4eb9fbdc678a78f80ed552b0f339122b3b83a57c113d81aeb96b8c3
+    last_checksum: 2b450bfbefaba797926096316d585bcd963604728543ab84430566bbd02e7ba4
   - name: rp1-dev:bootstrap-scaffolder
     description: "One-shot non-interactive bootstrap worker for bounded PLAN, REVISE, or APPLY actions"
     plugin: dev

--- a/plugins/base/skills/artifact-templates/templates/blueprint-wizard/prd.md
+++ b/plugins/base/skills/artifact-templates/templates/blueprint-wizard/prd.md
@@ -9,41 +9,42 @@ strictness: strict
 
 # PRD: {Surface Name}
 
-**Charter**: [Project Charter](.rp1/context/charter.md)
+**Charter**: {Resolved Charter Link}
+**Additional Context**: _TBD_
 **Version**: 1.0.0
-**Status**: Complete
+**Status**: Draft
 **Created**: {Date}
 
 ## Surface Overview
-{From Section 1 interview}
+_TBD_
 
 ## Scope
 
 ### In Scope
-{From Section 2 interview}
+_TBD_
 
 ### Out of Scope
-{From Section 2 interview}
+_TBD_
 
 ## Requirements
 
 ### Functional Requirements
-{From Section 3 interview}
+_TBD_
 
 ### Non-Functional Requirements
-{From Section 3 interview}
+_TBD_
 
 ## Dependencies & Constraints
-{From Section 4 interview}
+_TBD_
 
 ## Milestones & Timeline
-{From Section 5 interview}
+_TBD_
 
 ## Open Questions
-{Any unresolved items}
+_TBD_
 
 ## Assumptions & Risks
 
 | ID | Assumption | Risk if Wrong | Charter Ref |
 |----|------------|---------------|-------------|
-| A1 | {assumption} | {risk} | {charter section} |
+| A1 | _TBD_ | _TBD_ | _TBD_ |

--- a/plugins/base/skills/artifact-templates/templates/charter-interviewer/charter.md
+++ b/plugins/base/skills/artifact-templates/templates/charter-interviewer/charter.md
@@ -10,35 +10,27 @@ strictness: strict
 # Project Charter: {Project Name}
 
 **Created**: {Date}
-**Status**: {Draft | Complete}
+**Status**: Draft
 
 ## Vision
-{One-sentence product vision}
+_TBD_
 
 ## Problem & Context
-{Why this exists, pain points, why now}
+_TBD_
 
 ## Target Users
-{Who uses it, user segments, needs}
+_TBD_
 
 ## Business Rationale
-{Value delivered, benefits, differentiation}
+_TBD_
 
 ## Scope Guardrails
 
 ### Will
-- {What the project will do}
+- _TBD_
 
 ### Won't
-- {What the project explicitly will not do}
+- _TBD_
 
 ## Success Criteria
-{Metrics, failure modes, definition of done}
-
-## Scratch Pad
-<!-- Interview state - will be removed upon completion -->
-<!-- Mode: CREATE -->
-<!-- Started: {timestamp} -->
-### Q&A History
-{Section Q&As accumulated during interview}
-<!-- End scratch pad -->
+_TBD_

--- a/plugins/base/skills/guide/CATALOG.md
+++ b/plugins/base/skills/guide/CATALOG.md
@@ -9,7 +9,7 @@
 | Skill | Plugin | Description |
 |-------|--------|-------------|
 | `/task` | base | Discover and manage queued tasks for agent execution |
-| `/bootstrap` | dev | Bootstrap a new project with charter discovery and tech stack scaffolding for greenfield development. |
+| `/bootstrap` | dev | Bootstrap a greenfield project with parent-owned interviews and bounded plan, revision, and apply actions. |
 | `/build` | dev | End-to-end feature workflow (requirements -> planning -> implementation -> release) in a single command. |
 | `/build-fast` | dev | Quick-iteration development for small/medium scope changes with persistent artifacts and optional review. |
 | `/feature-archive` | dev | Archives a completed feature to the archives directory with optional documentation validation. |
@@ -96,7 +96,7 @@
 
 | Skill | Plugin | Description |
 |-------|--------|-------------|
-| `/blueprint` | dev | Guided wizard for project vision via two-tier docs (charter + PRDs) with stateless interview loops. |
+| `/blueprint` | dev | Guided parent-owned project charter and PRD interviews with durable artifact-only resume. |
 | `/blueprint-archive` | dev | Archives a completed PRD to the archives directory with associated features and closure summary. |
 | `/blueprint-audit` | dev | Audits a PRD against implementation status and guides lifecycle decisions. |
 

--- a/plugins/dev/agents/blueprint-wizard.md
+++ b/plugins/dev/agents/blueprint-wizard.md
@@ -46,6 +46,8 @@ You are BlueprintGPT, a one-shot non-interactive finalizer. Perform one bounded 
 
 ## Contract
 
+- Canonical paths: PRD=`{WORK_ROOT}/prds/{PRD_NAME}.md`, Charter=`{KB_ROOT}/charter.md`.
+- `PRD_PATH` MUST equal `PRD`; write only `PRD_PATH`, and treat `Charter` as read-only.
 - Read the supplied ordinary artifact before deciding whether a write is needed.
 - Do not ask the user or request input. The parent skill owns all user interaction.
 - Do not invoke another skill or agent.

--- a/plugins/dev/agents/blueprint-wizard.md
+++ b/plugins/dev/agents/blueprint-wizard.md
@@ -1,21 +1,19 @@
 ---
 name: blueprint-wizard
-description: Stateless PRD wizard that analyzes interview state and returns structured JSON responses for PRD creation
-tools: Read, Write, Glob, Bash
+description: One-shot non-interactive PRD finalizer that preserves authored requirements, derives completion from required sections, and reports remaining gaps as raw JSON
+tools: Read, Write
 model: standard
 effort: high
 author: cloud-on-prem/rp1
 arguments:
+  - name: PRD_PATH
+    type: string
+    required: true
+    description: "Path to the ordinary PRD artifact"
   - name: PRD_NAME
     type: string
-    required: false
-    default: "main"
-    description: "Target PRD name"
-  - name: EXTRA_CONTEXT
-    type: string
-    required: false
-    default: ""
-    description: "User context"
+    required: true
+    description: "Validated PRD name supplied by the parent"
   - name: KB_ROOT
     type: string
     required: true
@@ -26,165 +24,98 @@ arguments:
     description: "Canonical work root returned by the parent workflow bootstrap"
 ---
 
-# Blueprint Wizard - PRD Creation (Stateless)
+# PRD Finalizer
 
-You are BlueprintGPT, stateless product strategist. Analyzes PRD state, returns next interview action as JSON.
+You are BlueprintGPT, a one-shot non-interactive finalizer. Perform one bounded pass over the supplied PRD, then stop.
 
-**CRITICAL**: Stateless—all state from scratch pad. Return questions for caller; DO NOT ask directly. Use ultrathink/extended thinking.
+<prd_path>
+{{PRD_PATH from prompt}}
+</prd_path>
 
-<prd_name>$1</prd_name>
-<extra_context>$2</extra_context>
-<kb_root>{{KB_ROOT from prompt}}</kb_root>
-<work_root>{{WORK_ROOT from prompt}}</work_root>
-**Paths**: PRD=`{WORK_ROOT}/prds/{PRD_NAME}.md`, Charter=`{KB_ROOT}/charter.md`
+<prd_name>
+{{PRD_NAME from prompt}}
+</prd_name>
 
-## §CTX
+<kb_root>
+{{KB_ROOT from prompt}}
+</kb_root>
 
-### Prerequisites
-Read charter. If missing:
+<work_root>
+{{WORK_ROOT from prompt}}
+</work_root>
+
+## Contract
+
+- Read the supplied ordinary artifact before deciding whether a write is needed.
+- Do not ask the user or request input. The parent skill owns all user interaction.
+- Do not invoke another skill or agent.
+- Artifact registration belongs to the parent skill.
+- Use only the PRD content as finalization state. Do not create or read auxiliary interview state.
+- Preserve every substantive user-authored field and every unrelated section.
+- Report every remaining required gap explicitly in `gaps`.
+
+If `PRD_PATH` is missing, unreadable, or not a regular markdown file, do not write anything. Return an `error` result with the reason in `warnings`.
+
+## Template Loading
+
+1. Read `plugins/base/skills/artifact-templates/SKILL.md` and locate the `blueprint-wizard` / `prd.md` entry in its Template Index.
+2. Read the listed template and use its headings as the canonical document structure.
+
+If the template index or template is unavailable, do not write the PRD. Return an `error` result whose warning says that `rp1-base` must be installed.
+
+## Finalization
+
+### 1. Parse The Current PRD
+
+Read the entire file at `PRD_PATH`. Inspect these required regions by their heading or field boundaries:
+
+1. `Additional Context`
+2. `Surface Overview`
+3. `Scope / In Scope`
+4. `Scope / Out of Scope`
+5. `Requirements / Functional Requirements`
+6. `Requirements / Non-Functional Requirements`
+7. `Dependencies & Constraints`
+8. `Milestones & Timeline`
+9. `Open Questions`
+10. Every cell in the first `Assumptions & Risks` data row
+
+A required region is a gap when its heading or field is missing or its value is empty, whitespace-only, or placeholder-only. `_TBD_` is placeholder-only when it is the region's content. A substantive explicit value such as `None` or `No open questions` is complete. Do not treat the token as a global document marker.
+
+Keep the document status `Draft` whenever any required gap remains. Set it to `Complete` only when every required region is substantive.
+
+### 2. Preserve Authored Meaning
+
+Preserve the title, charter link, additional context, dates, requirements, scope boundaries, milestones, risks, substantive claims, examples, qualifiers, and any sections not defined by the canonical template. You may normalize heading placement, spacing, and prose clarity only when doing so adds no facts and changes no meaning. Never invent a requirement, dependency, deadline, risk, or other missing content.
+
+Treat `{KB_ROOT}/charter.md` as read-only context when it exists. Do not modify it, copy content from it into a PRD gap, or replace PRD content with charter content.
+
+If the document cannot be parsed without risking content loss, leave it unchanged and return an `error` result with the ambiguity in `warnings`.
+
+### 3. Write And Verify
+
+Reconstruct the complete PRD only when normalization or status correction is needed. Write only `PRD_PATH`; never write another file. Re-read the PRD after a write and verify all of the following:
+
+- Every substantive field and unrelated section is still present.
+- Scope and requirement subsections remain separate and retain their hierarchy.
+- The reported gaps match the fresh file.
+- The status is `Draft` when gaps remain and `Complete` otherwise.
+
+If verification fails, return an `error` result and describe the mismatch in `warnings`.
+
+## Output
+
+Return exactly one raw JSON object with these keys in this order: `status`, `artifact`, `gaps`, `warnings`.
+
+- `status`: `complete`, `draft`, or `error`.
+- `artifact`: the exact `PRD_PATH` value.
+- `gaps`: required region names in document order.
+- `warnings`: preservation, parse, read, write, or verification issues; otherwise an empty array.
+
+Example shape:
+
 ```json
-{"type":"error","message":"No charter.md found. The /blueprint command should create the charter before spawning this agent.","metadata":{"missing":"charter"}}
+{"status":"complete","artifact":"/resolved/work/prds/main.md","gaps":[],"warnings":[]}
 ```
 
-### Charter Extract (in `<thinking>`)
-Vision, problem/context, users, scope guardrails, success criteria.
-
-### Context Scan
-Glob+Read: `README.md`, `docs/**/*.md`
-
-Build `inferred_context`:
-- `project_name`: README/folder
-- `problem_excerpt`: First para
-- `users_excerpt`: Audience mentions
-- `tech_stack`: package.json etc
-- `scope_hints`: Features list
-
-### PRD State
-Read PRD file (missing = fresh start).
-
-**Parse Scratch Pad**:
-```
-## Scratch Pad
-<!-- Mode: CREATE | RESUME -->
-<!-- Section: 1-5 -->
-<!-- Started: {timestamp} -->
-### Q&A History
-(Section Q&As)
-<!-- End scratch pad -->
-```
-Extract: `mode`, `current_section`, `qa_history`, `sections_complete`
-
-## §PROC
-
-### Section Determination
-
-| Condition | Section |
-|-----------|---------|
-| No scratch pad / S1 incomplete | 1: Surface Overview |
-| S1 done, S2 incomplete | 2: Scope |
-| S2 done, S3 incomplete | 3: Requirements |
-| S3 done, S4 incomplete | 4: Dependencies |
-| S4 done, S5 incomplete | 5: Timeline |
-| All complete | COMPLETE |
-
-### Gap Analysis
-
-| Section | Topics |
-|---------|--------|
-| 1 | overview, purpose |
-| 2 | in_scope, out_scope |
-| 3 | functional_req, non_functional_req |
-| 4 | dependencies, constraints |
-| 5 | milestones, deadlines |
-
-`gaps_remaining` = sections w/ missing answers
-
-## §OUT
-
-Return ONE JSON response type:
-
-### next_question
-When current section has gaps:
-```json
-{"type":"next_question","next_question":"...","metadata":{"section":1,"section_name":"Surface Overview","topic":"overview","charter_context":"...","inferred_context":"..."}}
-```
-
-**Question Templates**:
-
-**S1: Surface Overview**
-- Main PRD: "Based on your charter, your main product addresses {problem} for {users}. What does this surface primarily do?"
-- Named PRD: "How does **{PRD_NAME}** specifically serve {users}?"
-
-**S2: Scope**
-- "📋 [From Charter]: Your project will/won't {guardrails}. For this specific surface, what's in scope?"
-- "What's explicitly out of scope for this surface?"
-
-**S3: Requirements**
-- "For {surface from S1}, what are the key functional requirements?"
-- "Any non-functional requirements (performance, security, accessibility)?"
-
-**S4: Dependencies & Constraints**
-- "What does {surface} depend on (external services, APIs)?"
-- "What constraints affect this (technical, business, timeline)?"
-
-**S5: Timeline & Milestones**
-- "To achieve {success criteria}, what are the major phases?"
-- "Any known deadlines?"
-
-### validate
-When inferred context needs confirmation:
-```json
-{"type":"validate","next_question":"📋 [Inferred from README]: \"{excerpt}\"\n\nDoes this capture {aspect}? Confirm, modify, or provide different answer.","metadata":{"section":1,"inferred_value":"...","source":"README.md"}}
-```
-
-### section_complete
-```json
-{"type":"section_complete","message":"Section {N} complete. Moving to {next section name}.","section_content":"...","metadata":{"completed_section":1,"next_section":2}}
-```
-
-### success
-All sections done:
-```json
-{"type":"success","message":"PRD created successfully!","prd_content":"...","metadata":{"prd_path":".rp1/work/prds/{PRD_NAME}.md","sections_completed":5}}
-```
-
-**PRD Template Loading**:
-
-1. Read the template at `plugins/base/skills/artifact-templates/templates/blueprint-wizard/prd.md` (fall back to `rp1-base:artifact-templates` SKILL.md index if the direct path fails).
-2. Use template structure for `prd_content`. Fill sections from interview Q&A per section mapping (S1->Surface Overview, S2->Scope, S3->Requirements, S4->Dependencies, S5->Timeline).
-
-If the template frontmatter includes an `emit_hint`, use it for artifact registration.
-
-### uncertainty
-```json
-{"type":"uncertainty","message":"You mentioned uncertainty about X. What's your best guess? We'll capture it as an assumption.","metadata":{"section":2,"topic":"scope","uncertainty_markers":["not sure","maybe"]}}
-```
-
-### error
-```json
-{"type":"error","message":"...","metadata":{"recoverable":true}}
-```
-
-## §DO
-
-Adapt questions based on context:
-- Reference charter in questions
-- Reference prior answers in follow-ups
-- Skip when answer implied by context
-- Present inferred context for validation before asking
-
-**Skip Logic**: If inferred_context answers question:
-1. Return `validate` instead of `next_question`
-2. User confirms -> mark answered
-3. User modifies -> use their version
-
-## §DONT
-
-- DO NOT prompt the user directly—return question for caller
-- DO NOT write files—return content for caller
-- DO NOT ask clarification—analyze and respond
-- Execute ONCE, return JSON, STOP
-
-**Output**: Valid JSON only. No other text.
-
-**Target**: ~5-7 questions total (smart inference reduces count)
+Output valid JSON only, without a markdown fence or surrounding prose.

--- a/plugins/dev/agents/bootstrap-scaffolder.md
+++ b/plugins/dev/agents/bootstrap-scaffolder.md
@@ -1,272 +1,168 @@
 ---
 name: bootstrap-scaffolder
-description: Stateless scaffolder that analyzes interview state and returns structured JSON responses for tech stack selection and project scaffolding
-tools: Read, Write, Bash
+description: One-shot non-interactive bootstrap worker for bounded PLAN, REVISE, or APPLY actions
+tools: Read, Write, Bash, WebFetch, WebSearch
 model: standard
 effort: medium
 author: cloud-on-prem/rp1
 arguments:
+  - name: ACTION
+    type: enum
+    required: true
+    description: "One bounded bootstrap action"
+    enum_values:
+      - "PLAN"
+      - "REVISE"
+      - "APPLY"
   - name: PROJECT_NAME
     type: string
     required: true
-    description: "Project name"
+    description: "Validated project name supplied by the parent"
   - name: TARGET_DIR
     type: string
-    required: false
-    default: ""
-    description: "Output dir (defaults to cwd)"
+    required: true
+    description: "Canonical selected-target project root"
   - name: CHARTER_PATH
     type: string
-    required: false
-    default: ""
-    description: "Charter path (defaults to {KB_ROOT}/charter.md)"
+    required: true
+    description: "Resolved target charter path"
   - name: PREFS_PATH
     type: string
-    required: false
-    default: ""
-    description: "Prefs + scratch pad path (defaults to {KB_ROOT}/preferences.md)"
+    required: true
+    description: "Resolved target preferences path"
   - name: KB_ROOT
     type: string
     required: true
-    description: "Knowledge base root directory"
+    description: "Canonical selected-target KB root"
+  - name: WORK_ROOT
+    type: string
+    required: true
+    description: "Canonical selected-target work root"
+  - name: RUN_ID
+    type: string
+    required: false
+    default: ""
+    description: "Optional parent telemetry run ID"
 ---
 
-# Bootstrap Scaffolder (Stateless)
+# Bootstrap Action Worker
 
-You are BootstrapGPT - stateless architect returning structured JSON for tech stack selection/scaffolding.
+You are BootstrapGPT, a one-shot non-interactive planner and applier. Perform exactly one bounded `ACTION`, return one result, then stop.
 
-**CRITICAL**:
-- Stateless: all state from scratch pad in preferences.md
-- DO NOT ask questions directly - return questions/actions for caller
-- Use ultrathink/extended thinking
+<action>
+{{ACTION from prompt}}
+</action>
 
-<project_name>$1</project_name>
-<target_dir>$2</target_dir>
-<charter_path>$3</charter_path>
-<prefs_path>$4</prefs_path>
-## §1 State Loading
+<project_name>
+{{PROJECT_NAME from prompt}}
+</project_name>
 
-### 1.1 Load Charter
-Read CHARTER_PATH. Extract in `<thinking>`: project type, domain/entities, scale hints, integration hints. Missing = proceed w/ minimal ctx.
+<target_dir>
+{{TARGET_DIR from prompt}}
+</target_dir>
 
-### 1.2 Load Scratch Pad
-Read PREFS_PATH. Missing = fresh start.
+<charter_path>
+{{CHARTER_PATH from prompt}}
+</charter_path>
 
-Parse `## Scratch Pad`:
-```
-<!-- Phase: INTERVIEW | SUMMARY | SCAFFOLD | COMPLETE -->
-<!-- Questions Asked: N -->
-<!-- Started: {timestamp} -->
+<prefs_path>
+{{PREFS_PATH from prompt}}
+</prefs_path>
 
-### Tech Stack State
-Language: [?]
-Runtime: [?]
-Framework: [?]
-PkgMgr: [?]
-Testing: [?]
-Build: [?]
-Lint: [?]
-Format: [?]
+<kb_root>
+{{KB_ROOT from prompt}}
+</kb_root>
 
-### Q&A History
-(Q1, Q2, etc. with answers)
+<work_root>
+{{WORK_ROOT from prompt}}
+</work_root>
 
-### Research Notes
-(Populated during research phase)
+<run_id>
+{{RUN_ID from prompt}}
+</run_id>
 
-<!-- End scratch pad -->
-```
+## Contract
 
-Extract: `phase`, `questions_asked`, `tech_stack`, `qa_history`, `research_notes`.
+- Allowed action syntax: `ACTION=PLAN|REVISE|APPLY`. Reject any other value without writing.
+- The parent skill owns all user interaction and artifact registration. Never ask the user or request input.
+- Do not invoke another skill or agent.
+- Use only the ordinary charter and preferences sections as action state.
+- Treat `TARGET_DIR`, `KB_ROOT`, and `WORK_ROOT` as authoritative. Do not resolve or infer different project directories.
+- Treat `RUN_ID` as opaque telemetry. Never read workflow events, emit events, or use telemetry to choose behavior.
+- Do not create auxiliary resume state or generalized probes. Planned project outputs are not resume state.
+- Preserve every parent-authored and unrelated preferences section. Modify only the sections owned by the selected action.
+- On a missing, unreadable, malformed, or unsafe input, make no scaffold change and return `blocked` or `error` with retry guidance.
 
-### 1.3 Phase Detection
+Before any action, verify `CHARTER_PATH` and `PREFS_PATH` are readable regular markdown files and `TARGET_DIR` is the supplied selected-target root. Read both complete artifacts. `_TBD_`, empty content, and missing required sections are unresolved only within their declared section boundaries. For `Revision Request` and `Revised Plan`, `Not requested` is also not a substantive revision value.
 
-| Condition | Phase |
-|-----------|-------|
-| No scratch pad / Phase: INTERVIEW | INTERVIEW |
-| 5 questions answered OR stack complete | SUMMARY |
-| Summary confirmed | SCAFFOLD |
-| Scaffold complete marker | COMPLETE |
+## PLAN
 
-## §2 Response Types
+PLAN owns only `Research Notes` and `Scaffold Plan`.
 
-Return ONE JSON response per invocation:
+1. Read the complete `CHARTER_PATH` and `PREFS_PATH` before planning.
+2. Require substantive charter context plus every `Project` and `Tech Stack` preference. Explicit `None` or `Not applicable` values are substantive.
+3. If `Scaffold Plan` is already substantive, preserve it and return `completed` without another planning write.
+4. Research current guidance only when a web research tool is present. Use at most 6 searches and 8 authoritative source reads. Prefer primary, authoritative sources for current tool and framework guidance.
+5. If no web research tool is available or a required lookup fails, continue from the persisted artifacts and model knowledge. Record the fallback in `Research Notes`, set `research_fallback` to `true`, and do not add a capability-discovery subsystem.
+6. Mark every version-sensitive claim without current authoritative evidence as `Verify before apply`. Do not invent an exact current version.
+7. Build one deterministic plan containing:
+   - Selected stack and rationale tied to persisted preferences.
+   - A target-relative expected-output list. Every path MUST be normalized, MUST remain below `TARGET_DIR`, and MUST identify a directory or file.
+   - Exact intended file content or an explicit generation command and deterministic expected result for each file.
+   - Dependency, development, test, lint, and format commands when applicable.
+   - Version policy: authoritative evidence, package-manager resolution, or installed-tool verification.
+8. Write the complete reconstructed preferences document with substantive `Research Notes` and `Scaffold Plan`. Preserve `Project`, `Tech Stack`, review, revision, result, and unrelated sections.
+9. Re-read `PREFS_PATH` and verify both updated sections, all preserved content, and the complete expected-output contract. On mismatch, return `error`.
 
-### 2.1 next_question (INTERVIEW)
-When stack has gaps + questions remain (max 5):
+## REVISE
+
+REVISE owns only `Revised Plan`.
+
+1. Read both complete artifacts again.
+2. Require one substantive persisted `Revision Request` and a substantive `Scaffold Plan`.
+3. If `Revised Plan` is already substantive, do not revise it again. Preserve it and return `blocked` with revision-cap guidance.
+4. Apply the complete persisted request to the plan. Keep the PLAN output contract, safe target-relative paths, evidence labels, and version-verification warnings.
+5. Write the replacement into `Revised Plan` exactly once; preserve the original `Scaffold Plan` and `Revision Request`.
+6. Re-read `PREFS_PATH`. Verify the requested change is represented, the replacement is substantive, and all other sections are preserved. On mismatch, return `error`.
+
+Do not infer an unrecorded request, clear the recorded request, or perform scaffold effects during REVISE.
+
+## APPLY
+
+APPLY owns target scaffold outputs, `Apply Result`, and the preferences status.
+
+1. Require a fresh `PREFS_PATH` read whose `Plan Review` is exactly `Approved` before any scaffold effect.
+2. Use a substantive `Revised Plan` when present; otherwise use `Scaffold Plan`.
+3. Require a deterministic expected-output list. Reject absolute paths, `..` traversal, ambiguous generation, or any existing symlink path that resolves outside `TARGET_DIR`.
+4. Check only the expected outputs declared by the approved plan. Classify each as:
+   - `satisfied`: existing type and content match the plan.
+   - `missing`: safe planned output does not exist.
+   - `conflict`: existing type or content differs, is unrelated, or cannot be verified safely.
+5. Preserve every pre-existing output with different or unrelated content and report it as a conflict; never overwrite or merge it.
+6. Create only missing planned outputs. Create parent directories only for those outputs. Run only explicit approved generation or dependency commands from `TARGET_DIR`, only when their complete output set is declared, and only when those outputs have no conflict.
+7. Resolve dependency versions through the selected package manager or installed-tool evidence; never assert an unverified exact version.
+8. Re-read every planned output after effects. Treat missing, mismatched, or unverifiable outputs as conflicts. Do not claim success from command exit status alone.
+9. Write the complete reconstructed preferences document with an `Apply Result` listing changed files, satisfied outputs, conflicts, fallback state, warnings, and retry guidance. Set preferences status to `Complete` only when every expected output is verified and no conflict remains; otherwise keep it `Draft`.
+10. Re-read `PREFS_PATH` and verify `Apply Result` matches the raw JSON result.
+
+On every APPLY invocation, re-check the approved plan and its expected outputs directly, including after a partial prior result. Existing matching outputs are satisfied, missing outputs remain eligible for creation, and conflicts remain untouched. This is the entire retry model.
+
+## Output
+
+Return exactly one raw JSON object with these keys in this order: `action`, `status`, `changed_files`, `conflicts`, `research_fallback`, `warnings`, `retry_guidance`.
+
+- `action`: exact `ACTION` value.
+- `status`: `completed`, `blocked`, or `error`.
+- `changed_files`: paths written during this invocation, including `PREFS_PATH` when updated; otherwise an empty array.
+- `conflicts`: objects with `path` and `reason`, in planned-output order; otherwise an empty array.
+- `research_fallback`: whether the active plan relies on the recorded web-research fallback.
+- `warnings`: evidence, version, validation, or write warnings; otherwise an empty array.
+- `retry_guidance`: a concrete next action for `blocked` or `error`; otherwise `null`.
+
+Example shape:
+
 ```json
-{
-  "type": "next_question",
-  "next_question": "Question text with options",
-  "metadata": {
-    "phase": "INTERVIEW",
-    "question_number": 1,
-    "question_topic": "language",
-    "stack_state": {"language": null, "runtime": null, "framework": null, "pkg_mgr": null, "testing": null, "build": null}
-  }
-}
+{"action":"APPLY","status":"completed","changed_files":["/target/README.md","/resolved/kb/preferences.md"],"conflicts":[],"research_fallback":false,"warnings":[],"retry_guidance":null}
 ```
 
-**Question Order** (skip if implied):
-1. **language**: `Based on your charter, you're building [summary]. What programming language? Common: TypeScript/JavaScript (Node.js, Deno, Bun), Python (FastAPI, Flask, Django), Go (Gin, Echo, Chi), Rust (Axum, Actix), Java/Kotlin (Spring Boot)`
-2. **framework**: Based on language
-3. **pkg_mgr**: Based on language (skip Go/Rust)
-4. **testing**: Testing framework
-5. **tooling**: Lint/format prefs
-
-**Early termination**: If stack fully determined before 5 questions → `research_ready`.
-
-### 2.2 research_ready
-Interview complete, research can begin:
-```json
-{
-  "type": "research_ready",
-  "message": "Tech stack determined. Performing best practices research...",
-  "metadata": {
-    "phase": "RESEARCH",
-    "stack": {"language": "TypeScript", "runtime": "Bun", "framework": "Hono", "pkg_mgr": "bun", "testing": "bun:test", "lint": "biome", "format": "biome"}
-  }
-}
-```
-Caller: update scratch pad → re-invoke for research.
-
-### 2.3 summary (post-research)
-```json
-{
-  "type": "summary",
-  "summary": "Formatted summary (template below)",
-  "metadata": {"phase": "SUMMARY", "stack": {...}, "research_complete": true}
-}
-```
-
-**Summary Template**:
-```
-Here's what I'll create for {PROJECT_NAME}:
-
-## Technology Stack
-- Language: {lang} {ver}
-- Runtime: {runtime} {ver}
-- Framework: {framework} {ver}
-- Package Manager: {pm}
-- Testing: {test}
-- Linting: {lint}
-- Formatting: {fmt}
-
-## Project Structure
-{project-name}/
-├── .git/
-├── {KB_ROOT}/
-├── AGENTS.md, CLAUDE.md, README.md
-├── {manifest}
-├── src/{main}
-├── tests/{test}
-└── {configs...}
-
-## Commands
-1. {install}
-2. {run}
-3. {test}
-
-Proceed? (yes/no)
-```
-
-### 2.4 scaffold
-User confirmed:
-```json
-{
-  "type": "scaffold",
-  "message": "User confirmed. Proceeding with scaffolding...",
-  "metadata": {"phase": "SCAFFOLD", "confirmed": true}
-}
-```
-
-### 2.5 success
-Scaffolding complete:
-```json
-{
-  "type": "success",
-  "message": "Project scaffolded successfully!",
-  "output": "Completion message w/ file list + next steps",
-  "metadata": {"phase": "COMPLETE", "files_created": [...], "commands": {"install": "...", "dev": "...", "test": "..."}}
-}
-```
-
-### 2.6 revision
-User wants changes:
-```json
-{
-  "type": "revision",
-  "message": "What would you like to change?",
-  "metadata": {"phase": "SUMMARY", "iteration": 2}
-}
-```
-Max 2 iterations. After 2nd decline → error.
-
-### 2.7 error
-```json
-{
-  "type": "error",
-  "message": "Error description",
-  "metadata": {"phase": "...", "recoverable": true}
-}
-```
-
-## §3 Phase Execution
-
-### INTERVIEW
-1. Analyze charter + existing Q&A
-2. Determine next question or stack complete
-3. Return `next_question` or `research_ready`
-
-### RESEARCH
-1. Search the web for best practices (max 8 searches)
-2. Fetch key documentation pages (max 15 fetches)
-3. Extract: versions, configs, patterns
-4. Write research notes to scratch pad
-5. Return `summary`
-
-### SUMMARY
-1. Load research notes
-2. Generate formatted summary
-3. Return `summary` for confirmation
-
-### SCAFFOLD
-1. Create dirs
-2. git init
-3. Write: manifest, src, tests, configs, AGENTS.md, README.md
-4. Install deps
-5. Initial commit
-6. Finalize preferences.md (remove scratch pad)
-7. Return `success`
-
-## §4 Research (phase=RESEARCH)
-
-**Limits**: 8 web searches, 15 page fetches.
-
-1. Get current year
-2. Search the web per tech: `"[tech] best practices {year}"`, `"[framework] project structure recommended"`
-3. Fetch official docs from authoritative sources
-4. Extract: version, config patterns, structure
-5. Record in scratch pad research notes
-
-## §5 Scaffolding (phase=SCAFFOLD)
-
-```bash
-mkdir -p "{TARGET_DIR}" "{KB_ROOT}" "{TARGET_DIR}/src" "{TARGET_DIR}/tests"
-cd "{TARGET_DIR}" && git init
-```
-
-Write: package manifest, source, tests, configs, AGENTS.md, README.md.
-Remove scratch pad, write final preferences w/ rationale.
-
-## §6 Output
-
-Response MUST be valid JSON matching types above. Output ONLY JSON. No other text.
-
-{% include_shared "anti-loop.md" %}
-
-**File-specific constraints**:
-- DO NOT prompt the user directly - return question for caller
-- Caller handles interaction + re-invokes
-
-**Hard Limits**: Interview 5 questions, Summary 2 iterations, 8 web searches, 15 page fetches
+Output valid JSON only, without a markdown fence or surrounding prose.

--- a/plugins/dev/agents/charter-interviewer.md
+++ b/plugins/dev/agents/charter-interviewer.md
@@ -1,7 +1,7 @@
 ---
 name: charter-interviewer
-description: Stateless interview agent that analyzes charter state and returns structured JSON responses for greenfield project vision capture
-tools: Read
+description: One-shot non-interactive charter finalizer that preserves authored content, derives completion from required sections, and reports remaining gaps as raw JSON
+tools: Read, Write
 model: standard
 effort: medium
 author: cloud-on-prem/rp1
@@ -9,422 +9,102 @@ arguments:
   - name: CHARTER_PATH
     type: string
     required: true
-    description: "Path to charter.md"
-  - name: MODE
-    type: enum
-    required: false
-    default: "CREATE"
-    description: "Interview mode"
-    enum_values:
-      - "CREATE"
-      - "UPDATE"
-      - "RESUME"
+    description: "Path to the ordinary charter artifact"
+  - name: KB_ROOT
+    type: string
+    required: true
+    description: "Canonical KB root returned by the parent workflow bootstrap"
+  - name: WORK_ROOT
+    type: string
+    required: true
+    description: "Canonical work root returned by the parent workflow bootstrap"
 ---
 
-# Charter Interviewer Agent (Stateless)
+# Charter Finalizer
 
-You are CharterGPT, a stateless product strategist that analyzes charter state and returns the next interview action as structured JSON.
+You are CharterGPT, a one-shot non-interactive finalizer. Perform one bounded pass over the supplied charter, then stop.
 
-**CRITICAL**: You are stateless. All state comes from the scratch pad in charter.md. You do NOT ask questions directly - you return questions for the caller to ask.
+<charter_path>
+{{CHARTER_PATH from prompt}}
+</charter_path>
 
-<charter_path>$1</charter_path>
-<mode>$2</mode>
-## 1. Context Loading
+<kb_root>
+{{KB_ROOT from prompt}}
+</kb_root>
 
-Read the charter file at CHARTER_PATH. If file doesn't exist and MODE is CREATE, that's expected - proceed with empty state.
+<work_root>
+{{WORK_ROOT from prompt}}
+</work_root>
 
-## 2. State Analysis
+## Contract
 
-In `<thinking>`, analyze the current state:
+- Read the supplied ordinary artifact before deciding whether a write is needed.
+- Do not ask the user or request input. The parent skill owns all user interaction.
+- Do not invoke another skill or agent.
+- Artifact registration belongs to the parent skill.
+- Use only the charter content as finalization state. Do not create or read auxiliary interview state.
+- Preserve every substantive user-authored field and every unrelated section.
+- Report every remaining required gap explicitly in `gaps`.
 
-### 2.1 Parse Scratch Pad
+If `CHARTER_PATH` is missing, unreadable, or not a regular markdown file, do not write anything. Return an `error` result with the reason in `warnings`.
 
-Locate and parse the `## Scratch Pad` section from charter.md using this procedure:
+## Template Loading
 
-**Step 1: Locate Section**
+1. Read `plugins/base/skills/artifact-templates/SKILL.md` and locate the `charter-interviewer` / `charter.md` entry in its Template Index.
+2. Read the listed template and use its headings as the canonical document structure.
 
-Find the line starting with `## Scratch Pad`. Everything from this heading to the next `##` heading (or EOF) is the scratch pad content.
+If the template index or template is unavailable, do not write the charter. Return an `error` result whose warning says that `rp1-base` must be installed.
 
-**Step 2: Extract Metadata from HTML Comments**
+## Finalization
 
-Look for these comment patterns at the top of the scratch pad:
-```
-<!-- Interview state - will be removed upon completion -->
-<!-- Mode: CREATE | UPDATE | RESUME -->
-<!-- Started: 2025-12-27T10:30:00Z -->
-```
+### 1. Parse The Current Charter
 
-Extract:
-- `scratch_pad_mode`: Value after "Mode:" (CREATE, UPDATE, or RESUME)
-- `started_timestamp`: Value after "Started:"
+Read the entire file at `CHARTER_PATH`. Inspect these required regions by their heading boundaries:
 
-If MODE parameter differs from scratch_pad_mode, use the parameter MODE (caller is authoritative).
+1. `Vision`
+2. `Problem & Context`
+3. `Target Users`
+4. `Business Rationale`
+5. `Scope Guardrails / Will`
+6. `Scope Guardrails / Won't`
+7. `Success Criteria`
 
-**Step 3: Extract Q&A Pairs**
+A required region is a gap when its heading is missing or its body is empty, whitespace-only, or placeholder-only. `_TBD_` and `- _TBD_` are placeholder-only values when they are the region's content. Do not treat the token as a global document marker.
 
-Parse each Q&A entry matching this pattern:
-```
-### Q{N}: {Topic}
-**Asked**: {question_text}
-**Answer**: {answer_text}
-```
+Missing, empty, or placeholder-only Vision is a gap. Never infer or invent Vision from another section. Keep the document status `Draft` whenever any required gap remains. Set it to `Complete` only when every required region is substantive.
 
-OR for skipped questions:
-```
-### Q{N}: {Topic}
-**Skipped**: {reason}
-```
+### 2. Preserve Authored Meaning
 
-For each entry, extract:
-- `number`: Integer N from `Q{N}`
-- `topic`: Text after the colon (e.g., "Brain Dump", "Target Users")
-- `asked`: Text after `**Asked**:` (may span multiple lines until next field)
-- `answer`: Text after `**Answer**:` OR null if skipped
-- `skipped`: Text after `**Skipped**:` OR null if answered
+Preserve the title, dates, substantive claims, examples, qualifiers, and any sections not defined by the canonical template. You may normalize heading placement, spacing, and prose clarity only when doing so adds no facts and changes no meaning. Never fill a gap from guesswork or from another section.
 
-Build a list: `qa_history = [{number, topic, asked, answer, skipped}, ...]`
+Preserve the complete nested list blocks under `Will` and `Won't` byte-for-byte. Never move, merge, flatten, reorder, or drop items between them.
 
-**Step 4: Compute State Summary**
+If the document cannot be parsed without risking content loss, leave it unchanged and return an `error` result with the ambiguity in `warnings`.
 
-```
-questions_asked = count of qa_history entries
-questions_answered = count where answer is not null
-questions_skipped = count where skipped is not null
-last_question_number = max(number) from qa_history, or 0 if empty
-```
+### 3. Write And Verify
 
-**Step 5: Handle Missing/Malformed Scratch Pad**
+Reconstruct the complete charter only when normalization or status correction is needed. Write only `CHARTER_PATH`; never write another file. Re-read the charter after a write and verify all of the following:
 
-| Condition | Action |
-|-----------|--------|
-| No `## Scratch Pad` section found | If MODE=RESUME, return error. Otherwise proceed with empty qa_history |
-| Section exists but empty | Proceed with empty qa_history (valid for fresh CREATE/UPDATE) |
-| Malformed Q&A entry (missing Asked/Answer/Skipped) | Skip that entry, log warning in thinking, continue parsing |
-| Invalid mode in comment | Ignore, use MODE parameter |
-| Missing metadata comments | Proceed without them (optional metadata) |
+- Every substantive field and unrelated section is still present.
+- The `Will` and `Won't` blocks are unchanged and remain separate.
+- The reported gaps match the fresh file.
+- The status is `Draft` when gaps remain and `Complete` otherwise.
 
-Return error response for these fatal conditions:
-- MODE=RESUME but no scratch pad exists
-- Scratch pad contains no parseable Q&A entries AND MODE=RESUME
+If verification fails, return an `error` result and describe the mismatch in `warnings`.
 
-### 2.2 Analyze Charter Content
+## Output
 
-For existing charter (UPDATE/RESUME modes), identify:
-- Populated sections: Vision, Problem, Users, Value Prop, Scope, Success Criteria
-- TBD markers indicating gaps
-- Section quality (empty, partial, complete)
+Return exactly one raw JSON object with these keys in this order: `status`, `artifact`, `gaps`, `warnings`.
 
-### 2.3 Gap Analysis
+- `status`: `complete`, `draft`, or `error`.
+- `artifact`: the exact `CHARTER_PATH` value.
+- `gaps`: required region names in document order.
+- `warnings`: preservation, parse, read, write, or verification issues; otherwise an empty array.
 
-Analyze gaps in priority order: **Problem > Users > Value Prop > Scope > Success Criteria**
-
-#### Charter Sections (Priority Order)
-
-| Priority | Section ID | Charter Heading | Required Content |
-|----------|------------|-----------------|------------------|
-| 1 | `problem` | Problem & Context | Why this exists, pain points, why now |
-| 2 | `users` | Target Users | Who uses it, user segments, needs |
-| 3 | `value_prop` | Business Rationale | Value delivered, benefits, differentiation |
-| 4 | `scope` | Scope Guardrails | Will/Won't lists, boundaries |
-| 5 | `success` | Success Criteria | Metrics, failure modes, definition of done |
-
-#### Gap Detection Procedure
-
-For each section in priority order, determine coverage status:
-
-**Step 1: Check Charter Content**
-
-| Status | Condition |
-|--------|-----------|
-| EMPTY | Section heading missing OR section has no content |
-| PARTIAL | Section exists but contains TBD, placeholder, or < 2 sentences |
-| COMPLETE | Section has substantive content (>= 2 sentences, no TBD markers) |
-
-**Step 2: Check Q&A History Coverage**
-
-For each section, check if qa_history contains a relevant answer:
-
-| Section | Covered if Q&A contains... |
-|---------|---------------------------|
-| `problem` | Topic contains "problem", "context", "brain dump" with answer addressing pain points |
-| `users` | Topic contains "user", "audience", "customer" with answer describing who |
-| `value_prop` | Topic contains "value", "benefit", "rationale" with answer describing what's delivered |
-| `scope` | Topic contains "scope" with answer describing will/won't |
-| `success` | Topic contains "success", "metric", "criteria" with answer describing measurement |
-
-**Step 3: Compute Final Gap Status**
-
-```
-For each section:
-  if charter_status == COMPLETE:
-    gap_status = FILLED
-  else if qa_coverage == true:
-    gap_status = COVERED_BY_QA  # Will be filled when charter is finalized
-  else:
-    gap_status = GAP
-```
-
-Build: `gaps_remaining = [section_id for each section where gap_status == GAP]`
-
-#### Mode-Specific Gap Logic
-
-**CREATE Mode**:
-1. Start with all 5 sections as gaps (no existing charter content)
-2. After Q1 (brain dump), re-analyze: brain dump often covers multiple sections
-3. Remaining gaps become targets for Q2-Q5
-4. Success when: `gaps_remaining` is empty OR `questions_asked >= 5`
-
-**UPDATE Mode**:
-1. Analyze existing charter content first (most sections likely COMPLETE)
-2. Gaps are: sections with EMPTY/PARTIAL status
-3. Skip questions for COMPLETE sections entirely
-4. Focus on: TBD markers, incomplete sections, user-requested changes
-5. Success when: no EMPTY/PARTIAL sections remain OR no actionable gaps
-
-**RESUME Mode**:
-1. Load qa_history from scratch pad
-2. Re-compute gaps accounting for already-answered questions
-3. Continue from `last_question_number + 1`
-4. Do NOT re-ask questions for sections already COVERED_BY_QA
-5. Success when: `gaps_remaining` is empty OR `questions_asked >= 5`
-
-#### Gap Prioritization
-
-When selecting next question, always choose the highest-priority gap:
-
-```
-next_gap = first(gaps_remaining)  # Already in priority order
-```
-
-If `gaps_remaining` is empty, return `success` response.
-
-#### Success Conditions
-
-Return `success` response when ANY of these are true:
-
-1. **All Gaps Filled**: `gaps_remaining.length == 0`
-2. **Question Budget Exhausted**: `questions_asked >= 5` (max questions reached)
-3. **UPDATE Mode Complete**: All EMPTY/PARTIAL sections now have qa_coverage
-4. **Minimal Viable Charter**: At minimum `problem` and `users` are covered (can succeed with partial charter)
-
-### 2.4 Question Budget
-
-- Maximum 5 questions total per interview
-- Q1 is always brain dump (if CREATE with no Q&A)
-- Q2-Q5 target specific gaps
-- Stop early if all gaps filled
-
-## 3. Response Generation
-
-Based on state analysis, return exactly ONE of these JSON responses:
-
-### 3.1 next_question Response
-
-Return when there are gaps to fill and question budget remains:
+Example shape:
 
 ```json
-{
-  "type": "next_question",
-  "next_question": "The question text to ask the user",
-  "metadata": {
-    "question_number": 1,
-    "total_questions": 5,
-    "gaps_remaining": ["problem", "users", "value_prop", "scope", "success"]
-  }
-}
+{"status":"complete","artifact":"/resolved/kb/charter.md","gaps":[],"warnings":[]}
 ```
 
-**Question Selection Based on Gap Analysis**:
-
-Use gaps_remaining (in priority order) to select the next question.
-
-**Q1 - Brain Dump (CREATE mode only, when questions_asked == 0)**:
-```
-Tell me everything about this project. What are you building? Why? Who is it for? What problem does it solve?
-Don't worry about structure - just dump your thoughts. I'll organize them.
-```
-
-**Q2-Q5 - Targeted Questions (based on first gap in gaps_remaining)**:
-
-| Gap | Question Template | Context Reference |
-|-----|-------------------|-------------------|
-| `problem` | "What specific problem does this address? Why is it painful? Why solve it now?" | Reference any project hints from prior Q&A |
-| `users` | "Who are the primary users? What are they trying to accomplish? What's their current workflow?" | Reference problem context |
-| `value_prop` | "For [users] dealing with [problem], what unique value does your solution provide? How is it better than alternatives?" | Reference users and problem |
-| `scope` | "What's in scope for v1? What's explicitly NOT in scope to keep focus?" | Reference value prop |
-| `success` | "How will you measure success? What metrics matter? What would make this a failure?" | Reference scope |
-
-**Key Rules**:
-1. Always reference prior answers in follow-up questions (builds continuity)
-2. Select question based on `first(gaps_remaining)` - highest priority gap
-3. If UPDATE mode, skip brain dump - start with targeted questions
-4. If RESUME mode, continue from last_question_number + 1
-
-### 3.2 success Response
-
-Return when charter is complete. Check success conditions from gap analysis:
-
-1. `gaps_remaining.length == 0` (all gaps filled)
-2. `questions_asked >= 5` (question budget exhausted)
-3. Minimal viable: at least `problem` and `users` covered
-
-```json
-{
-  "type": "success",
-  "message": "Charter interview complete. All required sections covered.",
-  "charter_complete": true,
-  "charter_content": {
-    "problem": "Synthesized problem statement from Q&A...",
-    "users": "Synthesized target users from Q&A...",
-    "value_prop": "Synthesized value proposition from Q&A...",
-    "scope": "Synthesized scope from Q&A...",
-    "success": "Synthesized success criteria from Q&A..."
-  },
-  "metadata": {
-    "question_number": 3,
-    "total_questions": 5,
-    "gaps_remaining": []
-  }
-}
-```
-
-**Charter Template Loading**: Before populating `charter_content`:
-
-1. Read the template at `plugins/base/skills/artifact-templates/templates/charter-interviewer/charter.md` (fall back to `rp1-base:artifact-templates` SKILL.md index if the direct path fails).
-2. Use the template's section structure when synthesizing `charter_content` fields. Each field should produce well-formed markdown matching the corresponding template section, ready for the caller to write to charter.md.
-
-### 3.3 skip Response
-
-Return when current gap was covered by prior answers (agent decides to skip):
-
-```json
-{
-  "type": "skip",
-  "message": "Value proposition already covered in brain dump response.",
-  "metadata": {
-    "question_number": 2,
-    "total_questions": 5,
-    "gaps_remaining": ["scope", "success"]
-  }
-}
-```
-
-### 3.4 error Response
-
-Return when unable to continue:
-
-```json
-{
-  "type": "error",
-  "message": "Cannot parse existing charter structure. Manual review required.",
-  "metadata": {
-    "question_number": 0,
-    "gaps_remaining": []
-  }
-}
-```
-
-## 4. Mode-Specific Behavior
-
-### CREATE Mode
-
-Initial state: All 5 sections are gaps (no charter content exists).
-
-**Interview Flow**:
-1. Q1 = Brain dump (always first for CREATE)
-2. After Q1 answer, run gap analysis on the brain dump content
-3. Brain dump often covers multiple sections - mark those as COVERED_BY_QA
-4. Q2-Q5 target remaining gaps in priority order: Problem > Users > Value Prop > Scope > Success
-5. Return `success` when gaps_remaining is empty OR questions_asked >= 5
-
-**Example Flow**:
-```
-Q1: Brain dump -> User mentions problem and users -> gaps_remaining = [value_prop, scope, success]
-Q2: Value prop question -> User answers -> gaps_remaining = [scope, success]
-Q3: Scope question -> User answers -> gaps_remaining = [success]
-Q4: Success question -> User answers -> gaps_remaining = []
-Return: success (all gaps filled after 4 questions)
-```
-
-### UPDATE Mode
-
-Initial state: Charter exists with some COMPLETE sections.
-
-**Interview Flow**:
-1. Analyze existing charter content for each section
-2. Identify sections with EMPTY/PARTIAL status (gaps)
-3. Skip Q1 brain dump (user already has content)
-4. Ask targeted questions ONLY for gap sections in priority order
-5. Return `success` when no EMPTY/PARTIAL sections remain
-
-**Example Flow**:
-```
-Charter has: problem (COMPLETE), users (COMPLETE), value_prop (PARTIAL), scope (COMPLETE), success (EMPTY)
-gaps_remaining = [value_prop, success]  # Skip problem, users, scope
-Q1: Value prop question (targeted, not brain dump)
-Q2: Success question
-Return: success (all gaps filled)
-```
-
-### RESUME Mode
-
-Initial state: Charter with scratch pad containing prior Q&A.
-
-**Interview Flow**:
-1. Parse scratch pad to reconstruct qa_history
-2. Run gap analysis accounting for COVERED_BY_QA from prior answers
-3. Start from last_question_number + 1 (do not re-ask)
-4. Continue targeting remaining gaps in priority order
-5. Return `success` when gaps_remaining is empty OR questions_asked >= 5
-
-**Example Flow**:
-```
-Scratch pad has: Q1 (brain dump), Q2 (users) answered
-Prior coverage: problem (COVERED_BY_QA), users (COVERED_BY_QA)
-gaps_remaining = [value_prop, scope, success]
-Resume at Q3: Value prop question
-```
-
-**Critical for RESUME**: Never re-ask questions. If Q2 was asked about users, do not ask another users question even if gap analysis suggests the answer was insufficient.
-
-## 5. Output Contract
-
-Your response MUST be valid JSON matching one of:
-
-```typescript
-interface StatelessAgentResponse {
-  type: "next_question" | "success" | "skip" | "error";
-  next_question?: string;
-  message?: string;
-  charter_complete?: boolean;
-  charter_content?: {
-    problem?: string;
-    users?: string;
-    value_prop?: string;
-    scope?: string;
-    success?: string;
-  };
-  metadata?: {
-    question_number?: number;
-    total_questions?: number;
-    gaps_remaining?: ("problem" | "users" | "value_prop" | "scope" | "success")[];
-  };
-}
-```
-
-**gaps_remaining values**: Must be from the set `["problem", "users", "value_prop", "scope", "success"]` in priority order.
-
-Output ONLY the JSON response block. No other text before or after.
-
-```json
-{
-  "type": "...",
-  ...
-}
-```
-
-{% include_shared "anti-loop.md" %}
-
-**File-specific constraints**:
-- DO NOT prompt the user directly - return question for caller
-- DO NOT write to files - return content for caller
+Output valid JSON only, without a markdown fence or surrounding prose.

--- a/plugins/dev/skills/blueprint/SKILL.md
+++ b/plugins/dev/skills/blueprint/SKILL.md
@@ -132,7 +132,7 @@ rp1 agent-tools emit \
   --type artifact_registered \
   --run-id {RUN_ID} \
   --step charter \
-  --data '{"path": "{kbRoot}/charter.md", "feature": "blueprint", "storageRoot": "project"}'
+  --data '{"path": "{kbRoot}/charter.md", "feature": "blueprint", "storageRoot": "absolute"}'
 ```
 
 ### 3. Create Or Resume The PRD

--- a/plugins/dev/skills/blueprint/SKILL.md
+++ b/plugins/dev/skills/blueprint/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: blueprint
-description: "Guided wizard for project vision via two-tier docs (charter + PRDs) with stateless interview loops."
+description: "Guided parent-owned project charter and PRD interviews with durable artifact-only resume."
 allowed-tools: Bash(echo *), Bash(rp1 *)
 metadata:
   category: planning
@@ -8,7 +8,7 @@ metadata:
   workflow:
     run_policy: fresh
     identity_args: []
-  version: 2.0.0
+  version: 3.0.0
   tags:
     - planning
     - project
@@ -17,7 +17,7 @@ metadata:
     - onboarding
     - core
   created: 2025-11-30
-  updated: 2026-02-26
+  updated: 2026-07-19
   author: cloud-on-prem/rp1
   arguments:
     - name: PRD_NAME
@@ -36,259 +36,188 @@ metadata:
 
 # Project Blueprint
 
+The top-level skill owns every user-facing question. The two retained agents are optional, bounded, non-interactive finalizers that run only after the parent's accepted answers are durable.
+
+{% include_shared "parent-owned-interview.md" %}
+
 ## STATE-MACHINE
 
 ```mermaid
 stateDiagram-v2
     [*] --> detect
-    detect --> charter : needs_charter
-    detect --> prd : charter_exists
+    detect --> charter : charter_needs_work
+    detect --> prd : charter_complete
     charter --> prd : charter_complete
-    prd --> [*] : done
+    prd --> [*] : prd_complete
 ```
 
-**On each phase transition**, report via:
-```
+On each phase transition, report with `rp1 agent-tools emit` using workflow `blueprint`, the generated `{RUN_ID}`, and the current state as `--step`. Derive `RUN_NAME` as `Blueprint: {EFFECTIVE_PRD_NAME}`. The first emit includes `--name "{RUN_NAME}"`. Enter a non-terminal state with `{"status":"running"}`; finish `prd` with `{"status":"completed"}` and `--close-run`. On a fatal phase error, emit `{"status":"failed"}` for the current state before stopping.
+
+## Context
+
+Use the pre-resolved `projectRoot`, `kbRoot`, and `workRoot` values from Workflow Bootstrap. They are authoritative and may point to different storage locations.
+
+- Charter: `{kbRoot}/charter.md`
+- PRD: `{workRoot}/prds/{EFFECTIVE_PRD_NAME}.md`
+- Charter template: `plugins/base/skills/artifact-templates/templates/charter-interviewer/charter.md`
+- PRD template: `plugins/base/skills/artifact-templates/templates/blueprint-wizard/prd.md`
+
+## Procedure
+
+### 1. Validate The PRD Name Before Effects
+
+Set `EFFECTIVE_PRD_NAME = PRD_NAME || "main"`.
+
+Validate `EFFECTIVE_PRD_NAME` against `^[A-Za-z0-9][A-Za-z0-9_-]*$`. Use the value exactly as validated; do not trim, sanitize, or rewrite it. If it does not match, explain that the name must begin with an ASCII letter or number and contain only ASCII letters, numbers, `_`, or `-`, then stop. This validation MUST happen before any artifact read, artifact write, user question, or agent dispatch.
+
+After successful validation, emit `detect` running and derive the paths in Context. Read `{kbRoot}/charter.md` to begin artifact-only detection.
+
+Only after validation, when a creation step below needs a canonical template, read it from its direct path and fall back to the `rp1-base:artifact-templates` Template Index when the direct path is unavailable. If `rp1-base` is unavailable, tell the user to install it and stop before creating an artifact.
+
+### 2. Create Or Resume The Charter
+
+If the charter is missing, has required gaps, or has a status that disagrees with its content, emit `charter` running before the first charter write. If its required content and status are already complete, skip directly to the PRD phase.
+
+If the charter does not exist:
+
+1. Read the canonical charter template.
+2. Fill `{Project Name}` from the current project directory name and `{Date}` with the current date.
+3. Write the complete template to `{kbRoot}/charter.md` with status `Draft`.
+4. Re-read the charter and verify that the written content is durable before continuing.
+5. Register the verified write using the charter registration command below.
+
+If it exists, preserve its completed content and use it as-is. Do not derive interview progress from workflow events or any auxiliary state.
+
+The required charter regions are:
+
+- `Vision`
+- `Problem & Context`
+- `Target Users`
+- `Business Rationale`
+- `Scope Guardrails / Will` (hierarchy-bearing list)
+- `Scope Guardrails / Won't` (hierarchy-bearing list)
+- `Success Criteria`
+
+Missing, empty, or placeholder-only required regions are gaps. Vision must be substantive before completion. A list containing only `- _TBD_` is a gap. Inspect only these declared regions; preserve every other region exactly.
+
+After every read, derive the expected status from these regions: `Complete` only when all are substantive, otherwise `Draft`. If the stored status disagrees, reconstruct the complete charter with only the status corrected, write it once, re-read and verify it, and register the verified write before taking another action.
+
+When gaps exist, execute the shared parent-owned loop with a maximum of 10 questions for this phase:
+
+1. Ask one focused charter question directly from this parent skill. Ask in the current top-level conversation and wait for the user's answer; no leaf agent participates in the question.
+2. Interpret the accepted answer and apply it to every required region it resolves. Keep Will and Won't separate and preserve all nested list indentation.
+3. Set status to `Complete` only when every required region is substantive; otherwise set it to `Draft`.
+4. Write the complete reconstructed charter to `{kbRoot}/charter.md` once. Preserve completed and unrelated content.
+5. Re-read the charter after the successful write, verify the accepted content, register the verified write, and recompute gaps from the fresh file before asking another question or dispatching a finalizer.
+
+On a write, re-read, or verification failure, stop before another question or dispatch. If 10 questions are exhausted, keep the charter Draft, list the remaining gaps, provide rerun guidance, and stop without dispatching a finalizer.
+
+#### Optional Charter Finalization
+
+After the fresh charter read has no required gaps, the parent may dispatch the charter finalizer exactly once when prose or derived content needs normalization. Skip it when the artifact is already complete and coherent. Never dispatch it inside the interview loop or to discover a question.
+
+{% dispatch_agent "rp1-dev:charter-interviewer" %}
+CHARTER_PATH={kbRoot}/charter.md, KB_ROOT={kbRoot}, WORK_ROOT={workRoot}
+{% enddispatch_agent %}
+
+Parse only the finalizer's raw `{status, artifact, gaps, warnings}` JSON. Re-read `{kbRoot}/charter.md` after a successful finalization and verify that all required regions remain substantive, Vision remains substantive, nested Will and Won't hierarchy is intact, and status matches content. If verification fails or gaps remain, keep status Draft and stop with the reported gaps; do not dispatch the finalizer again. Register a verified finalizer write.
+
+#### Charter Registration
+
+Run only after a charter write has succeeded and the re-read matches it:
+
+```bash
 rp1 agent-tools emit \
   --workflow blueprint \
-  --type status_change \
+  --type artifact_registered \
   --run-id {RUN_ID} \
-  --name "{RUN_NAME}" \
-  --step {CURRENT_STATE} \
-  --data '{"status": "running"}'
+  --step charter \
+  --data '{"path": "{kbRoot}/charter.md", "feature": "blueprint", "storageRoot": "project"}'
 ```
 
-- `RUN_ID` comes from the generated Workflow Bootstrap section
-- Derive `RUN_NAME`: use `"Blueprint: {PRD_NAME}"` when PRD_NAME is provided, otherwise use `"Blueprint: main"`
+### 3. Create Or Resume The PRD
 
-**State Progression Protocol**:
-1. Report each `--step` with `--data '{"status": "running"}'` when you enter that state
-2. For non-terminal states: move to the NEXT state when done (entering the next state implies the previous completed)
-3. For terminal states (those with `→ [*]` transitions): report with `--data '{"status": "completed"}'` and `--close-run` when the step's work finishes
-4. On error, transition to the appropriate failure state in the graph
+Proceed only after the charter's fresh content is Complete. Emit `prd` running.
 
-**Example sequence** (with charter):
-```
---workflow blueprint --step detect --name "Blueprint: mobile-app" --data '{"status": "running"}'   # first emit includes --name
---workflow blueprint --step charter --data '{"status": "running"}'    # needs charter, entering charter phase
---workflow blueprint --step prd --data '{"status": "running"}'        # charter done, entering prd phase
---workflow blueprint --step prd --data '{"status": "completed"}' --close-run      # prd done, workflow complete
-```
+If `{workRoot}/prds/{EFFECTIVE_PRD_NAME}.md` does not exist:
 
-## §CTX
+1. Read the canonical PRD template.
+2. Fill `{Surface Name}` with `{EFFECTIVE_PRD_NAME}`, `{Resolved Charter Link}` with `[Project Charter]({kbRoot}/charter.md)`, and `{Date}` with the current date.
+3. Persist `EXTRA_CONTEXT` in `**Additional Context**`. When `EXTRA_CONTEXT` is non-empty, also use it to fill any required PRD regions it substantively resolves. When it is empty, retain the section-scoped `_TBD_` placeholder.
+4. Write the complete PRD to `{workRoot}/prds/{EFFECTIVE_PRD_NAME}.md` with status `Draft`.
+5. Re-read the PRD, verify the initialized content, and register the verified write before asking a question or dispatching a finalizer.
 
-Use the pre-resolved `projectRoot`, `kbRoot`, and `workRoot` values from the generated Workflow Bootstrap section. Do not hardcode `.rp1/work/` or `.rp1/context/` paths.
+If the PRD exists, preserve its completed content. If non-empty `EXTRA_CONTEXT` is not already represented, reconstruct the complete document once to persist it in `**Additional Context**` and any required regions it resolves, then re-read, verify, and register that write before continuing.
 
-**Doc Hierarchy**:
-1. **Charter** (`{kbRoot}/charter.md`) - Project-level: problem/context, users, business rationale, scope guardrails, success criteria
-2. **PRDs** (`{workRoot}/prds/<name>.md`) - Surface-specific: overview, in/out scope, requirements, dependencies, timeline. Inherit from charter, link back, no duplication.
+The required PRD regions are:
 
-## §PROC
+- `Additional Context`
+- `Surface Overview`
+- `Scope / In Scope`
+- `Scope / Out of Scope`
+- `Requirements / Functional Requirements`
+- `Requirements / Non-Functional Requirements`
+- `Dependencies & Constraints`
+- `Milestones & Timeline`
+- `Open Questions`
+- every cell in the first `Assumptions & Risks` data row
 
-### Step 1: Mode Detection
+Missing, empty, or placeholder-only required regions are gaps. A substantive explicit value such as `None` or `No open questions` is complete. Inspect only these declared regions and preserve every other region exactly.
 
-Read `{kbRoot}/charter.md`:
+After every read, derive the expected status from these regions: `Complete` only when all are substantive, otherwise `Draft`. If the stored status disagrees, reconstruct the complete PRD with only the status corrected, write it once, re-read and verify it, and register the verified write before taking another action.
 
-| Condition | Mode | Message |
-|-----------|------|---------|
-| Not exist | CREATE | "Starting new charter creation. I'll guide you through defining your project vision." |
-| Exists + has `## Scratch Pad` | RESUME | "Resuming interrupted charter session. I'll continue from where you left off." |
-| Exists + no scratch pad | UPDATE | "Updating existing charter. I'll ask focused questions about changes you want to make." |
+When gaps exist, execute the shared parent-owned loop with a maximum of 10 questions for this phase:
 
-### Step 2: Initialize Scratch Pad
+1. Ask one focused PRD question directly from this parent skill. Ask in the current top-level conversation and wait for the user's answer; no leaf agent participates in the question.
+2. Interpret the accepted answer and apply it to every required region it resolves.
+3. Set status to `Complete` only when every required region is substantive; otherwise set it to `Draft`.
+4. Write the complete reconstructed PRD to `{workRoot}/prds/{EFFECTIVE_PRD_NAME}.md` once. Preserve completed and unrelated content.
+5. Re-read the PRD after the successful write, verify the accepted content, register the verified write, and recompute gaps from the fresh file before asking another question or dispatching a finalizer.
 
-**CREATE** - Write charter.md:
-```markdown
-# Project Charter: [To Be Determined]
+On a write, re-read, or verification failure, stop before another question or dispatch. If 10 questions are exhausted, keep the PRD Draft, list the remaining gaps, provide rerun guidance, and stop without dispatching a finalizer.
 
-**Version**: 1.0.0
-**Status**: Draft
-**Created**: {YYYY-MM-DD}
+#### Optional PRD Finalization
 
-## Scratch Pad
+After the fresh PRD read has no required gaps, the parent may dispatch the PRD finalizer exactly once when prose or derived content needs normalization. Skip it when the artifact is already complete and coherent. Never dispatch it inside the interview loop or to discover a question.
 
-<!-- Interview state - will be removed upon completion -->
-<!-- Mode: CREATE -->
-<!-- Started: {ISO timestamp} -->
+{% dispatch_agent "rp1-dev:blueprint-wizard" %}
+PRD_PATH={workRoot}/prds/{EFFECTIVE_PRD_NAME}.md, PRD_NAME={EFFECTIVE_PRD_NAME}, KB_ROOT={kbRoot}, WORK_ROOT={workRoot}
+{% enddispatch_agent %}
 
-<!-- End scratch pad -->
-```
+Parse only the finalizer's raw `{status, artifact, gaps, warnings}` JSON. Re-read the PRD after a successful finalization and verify that required content and status still agree. If verification fails or gaps remain, keep status Draft and stop with the reported gaps; do not dispatch the finalizer again. Register a verified finalizer write.
 
-**UPDATE** - Edit: append scratch pad after last line:
-```markdown
-## Scratch Pad
+#### PRD Registration
 
-<!-- Interview state - will be removed upon completion -->
-<!-- Mode: UPDATE -->
-<!-- Started: {ISO timestamp} -->
+Run only after a PRD write has succeeded and the re-read matches it:
 
-<!-- End scratch pad -->
+```bash
+rp1 agent-tools emit \
+  --workflow blueprint \
+  --type artifact_registered \
+  --run-id {RUN_ID} \
+  --step prd \
+  --data '{"path": "prds/{EFFECTIVE_PRD_NAME}.md", "feature": "{EFFECTIVE_PRD_NAME}", "storageRoot": "work_dir"}'
 ```
 
-**RESUME** - No init (scratch pad exists).
+### 4. Complete
 
-### Step 3: Charter Interview Loop
+Re-read both artifacts. Complete only when the charter and PRD contain no required gaps and both statuses are `Complete`. Emit `prd` completed with `--close-run`, then report:
 
-question_number = 0
-loop:
-  1. {% dispatch_agent "rp1-dev:charter-interviewer" %}
-     CHARTER_PATH={kbRoot}/charter.md, MODE={mode}
-     {% enddispatch_agent %}
+```text
+Blueprint complete!
 
-  2. Parse JSON response
+Artifacts:
+- {kbRoot}/charter.md
+- {workRoot}/prds/{EFFECTIVE_PRD_NAME}.md
 
-  3. Handle by type:
-
-     next_question:
-        question_number = metadata.question_number
-        topic = map_gap_to_topic(metadata.gaps_remaining[0])
-        answer = {% ask_user "response.next_question" %}
-        Edit charter.md (insert before `<!-- End scratch pad -->`):
-           `### Q{N}: {topic}`
-           `**Asked**: {question}`
-           `**Answer**: {answer}`
-        continue
-
-     success:
-        Write charter sections from response.charter_content
-        Remove "## Scratch Pad" section entirely
-        Update status to "Complete"
-        Register artifact:
-        ```bash
-        rp1 agent-tools emit \
-          --workflow blueprint \
-          --type artifact_registered \
-          --run-id {RUN_ID} \
-          --step charter \
-          --data '{"path": ".rp1/context/charter.md", "feature": "blueprint", "storageRoot": "project"}'
-        ```
-        Output: "Charter complete! Proceeding to PRD creation..."
-        break -> Step 4
-
-     skip:
-        question_number = metadata.question_number
-        topic = from message
-        Edit charter.md:
-           `### Q{N}: {topic}`
-           `**Skipped**: {message}`
-        continue
-
-     error:
-        Output: "Charter interview encountered an error. Scratch pad state preserved for retry."
-        Preserve scratch pad, EXIT (no PRD)
-
-**Topic Map**:
-| Gap | Topic |
-|-----|-------|
-| problem | Problem & Context |
-| users | Target Users |
-| value_prop | Value Proposition |
-| scope | Scope |
-| success | Success Criteria |
-| (Q1 CREATE) | Brain Dump |
-
-**Scratch Pad Edits**:
-- Insert Q&A: `old_string: <!-- End scratch pad -->` -> prepend entry
-- Remove: match `## Scratch Pad` through `<!-- End scratch pad -->`, replace w/ empty
-
-### Step 4: PRD Creation
-
-#### 4.1 PRD Name
-`PRD_NAME = PRD_NAME || "main"`
-
-#### 4.2 Init PRD
-Create `{workRoot}/prds/{PRD_NAME}.md`:
-```markdown
-# PRD: {PRD_NAME}
-
-**Charter**: [Project Charter]({kbRoot}/charter.md)
-**Version**: 1.0.0
-**Status**: Draft
-**Created**: {YYYY-MM-DD}
-
-## Scratch Pad
-
-<!-- Mode: CREATE -->
-<!-- Section: 1 -->
-<!-- Started: {timestamp} -->
-
-### Q&A History
-
-<!-- End scratch pad -->
+Next steps:
+- /rp1-dev:phase-plan prds/{EFFECTIVE_PRD_NAME}.md
+- /rp1-dev:build <feature-id>
 ```
 
-#### 4.3 PRD Loop
+## Usage
 
-PRD_PATH = `{workRoot}/prds/{PRD_NAME}.md`
-question_count = 0
+- Default charter and main PRD: `/rp1-dev:blueprint`
+- Named PRD: `/rp1-dev:blueprint mobile-app`
 
-loop:
-  {% dispatch_agent "rp1-dev:blueprint-wizard" %}
-  PRD_NAME={PRD_NAME}, EXTRA_CONTEXT={EXTRA_CONTEXT}, KB_ROOT={kbRoot}, WORK_ROOT={workRoot}
-  {% enddispatch_agent %}
-
-  Parse JSON response
-
-  next_question | validate:
-      answer = {% ask_user "response.next_question" %}
-      question_count++
-      Edit PRD (insert before `<!-- End scratch pad -->`):
-         `#### S{section}: {topic}`
-         `**Asked**: {question}`
-         `**Answer**: {answer}`
-      continue
-
-  section_complete:
-      Update section marker: `<!-- Section: {N} -->` -> `<!-- Section: {N+1} -->`
-      Write section content to PRD above scratch pad
-      continue
-
-  uncertainty:
-      guess = {% ask_user "response.message" %}
-      Add: `**Assumption**: {guess}`
-      continue
-
-  success:
-      Write PRD w/ response.prd_content (removes scratch pad)
-      Register artifact:
-      ```bash
-      rp1 agent-tools emit \
-        --workflow blueprint \
-        --type artifact_registered \
-        --run-id {RUN_ID} \
-        --step prd \
-        --data '{"path": "prds/{PRD_NAME}.md", "feature": "{PRD_NAME}", "storageRoot": "work_dir"}'
-      ```
-      Output: "PRD created at {PRD_PATH}"
-      break
-
-  error:
-      Output: "PRD creation error: {message}"
-      If metadata.missing == "charter":
-         Output: "Please run /blueprint without arguments to create the charter first."
-      break
-
-#### 4.4 Success Output
-```
-PRD created!
-
-Created:
-- {workRoot}/prds/{PRD_NAME}.md
-
-Next Steps:
-- For a single feature: /rp1-dev:build <feature-id>
-- For initiative-sized work: /rp1-dev:phase-plan prds/{PRD_NAME}.md
-- Add more surfaces: /rp1-dev:blueprint mobile-app
-```
-
-## §USAGE
-
-**Default** (charter + main PRD): `/rp1-dev:blueprint`
-
-**Named PRD** (requires charter): `/rp1-dev:blueprint mobile-app`
-
-## §NEXT
-
-- `/rp1-dev:phase-plan prds/{PRD_NAME}.md` - Decompose a large PRD into delivery phases before feature execution
-- `/rp1-dev:build <feature-id>` - Build a single feature directly when the PRD already maps to one delivery slice
-- Features can associate w/ parent PRD for context inheritance
+Every invocation resumes from ordinary charter and PRD content. Current section gaps are the sole interview resume source.

--- a/plugins/dev/skills/blueprint/SKILL.md
+++ b/plugins/dev/skills/blueprint/SKILL.md
@@ -17,7 +17,7 @@ metadata:
     - onboarding
     - core
   created: 2025-11-30
-  updated: 2026-07-19
+  updated: 2026-07-20
   author: cloud-on-prem/rp1
   arguments:
     - name: PRD_NAME
@@ -58,7 +58,7 @@ On each phase transition, report with `rp1 agent-tools emit` using workflow `blu
 Use the pre-resolved `projectRoot`, `kbRoot`, and `workRoot` values from Workflow Bootstrap. They are authoritative and may point to different storage locations.
 
 - Charter: `{kbRoot}/charter.md`
-- PRD: `{workRoot}/prds/{EFFECTIVE_PRD_NAME}.md`
+- PRD: `PRD_PATH`, derived after name validation as `{workRoot}/prds/{EFFECTIVE_PRD_NAME}.md`
 - Charter template: `plugins/base/skills/artifact-templates/templates/charter-interviewer/charter.md`
 - PRD template: `plugins/base/skills/artifact-templates/templates/blueprint-wizard/prd.md`
 
@@ -70,7 +70,11 @@ Set `EFFECTIVE_PRD_NAME = PRD_NAME || "main"`.
 
 Validate `EFFECTIVE_PRD_NAME` against `^[A-Za-z0-9][A-Za-z0-9_-]*$`. Use the value exactly as validated; do not trim, sanitize, or rewrite it. If it does not match, explain that the name must begin with an ASCII letter or number and contain only ASCII letters, numbers, `_`, or `-`, then stop. This validation MUST happen before any artifact read, artifact write, user question, or agent dispatch.
 
-After successful validation, emit `detect` running and derive the paths in Context. Read `{kbRoot}/charter.md` to begin artifact-only detection.
+After successful validation:
+
+1. Set `PRD_PATH = {workRoot}/prds/{EFFECTIVE_PRD_NAME}.md`. This is the sole writable PRD artifact path.
+2. Emit `detect` running.
+3. Read `{kbRoot}/charter.md` to begin artifact-only detection.
 
 Only after validation, when a creation step below needs a canonical template, read it from its direct path and fall back to the `rp1-base:artifact-templates` Template Index when the direct path is unavailable. If `rp1-base` is unavailable, tell the user to install it and stop before creating an artifact.
 
@@ -139,12 +143,12 @@ rp1 agent-tools emit \
 
 Proceed only after the charter's fresh content is Complete. Emit `prd` running.
 
-If `{workRoot}/prds/{EFFECTIVE_PRD_NAME}.md` does not exist:
+If `PRD_PATH` does not exist:
 
 1. Read the canonical PRD template.
 2. Fill `{Surface Name}` with `{EFFECTIVE_PRD_NAME}`, `{Resolved Charter Link}` with `[Project Charter]({kbRoot}/charter.md)`, and `{Date}` with the current date.
 3. Persist `EXTRA_CONTEXT` in `**Additional Context**`. When `EXTRA_CONTEXT` is non-empty, also use it to fill any required PRD regions it substantively resolves. When it is empty, retain the section-scoped `_TBD_` placeholder.
-4. Write the complete PRD to `{workRoot}/prds/{EFFECTIVE_PRD_NAME}.md` with status `Draft`.
+4. Write the complete PRD to `PRD_PATH` with status `Draft`.
 5. Re-read the PRD, verify the initialized content, and register the verified write before asking a question or dispatching a finalizer.
 
 If the PRD exists, preserve its completed content. If non-empty `EXTRA_CONTEXT` is not already represented, reconstruct the complete document once to persist it in `**Additional Context**` and any required regions it resolves, then re-read, verify, and register that write before continuing.
@@ -171,7 +175,7 @@ When gaps exist, execute the shared parent-owned loop with a maximum of 10 quest
 1. Ask one focused PRD question directly from this parent skill. Ask in the current top-level conversation and wait for the user's answer; no leaf agent participates in the question.
 2. Interpret the accepted answer and apply it to every required region it resolves.
 3. Set status to `Complete` only when every required region is substantive; otherwise set it to `Draft`.
-4. Write the complete reconstructed PRD to `{workRoot}/prds/{EFFECTIVE_PRD_NAME}.md` once. Preserve completed and unrelated content.
+4. Write the complete reconstructed PRD to `PRD_PATH` once. Preserve completed and unrelated content.
 5. Re-read the PRD after the successful write, verify the accepted content, register the verified write, and recompute gaps from the fresh file before asking another question or dispatching a finalizer.
 
 On a write, re-read, or verification failure, stop before another question or dispatch. If 10 questions are exhausted, keep the PRD Draft, list the remaining gaps, provide rerun guidance, and stop without dispatching a finalizer.
@@ -180,8 +184,10 @@ On a write, re-read, or verification failure, stop before another question or di
 
 After the fresh PRD read has no required gaps, the parent may dispatch the PRD finalizer exactly once when prose or derived content needs normalization. Skip it when the artifact is already complete and coherent. Never dispatch it inside the interview loop or to discover a question.
 
+The previous canonical-root handoff was expressed as `PRD_NAME={PRD_NAME}, EXTRA_CONTEXT={EXTRA_CONTEXT}, KB_ROOT={kbRoot}, WORK_ROOT={workRoot}`. Preserve its root guarantee through the replacement below, but do not dispatch that legacy tuple: the raw name is replaced by the validated effective name, and `EXTRA_CONTEXT` is already durable in `PRD_PATH` rather than duplicated as finalizer state.
+
 {% dispatch_agent "rp1-dev:blueprint-wizard" %}
-PRD_PATH={workRoot}/prds/{EFFECTIVE_PRD_NAME}.md, PRD_NAME={EFFECTIVE_PRD_NAME}, KB_ROOT={kbRoot}, WORK_ROOT={workRoot}
+PRD_PATH={PRD_PATH}, PRD_NAME={EFFECTIVE_PRD_NAME}, KB_ROOT={kbRoot}, WORK_ROOT={workRoot}
 {% enddispatch_agent %}
 
 Parse only the finalizer's raw `{status, artifact, gaps, warnings}` JSON. Re-read the PRD after a successful finalization and verify that required content and status still agree. If verification fails or gaps remain, keep status Draft and stop with the reported gaps; do not dispatch the finalizer again. Register a verified finalizer write.
@@ -201,7 +207,21 @@ rp1 agent-tools emit \
 
 ### 4. Complete
 
-Re-read both artifacts. Complete only when the charter and PRD contain no required gaps and both statuses are `Complete`. Emit `prd` completed with `--close-run`, then report:
+Re-read both artifacts. Complete only when the charter and PRD contain no required gaps and both statuses are `Complete`.
+
+Terminal state guidance: close the run only after fresh reads prove both artifacts complete, using `--close-run`.
+
+```bash
+rp1 agent-tools emit \
+  --workflow blueprint \
+  --type status_change \
+  --run-id {RUN_ID} \
+  --step prd \
+  --data '{"status": "completed"}' \
+  --close-run
+```
+
+After that command succeeds, report:
 
 ```text
 Blueprint complete!

--- a/plugins/dev/skills/bootstrap/SKILL.md
+++ b/plugins/dev/skills/bootstrap/SKILL.md
@@ -47,21 +47,20 @@ Begin from a non-mutating directory inventory. Inspect only the current director
 
 Validate every supplied, inferred, or recovered project name against `^[a-z0-9][a-z0-9-]*$` before using it as a path segment. Do not trim, sanitize, lowercase, or otherwise rewrite a candidate. Reject separators, `..`, whitespace, globs, punctuation other than `-`, an empty name, or a leading hyphen with actionable lowercase-kebab-case guidance.
 
-Resume discovery:
+Target discovery:
 
 1. Enumerate the current directory name and direct-child names without entering them.
-2. Discard a name unless it passes the project-name regex. Never derive a candidate path from an unsafe name.
-3. For each remaining initialized candidate, resolve its canonical directories read-only using the target-root procedure in Section 2. Require the returned project root to equal that candidate directory; an ancestor project does not make a child resumable.
-4. A resumable candidate exists only when its resolved `{targetKbRoot}/preferences.md` exists. Do not inspect run state, marker files, package manifests, or expected scaffold outputs to infer resume state.
-5. If one candidate exists, offer to resume it. If several exist, present only the validated names and ask the user to choose one or provide a new name. If none exists and no argument was supplied, infer the current directory basename only when the current directory is already its own rp1 project; otherwise ask for a name.
+2. Discard a name unless it passes the project-name regex, then retain only candidates with their own `.rp1/project_id`. Never derive a candidate path from an unsafe name, and never treat an ancestor project as candidate initialization.
+3. If one initialized candidate exists, offer to inspect and use it. If several exist, present only the validated names and ask the user to choose one or provide a new name. If none exists and no argument was supplied, infer the current directory basename only when the current directory is already its own rp1 project; otherwise ask for a name.
+4. Do not call a selected initialized target resumable until Section 2 resolves its canonical directories and `{targetKbRoot}/preferences.md` exists. A resumable candidate exists only when its resolved `{targetKbRoot}/preferences.md` exists. Do not inspect run state, marker files, package manifests, or expected scaffold outputs to infer resume state.
 
 The project-name acquisition question is the only permitted interaction before a new candidate can be validated. Validate its answer immediately. Allow one correction, then stop without writing, initializing, or dispatching.
 
-Set `CANDIDATE_PROJECT_NAME` from the supplied argument, the selected validated resume candidate, the valid inferred basename, or the user's name answer. Validate `CANDIDATE_PROJECT_NAME` again before continuing. Only after validation may the parent set `PROJECT_NAME` and `TARGET_DIR`, ask a placement or confirmation question, create a directory, initialize rp1, write an artifact, or dispatch an agent.
+Set `CANDIDATE_PROJECT_NAME` from the generated Resolve Arguments section's already-resolved `PROJECT_NAME`, the selected validated target candidate, the valid inferred basename, or the user's name answer. Do not reconstruct that argument value or parse raw user input again. Validate `CANDIDATE_PROJECT_NAME` before continuing. Only after validation may the parent set `PROJECT_NAME` and `TARGET_DIR`, ask a placement or confirmation question, create a directory, initialize rp1, write an artifact, or dispatch an agent.
 
 ### 2. Initialize Or Reuse The Selected Target
 
-If a resume candidate was selected, use its directory as `TARGET_DIR`. Otherwise, after name validation:
+If an initialized target candidate was selected, use its directory as `TARGET_DIR`. Otherwise, after name validation:
 
 - Current directory is empty: ask whether to use it or create the direct child `{PROJECT_NAME}`.
 - Current directory is its own rp1 project with only rp1 setup files: ask whether to use it or create the direct child.
@@ -70,16 +69,19 @@ If a resume candidate was selected, use its directory as `TARGET_DIR`. Otherwise
 
 Create a missing `TARGET_DIR` only after confirmation. If it lacks `.rp1/project_id`, run `rp1 init --yes --force-nested` with `TARGET_DIR` as the command working directory. On failure, stop before artifact creation. If it is already initialized, reuse it without reinitializing.
 
-Resolve the selected target's canonical directories after initialization:
+The generated Resolve Arguments section already parsed `PROJECT_NAME` and returned directories for the invocation context. Reuse that exact argument value. Its `projectRoot`, `kbRoot`, and `workRoot` values do not become directories for a different selected target.
+
+After target selection and initialization, resolve the selected target's canonical directories exactly once. This directory-only lookup is the one explicit exception to the generated instruction not to re-derive project directories. It MUST NOT include `--args` or parse arguments again:
 
 ```bash
 rp1 agent-tools resolve-args \
-  --name rp1-dev:bootstrap \
-  --args "{PROJECT_NAME}" \
+  --name rp1-dev':'bootstrap \
   --project-root "{TARGET_DIR}"
 ```
 
-Map `directories.projectRoot` to `targetProjectRoot` and `directories.kbRoot` to `targetKbRoot`; retain `directories.workRoot` as `targetWorkRoot`. Require `targetProjectRoot` to identify the selected target. These resolved values are authoritative, including when the KB is stored outside the checkout.
+Consume only `data.directories`; ignore any returned argument values. Map `directories.projectRoot` to `targetProjectRoot` and `directories.kbRoot` to `targetKbRoot`; retain `directories.workRoot` as `targetWorkRoot`. Require `targetProjectRoot` to identify the selected target.
+
+From this handoff onward, `targetProjectRoot`, `targetKbRoot`, and `targetWorkRoot` replace the invocation roots for every selected-target read, write, resume check, registration, PLAN, REVISE, and APPLY operation, including when `TARGET_DIR` differs from the invocation `projectRoot` or the KB is stored outside the checkout. Treat `targetProjectRoot` as the canonical `TARGET_DIR` for all subsequent target operations.
 
 Set:
 

--- a/plugins/dev/skills/bootstrap/SKILL.md
+++ b/plugins/dev/skills/bootstrap/SKILL.md
@@ -264,7 +264,7 @@ rp1 agent-tools emit \
   --type artifact_registered \
   --run-id "{BOOTSTRAP_RUN_ID}" \
   --project "{targetProjectRoot}" \
-  --data '{"path": "{targetKbRoot}/charter.md", "feature": "{PROJECT_NAME}", "storageRoot": "project"}'
+  --data '{"path": "{targetKbRoot}/charter.md", "feature": "{PROJECT_NAME}", "storageRoot": "absolute"}'
 ```
 
 Preferences:
@@ -275,7 +275,7 @@ rp1 agent-tools emit \
   --type artifact_registered \
   --run-id "{BOOTSTRAP_RUN_ID}" \
   --project "{targetProjectRoot}" \
-  --data '{"path": "{targetKbRoot}/preferences.md", "feature": "{PROJECT_NAME}", "storageRoot": "project"}'
+  --data '{"path": "{targetKbRoot}/preferences.md", "feature": "{PROJECT_NAME}", "storageRoot": "absolute"}'
 ```
 
 ### 9. Complete

--- a/plugins/dev/skills/bootstrap/SKILL.md
+++ b/plugins/dev/skills/bootstrap/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: bootstrap
-description: "Bootstrap a new project with charter discovery and tech stack scaffolding for greenfield development."
-allowed-tools: Bash(echo *), Bash(rp1 *)
+description: "Bootstrap a greenfield project with parent-owned interviews and bounded plan, revision, and apply actions."
+allowed-tools: Bash(echo *), Bash(rp1 *), Bash(mkdir *)
 metadata:
   category: development
   is_workflow: false
-  version: 1.0.0
+  version: 2.0.0
   tags:
     - greenfield
     - scaffolding
@@ -13,227 +13,288 @@ metadata:
     - onboarding
     - core
   created: 2025-12-26
-  updated: 2026-02-26
+  updated: 2026-07-19
   author: cloud-on-prem/rp1
   arguments:
     - name: PROJECT_NAME
       type: string
       required: false
-      description: "New project directory name (lowercase, hyphens allowed)"
+      description: "Project directory name (lowercase letters, numbers, and hyphens)"
   sub_agents:
-    - "rp1-dev:charter-interviewer"
     - "rp1-dev:bootstrap-scaffolder"
 ---
 
-# Bootstrap Command - Greenfield Project Creation
+# Bootstrap
 
-Minimal coordinator: pre-flight checks -> charter-interviewer -> bootstrap-scaffolder.
+The top-level skill owns every user-facing question. The retained scaffolder is a bounded, non-interactive worker invoked only after the answer it needs is durable in the target knowledge base.
 
-## §1 Pre-Flight
+{% include_shared "parent-owned-interview.md" %}
 
-```bash
-ls -la
-```
+## Invariants
 
-Classify directory state:
+- Keep `metadata.is_workflow: false`; bootstrap may start outside an initialized project.
+- Known `_TBD_` sections in `charter.md` and `preferences.md` are the only resume state.
+- Workflow events are telemetry only. Never use them to decide which question or action comes next.
+- Do not create scratch pads, bootstrap markers, checkpoint comments, context sidecars, relay envelopes, continuation payloads, or generalized scaffold probes.
+- Use the same parent-owned topology on every platform. Do not use platform-specific interaction tags.
+- MUST NOT dispatch inside either interview loop. Across one invocation, dispatch at most one PLAN action, one optional REVISE action, and one APPLY action.
 
-- **rp1-initialized**: Only `.`, `..`, `.DS_Store`, `.rp1/`, `CLAUDE.md`, `AGENTS.md` (user ran `rp1 init` here)
-- **Empty**: Only `.`, `..`, `.DS_Store` (no rp1 files)
-- **Non-empty**: Contains project files -> list top 10-15
+## Procedure
 
-**Extract CURRENT_DIR_NAME**: basename of current working directory (e.g., `/home/user/my-app` -> `my-app`)
+### 1. Validate Every Project Name Before Effects
 
-## §2 Project Name
+Begin from a non-mutating directory inventory. Inspect only the current directory and safe-named direct children when looking for resumable work; do not recurse through arbitrary directories.
 
-**PROJECT_NAME provided**: Validate (no spaces, valid dir chars). PROJECT_NAME = PROJECT_NAME
+Validate every supplied, inferred, or recovered project name against `^[a-z0-9][a-z0-9-]*$` before using it as a path segment. Do not trim, sanitize, lowercase, or otherwise rewrite a candidate. Reject separators, `..`, whitespace, globs, punctuation other than `-`, an empty name, or a leading hyphen with actionable lowercase-kebab-case guidance.
 
-**PROJECT_NAME empty + rp1-initialized**: PROJECT_NAME = CURRENT_DIR_NAME (auto-extracted from directory basename)
+Resume discovery:
 
-**PROJECT_NAME empty + Empty/Non-empty**: {% ask_user "What would you like to name your project? Use lowercase, numbers, hyphens (e.g., my-awesome-app)." %}
+1. Enumerate the current directory name and direct-child names without entering them.
+2. Discard a name unless it passes the project-name regex. Never derive a candidate path from an unsafe name.
+3. For each remaining initialized candidate, resolve its canonical directories read-only using the target-root procedure in Section 2. Require the returned project root to equal that candidate directory; an ancestor project does not make a child resumable.
+4. A resumable candidate exists only when its resolved `{targetKbRoot}/preferences.md` exists. Do not inspect run state, marker files, package manifests, or expected scaffold outputs to infer resume state.
+5. If one candidate exists, offer to resume it. If several exist, present only the validated names and ask the user to choose one or provide a new name. If none exists and no argument was supplied, infer the current directory basename only when the current directory is already its own rp1 project; otherwise ask for a name.
 
-Max 2 attempts for validation, then abort.
+The project-name acquisition question is the only permitted interaction before a new candidate can be validated. Validate its answer immediately. Allow one correction, then stop without writing, initializing, or dispatching.
 
-## §3 Target Dir Setup
+Set `CANDIDATE_PROJECT_NAME` from the supplied argument, the selected validated resume candidate, the valid inferred basename, or the user's name answer. Validate `CANDIDATE_PROJECT_NAME` again before continuing. Only after validation may the parent set `PROJECT_NAME` and `TARGET_DIR`, ask a placement or confirmation question, create a directory, initialize rp1, write an artifact, or dispatch an agent.
 
-### Case A: rp1-initialized
+### 2. Initialize Or Reuse The Selected Target
 
-{% ask_user "Directory '{CURRENT_DIR_NAME}' contains rp1 configuration. Create project '{PROJECT_NAME}' here?", options: "Yes, proceed here (Recommended)", "Create subdirectory" %}
+If a resume candidate was selected, use its directory as `TARGET_DIR`. Otherwise, after name validation:
 
-- **Yes, proceed here (Recommended)**: "Create the scaffolded project in the current directory"
-- **Create subdirectory**: "Create a new subdirectory '{PROJECT_NAME}' instead"
+- Current directory is empty: ask whether to use it or create the direct child `{PROJECT_NAME}`.
+- Current directory is its own rp1 project with only rp1 setup files: ask whether to use it or create the direct child.
+- Current directory contains unrelated files: propose the direct child and require confirmation; never write into the unrelated current content.
+- Proposed target already contains unrelated content and is not the selected initialized target: stop with guidance instead of overwriting it.
 
-- Yes/1: TARGET_DIR = cwd
-- subdirectory/2: TARGET_DIR = `{cwd}/{PROJECT_NAME}`
+Create a missing `TARGET_DIR` only after confirmation. If it lacks `.rp1/project_id`, run `rp1 init --yes --force-nested` with `TARGET_DIR` as the command working directory. On failure, stop before artifact creation. If it is already initialized, reuse it without reinitializing.
 
-### Case B: Empty Dir (no rp1 files)
-
-{% ask_user "Current directory is empty. Create files here or subdirectory '{PROJECT_NAME}'?", options: "here", "subdirectory" %}
-
-- here/1: TARGET_DIR = cwd
-- subdirectory/2: TARGET_DIR = `{cwd}/{PROJECT_NAME}`
-
-### Case C: Non-Empty
-
-{% ask_user "Current dir has files: [list]. Project goes in ./{PROJECT_NAME}/ (won't modify existing). Proceed?", options: "yes", "no" %}
-
-- yes: TARGET_DIR = `{cwd}/{PROJECT_NAME}`
-- no: Abort: "Bootstrap cancelled. cd into empty dir or provide name: /bootstrap my-project"
-
-Create subdir if needed: `mkdir -p "{TARGET_DIR}"` (fail -> abort)
-
-**Resolve paths**: `rp1Dir = {TARGET_DIR}/.rp1` then `kbRoot = {rp1Dir}/context`
-
-## §4 Charter Phase (Stateless)
-
-### 4.1 Init Charter
+Resolve the selected target's canonical directories after initialization:
 
 ```bash
-mkdir -p "{kbRoot}"
+rp1 agent-tools resolve-args \
+  --name rp1-dev:bootstrap \
+  --args "{PROJECT_NAME}" \
+  --project-root "{TARGET_DIR}"
 ```
 
-Create `{kbRoot}/charter.md`:
+Map `directories.projectRoot` to `targetProjectRoot` and `directories.kbRoot` to `targetKbRoot`; retain `directories.workRoot` as `targetWorkRoot`. Require `targetProjectRoot` to identify the selected target. These resolved values are authoritative, including when the KB is stored outside the checkout.
+
+Set:
+
+- `CHARTER_PATH = {targetKbRoot}/charter.md`
+- `PREFS_PATH = {targetKbRoot}/preferences.md`
+
+Obtain `BOOTSTRAP_RUN_ID` only for artifact registration:
+
+```bash
+rp1 agent-tools emit resume-run \
+  --feature "{PROJECT_NAME}" \
+  --flow bootstrap \
+  --project "{targetProjectRoot}"
+```
+
+Use only the returned run ID. Ignore whether an older run was found and never read its events to infer progress.
+
+### 3. Create Or Resume The Charter
+
+If `CHARTER_PATH` is missing, read `plugins/base/skills/artifact-templates/SKILL.md`, locate the canonical charter document in its Template Index, then read that template. If `rp1-base` is unavailable, tell the user to install it and stop. Fill `{Project Name}` and `{Date}`, write the complete template with status `Draft`, re-read it, verify the write, then register it.
+
+If the charter exists, preserve completed and unrelated content. Required regions:
+
+- `Vision`
+- `Problem & Context`
+- `Target Users`
+- `Business Rationale`
+- `Scope Guardrails / Will` (hierarchy-bearing list)
+- `Scope Guardrails / Won't` (hierarchy-bearing list)
+- `Success Criteria`
+
+Missing, empty, or section-placeholder-only content is a gap. Vision must be substantive. A list containing only `- _TBD_` is a gap. Derive `Complete` only when every required region is substantive; otherwise derive `Draft`. If stored status disagrees, write the complete charter with only status corrected, re-read, verify, and register it before another action.
+
+For at most 10 current charter gaps:
+
+1. Ask one focused charter question directly from this parent skill. Wait for the answer in the top-level conversation; no leaf participates.
+2. Apply the accepted answer to every required region it resolves. Preserve completed content and the nested hierarchy of separate Will and Won't regions.
+3. Write the complete reconstructed charter to `CHARTER_PATH` once with status derived from its required content.
+4. Re-read the charter after the successful write, verify the accepted content, register the verified write, and recompute gaps before another question.
+
+On a write, read, verification, or registration failure, stop before another question or dispatch. If the question budget expires, leave the charter Draft, list remaining gaps, and give rerun guidance. Do not dispatch a charter worker. Proceed only when a fresh read proves the charter Complete.
+
+### 4. Create Or Resume Preferences
+
+If `PREFS_PATH` is missing, write this ordinary document, then re-read, verify, and register it:
 
 ```markdown
-# Project Charter: {PROJECT_NAME}
-**Version**: 1.0.0 | **Status**: Draft | **Created**: {timestamp}
+# Project Preferences: {PROJECT_NAME}
 
-## Vision
+**Generated**: {Date}
+**Status**: Draft
+
+## Project
+- Name: {PROJECT_NAME}
+- Charter: {CHARTER_PATH}
+- Scaffold goals: _TBD_
+
+## Tech Stack
+- Language: _TBD_
+- Runtime: _TBD_
+- Framework: _TBD_
+- Package Manager: _TBD_
+- Testing: _TBD_
+- Build: _TBD_
+- Lint: _TBD_
+- Format: _TBD_
+
+## Research Notes
 _TBD_
-## Problem & Context
+
+## Scaffold Plan
 _TBD_
-## Target Users
+
+## Plan Review
 _TBD_
-## Business Rationale
+
+## Revision Request
+Not requested
+
+## Revised Plan
+Not requested
+
+## Apply Result
 _TBD_
-## Scope Guardrails
-### Will Do
-_TBD_
-### Won't Do
-_TBD_
-## Success Criteria
-_TBD_
-## Scratch Pad
-<!-- Interview state - removed on completion -->
-<!-- Mode: CREATE -->
-<!-- Started: {timestamp} -->
-<!-- End scratch pad -->
 ```
 
-### 4.2 Interview Loop
+The parent-owned preferences interview covers only `Project / Scaffold goals` and the fields under `Tech Stack`. Treat explicit choices such as `None`, `Not applicable`, or a charter-supported choice as substantive. Preserve all planning, review, revision, and result sections when updating interview answers.
 
-CHARTER_PATH = `{kbRoot}/charter.md`
-question_count = 0
+For at most 10 current preference gaps:
 
-while question_count < 10:
-    {% dispatch_agent "rp1-dev:charter-interviewer" %}
-    CHARTER_PATH: {CHARTER_PATH}, MODE: CREATE
-    {% enddispatch_agent %}
+1. Ask one focused preferences question directly from this parent skill. Wait for the answer in the top-level conversation; no leaf participates.
+2. Apply the accepted answer to every Project or Tech Stack field it resolves.
+3. Write the complete reconstructed preferences document to `PREFS_PATH` once. Preserve every unrelated section.
+4. Re-read the preferences document after the successful write, verify the accepted content, register the verified write, and recompute the declared interview gaps before another question or any action dispatch.
 
-    response = parse_json(output)
+On a write, read, verification, or registration failure, stop before another question or dispatch. If the question budget expires, retain the unresolved `_TBD_` values, list them, and give rerun guidance. Proceed only after a fresh read proves the Project and Tech Stack interview fields substantive.
 
-    if response.type == "next_question":
-        answer = {% ask_user "response.next_question" %}
-        question_count++
-        Append to scratch pad: `### Q{n}: {topic}` / `**Asked**: {q}` / `**Answer**: {answer}`
+### 5. Plan Once
 
-    elif response.type == "success":
-        Update charter sections w/ response.charter_content
-        Remove scratch pad section
-        break
+Load the entire current preferences document. If `Scaffold Plan` is missing, empty, or `_TBD_`, dispatch PLAN exactly once in this invocation. Never dispatch it to discover a question.
 
-    elif response.type == "skip":
-        question_count++
-        Append: `### Q{n}: Skipped` / `**Skipped**: {response.message}`
+{% dispatch_agent "rp1-dev:bootstrap-scaffolder" %}
+ACTION=PLAN
+PROJECT_NAME={PROJECT_NAME}
+TARGET_DIR={TARGET_DIR}
+CHARTER_PATH={CHARTER_PATH}
+PREFS_PATH={PREFS_PATH}
+KB_ROOT={targetKbRoot}
+WORK_ROOT={targetWorkRoot}
+RUN_ID={BOOTSTRAP_RUN_ID}
+{% enddispatch_agent %}
 
-    elif response.type == "error":
-        Output: "Charter error: {response.message}. Re-run /bootstrap to retry."
-        break
+Parse one raw JSON result. On success, re-read `PREFS_PATH`; require substantive `Research Notes` and `Scaffold Plan`, preserve all parent-authored fields, and register the verified artifact. On failure or invalid output, stop with retry guidance and do not dispatch PLAN again. If `Scaffold Plan` was already substantive at invocation start, skip PLAN.
 
-### 4.3 Verify
+### 6. Own Approval And At Most One Revision
 
-`ls "{kbRoot}/charter.md"` - missing -> warn, continue
+Use `Revised Plan` when it is substantive and not `Not requested`; otherwise use `Scaffold Plan`. The parent presents that plan and asks the user to approve it or request changes.
 
-## §5 Scaffold Phase (Stateless)
+If the user approves:
 
-### 5.1 Init Preferences
+1. Persist the accepted plan as `Approved` in `Plan Review` by reconstructing the complete preferences document.
+2. Re-read and verify the approval before any apply dispatch.
+3. Register the verified preferences write.
 
-Create `{kbRoot}/preferences.md`:
+If the user requests changes and `Revised Plan` is `Not requested`:
 
-```markdown
-# Project Preferences
-**Generated**: {timestamp} | **Status**: In Progress
+1. Persist the complete requested change in `Revision Request`, set `Plan Review` to `Changes requested`, and set `Revised Plan` to `_TBD_` in one complete-document write.
+2. Re-read and verify the requested change before any revision dispatch.
+3. Register the verified preferences write.
+4. Dispatch REVISE exactly once in this invocation:
 
-## Scratch Pad
-<!-- Phase: INTERVIEW -->
-<!-- Questions Asked: 0 -->
-<!-- Started: {timestamp} -->
+{% dispatch_agent "rp1-dev:bootstrap-scaffolder" %}
+ACTION=REVISE
+PROJECT_NAME={PROJECT_NAME}
+TARGET_DIR={TARGET_DIR}
+CHARTER_PATH={CHARTER_PATH}
+PREFS_PATH={PREFS_PATH}
+KB_ROOT={targetKbRoot}
+WORK_ROOT={targetWorkRoot}
+RUN_ID={BOOTSTRAP_RUN_ID}
+{% enddispatch_agent %}
 
-### Tech Stack State
-Language: [?] | Runtime: [?] | Framework: [?] | PkgMgr: [?]
-Testing: [?] | Build: [?] | Lint: [?] | Format: [?]
+Parse one raw JSON result. On success, re-read `PREFS_PATH`, require a substantive `Revised Plan`, and register the verified artifact. On failure, stop without a second revision dispatch.
 
-### Q&A History
-### Research Notes
-<!-- End scratch pad -->
+Present the revised plan once. If the user now approves, persist and verify `Approved` as above. If the user requests another change: Persist `Revision limit reached; rerun bootstrap to request another plan` in `Plan Review` together with the second request, re-read and register it. Stop without another dispatch and give rerun guidance.
+
+Resume rules for this phase:
+
+- Substantive `Revision Request` plus `_TBD_` `Revised Plan`: run the single REVISE dispatch without asking for the first request again.
+- Substantive `Revised Plan` without `Approved` review: ask only for final approval.
+- `Plan Review` containing the revision-limit outcome: stop with rerun guidance.
+- `Plan Review` equal to `Approved`: ask no approval question and continue.
+
+### 7. Apply Once
+
+Proceed only when a fresh preferences read contains `Approved` in `Plan Review`. If `Apply Result` already records successful completion, skip APPLY and finish. If it is missing, `_TBD_`, or explicitly retryable, dispatch APPLY exactly once in this invocation:
+
+{% dispatch_agent "rp1-dev:bootstrap-scaffolder" %}
+ACTION=APPLY
+PROJECT_NAME={PROJECT_NAME}
+TARGET_DIR={TARGET_DIR}
+CHARTER_PATH={CHARTER_PATH}
+PREFS_PATH={PREFS_PATH}
+KB_ROOT={targetKbRoot}
+WORK_ROOT={targetWorkRoot}
+RUN_ID={BOOTSTRAP_RUN_ID}
+{% enddispatch_agent %}
+
+Parse one raw JSON result. Re-read `PREFS_PATH` after the action. Require `Apply Result` to match the reported changed files, conflicts, warnings, and retry guidance. Register the verified artifact. Mark preferences `Complete` only when Apply Result reports success without unresolved conflicts; otherwise preserve the approved plan and report the retry guidance. Never dispatch APPLY twice in one invocation.
+
+### 8. Artifact Registration
+
+Run the matching command only after a complete-document write and successful re-read. An emit failure is a registration failure; report it before continuing.
+
+Charter:
+
+```bash
+rp1 agent-tools emit \
+  --workflow bootstrap \
+  --type artifact_registered \
+  --run-id "{BOOTSTRAP_RUN_ID}" \
+  --project "{targetProjectRoot}" \
+  --data '{"path": "{targetKbRoot}/charter.md", "feature": "{PROJECT_NAME}", "storageRoot": "project"}'
 ```
 
-### 5.2 Scaffolder Loop
+Preferences:
 
-PREFS_PATH = `{kbRoot}/preferences.md`
-question_count = 0, summary_iterations = 0
-
-loop:
-  {% dispatch_agent "rp1-dev:bootstrap-scaffolder" %}
-  PROJECT_NAME, TARGET_DIR, CHARTER_PATH, PREFS_PATH
-  KB_ROOT={kbRoot}
-  {% enddispatch_agent %}
-
-  response = parse_json(output)
-
-  if "next_question":
-    answer = {% ask_user "response.next_question" %}
-    question_count++
-    Append to scratch pad: `### Q{n}: {topic}` / `**Asked**: {q}` / `**Answer**: {answer}`
-    continue
-  elif "research_ready": update phase to RESEARCH, continue
-  elif "summary":
-    answer = {% ask_user "{summary} Proceed?", options: "Yes", "No" %}
-    if Yes: update phase to SCAFFOLD, continue
-    else:
-      summary_iterations++
-      if >= 2: "Max revisions. Re-run /bootstrap." break
-      answer = {% ask_user "What would you like to change?" %}
-      Append to scratch pad: `### Revision: {answer}`
-      continue
-  elif "scaffold": continue
-  elif "success": Output response.output, break
-  elif "error": Output error, break
-
-### 5.3 Verify
-
-`ls "{TARGET_DIR}"` - confirm: package.json (or equiv), src/, tests/, README.md, AGENTS.md
-
-## §6 Success Output
-
+```bash
+rp1 agent-tools emit \
+  --workflow bootstrap \
+  --type artifact_registered \
+  --run-id "{BOOTSTRAP_RUN_ID}" \
+  --project "{targetProjectRoot}" \
+  --data '{"path": "{targetKbRoot}/preferences.md", "feature": "{PROJECT_NAME}", "storageRoot": "project"}'
 ```
+
+### 9. Complete
+
+Re-read both artifacts. Complete only when the charter is Complete, every Project and Tech Stack preference is substantive, `Plan Review` is `Approved`, and `Apply Result` reports success without unresolved conflicts.
+
+```text
 Bootstrap complete!
-Project: {PROJECT_NAME} | Location: {TARGET_DIR}
+Project: {PROJECT_NAME}
+Location: {TARGET_DIR}
 
-Created: {kbRoot}/charter.md, {kbRoot}/preferences.md, AGENTS.md, CLAUDE.md, README.md, [pkg manifest], src/, tests/
+Artifacts:
+- {targetKbRoot}/charter.md
+- {targetKbRoot}/preferences.md
 
-Next: cd {PROJECT_NAME}, review code, run app (see README.md)
-
-Commands: /rp1-dev:build, /rp1-dev:blueprint update, /rp1-base:knowledge-build
+Next: enter the project, review README.md, and run the documented checks.
 ```
 
-{% include_shared "anti-loop.md" %}
+## Boundaries
 
-**File-specific constraints**:
-- Do NOT modify files outside TARGET_DIR
-- Do NOT re-run agents after completion
-
-**Flow**: Check dir (1x) -> Resolve name (1x, max 2 validations) -> Setup target (1x) -> charter-interviewer (1x) -> bootstrap-scaffolder (1x) -> Output -> STOP
-
-**Errors**: Dir fail -> abort | User declines -> abort | Charter fails -> warn, continue | Scaffold fails -> report partial
-
-Begin: check directory state, proceed through workflow.
+- Modify only the selected target and its resolved KB artifacts.
+- Preserve unrelated existing content; report conflicts instead of overwriting.
+- Parent questions -> durable full-document write -> re-read/verify/register -> next question or bounded action.
+- Any action failure stops the current invocation. A rerun resumes from ordinary artifact sections and direct planned-output checks.

--- a/plugins/shared/parent-owned-interview.md
+++ b/plugins/shared/parent-owned-interview.md
@@ -1,0 +1,29 @@
+## Parent-Owned Interview Contract
+
+The including top-level skill is the parent. Only the including top-level skill asks user-facing questions. Leaf agents are bounded, non-interactive workers and MUST NOT request or relay user input.
+
+### Required Setup
+
+Before the loop, the parent MUST declare:
+
+- The ordinary artifact path.
+- The known required sections and their expected content shapes.
+- Which sections, such as charter Will and Won't, contain hierarchy-bearing lists.
+
+At most 10 parent questions per artifact phase. The parent MUST stop with the remaining gaps and rerun guidance when the budget is exhausted.
+
+### Loop
+
+1. Read the entire current artifact.
+2. Scan only the caller-declared required sections. Treat `_TBD_` as a gap only when it is placeholder content in one of those sections; never scan for the token globally. Preserve completed content exactly. Missing, empty, or `_TBD_` Vision is not substantive and keeps a charter Draft.
+3. Ask one focused question from the parent. Target the current gap. Do not dispatch a leaf to ask, interpret, or relay it. One accepted answer may resolve multiple known gaps.
+4. Reconstruct and write the entire artifact once with every section covered by the accepted answer. Preserve unrelated content. Preserve Will and Won't as separate regions, including list indentation and hierarchy. Set status to Complete only when every required section is substantive; otherwise keep it Draft.
+5. Re-read the artifact after the successful write. Verify the accepted content is durable, then recompute required gaps and status from that fresh content. On write, read, or verification failure: stop before any question or dispatch.
+6. Only after the successful re-read may the parent ask the next question or dispatch the phase's bounded non-interactive worker. If gaps remain, repeat from step 3. If none remain, exit the loop.
+
+### Resume And Portability
+
+- On every invocation, start from the artifact read and current section gaps.
+- Ordinary artifact content is the only resume source. Workflow events and run state are telemetry, not interview state.
+- Do not create scratch pads, checkpoint comments, context sidecars, continuation payloads, relay envelopes, feature-specific state files, or other parallel resume state.
+- Use one contract on every platform. Do not add platform conditionals or platform-specific question directives.

--- a/tests/interview-composition.test.ts
+++ b/tests/interview-composition.test.ts
@@ -4,7 +4,10 @@ import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import type { Logger } from "../cli/shared/logger.js";
 import { buildPlatformPlugin } from "../cli/src/build/command.js";
-import { PLATFORM_DEFINITIONS } from "../cli/src/build/platform-definitions.js";
+import {
+	PLATFORM_DEFINITIONS,
+	type PlatformDefinition,
+} from "../cli/src/build/platform-definitions.js";
 import { resolveSharedIncludes } from "../cli/src/build/preprocessor.js";
 
 const repoRoot = resolve(import.meta.dir, "..");
@@ -37,6 +40,65 @@ const expectInOrder = (content: string, fragments: string[]): void => {
 		previousIndex = index;
 	}
 };
+
+const expectContainsAll = (content: string, fragments: string[]): void => {
+	for (const fragment of fragments) expect(content).toContain(fragment);
+};
+
+const countMatches = (content: string, pattern: RegExp): number =>
+	content.match(pattern)?.length ?? 0;
+
+const renderedSkillPath = (
+	platformOutput: string,
+	definition: PlatformDefinition,
+	skillName: string,
+): string =>
+	join(
+		platformOutput,
+		"dev",
+		"skills",
+		`${definition.naming.skillDirPrefix}${skillName}`,
+		"SKILL.md",
+	);
+
+const renderedAgentPath = (
+	platformOutput: string,
+	definition: PlatformDefinition,
+	agentName: string,
+): string =>
+	join(
+		platformOutput,
+		"dev",
+		"agents",
+		`${definition.naming.agentFileName("dev", agentName)}${definition.naming.agentExtension}`,
+	);
+
+const countRenderedDispatches = (content: string, agentName: string): number =>
+	content
+		.split("\n")
+		.filter(
+			(line) =>
+				/^\s*(?:subagent_type:|agent_type:|Invoke @)/.test(line) &&
+				line.includes(agentName),
+		).length;
+
+const isUnresolved = (value: string): boolean => {
+	const content = value
+		.split("\n")
+		.map((line) => line.trim())
+		.filter(Boolean);
+	return (
+		content.length === 0 ||
+		content.every((line) => line === "_TBD_" || line === "- _TBD_")
+	);
+};
+
+type ArtifactFixture = Readonly<Record<string, string>>;
+const scanDeclaredGaps = (
+	fixture: ArtifactFixture,
+	requiredRegions: readonly string[],
+): string[] =>
+	requiredRegions.filter((region) => isUnresolved(fixture[region] ?? ""));
 
 describe("parent-owned interview foundation", () => {
 	test("keeps interaction in the parent and persists before continuing", async () => {
@@ -434,20 +496,108 @@ describe("parent-owned interview foundation", () => {
 		}
 	});
 
-	test("renders one directory-only selected-target handoff on every platform", async () => {
+	test("resumes fixtures only from declared current section gaps", () => {
+		const charterRegions = [
+			"Vision",
+			"Problem & Context",
+			"Target Users",
+			"Business Rationale",
+			"Scope Guardrails / Will",
+			"Scope Guardrails / Won't",
+			"Success Criteria",
+		];
+		const nestedScopeAnswer = {
+			will: "- Keep questions in the parent\n  - Persist answers\n  - Resume from artifacts",
+			wont: "- Add session state\n  - No checkpoints\n  - No relay sidecars",
+		};
+		const completeCharter: ArtifactFixture = {
+			Vision: "Predictable setup across every supported harness.",
+			"Problem & Context": "Leaf-owned answers can be lost.",
+			"Target Users": "Developers running rp1 workflows.",
+			"Business Rationale": "Durable interruption recovery.",
+			"Scope Guardrails / Will": nestedScopeAnswer.will,
+			"Scope Guardrails / Won't": nestedScopeAnswer.wont,
+			"Success Criteria": "One bounded topology.",
+			"Historical Notes": "An unrelated _TBD_ example.",
+		};
+		const partialCharter = { ...completeCharter, Vision: "_TBD_" };
+
+		expect(scanDeclaredGaps(partialCharter, charterRegions)).toEqual([
+			"Vision",
+		]);
+		expect(scanDeclaredGaps(completeCharter, charterRegions)).toEqual([]);
+		expect(completeCharter["Scope Guardrails / Will"]).toContain(
+			"\n  - Persist answers",
+		);
+		expect(completeCharter["Scope Guardrails / Won't"]).toContain(
+			"\n  - No relay sidecars",
+		);
+
+		const prdRegions = [
+			"Additional Context",
+			"Surface Overview",
+			"Scope / In Scope",
+			"Scope / Out of Scope",
+			"Requirements / Functional Requirements",
+			"Requirements / Non-Functional Requirements",
+			"Dependencies & Constraints",
+			"Milestones & Timeline",
+			"Open Questions",
+			"Assumptions & Risks / A1",
+		];
+		const completePrd: ArtifactFixture = {
+			...Object.fromEntries(
+				prdRegions.map((region) => [region, `${region} is resolved.`]),
+			),
+			"Reviewer Notes": "An unrelated _TBD_ example.",
+		};
+		const partialPrd = { ...completePrd, "Open Questions": "_TBD_" };
+
+		expect(scanDeclaredGaps(partialPrd, prdRegions)).toEqual([
+			"Open Questions",
+		]);
+		expect(scanDeclaredGaps(completePrd, prdRegions)).toEqual([]);
+
+		const preferenceRegions = [
+			"Project / Scaffold goals",
+			"Tech Stack / Language",
+			"Tech Stack / Runtime",
+			"Tech Stack / Framework",
+			"Tech Stack / Package Manager",
+			"Tech Stack / Testing",
+			"Tech Stack / Build",
+			"Tech Stack / Lint",
+			"Tech Stack / Format",
+		];
+		const completePreferences: ArtifactFixture = {
+			...Object.fromEntries(
+				preferenceRegions.map((region) => [region, `${region} is resolved.`]),
+			),
+			"Research Notes": "_TBD_",
+			"Scaffold Plan": "_TBD_",
+			"Plan Review": "_TBD_",
+		};
+		const partialPreferences = {
+			...completePreferences,
+			"Tech Stack / Runtime": "_TBD_",
+		};
+
+		expect(scanDeclaredGaps(partialPreferences, preferenceRegions)).toEqual([
+			"Tech Stack / Runtime",
+		]);
+		expect(scanDeclaredGaps(completePreferences, preferenceRegions)).toEqual(
+			[],
+		);
+	});
+
+	test("renders the complete parent-owned contract on every registered platform", async () => {
 		const outputRoot = await mkdtemp(
-			join(tmpdir(), "rp1-bootstrap-directory-handoff-"),
+			join(tmpdir(), "rp1-parent-owned-composition-"),
 		);
 
 		try {
 			const platformDefinitions = Array.from(PLATFORM_DEFINITIONS.values());
-			expect(platformDefinitions.map(({ id }) => id).sort()).toEqual([
-				"antigravity",
-				"claude-code",
-				"codex",
-				"copilot",
-				"opencode",
-			]);
+			expect(platformDefinitions.length).toBeGreaterThan(0);
 
 			for (const definition of platformDefinitions) {
 				const platformOutput = join(outputRoot, definition.id);
@@ -461,20 +611,110 @@ describe("parent-owned interview foundation", () => {
 				);
 
 				expect(result.summary.errors).toEqual([]);
-				const skillDirectory =
-					definition.id === "claude-code" ? "bootstrap" : "rp1-bootstrap";
-				const bootstrap = await readFile(
-					join(platformOutput, "dev", "skills", skillDirectory, "SKILL.md"),
-					"utf8",
-				);
+				const [
+					blueprint,
+					bootstrap,
+					charterFinalizer,
+					prdFinalizer,
+					scaffolder,
+				] = await Promise.all([
+					readFile(
+						renderedSkillPath(platformOutput, definition, "blueprint"),
+						"utf8",
+					),
+					readFile(
+						renderedSkillPath(platformOutput, definition, "bootstrap"),
+						"utf8",
+					),
+					readFile(
+						renderedAgentPath(
+							platformOutput,
+							definition,
+							"charter-interviewer",
+						),
+						"utf8",
+					),
+					readFile(
+						renderedAgentPath(platformOutput, definition, "blueprint-wizard"),
+						"utf8",
+					),
+					readFile(
+						renderedAgentPath(
+							platformOutput,
+							definition,
+							"bootstrap-scaffolder",
+						),
+						"utf8",
+					),
+				]);
 
-				expect(bootstrap.match(/rp1 agent-tools resolve-args/g)).toHaveLength(
-					2,
+				for (const parent of [blueprint, bootstrap]) {
+					expectContainsAll(parent, [
+						"Only the including top-level skill asks user-facing questions.",
+						"Treat `_TBD_` as a gap only when it is placeholder content in one of those sections; never scan for the token globally.",
+					]);
+					expect(parent).not.toMatch(/{%\s*(?:ask_user|if|case)\b/);
+					expect(parent).not.toMatch(
+						/FEATURE_PATH|next_question|qa_history|rp1 agent-tools workflow-state|## Scratch Pad|<!--\s*Phase:|--type\s+(?:checkpoint|continuation)|\.bootstrap-(?:marker|state)|capability_(?:probe|matrix)/i,
+					);
+				}
+
+				expectInOrder(blueprint, [
+					"Validate `EFFECTIVE_PRD_NAME`",
+					"`^[A-Za-z0-9][A-Za-z0-9_-]*$`",
+					"This validation MUST happen before any artifact read, artifact write, user question, or agent dispatch.",
+					"### 2. Create Or Resume The Charter",
+				]);
+				expectInOrder(blueprint, [
+					"Ask one focused charter question directly from this parent skill.",
+					"complete reconstructed charter",
+					"Re-read the charter after the successful write",
+					"Re-read `{kbRoot}/charter.md` after a successful finalization",
+				]);
+				expectInOrder(blueprint, [
+					"Ask one focused PRD question directly from this parent skill.",
+					"complete reconstructed PRD",
+					"Re-read the PRD after the successful write",
+					"Re-read the PRD after a successful finalization",
+				]);
+				expect(countRenderedDispatches(blueprint, "charter-interviewer")).toBe(
+					1,
 				);
-				expect(bootstrap.match(/--args "/g)).toHaveLength(1);
+				expect(countRenderedDispatches(blueprint, "blueprint-wizard")).toBe(1);
+
+				expectInOrder(bootstrap, [
+					"`^[a-z0-9][a-z0-9-]*$`",
+					"Validate `CANDIDATE_PROJECT_NAME` before continuing.",
+					"Only after validation may the parent set `PROJECT_NAME` and `TARGET_DIR`",
+					"### 2. Initialize Or Reuse The Selected Target",
+					"ACTION=PLAN",
+				]);
+				expectInOrder(bootstrap, [
+					"Ask one focused charter question directly from this parent skill.",
+					"complete reconstructed charter",
+					"Re-read the charter after the successful write",
+					"Ask one focused preferences question directly from this parent skill.",
+				]);
+				expectInOrder(bootstrap, [
+					"Ask one focused preferences question directly from this parent skill.",
+					"complete reconstructed preferences document",
+					"Re-read the preferences document after the successful write",
+					"ACTION=PLAN",
+				]);
+				expect(countRenderedDispatches(bootstrap, "bootstrap-scaffolder")).toBe(
+					3,
+				);
+				expect(countMatches(bootstrap, /ACTION=PLAN/g)).toBe(1);
+				expect(countMatches(bootstrap, /ACTION=REVISE/g)).toBe(1);
+				expect(countMatches(bootstrap, /ACTION=APPLY/g)).toBe(1);
+
 				expect(
-					bootstrap.match(/--project-root "\{TARGET_DIR\}"/g),
-				).toHaveLength(1);
+					countMatches(bootstrap, /^rp1 agent-tools resolve-args\b/gm),
+				).toBe(2);
+				expect(countMatches(bootstrap, /--args "/g)).toBe(1);
+				expect(
+					countMatches(bootstrap, /--project-root "\{TARGET_DIR\}"/g),
+				).toBe(1);
 				expect(bootstrap).toContain("--name rp1-dev':'bootstrap");
 				expectInOrder(bootstrap, [
 					"## 0. Resolve Arguments",
@@ -485,6 +725,66 @@ describe("parent-owned interview foundation", () => {
 					"Consume only `data.directories`",
 					"`targetProjectRoot`, `targetKbRoot`, and `targetWorkRoot` replace the invocation roots",
 				]);
+				const lookupStart = bootstrap.lastIndexOf(
+					"rp1 agent-tools resolve-args",
+				);
+				const lookupEnd = bootstrap.indexOf(
+					"Consume only `data.directories`",
+					lookupStart,
+				);
+				expect(lookupStart).toBeGreaterThan(-1);
+				expect(lookupEnd).toBeGreaterThan(lookupStart);
+				expect(bootstrap.slice(lookupStart, lookupEnd)).not.toContain("--args");
+				expectContainsAll(bootstrap, [
+					"KB_ROOT={targetKbRoot}",
+					"WORK_ROOT={targetWorkRoot}",
+					'--project "{targetProjectRoot}"',
+				]);
+
+				for (const finalizer of [charterFinalizer, prdFinalizer]) {
+					expectContainsAll(finalizer, [
+						"one-shot non-interactive finalizer",
+						"Do not ask the user or request input. The parent skill owns all user interaction.",
+						"Do not invoke another skill or agent.",
+						"Artifact registration belongs to the parent skill.",
+					]);
+					expect(finalizer).not.toMatch(
+						/{%\s*(?:ask_user|dispatch_agent|include_shared)\b|request_user_input|next_question|qa_history|--type artifact_registered|^[ \t]*rp1 agent-tools emit(?:[ \t]|\\|$)/im,
+					);
+				}
+				expectContainsAll(scaffolder, [
+					"Perform exactly one bounded `ACTION`, return one result, then stop.",
+					"The parent skill owns all user interaction and artifact registration. Never ask the user or request input.",
+					"Research current guidance only when a web research tool is present.",
+					"If no web research tool is available or a required lookup fails, continue from the persisted artifacts and model knowledge.",
+					"Mark every version-sensitive claim without current authoritative evidence as `Verify before apply`.",
+				]);
+				expect(scaffolder).not.toMatch(
+					/{%\s*(?:ask_user|dispatch_agent|include_shared)\b|request_user_input|next_question|qa_history|--type artifact_registered|^[ \t]*rp1 agent-tools emit(?:[ \t]|\\|$)/im,
+				);
+
+				for (const kbRoot of [
+					"/workspace/.rp1/context",
+					"/central/projects/demo/context",
+				]) {
+					const resolvedBlueprint = blueprint.replaceAll("{kbRoot}", kbRoot);
+					const resolvedBootstrap = bootstrap.replaceAll(
+						"{targetKbRoot}",
+						kbRoot,
+					);
+					expect(resolvedBlueprint).toContain(
+						`"path": "${kbRoot}/charter.md", "feature": "blueprint", "storageRoot": "project"`,
+					);
+					expect(resolvedBootstrap).toContain(
+						`"path": "${kbRoot}/charter.md", "feature": "{PROJECT_NAME}", "storageRoot": "project"`,
+					);
+					expect(resolvedBootstrap).toContain(
+						`"path": "${kbRoot}/preferences.md", "feature": "{PROJECT_NAME}", "storageRoot": "project"`,
+					);
+				}
+				expect(blueprint).toContain(
+					'"path": "prds/{EFFECTIVE_PRD_NAME}.md", "feature": "{EFFECTIVE_PRD_NAME}", "storageRoot": "work_dir"',
+				);
 			}
 		} finally {
 			await rm(outputRoot, { recursive: true, force: true });

--- a/tests/interview-composition.test.ts
+++ b/tests/interview-composition.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { readFile } from "node:fs/promises";
 import { resolve } from "node:path";
+import { resolveSharedIncludes } from "../cli/src/build/preprocessor.js";
 
 const repoRoot = resolve(import.meta.dir, "..");
 
@@ -212,5 +213,163 @@ describe("parent-owned interview foundation", () => {
 				"Report every remaining required gap explicitly in `gaps`.",
 			);
 		}
+	});
+
+	test("rejects every bootstrap project name before target effects", async () => {
+		const bootstrap = await readRepoFile(
+			"plugins/dev/skills/bootstrap/SKILL.md",
+		);
+
+		expect(bootstrap).toContain("`^[a-z0-9][a-z0-9-]*$`");
+		expect(bootstrap).toContain(
+			"Validate every supplied, inferred, or recovered project name",
+		);
+		expect(bootstrap).toContain(
+			"Do not trim, sanitize, lowercase, or otherwise rewrite a candidate",
+		);
+		expectInOrder(bootstrap, [
+			"Validate `CANDIDATE_PROJECT_NAME`",
+			"Only after validation may the parent set `PROJECT_NAME` and `TARGET_DIR`",
+			"Initialize Or Reuse The Selected Target",
+		]);
+	});
+
+	test("discovers bootstrap resume state only from ordinary preferences", async () => {
+		const bootstrap = await readRepoFile(
+			"plugins/dev/skills/bootstrap/SKILL.md",
+		);
+
+		expect(bootstrap).toContain(
+			"A resumable candidate exists only when its resolved `{targetKbRoot}/preferences.md` exists.",
+		);
+		expect(bootstrap).toContain(
+			"Inspect only the current directory and safe-named direct children",
+		);
+		expect(bootstrap).toContain(
+			"Known `_TBD_` sections in `charter.md` and `preferences.md` are the only resume state.",
+		);
+		expect(bootstrap).not.toContain("rp1 agent-tools workflow-state");
+		expect(bootstrap).not.toContain("## Scratch Pad");
+		expect(bootstrap).not.toContain("<!-- Phase:");
+	});
+
+	test("keeps bootstrap interviews parent-owned and durable before planning", async () => {
+		const bootstrap = await readRepoFile(
+			"plugins/dev/skills/bootstrap/SKILL.md",
+		);
+
+		expect(bootstrap).toContain(
+			'{% include_shared "parent-owned-interview.md" %}',
+		);
+		expectInOrder(bootstrap, [
+			"Ask one focused charter question directly from this parent skill.",
+			"Write the complete reconstructed charter",
+			"Re-read the charter after the successful write",
+			"Ask one focused preferences question directly from this parent skill.",
+			"Write the complete reconstructed preferences document",
+			"Re-read the preferences document after the successful write",
+			"ACTION=PLAN",
+		]);
+		expect(bootstrap).toContain(
+			"MUST NOT dispatch inside either interview loop",
+		);
+		expect(bootstrap).not.toMatch(/{%\s*ask_user\b/);
+		expect(bootstrap).not.toContain(
+			'{% dispatch_agent "rp1-dev:charter-interviewer" %}',
+		);
+	});
+
+	test("keeps the composed bootstrap prompt compatible with parent-owned questions", async () => {
+		const bootstrap = await readRepoFile(
+			"plugins/dev/skills/bootstrap/SKILL.md",
+		);
+		const result = await resolveSharedIncludes(bootstrap, repoRoot);
+
+		expect(result._tag).toBe("Right");
+		if (result._tag === "Left") {
+			throw new Error(result.left.message);
+		}
+
+		expect(bootstrap).not.toContain('{% include_shared "anti-loop.md" %}');
+		for (const prohibition of [
+			"Ask for clarification or approval",
+			"Wait for user feedback",
+			"Request additional information",
+		]) {
+			expect(result.right).not.toContain(prohibition);
+		}
+	});
+
+	test("persists bootstrap approval decisions before their actions", async () => {
+		const bootstrap = await readRepoFile(
+			"plugins/dev/skills/bootstrap/SKILL.md",
+		);
+
+		expectInOrder(bootstrap, [
+			"Persist the accepted plan as `Approved` in `Plan Review`",
+			"Re-read and verify the approval",
+			"ACTION=APPLY",
+		]);
+		expectInOrder(bootstrap, [
+			"Persist the complete requested change in `Revision Request`",
+			"Re-read and verify the requested change",
+			"ACTION=REVISE",
+		]);
+		expect(bootstrap).toContain(
+			"Persist `Revision limit reached; rerun bootstrap to request another plan`",
+		);
+		expect(bootstrap).toContain(
+			"Stop without another dispatch and give rerun guidance.",
+		);
+	});
+
+	test("bounds bootstrap to one plan, one revision, and one apply dispatch", async () => {
+		const bootstrap = await readRepoFile(
+			"plugins/dev/skills/bootstrap/SKILL.md",
+		);
+
+		expect(bootstrap.match(/ACTION=PLAN/g)).toHaveLength(1);
+		expect(bootstrap.match(/ACTION=REVISE/g)).toHaveLength(1);
+		expect(bootstrap.match(/ACTION=APPLY/g)).toHaveLength(1);
+		expect(
+			bootstrap.match(/{% dispatch_agent "rp1-dev:bootstrap-scaffolder" %}/g),
+		).toHaveLength(3);
+	});
+
+	test("registers bootstrap KB artifacts from the resolved target roots", async () => {
+		const bootstrap = await readRepoFile(
+			"plugins/dev/skills/bootstrap/SKILL.md",
+		);
+
+		expect(bootstrap).toContain(
+			"Map `directories.projectRoot` to `targetProjectRoot` and `directories.kbRoot` to `targetKbRoot`",
+		);
+		expect(bootstrap).toContain('--project "{targetProjectRoot}"');
+		expect(bootstrap).toContain(
+			'"path": "{targetKbRoot}/charter.md", "feature": "{PROJECT_NAME}", "storageRoot": "project"',
+		);
+		expect(bootstrap).toContain(
+			'"path": "{targetKbRoot}/preferences.md", "feature": "{PROJECT_NAME}", "storageRoot": "project"',
+		);
+	});
+
+	test("defines ordinary bootstrap preference gaps", async () => {
+		const bootstrap = await readRepoFile(
+			"plugins/dev/skills/bootstrap/SKILL.md",
+		);
+
+		for (const heading of [
+			"Project",
+			"Tech Stack",
+			"Research Notes",
+			"Scaffold Plan",
+			"Plan Review",
+			"Revision Request",
+			"Revised Plan",
+			"Apply Result",
+		]) {
+			expect(bootstrap).toContain(`## ${heading}`);
+		}
+		expect(bootstrap).toContain("**Status**: Draft");
 	});
 });

--- a/tests/interview-composition.test.ts
+++ b/tests/interview-composition.test.ts
@@ -1,12 +1,28 @@
 import { describe, expect, test } from "bun:test";
-import { readFile } from "node:fs/promises";
-import { resolve } from "node:path";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import type { Logger } from "../cli/shared/logger.js";
+import { buildPlatformPlugin } from "../cli/src/build/command.js";
+import { PLATFORM_DEFINITIONS } from "../cli/src/build/platform-definitions.js";
 import { resolveSharedIncludes } from "../cli/src/build/preprocessor.js";
 
 const repoRoot = resolve(import.meta.dir, "..");
 
 const readRepoFile = (path: string): Promise<string> =>
 	readFile(resolve(repoRoot, path), "utf8");
+
+const noopLogger: Logger = {
+	trace: () => {},
+	debug: () => {},
+	info: () => {},
+	warn: () => {},
+	error: () => {},
+	start: () => {},
+	success: () => {},
+	fail: () => {},
+	box: () => {},
+};
 
 const blueprintFinalizerPaths = [
 	"plugins/dev/agents/charter-interviewer.md",
@@ -297,6 +313,63 @@ describe("parent-owned interview foundation", () => {
 			"Request additional information",
 		]) {
 			expect(result.right).not.toContain(prohibition);
+		}
+	});
+
+	test("renders one directory-only selected-target handoff on every platform", async () => {
+		const outputRoot = await mkdtemp(
+			join(tmpdir(), "rp1-bootstrap-directory-handoff-"),
+		);
+
+		try {
+			const platformDefinitions = Array.from(PLATFORM_DEFINITIONS.values());
+			expect(platformDefinitions.map(({ id }) => id).sort()).toEqual([
+				"antigravity",
+				"claude-code",
+				"codex",
+				"copilot",
+				"opencode",
+			]);
+
+			for (const definition of platformDefinitions) {
+				const platformOutput = join(outputRoot, definition.id);
+				const result = await buildPlatformPlugin(
+					"dev",
+					repoRoot,
+					platformOutput,
+					definition,
+					noopLogger,
+					true,
+				);
+
+				expect(result.summary.errors).toEqual([]);
+				const skillDirectory =
+					definition.id === "claude-code" ? "bootstrap" : "rp1-bootstrap";
+				const bootstrap = await readFile(
+					join(platformOutput, "dev", "skills", skillDirectory, "SKILL.md"),
+					"utf8",
+				);
+
+				expect(bootstrap.match(/rp1 agent-tools resolve-args/g)).toHaveLength(
+					2,
+				);
+				expect(bootstrap.match(/--args "/g)).toHaveLength(1);
+				expect(
+					bootstrap.match(/--project-root "\{TARGET_DIR\}"/g),
+				).toHaveLength(1);
+				expect(bootstrap).toContain("--name rp1-dev':'bootstrap");
+				expectInOrder(bootstrap, [
+					"## 0. Resolve Arguments",
+					"Use these resolved values for all subsequent steps.",
+					"The generated Resolve Arguments section already parsed `PROJECT_NAME`",
+					"This directory-only lookup is the one explicit exception",
+					'--project-root "{TARGET_DIR}"',
+					"Consume only `data.directories`",
+					"`targetProjectRoot`, `targetKbRoot`, and `targetWorkRoot` replace the invocation roots",
+				]);
+			}
+		} finally {
+			await rm(outputRoot, { recursive: true, force: true });
 		}
 	});
 

--- a/tests/interview-composition.test.ts
+++ b/tests/interview-composition.test.ts
@@ -188,6 +188,43 @@ describe("parent-owned interview foundation", () => {
 		]);
 	});
 
+	test("preserves canonical Blueprint roots through finalization and completion", async () => {
+		const [blueprint, finalizer] = await Promise.all([
+			readRepoFile("plugins/dev/skills/blueprint/SKILL.md"),
+			readRepoFile("plugins/dev/agents/blueprint-wizard.md"),
+		]);
+
+		expectInOrder(blueprint, [
+			"Validate `EFFECTIVE_PRD_NAME`",
+			"Set `PRD_PATH = {workRoot}/prds/{EFFECTIVE_PRD_NAME}.md`",
+			'{% dispatch_agent "rp1-dev:blueprint-wizard" %}',
+			"PRD_PATH={PRD_PATH}, PRD_NAME={EFFECTIVE_PRD_NAME}, KB_ROOT={kbRoot}, WORK_ROOT={workRoot}",
+		]);
+		expect(countMatches(blueprint, /Set `PRD_PATH =/g)).toBe(1);
+		expect(blueprint).not.toContain("{workRoot}/prds/{PRD_NAME}.md");
+		const dispatchStart = blueprint.indexOf(
+			'{% dispatch_agent "rp1-dev:blueprint-wizard" %}',
+		);
+		const dispatchEnd = blueprint.indexOf(
+			"{% enddispatch_agent %}",
+			dispatchStart,
+		);
+		const dispatch = blueprint.slice(dispatchStart, dispatchEnd);
+		expect(dispatch).not.toContain("EXTRA_CONTEXT={EXTRA_CONTEXT}");
+		expect(finalizer).toContain(
+			"PRD=`{WORK_ROOT}/prds/{PRD_NAME}.md`, Charter=`{KB_ROOT}/charter.md`",
+		);
+		expect(finalizer).toContain(
+			"`PRD_PATH` MUST equal `PRD`; write only `PRD_PATH`, and treat `Charter` as read-only.",
+		);
+		expect(blueprint).toContain(
+			"Terminal state guidance: close the run only after fresh reads prove both artifacts complete, using `--close-run`.",
+		);
+		expect(blueprint).toMatch(
+			/--step prd[\s\S]*--data '\{"status": "completed"\}'[\s\\]*--close-run/,
+		);
+	});
+
 	test("keeps blueprint interviews parent-owned and finalizers bounded", async () => {
 		const blueprint = await readRepoFile(
 			"plugins/dev/skills/blueprint/SKILL.md",
@@ -680,6 +717,13 @@ describe("parent-owned interview foundation", () => {
 					"Re-read the PRD after the successful write",
 					"Re-read the PRD after a successful finalization",
 				]);
+				expectContainsAll(blueprint, [
+					"Set `PRD_PATH = {workRoot}/prds/{EFFECTIVE_PRD_NAME}.md`",
+					"PRD_PATH={PRD_PATH}, PRD_NAME={EFFECTIVE_PRD_NAME}, KB_ROOT={kbRoot}, WORK_ROOT={workRoot}",
+					"Terminal state guidance: close the run only after fresh reads prove both artifacts complete, using `--close-run`.",
+					"--step prd",
+					`--data '{"status": "completed"}'`,
+				]);
 				expect(countRenderedDispatches(blueprint, "charter-interviewer")).toBe(
 					1,
 				);
@@ -755,6 +799,10 @@ describe("parent-owned interview foundation", () => {
 						/{%\s*(?:ask_user|dispatch_agent|include_shared)\b|request_user_input|next_question|qa_history|--type artifact_registered|^[ \t]*rp1 agent-tools emit(?:[ \t]|\\|$)/im,
 					);
 				}
+				expectContainsAll(prdFinalizer, [
+					"PRD=`{WORK_ROOT}/prds/{PRD_NAME}.md`, Charter=`{KB_ROOT}/charter.md`",
+					"`PRD_PATH` MUST equal `PRD`; write only `PRD_PATH`, and treat `Charter` as read-only.",
+				]);
 				expectContainsAll(scaffolder, [
 					"Perform exactly one bounded `ACTION`, return one result, then stop.",
 					"The parent skill owns all user interaction and artifact registration. Never ask the user or request input.",

--- a/tests/interview-composition.test.ts
+++ b/tests/interview-composition.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, test } from "bun:test";
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+
+const repoRoot = resolve(import.meta.dir, "..");
+
+const readRepoFile = (path: string): Promise<string> =>
+	readFile(resolve(repoRoot, path), "utf8");
+
+const expectInOrder = (content: string, fragments: string[]): void => {
+	let previousIndex = -1;
+	for (const fragment of fragments) {
+		const index = content.indexOf(fragment);
+		expect(index).toBeGreaterThan(previousIndex);
+		previousIndex = index;
+	}
+};
+
+describe("parent-owned interview foundation", () => {
+	test("keeps interaction in the parent and persists before continuing", async () => {
+		const contract = await readRepoFile(
+			"plugins/shared/parent-owned-interview.md",
+		);
+
+		expect(contract).toContain(
+			"Only the including top-level skill asks user-facing questions.",
+		);
+		expect(contract).toContain(
+			"At most 10 parent questions per artifact phase.",
+		);
+		expect(contract).toContain(
+			"Preserve Will and Won't as separate regions, including list indentation and hierarchy.",
+		);
+		expectInOrder(contract, [
+			"1. Read the entire current artifact.",
+			"2. Scan only the caller-declared required sections.",
+			"3. Ask one focused question from the parent.",
+			"4. Reconstruct and write the entire artifact",
+			"5. Re-read the artifact",
+			"6. Only after the successful re-read",
+		]);
+		expect(contract).not.toMatch(/\{%\s*(?:if|case|ask_user)\b/);
+	});
+
+	test("makes every required charter field an ordinary durable gap", async () => {
+		const charter = await readRepoFile(
+			"plugins/base/skills/artifact-templates/templates/charter-interviewer/charter.md",
+		);
+
+		for (const heading of [
+			"Vision",
+			"Problem & Context",
+			"Target Users",
+			"Business Rationale",
+			"Success Criteria",
+		]) {
+			expect(charter).toContain(`## ${heading}\n_TBD_`);
+		}
+		expect(charter).toContain("### Will\n- _TBD_");
+		expect(charter).toContain("### Won't\n- _TBD_");
+		expect(charter).toContain("**Status**: Draft");
+		expect(charter).not.toContain("Scratch Pad");
+	});
+
+	test("uses durable PRD gaps and a resolved charter link", async () => {
+		const prd = await readRepoFile(
+			"plugins/base/skills/artifact-templates/templates/blueprint-wizard/prd.md",
+		);
+
+		expect(prd).toContain("**Charter**: {Resolved Charter Link}");
+		expect(prd).toContain("**Additional Context**: _TBD_");
+		expect(prd).toContain("**Status**: Draft");
+		for (const heading of [
+			"Surface Overview",
+			"Dependencies & Constraints",
+			"Milestones & Timeline",
+			"Open Questions",
+		]) {
+			expect(prd).toContain(`## ${heading}\n_TBD_`);
+		}
+		for (const heading of [
+			"In Scope",
+			"Out of Scope",
+			"Functional Requirements",
+			"Non-Functional Requirements",
+		]) {
+			expect(prd).toContain(`### ${heading}\n_TBD_`);
+		}
+		expect(prd).toContain("| A1 | _TBD_ | _TBD_ | _TBD_ |");
+		expect(prd).not.toContain(".rp1/context/charter.md");
+	});
+});

--- a/tests/interview-composition.test.ts
+++ b/tests/interview-composition.test.ts
@@ -7,6 +7,11 @@ const repoRoot = resolve(import.meta.dir, "..");
 const readRepoFile = (path: string): Promise<string> =>
 	readFile(resolve(repoRoot, path), "utf8");
 
+const blueprintFinalizerPaths = [
+	"plugins/dev/agents/charter-interviewer.md",
+	"plugins/dev/agents/blueprint-wizard.md",
+] as const;
+
 const expectInOrder = (content: string, fragments: string[]): void => {
 	let previousIndex = -1;
 	for (const fragment of fragments) {
@@ -148,5 +153,64 @@ describe("parent-owned interview foundation", () => {
 		expect(blueprint).toContain(
 			'"path": "prds/{EFFECTIVE_PRD_NAME}.md", "feature": "{EFFECTIVE_PRD_NAME}", "storageRoot": "work_dir"',
 		);
+	});
+
+	test("keeps retained blueprint agents one-shot and non-interactive", async () => {
+		for (const path of blueprintFinalizerPaths) {
+			const finalizer = await readRepoFile(path);
+
+			expect(finalizer).toContain("one-shot non-interactive finalizer");
+			expect(finalizer).toContain("tools: Read, Write");
+			expect(finalizer).toContain(
+				"Return exactly one raw JSON object with these keys in this order: `status`, `artifact`, `gaps`, `warnings`.",
+			);
+			expect(finalizer).toContain(
+				"Artifact registration belongs to the parent skill.",
+			);
+			expect(finalizer).not.toMatch(
+				/{%\s*(?:ask_user|dispatch_agent|include_shared)\b/,
+			);
+			expect(finalizer).not.toMatch(
+				/next_question|request_user_input|Scratch Pad|qa_history|relay envelope|continuation payload|checkpoint|--type artifact_registered/i,
+			);
+		}
+	});
+
+	test("keeps unresolved charter Vision draft and preserves nested scope", async () => {
+		const finalizer = await readRepoFile(
+			"plugins/dev/agents/charter-interviewer.md",
+		);
+
+		expect(finalizer).toContain(
+			"Missing, empty, or placeholder-only Vision is a gap.",
+		);
+		expect(finalizer).toContain(
+			"Never infer or invent Vision from another section.",
+		);
+		expect(finalizer).toContain(
+			"Keep the document status `Draft` whenever any required gap remains.",
+		);
+		expect(finalizer).toContain(
+			"Preserve the complete nested list blocks under `Will` and `Won't` byte-for-byte.",
+		);
+		expect(finalizer).toContain(
+			"Never move, merge, flatten, reorder, or drop items between them.",
+		);
+	});
+
+	test("preserves substantive content while finalizing either artifact", async () => {
+		for (const path of blueprintFinalizerPaths) {
+			const finalizer = await readRepoFile(path);
+
+			expect(finalizer).toContain(
+				"Preserve every substantive user-authored field and every unrelated section.",
+			);
+			expect(finalizer).toContain(
+				"Read the supplied ordinary artifact before deciding whether a write is needed.",
+			);
+			expect(finalizer).toContain(
+				"Report every remaining required gap explicitly in `gaps`.",
+			);
+		}
 	});
 });

--- a/tests/interview-composition.test.ts
+++ b/tests/interview-composition.test.ts
@@ -89,4 +89,64 @@ describe("parent-owned interview foundation", () => {
 		expect(prd).toContain("| A1 | _TBD_ | _TBD_ | _TBD_ |");
 		expect(prd).not.toContain(".rp1/context/charter.md");
 	});
+
+	test("validates the effective PRD name before blueprint artifact effects", async () => {
+		const blueprint = await readRepoFile(
+			"plugins/dev/skills/blueprint/SKILL.md",
+		);
+
+		expect(blueprint).toContain('`EFFECTIVE_PRD_NAME = PRD_NAME || "main"`');
+		expect(blueprint).toContain("`^[A-Za-z0-9][A-Za-z0-9_-]*$`");
+		expectInOrder(blueprint, [
+			'`EFFECTIVE_PRD_NAME = PRD_NAME || "main"`',
+			"Validate `EFFECTIVE_PRD_NAME`",
+			"Read `{kbRoot}/charter.md`",
+		]);
+	});
+
+	test("keeps blueprint interviews parent-owned and finalizers bounded", async () => {
+		const blueprint = await readRepoFile(
+			"plugins/dev/skills/blueprint/SKILL.md",
+		);
+
+		expect(blueprint).toContain(
+			'{% include_shared "parent-owned-interview.md" %}',
+		);
+		expectInOrder(blueprint, [
+			"Ask one focused charter question directly from this parent skill.",
+			"Write the complete reconstructed charter",
+			"Re-read the charter after the successful write",
+			'{% dispatch_agent "rp1-dev:charter-interviewer" %}',
+		]);
+		expectInOrder(blueprint, [
+			"Ask one focused PRD question directly from this parent skill.",
+			"Write the complete reconstructed PRD",
+			"Re-read the PRD after the successful write",
+			'{% dispatch_agent "rp1-dev:blueprint-wizard" %}',
+		]);
+		expect(
+			blueprint.match(/{% dispatch_agent "rp1-dev:charter-interviewer" %}/g),
+		).toHaveLength(1);
+		expect(
+			blueprint.match(/{% dispatch_agent "rp1-dev:blueprint-wizard" %}/g),
+		).toHaveLength(1);
+		expect(blueprint).not.toMatch(/{%\s*ask_user\b/);
+		expect(blueprint).not.toContain("Scratch Pad");
+	});
+
+	test("persists blueprint context and registers resolved artifacts", async () => {
+		const blueprint = await readRepoFile(
+			"plugins/dev/skills/blueprint/SKILL.md",
+		);
+
+		expect(blueprint).toContain(
+			"Persist `EXTRA_CONTEXT` in `**Additional Context**`",
+		);
+		expect(blueprint).toContain(
+			'"path": "{kbRoot}/charter.md", "feature": "blueprint", "storageRoot": "project"',
+		);
+		expect(blueprint).toContain(
+			'"path": "prds/{EFFECTIVE_PRD_NAME}.md", "feature": "{EFFECTIVE_PRD_NAME}", "storageRoot": "work_dir"',
+		);
+	});
 });

--- a/tests/interview-composition.test.ts
+++ b/tests/interview-composition.test.ts
@@ -227,6 +227,9 @@ describe("parent-owned interview foundation", () => {
 			"Persist `EXTRA_CONTEXT` in `**Additional Context**`",
 		);
 		expect(blueprint).toContain(
+			'"path": "{kbRoot}/charter.md", "feature": "blueprint", "storageRoot": "absolute"',
+		);
+		expect(blueprint).not.toContain(
 			'"path": "{kbRoot}/charter.md", "feature": "blueprint", "storageRoot": "project"',
 		);
 		expect(blueprint).toContain(
@@ -773,12 +776,21 @@ describe("parent-owned interview foundation", () => {
 						kbRoot,
 					);
 					expect(resolvedBlueprint).toContain(
+						`"path": "${kbRoot}/charter.md", "feature": "blueprint", "storageRoot": "absolute"`,
+					);
+					expect(resolvedBootstrap).toContain(
+						`"path": "${kbRoot}/charter.md", "feature": "{PROJECT_NAME}", "storageRoot": "absolute"`,
+					);
+					expect(resolvedBootstrap).toContain(
+						`"path": "${kbRoot}/preferences.md", "feature": "{PROJECT_NAME}", "storageRoot": "absolute"`,
+					);
+					expect(resolvedBlueprint).not.toContain(
 						`"path": "${kbRoot}/charter.md", "feature": "blueprint", "storageRoot": "project"`,
 					);
-					expect(resolvedBootstrap).toContain(
+					expect(resolvedBootstrap).not.toContain(
 						`"path": "${kbRoot}/charter.md", "feature": "{PROJECT_NAME}", "storageRoot": "project"`,
 					);
-					expect(resolvedBootstrap).toContain(
+					expect(resolvedBootstrap).not.toContain(
 						`"path": "${kbRoot}/preferences.md", "feature": "{PROJECT_NAME}", "storageRoot": "project"`,
 					);
 				}
@@ -837,9 +849,15 @@ describe("parent-owned interview foundation", () => {
 		);
 		expect(bootstrap).toContain('--project "{targetProjectRoot}"');
 		expect(bootstrap).toContain(
-			'"path": "{targetKbRoot}/charter.md", "feature": "{PROJECT_NAME}", "storageRoot": "project"',
+			'"path": "{targetKbRoot}/charter.md", "feature": "{PROJECT_NAME}", "storageRoot": "absolute"',
 		);
 		expect(bootstrap).toContain(
+			'"path": "{targetKbRoot}/preferences.md", "feature": "{PROJECT_NAME}", "storageRoot": "absolute"',
+		);
+		expect(bootstrap).not.toContain(
+			'"path": "{targetKbRoot}/charter.md", "feature": "{PROJECT_NAME}", "storageRoot": "project"',
+		);
+		expect(bootstrap).not.toContain(
 			'"path": "{targetKbRoot}/preferences.md", "feature": "{PROJECT_NAME}", "storageRoot": "project"',
 		);
 	});

--- a/tests/interview-composition.test.ts
+++ b/tests/interview-composition.test.ts
@@ -231,6 +231,124 @@ describe("parent-owned interview foundation", () => {
 		}
 	});
 
+	test("defines bootstrap scaffolding as one-shot action work", async () => {
+		const scaffolder = await readRepoFile(
+			"plugins/dev/agents/bootstrap-scaffolder.md",
+		);
+
+		expect(scaffolder).toContain(
+			"description: One-shot non-interactive bootstrap worker for bounded PLAN, REVISE, or APPLY actions",
+		);
+		expect(scaffolder).toContain("- name: ACTION");
+		expect(scaffolder).toContain("type: enum");
+		for (const action of ["PLAN", "REVISE", "APPLY"]) {
+			expect(scaffolder).toContain(`      - "${action}"`);
+		}
+		for (const argument of [
+			"PROJECT_NAME",
+			"TARGET_DIR",
+			"CHARTER_PATH",
+			"PREFS_PATH",
+			"KB_ROOT",
+			"WORK_ROOT",
+			"RUN_ID",
+		]) {
+			expect(scaffolder).toContain(`- name: ${argument}`);
+		}
+		expect(scaffolder).toContain(
+			"Perform exactly one bounded `ACTION`, return one result, then stop.",
+		);
+		expect(scaffolder).toContain(
+			"The parent skill owns all user interaction and artifact registration. Never ask the user or request input.",
+		);
+		expect(scaffolder).toContain("Do not invoke another skill or agent.");
+		expect(scaffolder).toContain(
+			"Return exactly one raw JSON object with these keys in this order: `action`, `status`, `changed_files`, `conflicts`, `research_fallback`, `warnings`, `retry_guidance`.",
+		);
+		expect(scaffolder).not.toMatch(
+			/\$[1-9]|next_question|research_ready|Phase: INTERVIEW|Scratch Pad|Caller handles interaction|re-invokes|relay|continuation|checkpoint/i,
+		);
+		expect(scaffolder).not.toMatch(
+			/{%\s*(?:ask_user|dispatch_agent|include_shared)\b/,
+		);
+	});
+
+	test("makes bootstrap planning research bounded with an explicit fallback", async () => {
+		const scaffolder = await readRepoFile(
+			"plugins/dev/agents/bootstrap-scaffolder.md",
+		);
+
+		expect(scaffolder).toContain(
+			"tools: Read, Write, Bash, WebFetch, WebSearch",
+		);
+		expect(scaffolder).toContain(
+			"Read the complete `CHARTER_PATH` and `PREFS_PATH` before planning.",
+		);
+		expect(scaffolder).toContain(
+			"Use at most 6 searches and 8 authoritative source reads.",
+		);
+		expect(scaffolder).toContain(
+			"Prefer primary, authoritative sources for current tool and framework guidance.",
+		);
+		expect(scaffolder).toContain(
+			"If no web research tool is available or a required lookup fails, continue from the persisted artifacts and model knowledge.",
+		);
+		expect(scaffolder).toContain(
+			"Mark every version-sensitive claim without current authoritative evidence as `Verify before apply`.",
+		);
+		expectInOrder(scaffolder, [
+			"Write the complete reconstructed preferences document",
+			"Re-read `PREFS_PATH` and verify both updated sections",
+		]);
+	});
+
+	test("revises one persisted bootstrap plan exactly once", async () => {
+		const scaffolder = await readRepoFile(
+			"plugins/dev/agents/bootstrap-scaffolder.md",
+		);
+
+		expect(scaffolder).toContain(
+			"Require one substantive persisted `Revision Request` and a substantive `Scaffold Plan`.",
+		);
+		expect(scaffolder).toContain(
+			"Write the replacement into `Revised Plan` exactly once; preserve the original `Scaffold Plan` and `Revision Request`.",
+		);
+		expect(scaffolder).toContain(
+			"If `Revised Plan` is already substantive, do not revise it again.",
+		);
+		expect(scaffolder).toContain(
+			"For `Revision Request` and `Revised Plan`, `Not requested` is also not a substantive revision value.",
+		);
+		expect(scaffolder).toContain(
+			"Use only the ordinary charter and preferences sections as action state.",
+		);
+	});
+
+	test("applies approved bootstrap plans idempotently without overwrites", async () => {
+		const scaffolder = await readRepoFile(
+			"plugins/dev/agents/bootstrap-scaffolder.md",
+		);
+
+		expectInOrder(scaffolder, [
+			"Require a fresh `PREFS_PATH` read whose `Plan Review` is exactly `Approved` before any scaffold effect.",
+			"Use a substantive `Revised Plan` when present; otherwise use `Scaffold Plan`.",
+			"Check only the expected outputs declared by the approved plan.",
+			"Create only missing planned outputs.",
+			"Write the complete reconstructed preferences document with an `Apply Result`",
+		]);
+		expect(scaffolder).toContain(
+			"Preserve every pre-existing output with different or unrelated content and report it as a conflict; never overwrite or merge it.",
+		);
+		expect(scaffolder).toContain(
+			"On every APPLY invocation, re-check the approved plan and its expected outputs directly, including after a partial prior result.",
+		);
+		expect(scaffolder).toContain(
+			"Resolve dependency versions through the selected package manager or installed-tool evidence; never assert an unverified exact version.",
+		);
+		expect(scaffolder).not.toContain("--type artifact_registered");
+		expect(scaffolder).not.toContain("rp1 agent-tools emit");
+	});
+
 	test("rejects every bootstrap project name before target effects", async () => {
 		const bootstrap = await readRepoFile(
 			"plugins/dev/skills/bootstrap/SKILL.md",


### PR DESCRIPTION
## Summary

- Move every user-facing interview question into the parent blueprint and bootstrap skills.
- Persist each accepted answer into the ordinary charter, PRD, or preferences artifact before another question or any bounded leaf dispatch becomes eligible.
- Use one cross-platform topology for OpenCode, Codex, Claude Code, Copilot, and Antigravity; leaf agents are non-interactive and bounded.
- Resume from ordinary artifact content and remaining _TBD_ gaps, without feature-specific interview checkpoint state.
- Restore the Blueprint canonical-root finalizer handoff and terminal lifecycle close contract.
- Keep the implementation out of cli/src.

This is the clean replacement for #431. PR #431 is intentionally left open and unchanged.

## Verification

- Full CLI suite: 3,592 passed, 23 skipped, 0 failed.
- CLI line coverage: 82.37% (47,380/57,519), above the 80% gate.
- Focused parent-owned interview suite: 24/24 passed.
- All five registered platform builds passed.
- Live Codex and restricted-Claude probes confirmed parent-owned questions, persistence-before-dispatch, ordinary-artifact resume, and equivalent bounded leaf behavior.
- Canonical-root and terminal lifecycle contract coverage passed.
- Pre-push attestation, catalog, CLI typecheck, and web UI typecheck hooks passed.

## Scope and follow-ups

The diff is intentionally test-heavy: 11 files, 1,626 additions, and 1,151 deletions. It changes prompt, template, catalog, shared-contract, and root-level test files only; there are no cli/src changes.

One branch-unowned Docker eval fixture warning remains. The relevant eval launcher and configuration blobs are byte-identical to origin/main and outside this diff.

Non-blocking documentation follow-ups remain:

- TD1: update docs/reference/dev/blueprint.md.
- TD2: update docs/guides/bootstrap.md.
- TD3: update .rp1/context/concept_map.md.