### PR TITLE
fix(antigravity): sync active plugin registry on update and check current registry path

### DIFF
--- a/cli/src/__tests__/install/antigravity/active-registry.test.ts
+++ b/cli/src/__tests__/install/antigravity/active-registry.test.ts
@@ -198,6 +198,43 @@ describe("syncAntigravityActivePlugins", () => {
 		}
 	});
 
+	test("treats a manifest-recorded import with no registry directories as drift", async () => {
+		const homeDir = await createTempDir(
+			"antigravity-active-registry-manifest-only",
+		);
+		try {
+			await writeActiveAsset(
+				join(homeDir, ".gemini/config/import_manifest.json"),
+				JSON.stringify({
+					imports: [
+						{ name: "rp1-base", source: "antigravity" },
+						{ name: "rp1-dev", source: "antigravity" },
+					],
+				}),
+			);
+
+			const manifestOnly = await syncAntigravityActivePlugins({
+				dryRun: true,
+				homeDir,
+				assetManifest: bundleAssets,
+			});
+			expect(manifestOnly.driftDetected).toBe(true);
+			expect(manifestOnly.driftIssue).toContain(
+				"has no active plugin registry directory",
+			);
+
+			await writeActiveRegistry(homeDir, CURRENT_REGISTRY_ROOT);
+			const repaired = await syncAntigravityActivePlugins({
+				dryRun: true,
+				homeDir,
+				assetManifest: bundleAssets,
+			});
+			expect(repaired.driftDetected).toBe(false);
+		} finally {
+			await cleanupTempDir(homeDir);
+		}
+	});
+
 	test("reads the current import manifest before the legacy one", async () => {
 		const homeDir = await createTempDir("antigravity-active-registry-manifest");
 		try {
@@ -231,7 +268,15 @@ describe("syncAntigravityActivePlugins", () => {
 				homeDir,
 				assetManifest: bundleAssets,
 			});
-			expect(currentWins.driftDetected).toBe(false);
+			expect(currentWins.driftIssue).not.toContain("Gemini CLI");
+
+			await writeActiveRegistry(homeDir, CURRENT_REGISTRY_ROOT);
+			const settled = await syncAntigravityActivePlugins({
+				dryRun: true,
+				homeDir,
+				assetManifest: bundleAssets,
+			});
+			expect(settled.driftDetected).toBe(false);
 		} finally {
 			await cleanupTempDir(homeDir);
 		}

--- a/cli/src/__tests__/install/antigravity/active-registry.test.ts
+++ b/cli/src/__tests__/install/antigravity/active-registry.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Tests for Antigravity active plugin registry synchronization.
+ * Covers current (`~/.gemini/config/plugins/`) vs legacy
+ * (`~/.gemini/antigravity-cli/plugins/`) registry precedence and the
+ * update-flow drift sync.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { syncAntigravityActivePlugins } from "../../../install/antigravity/index.js";
+import { createAntigravityBundleAssetManifestFixture } from "../../helpers/antigravity-bundle.js";
+import { cleanupTempDir, createTempDir } from "../../helpers/index.js";
+
+const bundleAssets = createAntigravityBundleAssetManifestFixture();
+
+const commandAsset = bundleAssets.find((asset) => asset.kind === "command");
+if (!commandAsset) throw new Error("Fixture is missing a command asset");
+
+const activePathFor = (
+	homeDir: string,
+	registryRoot: ".gemini/config/plugins" | ".gemini/antigravity-cli/plugins",
+): string =>
+	join(
+		homeDir,
+		registryRoot,
+		commandAsset.relativePath.replace(/^\.gemini\/antigravity-cli\//, ""),
+	);
+
+const writeActiveAsset = async (path: string, content: string) => {
+	await mkdir(dirname(path), { recursive: true });
+	await writeFile(path, content, "utf-8");
+};
+
+describe("syncAntigravityActivePlugins", () => {
+	test("reports no drift when no active registry copies exist", async () => {
+		const homeDir = await createTempDir("antigravity-active-registry-none");
+		try {
+			const result = await syncAntigravityActivePlugins({
+				dryRun: false,
+				homeDir,
+				assetManifest: bundleAssets,
+			});
+			expect(result).toEqual({
+				driftDetected: false,
+				driftIssue: null,
+				install: null,
+			});
+		} finally {
+			await cleanupTempDir(homeDir);
+		}
+	});
+
+	test("prefers the current registry over a stale legacy leftover", async () => {
+		const homeDir = await createTempDir("antigravity-active-registry-current");
+		try {
+			await writeActiveAsset(
+				activePathFor(homeDir, ".gemini/config/plugins"),
+				commandAsset.expectedContent,
+			);
+			await writeActiveAsset(
+				activePathFor(homeDir, ".gemini/antigravity-cli/plugins"),
+				"stale legacy content",
+			);
+
+			const result = await syncAntigravityActivePlugins({
+				dryRun: false,
+				homeDir,
+				assetManifest: bundleAssets,
+			});
+			expect(result.driftDetected).toBe(false);
+			expect(result.install).toBeNull();
+		} finally {
+			await cleanupTempDir(homeDir);
+		}
+	});
+
+	test("detects drift in the current registry and reimports plugins", async () => {
+		const homeDir = await createTempDir("antigravity-active-registry-drift");
+		try {
+			await writeActiveAsset(
+				activePathFor(homeDir, ".gemini/config/plugins"),
+				"drifted content",
+			);
+
+			const installedDirs: string[] = [];
+			const result = await syncAntigravityActivePlugins({
+				dryRun: false,
+				homeDir,
+				assetManifest: bundleAssets,
+				getAntigravityBinaryPath: () => "/usr/local/bin/agy",
+				runAgyPluginInstall: async (_binaryPath, pluginDir) => {
+					installedDirs.push(pluginDir);
+					return { exitCode: 0, stdout: "ok", stderr: "" };
+				},
+			});
+
+			expect(result.driftDetected).toBe(true);
+			expect(result.driftIssue).toContain(
+				".gemini/config/plugins/rp1-base/commands/rp1-base/guide.toml",
+			);
+			expect(result.install?.status).toBe("passed");
+			expect(installedDirs).toEqual(
+				expect.arrayContaining([
+					join(homeDir, ".gemini/antigravity-cli/rp1-base"),
+					join(homeDir, ".gemini/antigravity-cli/rp1-dev"),
+				]),
+			);
+		} finally {
+			await cleanupTempDir(homeDir);
+		}
+	});
+
+	test("detects legacy-only drift when no current registry exists", async () => {
+		const homeDir = await createTempDir("antigravity-active-registry-legacy");
+		try {
+			await writeActiveAsset(
+				activePathFor(homeDir, ".gemini/antigravity-cli/plugins"),
+				"stale legacy content",
+			);
+
+			const result = await syncAntigravityActivePlugins({
+				dryRun: true,
+				homeDir,
+				assetManifest: bundleAssets,
+			});
+			expect(result.driftDetected).toBe(true);
+			expect(result.driftIssue).toContain(
+				".gemini/antigravity-cli/plugins/rp1-base/commands/rp1-base/guide.toml",
+			);
+			expect(result.install).toBeNull();
+		} finally {
+			await cleanupTempDir(homeDir);
+		}
+	});
+
+	test("reads the current import manifest before the legacy one", async () => {
+		const homeDir = await createTempDir("antigravity-active-registry-manifest");
+		try {
+			const legacyManifestPath = join(
+				homeDir,
+				".gemini/antigravity-cli/import_manifest.json",
+			);
+			await writeActiveAsset(
+				legacyManifestPath,
+				JSON.stringify({
+					imports: [{ name: "rp1-base", source: "gemini-cli" }],
+				}),
+			);
+
+			const legacyOnly = await syncAntigravityActivePlugins({
+				dryRun: true,
+				homeDir,
+				assetManifest: bundleAssets,
+			});
+			expect(legacyOnly.driftDetected).toBe(true);
+			expect(legacyOnly.driftIssue).toContain("Gemini CLI");
+
+			await writeActiveAsset(
+				join(homeDir, ".gemini/config/import_manifest.json"),
+				JSON.stringify({
+					imports: [{ name: "rp1-base", source: "antigravity" }],
+				}),
+			);
+			const currentWins = await syncAntigravityActivePlugins({
+				dryRun: true,
+				homeDir,
+				assetManifest: bundleAssets,
+			});
+			expect(currentWins.driftDetected).toBe(false);
+		} finally {
+			await cleanupTempDir(homeDir);
+		}
+	});
+});

--- a/cli/src/__tests__/install/antigravity/active-registry.test.ts
+++ b/cli/src/__tests__/install/antigravity/active-registry.test.ts
@@ -1,39 +1,55 @@
 /**
  * Tests for Antigravity active plugin registry synchronization.
  * Covers current (`~/.gemini/config/plugins/`) vs legacy
- * (`~/.gemini/antigravity-cli/plugins/`) registry precedence and the
- * update-flow drift sync.
+ * (`~/.gemini/antigravity-cli/plugins/`) registry precedence, missing-asset
+ * drift within the authoritative registry, and the update-flow drift sync.
  */
 
 import { describe, expect, test } from "bun:test";
-import { mkdir, writeFile } from "node:fs/promises";
+import { mkdir, rm, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { syncAntigravityActivePlugins } from "../../../install/antigravity/index.js";
 import { createAntigravityBundleAssetManifestFixture } from "../../helpers/antigravity-bundle.js";
 import { cleanupTempDir, createTempDir } from "../../helpers/index.js";
+
+const CURRENT_REGISTRY_ROOT = ".gemini/config/plugins";
+const LEGACY_REGISTRY_ROOT = ".gemini/antigravity-cli/plugins";
 
 const bundleAssets = createAntigravityBundleAssetManifestFixture();
 
 const commandAsset = bundleAssets.find((asset) => asset.kind === "command");
 if (!commandAsset) throw new Error("Fixture is missing a command asset");
 
+const registrySuffixFor = (relativePath: string): string =>
+	relativePath.replace(/^\.gemini\/antigravity-cli\//, "");
+
 const activePathFor = (
 	homeDir: string,
-	registryRoot: ".gemini/config/plugins" | ".gemini/antigravity-cli/plugins",
-): string =>
-	join(
-		homeDir,
-		registryRoot,
-		commandAsset.relativePath.replace(/^\.gemini\/antigravity-cli\//, ""),
-	);
+	registryRoot: string,
+	relativePath: string = commandAsset.relativePath,
+): string => join(homeDir, registryRoot, registrySuffixFor(relativePath));
 
 const writeActiveAsset = async (path: string, content: string) => {
 	await mkdir(dirname(path), { recursive: true });
 	await writeFile(path, content, "utf-8");
 };
 
+const writeActiveRegistry = async (
+	homeDir: string,
+	registryRoot: string,
+	overrides: Readonly<Record<string, string>> = {},
+) => {
+	for (const asset of bundleAssets) {
+		const suffix = registrySuffixFor(asset.relativePath);
+		await writeActiveAsset(
+			join(homeDir, registryRoot, suffix),
+			overrides[suffix] ?? asset.expectedContent,
+		);
+	}
+};
+
 describe("syncAntigravityActivePlugins", () => {
-	test("reports no drift when no active registry copies exist", async () => {
+	test("reports no drift when no active registry exists", async () => {
 		const homeDir = await createTempDir("antigravity-active-registry-none");
 		try {
 			const result = await syncAntigravityActivePlugins({
@@ -54,12 +70,9 @@ describe("syncAntigravityActivePlugins", () => {
 	test("prefers the current registry over a stale legacy leftover", async () => {
 		const homeDir = await createTempDir("antigravity-active-registry-current");
 		try {
+			await writeActiveRegistry(homeDir, CURRENT_REGISTRY_ROOT);
 			await writeActiveAsset(
-				activePathFor(homeDir, ".gemini/config/plugins"),
-				commandAsset.expectedContent,
-			);
-			await writeActiveAsset(
-				activePathFor(homeDir, ".gemini/antigravity-cli/plugins"),
+				activePathFor(homeDir, LEGACY_REGISTRY_ROOT),
 				"stale legacy content",
 			);
 
@@ -78,10 +91,10 @@ describe("syncAntigravityActivePlugins", () => {
 	test("detects drift in the current registry and reimports plugins", async () => {
 		const homeDir = await createTempDir("antigravity-active-registry-drift");
 		try {
-			await writeActiveAsset(
-				activePathFor(homeDir, ".gemini/config/plugins"),
-				"drifted content",
-			);
+			const driftedSuffix = registrySuffixFor(commandAsset.relativePath);
+			await writeActiveRegistry(homeDir, CURRENT_REGISTRY_ROOT, {
+				[driftedSuffix]: "drifted content",
+			});
 
 			const installedDirs: string[] = [];
 			const result = await syncAntigravityActivePlugins({
@@ -99,6 +112,7 @@ describe("syncAntigravityActivePlugins", () => {
 			expect(result.driftIssue).toContain(
 				".gemini/config/plugins/rp1-base/commands/rp1-base/guide.toml",
 			);
+			expect(result.driftIssue).toContain("does not match");
 			expect(result.install?.status).toBe("passed");
 			expect(installedDirs).toEqual(
 				expect.arrayContaining([
@@ -111,13 +125,36 @@ describe("syncAntigravityActivePlugins", () => {
 		}
 	});
 
+	test("treats an asset missing from the authoritative registry as drift", async () => {
+		const homeDir = await createTempDir("antigravity-active-registry-missing");
+		try {
+			await writeActiveRegistry(homeDir, CURRENT_REGISTRY_ROOT);
+			await rm(activePathFor(homeDir, CURRENT_REGISTRY_ROOT));
+			// A complete legacy copy must not mask the missing current asset.
+			await writeActiveRegistry(homeDir, LEGACY_REGISTRY_ROOT);
+
+			const result = await syncAntigravityActivePlugins({
+				dryRun: true,
+				homeDir,
+				assetManifest: bundleAssets,
+			});
+			expect(result.driftDetected).toBe(true);
+			expect(result.driftIssue).toContain(
+				".gemini/config/plugins/rp1-base/commands/rp1-base/guide.toml",
+			);
+			expect(result.driftIssue).toContain("is missing");
+		} finally {
+			await cleanupTempDir(homeDir);
+		}
+	});
+
 	test("detects legacy-only drift when no current registry exists", async () => {
 		const homeDir = await createTempDir("antigravity-active-registry-legacy");
 		try {
-			await writeActiveAsset(
-				activePathFor(homeDir, ".gemini/antigravity-cli/plugins"),
-				"stale legacy content",
-			);
+			const driftedSuffix = registrySuffixFor(commandAsset.relativePath);
+			await writeActiveRegistry(homeDir, LEGACY_REGISTRY_ROOT, {
+				[driftedSuffix]: "stale legacy content",
+			});
 
 			const result = await syncAntigravityActivePlugins({
 				dryRun: true,
@@ -129,6 +166,33 @@ describe("syncAntigravityActivePlugins", () => {
 				".gemini/antigravity-cli/plugins/rp1-base/commands/rp1-base/guide.toml",
 			);
 			expect(result.install).toBeNull();
+		} finally {
+			await cleanupTempDir(homeDir);
+		}
+	});
+
+	test("honors an injected binary resolver that returns null", async () => {
+		const homeDir = await createTempDir(
+			"antigravity-active-registry-no-binary",
+		);
+		try {
+			const driftedSuffix = registrySuffixFor(commandAsset.relativePath);
+			await writeActiveRegistry(homeDir, CURRENT_REGISTRY_ROOT, {
+				[driftedSuffix]: "drifted content",
+			});
+
+			const result = await syncAntigravityActivePlugins({
+				dryRun: false,
+				homeDir,
+				assetManifest: bundleAssets,
+				getAntigravityBinaryPath: () => null,
+				runAgyPluginInstall: async () => {
+					throw new Error("must not be invoked without a binary");
+				},
+			});
+
+			expect(result.driftDetected).toBe(true);
+			expect(result.install?.status).toBe("missing_binary");
 		} finally {
 			await cleanupTempDir(homeDir);
 		}

--- a/cli/src/__tests__/shared/install-core.test.ts
+++ b/cli/src/__tests__/shared/install-core.test.ts
@@ -1033,6 +1033,269 @@ describe("install-core tool routing", () => {
 		}
 	});
 
+	test("direct Antigravity update route honors the caller-provided home directory", async () => {
+		const processHome = await createTempDir(
+			"install-core-antigravity-process-home",
+		);
+		const targetHome = await createTempDir(
+			"install-core-antigravity-target-home",
+		);
+		const restoreHome = withEnvOverride("HOME", processHome);
+		const restoreBundle = await withAntigravityBundleDir(targetHome);
+
+		try {
+			const registry = { version: "1.0.0", tools: [createAntigravityTool()] };
+			const result = await expectTaskRight(
+				updateForSpecificToolDirect(
+					"antigravity",
+					registry,
+					createMockContext({ dryRun: false, homeDir: targetHome }),
+				),
+			);
+
+			expect(result.success).toBe(true);
+			expect(
+				await Bun.file(
+					join(targetHome, ".gemini/antigravity-cli/rp1-base/plugin.json"),
+				).exists(),
+			).toBe(true);
+			expect(
+				await Bun.file(
+					join(processHome, ".gemini/antigravity-cli/rp1-base/plugin.json"),
+				).exists(),
+			).toBe(false);
+		} finally {
+			restoreBundle();
+			restoreHome();
+			await cleanupTempDir(targetHome);
+			await cleanupTempDir(processHome);
+		}
+	});
+
+	test("direct Antigravity update route warns when active drift exists but agy is missing", async () => {
+		const homeDir = await createTempDir(
+			"install-core-antigravity-sync-no-binary",
+		);
+		const restoreHome = withEnvOverride("HOME", homeDir);
+		const restoreBundle = await withAntigravityBundleDir(homeDir);
+		const originalWhich = Bun.which;
+		Bun.which = ((command: string) =>
+			command === "agy" ? null : originalWhich(command)) as typeof Bun.which;
+
+		try {
+			const registry = { version: "1.0.0", tools: [createAntigravityTool()] };
+			const seeded = await expectTaskRight(
+				updateForSpecificToolDirect(
+					"antigravity",
+					registry,
+					createMockContext({ dryRun: false }),
+				),
+			);
+			expect(seeded.success).toBe(true);
+
+			const driftedActivePath = join(
+				homeDir,
+				".gemini/config/plugins/rp1-base/commands/rp1-base/guide.toml",
+			);
+			await mkdir(dirname(driftedActivePath), { recursive: true });
+			await writeFile(driftedActivePath, 'description = "Stale"\n', "utf-8");
+
+			const result = await expectTaskRight(
+				updateForSpecificToolDirect(
+					"antigravity",
+					registry,
+					createMockContext({ dryRun: false }),
+				),
+			);
+			expect(result).toMatchObject({
+				toolId: "antigravity",
+				success: true,
+				restartRequired: false,
+			});
+			expect(result.warnings.join("\n")).toContain(
+				"`agy` was not found in PATH",
+			);
+			expect(result.details?.join("\n")).toContain(
+				"Active plugin registry: skipped",
+			);
+		} finally {
+			Bun.which = originalWhich;
+			restoreBundle();
+			restoreHome();
+			await cleanupTempDir(homeDir);
+		}
+	});
+
+	test("direct Antigravity update route fails when the active plugin reimport fails", async () => {
+		const homeDir = await createTempDir(
+			"install-core-antigravity-sync-failure",
+		);
+		const restoreHome = withEnvOverride("HOME", homeDir);
+		const restorePath = withEnvOverride(
+			"PATH",
+			[homeDir, process.env.PATH ?? ""].filter(Boolean).join(delimiter),
+		);
+		const restoreBundle = await withAntigravityBundleDir(homeDir);
+		const agyPath = join(homeDir, "agy");
+		const originalWhich = Bun.which;
+
+		await writeFile(
+			agyPath,
+			[
+				"#!/bin/sh",
+				'if [ "$1" = "plugin" ] && [ "$2" = "install" ]; then',
+				'  echo "import rejected" >&2',
+				"  exit 1",
+				"fi",
+				"exit 0",
+				"",
+			].join("\n"),
+			"utf-8",
+		);
+		await chmod(agyPath, 0o755);
+		Bun.which = ((command: string) =>
+			command === "agy" ? agyPath : originalWhich(command)) as typeof Bun.which;
+
+		try {
+			const registry = { version: "1.0.0", tools: [createAntigravityTool()] };
+			const seeded = await expectTaskRight(
+				updateForSpecificToolDirect(
+					"antigravity",
+					registry,
+					createMockContext({ dryRun: false }),
+				),
+			);
+			expect(seeded.success).toBe(true);
+
+			const driftedActivePath = join(
+				homeDir,
+				".gemini/config/plugins/rp1-base/commands/rp1-base/guide.toml",
+			);
+			await mkdir(dirname(driftedActivePath), { recursive: true });
+			await writeFile(driftedActivePath, 'description = "Stale"\n', "utf-8");
+
+			const result = await expectTaskRight(
+				updateForSpecificToolDirect(
+					"antigravity",
+					registry,
+					createMockContext({ dryRun: false }),
+				),
+			);
+			expect(result).toMatchObject({
+				toolId: "antigravity",
+				success: false,
+			});
+			expect(result.error).toBeDefined();
+			expect(getErrorMessage(result.error as CLIError)).toContain(
+				"import rejected",
+			);
+			expect(result.details?.join("\n")).toContain(
+				"Active plugin registry: refresh failed",
+			);
+		} finally {
+			Bun.which = originalWhich;
+			restoreBundle();
+			restorePath();
+			restoreHome();
+			await cleanupTempDir(homeDir);
+		}
+	});
+
+	test("direct Antigravity update route is idempotent once the reimport lands active assets", async () => {
+		const homeDir = await createTempDir(
+			"install-core-antigravity-sync-idempotent",
+		);
+		const restoreHome = withEnvOverride("HOME", homeDir);
+		const restorePath = withEnvOverride(
+			"PATH",
+			[homeDir, process.env.PATH ?? ""].filter(Boolean).join(delimiter),
+		);
+		const restoreBundle = await withAntigravityBundleDir(homeDir);
+		const agyPath = join(homeDir, "agy");
+		const installLogPath = join(homeDir, "agy-plugin-install.log");
+		const originalWhich = Bun.which;
+
+		// Fake agy that mimics the real import: copies the package directory
+		// into the current active registry location.
+		await writeFile(
+			agyPath,
+			[
+				"#!/bin/sh",
+				'if [ "$1" = "plugin" ] && [ "$2" = "install" ]; then',
+				'  name=$(basename "$3")',
+				`  mkdir -p "$HOME/.gemini/config/plugins/$name"`,
+				`  cp -R "$3/." "$HOME/.gemini/config/plugins/$name/"`,
+				`  echo "$3" >> "${installLogPath}"`,
+				"  exit 0",
+				"fi",
+				"exit 0",
+				"",
+			].join("\n"),
+			"utf-8",
+		);
+		await chmod(agyPath, 0o755);
+		Bun.which = ((command: string) =>
+			command === "agy" ? agyPath : originalWhich(command)) as typeof Bun.which;
+
+		try {
+			const registry = { version: "1.0.0", tools: [createAntigravityTool()] };
+			const seeded = await expectTaskRight(
+				updateForSpecificToolDirect(
+					"antigravity",
+					registry,
+					createMockContext({ dryRun: false }),
+				),
+			);
+			expect(seeded.success).toBe(true);
+
+			const driftedActivePath = join(
+				homeDir,
+				".gemini/config/plugins/rp1-base/commands/rp1-base/guide.toml",
+			);
+			await mkdir(dirname(driftedActivePath), { recursive: true });
+			await writeFile(driftedActivePath, 'description = "Stale"\n', "utf-8");
+
+			const refreshed = await expectTaskRight(
+				updateForSpecificToolDirect(
+					"antigravity",
+					registry,
+					createMockContext({ dryRun: false }),
+				),
+			);
+			expect(refreshed).toMatchObject({
+				success: true,
+				restartRequired: true,
+			});
+			expect(refreshed.details?.join("\n")).toContain(
+				"Active plugin registry: refreshed",
+			);
+
+			const second = await expectTaskRight(
+				updateForSpecificToolDirect(
+					"antigravity",
+					registry,
+					createMockContext({ dryRun: false }),
+				),
+			);
+			expect(second).toMatchObject({
+				success: true,
+				restartRequired: false,
+			});
+			expect(second.details?.join("\n")).toContain(
+				"Active plugin registry: current",
+			);
+
+			const installLog = await Bun.file(installLogPath).text();
+			expect(installLog.trim().split("\n")).toHaveLength(2);
+		} finally {
+			Bun.which = originalWhich;
+			restoreBundle();
+			restorePath();
+			restoreHome();
+			await cleanupTempDir(homeDir);
+		}
+	});
+
 	test("installAllDetectedTools imports Antigravity active plugins during automatic install", async () => {
 		const homeDir = await createTempDir(
 			"install-core-antigravity-auto-install",

--- a/cli/src/__tests__/shared/install-core.test.ts
+++ b/cli/src/__tests__/shared/install-core.test.ts
@@ -5,7 +5,7 @@
 
 import { afterEach, describe, expect, mock, test } from "bun:test";
 import { chmod, mkdir, rm, writeFile } from "node:fs/promises";
-import { delimiter, join } from "node:path";
+import { delimiter, dirname, join } from "node:path";
 import * as TE from "fp-ts/lib/TaskEither.js";
 import { type CLIError, installError } from "../../../shared/errors.js";
 import type { Logger } from "../../../shared/logger.js";
@@ -921,6 +921,113 @@ describe("install-core tool routing", () => {
 			expect(blocked.details?.join("\n")).toContain("Check file permissions");
 		} finally {
 			restoreBundle();
+			restoreHome();
+			await cleanupTempDir(homeDir);
+		}
+	});
+
+	test("direct Antigravity update route refreshes the active plugin registry when it drifts", async () => {
+		const homeDir = await createTempDir("install-core-antigravity-active-sync");
+		const restoreHome = withEnvOverride("HOME", homeDir);
+		const restorePath = withEnvOverride(
+			"PATH",
+			[homeDir, process.env.PATH ?? ""].filter(Boolean).join(delimiter),
+		);
+		const restoreBundle = await withAntigravityBundleDir(homeDir);
+		const agyPath = join(homeDir, "agy");
+		const installLogPath = join(homeDir, "agy-plugin-install.log");
+		const originalWhich = Bun.which;
+
+		await writeFile(
+			agyPath,
+			[
+				"#!/bin/sh",
+				'if [ "$1" = "--version" ]; then echo "agy 1.0.0"; exit 0; fi',
+				'if [ "$1" = "plugin" ] && [ "$2" = "install" ]; then',
+				`  echo "$3" >> "${installLogPath}"`,
+				"  exit 0",
+				"fi",
+				'if [ "$1" = "plugin" ] && [ "$2" = "validate" ]; then exit 0; fi',
+				"exit 1",
+				"",
+			].join("\n"),
+			"utf-8",
+		);
+		await chmod(agyPath, 0o755);
+		Bun.which = ((command: string) =>
+			command === "agy" ? agyPath : originalWhich(command)) as typeof Bun.which;
+
+		try {
+			const registry = { version: "1.0.0", tools: [createAntigravityTool()] };
+
+			const seeded = await expectTaskRight(
+				updateForSpecificToolDirect(
+					"antigravity",
+					registry,
+					createMockContext({ dryRun: false }),
+				),
+			);
+			expect(seeded.success).toBe(true);
+			expect(seeded.details?.join("\n")).toContain(
+				"Active plugin registry: current",
+			);
+			expect(await Bun.file(installLogPath).exists()).toBe(false);
+
+			const driftedActivePath = join(
+				homeDir,
+				".gemini/antigravity-cli/plugins/rp1-base/commands/rp1-base/guide.toml",
+			);
+			await mkdir(dirname(driftedActivePath), { recursive: true });
+			await writeFile(driftedActivePath, 'description = "Stale"\n', "utf-8");
+
+			const dryRun = await expectTaskRight(
+				updateForSpecificToolDirect(
+					"antigravity",
+					registry,
+					createMockContext({ dryRun: true }),
+				),
+			);
+			expect(dryRun).toMatchObject({
+				toolId: "antigravity",
+				success: true,
+				restartRequired: false,
+			});
+			expect(dryRun.details?.join("\n")).toContain(
+				"Would refresh Antigravity's active plugin registry",
+			);
+			expect(await Bun.file(installLogPath).exists()).toBe(false);
+
+			const updated = await expectTaskRight(
+				updateForSpecificToolDirect(
+					"antigravity",
+					registry,
+					createMockContext({ dryRun: false }),
+				),
+			);
+			expect(updated).toMatchObject({
+				toolId: "antigravity",
+				success: true,
+				restartRequired: true,
+			});
+			expect(updated.details?.join("\n")).toContain(
+				"Lifecycle result: refreshed",
+			);
+			expect(updated.details?.join("\n")).toContain(
+				"Active plugin registry: refreshed",
+			);
+			expect(updated.details?.join("\n")).toContain("Restart Antigravity CLI");
+
+			const installLog = await Bun.file(installLogPath).text();
+			expect(installLog).toContain(
+				join(homeDir, ".gemini/antigravity-cli/rp1-base"),
+			);
+			expect(installLog).toContain(
+				join(homeDir, ".gemini/antigravity-cli/rp1-dev"),
+			);
+		} finally {
+			Bun.which = originalWhich;
+			restoreBundle();
+			restorePath();
 			restoreHome();
 			await cleanupTempDir(homeDir);
 		}

--- a/cli/src/install/antigravity/index.ts
+++ b/cli/src/install/antigravity/index.ts
@@ -220,13 +220,13 @@ const inspectActiveAntigravityImports = async (options: {
 		);
 		if (importManifest !== null) break;
 	}
+	const latestImportSourceByName = new Map<string, unknown>();
 	if (
 		importManifest &&
 		typeof importManifest === "object" &&
 		"imports" in importManifest &&
 		Array.isArray((importManifest as { readonly imports?: unknown }).imports)
 	) {
-		const latestImportSourceByName = new Map<string, unknown>();
 		for (const entry of (importManifest as { readonly imports: unknown[] })
 			.imports) {
 			if (typeof entry !== "object" || entry === null) continue;
@@ -258,14 +258,27 @@ const inspectActiveAntigravityImports = async (options: {
 		"support_matrix",
 		"support_metadata",
 	]);
+	const activeRefreshRemediation =
+		"Run `rp1 update plugins antigravity -y` (or `rp1 install antigravity`) to refresh Antigravity's active plugin registry.";
 	const registryRoot = await detectActivePluginRegistryRoot(
 		options.homeDir,
 		expectedPlugins,
 	);
-	if (!registryRoot) return null;
-
-	const activeRefreshRemediation =
-		"Run `rp1 update plugins antigravity -y` (or `rp1 install antigravity`) to refresh Antigravity's active plugin registry.";
+	if (!registryRoot) {
+		// The import manifest claims rp1 plugins are imported, yet no active
+		// registry directory exists in either layout — the registry was
+		// removed or never materialized and must be re-imported.
+		const importedPlugin = latestImportSourceByName.keys().next().value as
+			| string
+			| undefined;
+		if (importedPlugin !== undefined) {
+			return {
+				issue: `${importedPlugin} is recorded in Antigravity's import manifest but has no active plugin registry directory.`,
+				remediation: activeRefreshRemediation,
+			};
+		}
+		return null;
+	}
 	for (const asset of options.assets) {
 		if (!activeComparableKinds.has(asset.kind)) continue;
 		const activeRelativePath = activePluginRelativePathFor(asset, registryRoot);

--- a/cli/src/install/antigravity/index.ts
+++ b/cli/src/install/antigravity/index.ts
@@ -65,6 +65,23 @@ export interface AntigravityVerifyDeps {
 	readonly runAgyPluginValidate?: AntigravityPluginValidationOptions["runAgyPluginValidate"];
 }
 
+export interface AntigravityActivePluginSyncOptions {
+	readonly dryRun: boolean;
+	readonly homeDir?: string;
+	readonly getAntigravityBinaryPath?: () => string | null;
+	readonly assetManifest?: readonly AntigravityAssetManifestEntry[];
+	readonly bundledAssets?: BundledAssets;
+	readonly distDir?: string;
+	readonly readAssetFile?: (path: string) => Promise<string>;
+	readonly runAgyPluginInstall?: AntigravityInstallOptions["runAgyPluginInstall"];
+}
+
+export interface AntigravityActivePluginSyncResult {
+	readonly driftDetected: boolean;
+	readonly driftIssue: string | null;
+	readonly install: AntigravityPluginInstallResult | null;
+}
+
 const PLATFORM_ID = "antigravity";
 
 const homeDirFor = (homeDir?: string): string =>
@@ -78,7 +95,10 @@ export const getAntigravityPaths = (
 });
 
 const bundleOptionsFor = (
-	options: AntigravityInstallOptions | AntigravityVerifyDeps,
+	options:
+		| AntigravityInstallOptions
+		| AntigravityVerifyDeps
+		| AntigravityActivePluginSyncOptions,
 ): AntigravityBundleAssetManifestOptions => ({
 	assetManifest: options.assetManifest,
 	bundledAssets: options.bundledAssets,
@@ -107,9 +127,17 @@ const pluginDirs = (
 ): readonly string[] =>
 	pluginRelativeDirs(assets).map((relativeDir) => join(homeDir, relativeDir));
 
-const activePluginRelativePath = (
+/**
+ * Candidate locations of an asset in Antigravity's active plugin registry,
+ * most current layout first. Antigravity CLI >= 1.1.x imports plugins into
+ * `~/.gemini/config/plugins/`; older releases used
+ * `~/.gemini/antigravity-cli/plugins/`. The first readable candidate is the
+ * authoritative active copy — a stale file left behind in the legacy
+ * location must not be reported as drift once the current registry matches.
+ */
+const activePluginRelativePaths = (
 	asset: AntigravityAssetManifestEntry,
-): string | null => {
+): readonly string[] => {
 	const parts = asset.relativePath.split("/");
 	if (
 		parts[0] !== ".gemini" ||
@@ -117,13 +145,20 @@ const activePluginRelativePath = (
 		!parts[2] ||
 		parts.length < 4
 	) {
-		return null;
+		return [];
 	}
 
-	return [".gemini", "antigravity-cli", "plugins", parts[2], ...parts.slice(3)]
-		.join("/")
-		.replace(/\/+/g, "/");
+	const pluginSuffix = [parts[2], ...parts.slice(3)];
+	return [
+		[".gemini", "config", "plugins", ...pluginSuffix].join("/"),
+		[".gemini", "antigravity-cli", "plugins", ...pluginSuffix].join("/"),
+	].map((path) => path.replace(/\/+/g, "/"));
 };
+
+const ACTIVE_IMPORT_MANIFEST_RELATIVE_PATHS = [
+	".gemini/config/import_manifest.json",
+	".gemini/antigravity-cli/import_manifest.json",
+] as const;
 
 const readJsonFile = async (path: string): Promise<unknown | null> => {
 	try {
@@ -151,9 +186,13 @@ const inspectActiveAntigravityImports = async (options: {
 			relativeDir.split("/").at(-1),
 		),
 	);
-	const importManifest = await readJsonFile(
-		join(options.homeDir, ".gemini/antigravity-cli/import_manifest.json"),
-	);
+	let importManifest: unknown | null = null;
+	for (const manifestRelativePath of ACTIVE_IMPORT_MANIFEST_RELATIVE_PATHS) {
+		importManifest = await readJsonFile(
+			join(options.homeDir, manifestRelativePath),
+		);
+		if (importManifest !== null) break;
+	}
 	if (
 		importManifest &&
 		typeof importManifest === "object" &&
@@ -194,19 +233,23 @@ const inspectActiveAntigravityImports = async (options: {
 	]);
 	for (const asset of options.assets) {
 		if (!activeComparableKinds.has(asset.kind)) continue;
-		const activeRelativePath = activePluginRelativePath(asset);
-		if (!activeRelativePath) continue;
-		const activePath = join(options.homeDir, activeRelativePath);
-		try {
-			const activeContent = await readActiveAsset(activePath);
+		for (const activeRelativePath of activePluginRelativePaths(asset)) {
+			const activePath = join(options.homeDir, activeRelativePath);
+			let activeContent: string;
+			try {
+				activeContent = await readActiveAsset(activePath);
+			} catch {
+				continue;
+			}
 			if (activeContent !== asset.expectedContent) {
 				return {
 					issue: `Active Antigravity plugin asset ~/${activeRelativePath} does not match the installed rp1 Antigravity package asset.`,
 					remediation:
-						"Run `rp1 install antigravity` to refresh Antigravity's active plugin registry.",
+						"Run `rp1 update plugins antigravity -y` (or `rp1 install antigravity`) to refresh Antigravity's active plugin registry.",
 				};
 			}
-		} catch {}
+			break;
+		}
 	}
 
 	return null;
@@ -358,6 +401,43 @@ const installAntigravityActivePlugins = async (options: {
 		issue,
 		remediation: activePluginInstallRemediation(status),
 	};
+};
+
+/**
+ * Re-imports rp1 package assets into Antigravity's active plugin registry
+ * (`~/.gemini/antigravity-cli/plugins/`) when the registry has drifted from
+ * the installed package assets. Used by the update flow so that
+ * `rp1 update plugins antigravity` clears the drift that
+ * `rp1 verify antigravity` reports, instead of requiring a full
+ * `rp1 install antigravity`.
+ */
+export const syncAntigravityActivePlugins = async (
+	options: AntigravityActivePluginSyncOptions,
+): Promise<AntigravityActivePluginSyncResult> => {
+	const homeDir = homeDirFor(options.homeDir);
+	const assets = await loadAntigravityBundleAssetManifest(
+		bundleOptionsFor(options),
+	);
+	const drift = await inspectActiveAntigravityImports({
+		homeDir,
+		assets,
+		readAssetFile: options.readAssetFile,
+	});
+	if (!drift) {
+		return { driftDetected: false, driftIssue: null, install: null };
+	}
+	if (options.dryRun) {
+		return { driftDetected: true, driftIssue: drift.issue, install: null };
+	}
+
+	const binaryPath = options.getAntigravityBinaryPath?.() ?? Bun.which("agy");
+	const install = await installAntigravityActivePlugins({
+		binaryPath,
+		pluginDirs: pluginDirs(homeDir, assets),
+		pluginDisplayDirs: pluginDisplayDirs(assets),
+		runAgyPluginInstall: options.runAgyPluginInstall,
+	});
+	return { driftDetected: true, driftIssue: drift.issue, install };
 };
 
 const defaultAntigravityVersion = async (): Promise<string | null> => {

--- a/cli/src/install/antigravity/index.ts
+++ b/cli/src/install/antigravity/index.ts
@@ -1,4 +1,4 @@
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { basename, dirname, join } from "node:path";
 import * as E from "fp-ts/lib/Either.js";
@@ -128,16 +128,45 @@ const pluginDirs = (
 	pluginRelativeDirs(assets).map((relativeDir) => join(homeDir, relativeDir));
 
 /**
- * Candidate locations of an asset in Antigravity's active plugin registry,
- * most current layout first. Antigravity CLI >= 1.1.x imports plugins into
+ * Locations of Antigravity's active plugin registry, most current layout
+ * first. Antigravity CLI >= 1.1.x imports plugins into
  * `~/.gemini/config/plugins/`; older releases used
- * `~/.gemini/antigravity-cli/plugins/`. The first readable candidate is the
- * authoritative active copy — a stale file left behind in the legacy
- * location must not be reported as drift once the current registry matches.
+ * `~/.gemini/antigravity-cli/plugins/`. Exactly one root is authoritative:
+ * whichever contains an expected rp1 plugin directory, preferring the
+ * current layout. A stale file left behind in the legacy location must not
+ * be reported as drift once the current registry is authoritative, and a
+ * file missing from the authoritative root is drift — a per-file fallback
+ * would mask it.
  */
-const activePluginRelativePaths = (
+const ACTIVE_PLUGIN_REGISTRY_ROOTS = {
+	current: ".gemini/config/plugins",
+	legacy: ".gemini/antigravity-cli/plugins",
+} as const;
+
+type ActivePluginRegistryRoot = keyof typeof ACTIVE_PLUGIN_REGISTRY_ROOTS;
+
+const detectActivePluginRegistryRoot = async (
+	homeDir: string,
+	pluginNames: ReadonlySet<string | undefined>,
+): Promise<ActivePluginRegistryRoot | null> => {
+	for (const root of ["current", "legacy"] as const) {
+		for (const pluginName of pluginNames) {
+			if (!pluginName) continue;
+			try {
+				const stats = await stat(
+					join(homeDir, ACTIVE_PLUGIN_REGISTRY_ROOTS[root], pluginName),
+				);
+				if (stats.isDirectory()) return root;
+			} catch {}
+		}
+	}
+	return null;
+};
+
+const activePluginRelativePathFor = (
 	asset: AntigravityAssetManifestEntry,
-): readonly string[] => {
+	root: ActivePluginRegistryRoot,
+): string | null => {
 	const parts = asset.relativePath.split("/");
 	if (
 		parts[0] !== ".gemini" ||
@@ -145,14 +174,12 @@ const activePluginRelativePaths = (
 		!parts[2] ||
 		parts.length < 4
 	) {
-		return [];
+		return null;
 	}
 
-	const pluginSuffix = [parts[2], ...parts.slice(3)];
-	return [
-		[".gemini", "config", "plugins", ...pluginSuffix].join("/"),
-		[".gemini", "antigravity-cli", "plugins", ...pluginSuffix].join("/"),
-	].map((path) => path.replace(/\/+/g, "/"));
+	return [ACTIVE_PLUGIN_REGISTRY_ROOTS[root], parts[2], ...parts.slice(3)]
+		.join("/")
+		.replace(/\/+/g, "/");
 };
 
 const ACTIVE_IMPORT_MANIFEST_RELATIVE_PATHS = [
@@ -231,24 +258,38 @@ const inspectActiveAntigravityImports = async (options: {
 		"support_matrix",
 		"support_metadata",
 	]);
+	const registryRoot = await detectActivePluginRegistryRoot(
+		options.homeDir,
+		expectedPlugins,
+	);
+	if (!registryRoot) return null;
+
+	const activeRefreshRemediation =
+		"Run `rp1 update plugins antigravity -y` (or `rp1 install antigravity`) to refresh Antigravity's active plugin registry.";
 	for (const asset of options.assets) {
 		if (!activeComparableKinds.has(asset.kind)) continue;
-		for (const activeRelativePath of activePluginRelativePaths(asset)) {
-			const activePath = join(options.homeDir, activeRelativePath);
-			let activeContent: string;
-			try {
-				activeContent = await readActiveAsset(activePath);
-			} catch {
-				continue;
-			}
-			if (activeContent !== asset.expectedContent) {
-				return {
-					issue: `Active Antigravity plugin asset ~/${activeRelativePath} does not match the installed rp1 Antigravity package asset.`,
-					remediation:
-						"Run `rp1 update plugins antigravity -y` (or `rp1 install antigravity`) to refresh Antigravity's active plugin registry.",
-				};
-			}
-			break;
+		const activeRelativePath = activePluginRelativePathFor(asset, registryRoot);
+		if (!activeRelativePath) continue;
+		const activePath = join(options.homeDir, activeRelativePath);
+		let activeContent: string;
+		try {
+			activeContent = await readActiveAsset(activePath);
+		} catch (error) {
+			const code =
+				typeof error === "object" && error !== null && "code" in error
+					? String((error as { readonly code?: unknown }).code)
+					: undefined;
+			if (code !== "ENOENT") continue;
+			return {
+				issue: `Active Antigravity plugin asset ~/${activeRelativePath} is missing from Antigravity's active plugin registry.`,
+				remediation: activeRefreshRemediation,
+			};
+		}
+		if (activeContent !== asset.expectedContent) {
+			return {
+				issue: `Active Antigravity plugin asset ~/${activeRelativePath} does not match the installed rp1 Antigravity package asset.`,
+				remediation: activeRefreshRemediation,
+			};
 		}
 	}
 
@@ -295,25 +336,31 @@ const notRunActivePluginInstall = (
 	remediation: activePluginInstallRemediation("not_run"),
 });
 
-const defaultRunAgyPluginInstall = async (
-	binaryPath: string,
-	pluginDir: string,
-): Promise<{
-	readonly exitCode: number;
-	readonly stdout: string;
-	readonly stderr: string;
-}> => {
-	const proc = Bun.spawn([binaryPath, "plugin", "install", pluginDir], {
-		stdout: "pipe",
-		stderr: "pipe",
-	});
-	const [exitCode, stdout, stderr] = await Promise.all([
-		proc.exited,
-		new Response(proc.stdout).text(),
-		new Response(proc.stderr).text(),
-	]);
-	return { exitCode, stdout, stderr };
-};
+// HOME is passed explicitly: Bun.spawn's default child env is a startup
+// snapshot, so runtime homeDir overrides would otherwise never reach agy,
+// which resolves its active plugin registry from HOME.
+const defaultRunAgyPluginInstall =
+	(homeDir: string) =>
+	async (
+		binaryPath: string,
+		pluginDir: string,
+	): Promise<{
+		readonly exitCode: number;
+		readonly stdout: string;
+		readonly stderr: string;
+	}> => {
+		const proc = Bun.spawn([binaryPath, "plugin", "install", pluginDir], {
+			stdout: "pipe",
+			stderr: "pipe",
+			env: { ...process.env, HOME: homeDir },
+		});
+		const [exitCode, stdout, stderr] = await Promise.all([
+			proc.exited,
+			new Response(proc.stdout).text(),
+			new Response(proc.stderr).text(),
+		]);
+		return { exitCode, stdout, stderr };
+	};
 
 const activePluginInstallStatus = (
 	results: readonly { readonly status: AntigravityPluginInstallStatus }[],
@@ -329,6 +376,7 @@ const activePluginInstallStatus = (
 };
 
 const installAntigravityActivePlugins = async (options: {
+	readonly homeDir: string;
 	readonly binaryPath: string | null;
 	readonly pluginDirs: readonly string[];
 	readonly pluginDisplayDirs: readonly string[];
@@ -357,7 +405,8 @@ const installAntigravityActivePlugins = async (options: {
 		};
 	}
 
-	const runInstall = options.runAgyPluginInstall ?? defaultRunAgyPluginInstall;
+	const runInstall =
+		options.runAgyPluginInstall ?? defaultRunAgyPluginInstall(options.homeDir);
 	const plugins: AntigravityPluginInstallPluginResult[] = [];
 
 	for (let i = 0; i < options.pluginDirs.length; i++) {
@@ -430,9 +479,11 @@ export const syncAntigravityActivePlugins = async (
 		return { driftDetected: true, driftIssue: drift.issue, install: null };
 	}
 
-	const binaryPath = options.getAntigravityBinaryPath?.() ?? Bun.which("agy");
+	const resolveBinaryPath =
+		options.getAntigravityBinaryPath ?? (() => Bun.which("agy"));
 	const install = await installAntigravityActivePlugins({
-		binaryPath,
+		homeDir,
+		binaryPath: resolveBinaryPath(),
 		pluginDirs: pluginDirs(homeDir, assets),
 		pluginDisplayDirs: pluginDisplayDirs(assets),
 		runAgyPluginInstall: options.runAgyPluginInstall,
@@ -477,8 +528,9 @@ export const installAntigravityBundleAssets = (
 			const assets = await loadAntigravityBundleAssetManifest(
 				bundleOptionsFor(options),
 			);
-			const binaryPath =
-				options.getAntigravityBinaryPath?.() ?? Bun.which("agy");
+			const binaryPath = (
+				options.getAntigravityBinaryPath ?? (() => Bun.which("agy"))
+			)();
 			const warnings: string[] = [];
 
 			if (!binaryPath) {
@@ -500,6 +552,7 @@ export const installAntigravityBundleAssets = (
 			const activePluginInstall = options.dryRun
 				? notRunActivePluginInstall(binaryPath)
 				: await installAntigravityActivePlugins({
+						homeDir,
 						binaryPath,
 						pluginDirs: pluginDirsToValidate,
 						pluginDisplayDirs: pluginDisplayDirsToValidate,

--- a/cli/src/shared/install-core.ts
+++ b/cli/src/shared/install-core.ts
@@ -30,11 +30,13 @@ import {
 	type ToolDetectionResult,
 } from "../init/tool-detector.js";
 import {
+	type AntigravityActivePluginSyncResult,
 	type AntigravityManifestRefreshResult,
 	antigravityBundleScope,
 	antigravityPackageDisplayRoot,
 	installAntigravityBundleAssets,
 	refreshAntigravityManifestAssets,
+	syncAntigravityActivePlugins,
 } from "../install/antigravity/index.js";
 import { extractPlatformAssets } from "../install/asset-extractor.js";
 import { installAllPlugins } from "../install/claudecode/installer.js";
@@ -576,8 +578,29 @@ const antigravityInstallDetails = (
 		: "Next action: restart Antigravity CLI, then run `rp1 verify antigravity` for manifest, version marker, MCP, and plugin validation status.",
 ];
 
+const antigravityActiveRegistryDetail = (
+	dryRun: boolean,
+	sync: AntigravityActivePluginSyncResult | null,
+): readonly string[] => {
+	if (!sync) return [];
+	if (!sync.driftDetected) return ["Active plugin registry: current"];
+	if (dryRun) {
+		return [
+			"Would refresh Antigravity's active plugin registry via `agy plugin install`.",
+		];
+	}
+	const status = sync.install?.status ?? "not_run";
+	if (status === "passed") return ["Active plugin registry: refreshed"];
+	if (status === "missing_binary") {
+		return ["Active plugin registry: skipped (`agy` not found in PATH)"];
+	}
+	if (status === "failed") return ["Active plugin registry: refresh failed"];
+	return ["Active plugin registry: not refreshed"];
+};
+
 const antigravityUpdateDetails = (
 	result: AntigravityManifestRefreshResult,
+	sync: AntigravityActivePluginSyncResult | null,
 ): readonly string[] => {
 	if (result.initialStatus.state === "blocked") {
 		return [
@@ -587,23 +610,38 @@ const antigravityUpdateDetails = (
 		];
 	}
 
-	if (result.dryRun && result.refreshableAssets.length > 0) {
+	const activeRegistry = antigravityActiveRegistryDetail(result.dryRun, sync);
+
+	if (
+		result.dryRun &&
+		(result.refreshableAssets.length > 0 || sync?.driftDetected)
+	) {
 		return [
 			"Lifecycle stage: update",
 			`Lifecycle state: ${result.initialStatus.state}`,
-			`Would refresh: ${formatAssetDisplayList(result.refreshableAssets)}`,
+			...(result.refreshableAssets.length > 0
+				? [`Would refresh: ${formatAssetDisplayList(result.refreshableAssets)}`]
+				: []),
+			...activeRegistry,
 			"Next action: Run `rp1 update plugins antigravity -y` to refresh, then restart Antigravity CLI and run `rp1 verify antigravity`.",
 		];
 	}
 
-	if (result.refreshedAssets.length > 0 || result.versionMarkerWritten) {
+	if (
+		result.refreshedAssets.length > 0 ||
+		result.versionMarkerWritten ||
+		sync?.install?.status === "passed"
+	) {
 		return [
 			"Lifecycle stage: update",
 			"Lifecycle result: refreshed",
-			`Refreshed: ${formatAssetDisplayList(result.refreshedAssets)}`,
+			...(result.refreshedAssets.length > 0
+				? [`Refreshed: ${formatAssetDisplayList(result.refreshedAssets)}`]
+				: []),
 			`Version marker: ${
 				result.versionMarkerWritten ? "current" : "unchanged"
 			}`,
+			...activeRegistry,
 			"Next action: Restart Antigravity CLI, then run `rp1 verify antigravity`.",
 		];
 	}
@@ -612,6 +650,7 @@ const antigravityUpdateDetails = (
 		"Lifecycle stage: update",
 		"Lifecycle state: current",
 		`Version marker: ${result.finalStatus.versionMarker.freshness}`,
+		...activeRegistry,
 		`Next action: ${result.finalStatus.userAction}`,
 	];
 };
@@ -645,31 +684,70 @@ export const updateForSpecificTool = (
 	if (lookup.tool.id === "antigravity") {
 		return pipe(
 			refreshAntigravityManifestAssets({ dryRun: ctx.dryRun }),
-			TE.map((result): ToolInstallResult => {
+			TE.chain((result) =>
+				TE.tryCatch(
+					async () => ({
+						result,
+						sync:
+							result.initialStatus.state === "blocked"
+								? null
+								: await syncAntigravityActivePlugins({ dryRun: ctx.dryRun }),
+					}),
+					(error) =>
+						installError(
+							"antigravity-active-plugin-refresh",
+							error instanceof Error
+								? error.message
+								: "Failed to refresh Antigravity's active plugin registry.",
+						),
+				),
+			),
+			TE.map(({ result, sync }): ToolInstallResult => {
 				const blocked = result.initialStatus.state === "blocked";
+				const activeInstallStatus = sync?.install?.status ?? null;
 				const toolResult = {
 					toolId: lookup.tool.id,
 					toolName: lookup.tool.name,
-					success: !blocked,
+					success: !blocked && activeInstallStatus !== "failed",
 					restartRequired:
 						!ctx.dryRun &&
 						!blocked &&
-						(result.refreshedAssets.length > 0 || result.versionMarkerWritten),
+						(result.refreshedAssets.length > 0 ||
+							result.versionMarkerWritten ||
+							activeInstallStatus === "passed"),
 					pluginsInstalled: [],
-					details: antigravityUpdateDetails(result),
-					warnings: [],
+					details: antigravityUpdateDetails(result, sync),
+					warnings:
+						activeInstallStatus === "missing_binary"
+							? [
+									"Antigravity active plugin refresh was skipped because `agy` was not found in PATH.",
+								]
+							: [],
 				};
 
-				if (!blocked) return toolResult;
+				if (blocked) {
+					return {
+						...toolResult,
+						error: installError(
+							"antigravity-lifecycle-update",
+							result.initialStatus.issue ??
+								"Antigravity lifecycle update blocked.",
+						),
+					};
+				}
 
-				return {
-					...toolResult,
-					error: installError(
-						"antigravity-lifecycle-update",
-						result.initialStatus.issue ??
-							"Antigravity lifecycle update blocked.",
-					),
-				};
+				if (activeInstallStatus === "failed") {
+					return {
+						...toolResult,
+						error: installError(
+							"antigravity-active-plugin-refresh",
+							sync?.install?.issue ??
+								"Antigravity active plugin refresh failed.",
+						),
+					};
+				}
+
+				return toolResult;
 			}),
 			TE.orElse((error) =>
 				TE.right<CLIError, ToolInstallResult>(

--- a/cli/src/shared/install-core.ts
+++ b/cli/src/shared/install-core.ts
@@ -482,7 +482,10 @@ const installForTool = (
 
 	if (tool.tool.id === "antigravity") {
 		return pipe(
-			installAntigravityBundleAssets({ dryRun: ctx.dryRun }),
+			installAntigravityBundleAssets({
+				dryRun: ctx.dryRun,
+				homeDir: ctx.homeDir,
+			}),
 			TE.map(
 				(result): ToolInstallResult => ({
 					...baseResult,
@@ -683,7 +686,10 @@ export const updateForSpecificTool = (
 
 	if (lookup.tool.id === "antigravity") {
 		return pipe(
-			refreshAntigravityManifestAssets({ dryRun: ctx.dryRun }),
+			refreshAntigravityManifestAssets({
+				dryRun: ctx.dryRun,
+				homeDir: ctx.homeDir,
+			}),
 			TE.chain((result) =>
 				TE.tryCatch(
 					async () => ({
@@ -691,7 +697,10 @@ export const updateForSpecificTool = (
 						sync:
 							result.initialStatus.state === "blocked"
 								? null
-								: await syncAntigravityActivePlugins({ dryRun: ctx.dryRun }),
+								: await syncAntigravityActivePlugins({
+										dryRun: ctx.dryRun,
+										homeDir: ctx.homeDir,
+									}),
 					}),
 					(error) =>
 						installError(
@@ -843,7 +852,10 @@ export const installForSpecificTool = (
 
 	if (tool.id === "antigravity") {
 		return pipe(
-			installAntigravityBundleAssets({ dryRun: ctx.dryRun }),
+			installAntigravityBundleAssets({
+				dryRun: ctx.dryRun,
+				homeDir: ctx.homeDir,
+			}),
 			TE.map(
 				(result): ToolInstallResult => ({
 					toolId: tool.id,


### PR DESCRIPTION
## Problem

`rp1 verify antigravity` could get stuck permanently degraded with:

```
Active Antigravity plugin asset ~/.gemini/antigravity-cli/plugins/rp1-base/commands/rp1-base/artifact-templates.toml does not match the installed rp1 Antigravity package asset.
degraded: package assets stale
Next actions:
  Refresh Antigravity assets with `rp1 update plugins antigravity -y`.
```

...while the suggested `rp1 update plugins antigravity -y` reported success and changed nothing. Two bugs compounded:

1. **Update never touched the active registry.** `rp1 update plugins antigravity` only rewrote package assets (`~/.gemini/antigravity-cli/rp1-*`) and the version marker. It never re-ran `agy plugin install` — only `rp1 install antigravity` did. Once package assets were current, update was a permanent no-op while verify kept flagging active-registry drift, so the remediation loop could never converge.

2. **Verify compared against a dead path.** Antigravity CLI >= 1.1.x imports plugins into `~/.gemini/config/plugins/` (manifest at `~/.gemini/config/import_manifest.json`). The legacy `~/.gemini/antigravity-cli/plugins/` tree is an orphaned leftover that agy no longer maintains, so even a successful re-import (which writes to the new location and matches package assets exactly) left verify reporting the stale legacy copy forever.

## Fix

- **New `syncAntigravityActivePlugins`** (`cli/src/install/antigravity/index.ts`): the update flow now inspects the active registry after refreshing package assets and re-imports rp1 packages via `agy plugin install` when drift is detected. Dry-run reports "would refresh"; a missing `agy` binary downgrades to a warning; a failed `agy plugin install` fails the update with the underlying output.
- **Authoritative registry root**: drift inspection selects a single authoritative registry root — `~/.gemini/config/plugins/` when an expected rp1 plugin directory exists there, else the legacy `~/.gemini/antigravity-cli/plugins/`. Assets missing from the authoritative root count as drift (so unimported or partially missing registries get re-imported), while stale legacy leftovers are ignored once the current registry is authoritative. The import manifest is read from the current location first, legacy second.
- **HOME-aware `agy` spawn**: `agy plugin install` is spawned with an explicit `HOME` because Bun.spawn's default child env is a startup snapshot — otherwise alternate-home (`InstallContext.homeDir`) callers would import into the wrong home. `homeDir` is now threaded through the install, refresh, and sync flows.
- **Surfaced state**: update details gain an `Active plugin registry: current | refreshed | skipped | refresh failed` line, restart is requested when the registry was re-imported, and the verify remediation now points at `rp1 update plugins antigravity -y` (with `rp1 install antigravity` as the alternative).

## Validation

- `tsc --noEmit` and `biome check` clean; full unit suite: 3455 pass, 0 fail.
- Affected suites (75 tests) include:
  - `cli/src/__tests__/install/antigravity/active-registry.test.ts` — registry precedence (current masks stale legacy), missing-asset drift in the authoritative root, current-registry drift triggers re-import, legacy-only fallback, null binary resolver honored, import-manifest ordering;
  - install-core integration tests — drift re-import with restart, dry-run read-only, alternate-home update honoring `ctx.homeDir`, missing-`agy` warning, failed re-import fails the update, and a realistic two-update idempotence test whose fake `agy` actually lands active assets.
- Reproduced end-to-end on a machine stuck in the degraded loop (agy 1.1.4): with this branch, `rp1 update plugins antigravity -y` re-imported the plugins (confirmed via `agy plugin list` timestamps and `~/.gemini/config/plugins/` contents), a second update is idempotent (`Active plugin registry: current`), and `rp1 verify antigravity` reports **ready**.

🤖 Generated using: 🎮 [rp1.run](https://rp1.run)