### PR TITLE
feat(build-fast): redesign quick-build plan artifact and switch to append semantics

### DIFF
--- a/catalog/agents.yaml
+++ b/catalog/agents.yaml
@@ -98,7 +98,7 @@ agents:
   - name: rp1-dev:build-fast-planner
     description: "Quick-iteration workflow planner. Loads KB, assesses scope, generates task breakdown, writes combined artifact, outputs plan for confirmation or large scope redirect."
     plugin: dev
-    last_checksum: 61fb505e572b04f894bc5bb53f10fc46866f538ba2208e46147658a9adbb23cb
+    last_checksum: 8fc2cc3f4403755b91fc4a082ae0c572dd60d2834bf5e6bcc9115e209b557f2d
   - name: rp1-dev:build-task-grouper
     description: "Batches parsed tasks into execution units based on complexity rules"
     plugin: dev
@@ -206,11 +206,11 @@ agents:
   - name: rp1-dev:task-builder
     description: "Implements assigned task(s) w/ full context, writes summaries to the resolved task file. Uses extended thinking (or ultrathink)."
     plugin: dev
-    last_checksum: af9935b641aa18addcaa5125ab269946dc37bffb3ba3f3e510cddb7816aa43f0
+    last_checksum: a501ad2af781a070c22840e673defd13f12d0bd9a679029d7e1fe5f5ec44a206
   - name: rp1-dev:task-reviewer
     description: "Verifies builder's work for discipline, accuracy, completeness, and commit quality. Returns SUCCESS or FAILURE with actionable feedback. Uses extended thinking for careful verification."
     plugin: dev
-    last_checksum: 127b1f730e6983fbaf645d5b8a086e9af8b9e662c0ab64874320be2d597f9be1
+    last_checksum: 1b8c0c2e5cc9360a6942962c884c87c453ad9d70b768471b85a3e38b4c250451
   - name: rp1-dev:test-runner
     description: "Executes comprehensive functional testing of implemented features including automated tests, coverage measurement, acceptance criteria verification, and detailed test reporting"
     plugin: dev

--- a/catalog/agents.yaml
+++ b/catalog/agents.yaml
@@ -206,11 +206,11 @@ agents:
   - name: rp1-dev:task-builder
     description: "Implements assigned task(s) w/ full context, writes summaries to the resolved task file. Uses extended thinking (or ultrathink)."
     plugin: dev
-    last_checksum: a501ad2af781a070c22840e673defd13f12d0bd9a679029d7e1fe5f5ec44a206
+    last_checksum: 47643dc7369328c0f732ba6ce6007983ee6b51795cf7f81d269ce2c42ce8303e
   - name: rp1-dev:task-reviewer
     description: "Verifies builder's work for discipline, accuracy, completeness, and commit quality. Returns SUCCESS or FAILURE with actionable feedback. Uses extended thinking for careful verification."
     plugin: dev
-    last_checksum: 1b8c0c2e5cc9360a6942962c884c87c453ad9d70b768471b85a3e38b4c250451
+    last_checksum: 921c8a75c2de93464266d45281e06bceb6a14d105a9b53d6e79062d0321b1e30
   - name: rp1-dev:test-runner
     description: "Executes comprehensive functional testing of implemented features including automated tests, coverage measurement, acceptance criteria verification, and detailed test reporting"
     plugin: dev

--- a/plugins/base/skills/artifact-templates/templates/build-fast-planner/quick-build.md
+++ b/plugins/base/skills/artifact-templates/templates/build-fast-planner/quick-build.md
@@ -16,26 +16,36 @@ emit_hint: |
 
 # Quick Build: {Feature Slug Title Case}
 
-**Created**: {ISO timestamp}
-**Request**: {original REQUEST}
-**Scope**: {Small | Medium}
+- **Created**: {ISO timestamp}
+- **Scope**: {Small | Medium}
+
+## Summary
+
+- **Problem**: {1-2 sentence description of the problem or need}
+- **Outcome**: {1-2 sentence description of the desired result}
+
+## Scope
+
+### In
+
+- {in-scope item 1}
+- {in-scope item 2}
+
+### Out
+
+- {out-of-scope item 1}
+- {out-of-scope item 2}
 
 ## Plan
 
-**Reasoning**: {why this scope assessment - files, systems, risk}
-**Files Affected**: {list of files or patterns}
-**Approach**: {2-4 sentence summary of implementation approach}
-**Estimated Effort**: {hours estimate}
+- **Reasoning**: {why this scope assessment -- files, systems, risk}
+- **Files Affected**:
+  - `{file/pattern 1}`
+  - `{file/pattern 2}`
+- **Approach**: {2-4 sentence summary of implementation approach}
+- **Estimated Effort**: {hours estimate}
 
 ## Tasks
 
 - [ ] **T1**: {description} `[complexity:simple|medium]`
 - [ ] **T2**: {description} `[complexity:simple|medium]`
-
-## Implementation Summary
-
-{To be added by task-builder}
-
-## Verification
-
-{To be added by task-reviewer if --review flag used}

--- a/plugins/dev/agents/build-fast-planner.md
+++ b/plugins/dev/agents/build-fast-planner.md
@@ -165,9 +165,10 @@ Write the file to `{WORK_ROOT}/quick-builds/{filename}`.
 
 #### Content Guidance
 
-- **Plan section**: Include reasoning (scope assessment), files affected, approach (2-4 sentences), estimated effort.
+- **Summary section**: Fill Problem (1-2 sentences describing the problem or need) and Outcome (1-2 sentences describing the desired result), derived from the REQUEST.
+- **Scope section**: Fill In (bullet list of what is in scope) and Out (bullet list of what is explicitly out of scope). Aim for 2-5 items each.
+- **Plan section**: Include reasoning (scope assessment), files affected (as a nested bullet list of file paths), approach (2-4 sentences), and estimated effort.
 - **Tasks section**: Max 5 tasks, each with description + complexity tag (`simple` or `medium`).
-- **Implementation Summary / Verification**: Left for task-builder and task-reviewer to fill.
 
 ### 4.4 Artifact Registration
 

--- a/plugins/dev/agents/task-builder.md
+++ b/plugins/dev/agents/task-builder.md
@@ -358,7 +358,7 @@ If the process fails after acquiring the lock, remove the lock before returning 
 
 **IF QUICK_BUILD_PATH is not empty** (Quick-build mode):
 
-Add or update `## Implementation Summary` section in the quick-build artifact with table format:
+Append a `## Implementation Summary` section to the end of the quick-build artifact (do not search for or replace an existing section -- the template does not pre-stub one). Use table format:
 
 ```markdown
 ## Implementation Summary

--- a/plugins/dev/agents/task-builder.md
+++ b/plugins/dev/agents/task-builder.md
@@ -358,7 +358,7 @@ If the process fails after acquiring the lock, remove the lock before returning 
 
 **IF QUICK_BUILD_PATH is not empty** (Quick-build mode):
 
-Append a `## Implementation Summary` section to the end of the quick-build artifact (do not search for or replace an existing section -- the template does not pre-stub one). Use table format:
+The template does not pre-stub this section. If the artifact has no `## Implementation Summary` heading, append the section to the end. If the heading already exists (retry or Add/Edit re-run), update that section in place: add or update the rows for {TASK_IDS}, keep rows for other tasks, and never append a second heading. Use table format:
 
 ```markdown
 ## Implementation Summary

--- a/plugins/dev/agents/task-reviewer.md
+++ b/plugins/dev/agents/task-reviewer.md
@@ -442,7 +442,7 @@ Legacy milestone/quick-build mode:
 
 **If QUICK_BUILD_PATH is not empty** (quick-build mode):
 
-Append a `## Verification` section to the end of the quick-build artifact (do not search for or replace an existing section -- the template does not pre-stub one):
+The template does not pre-stub this section. If the artifact has no `## Verification` heading, append the section to the end. If the heading already exists (a prior review of this run wrote it), replace that section's content with the current results -- never append a second heading:
 
 ```markdown
 ## Verification

--- a/plugins/dev/agents/task-reviewer.md
+++ b/plugins/dev/agents/task-reviewer.md
@@ -442,7 +442,7 @@ Legacy milestone/quick-build mode:
 
 **If QUICK_BUILD_PATH is not empty** (quick-build mode):
 
-Write or update the `## Verification` section in the quick-build artifact:
+Append a `## Verification` section to the end of the quick-build artifact (do not search for or replace an existing section -- the template does not pre-stub one):
 
 ```markdown
 ## Verification

--- a/plugins/dev/skills/build-fast/SKILL.md
+++ b/plugins/dev/skills/build-fast/SKILL.md
@@ -170,7 +170,7 @@ Interpret the planner redirect before stopping:
 
 When skipped: Do NOT prompt the user. Proceed directly to §PHASE-2.
 
-**Interactive plan gate rule**: When `AFK=false`, this checkpoint is REQUIRED after the planner registers the quick-build artifact and before entering §PHASE-2. Complete both actions below in order:
+**Interactive plan gate rule**: When `AFK=false`, this checkpoint is REQUIRED after the planner writes and registers the quick-build artifact (via `artifact_registered` with `--step plan`) and before entering §PHASE-2. The planner's registration is the initial one -- the user sees the plan in the Arcade before this gate. Complete both actions below in order:
 1. Emit `waiting_for_user` for the plan gate
 2. Call `ask_user` and wait for the answer
 
@@ -396,7 +396,7 @@ Review the changes.
 
 ## §OUTPUT
 
-Register the artifact in the database:
+Re-register the artifact for the build-completion lifecycle (the planner already registered it under `--step plan` so the Arcade shows it during planning; this re-registration under `--step build` marks the artifact as associated with the completed build phase):
 
 ```bash
 rp1 agent-tools emit \


### PR DESCRIPTION
## Why

The `/build-fast` plan artifact was noticeably less friendly than `/build`'s: a cluttered run-on metadata header (the `Created / Request / Scope` lines collapsed into one rendered paragraph), no explicit in/out scope boundaries, and empty pre-stubbed `## Implementation Summary` / `## Verification` placeholders cluttering the plan before those agents ever ran.

## What changed

**Template redesign** (`templates/build-fast-planner/quick-build.md`):
- Metadata is now a bullet list (`Created`, `Scope`) so each field renders on its own line; the long `Request` echo is dropped in favor of a `## Summary` section with **Problem** / **Outcome**
- New `## Scope` section with explicit `### In` / `### Out` subsections
- `## Plan` restructured as a bullet list with `Files Affected` as a nested file list
- Pre-stubbed `## Implementation Summary` and `## Verification` placeholder sections removed entirely

**Append-on-demand semantics**:
- `task-builder.md` quick-build mode now **appends** `## Implementation Summary` to the end of the artifact when it runs (previously updated a pre-existing stub)
- `task-reviewer.md` quick-build mode now **appends** `## Verification` the same way
- `build-fast-planner.md` content guidance updated for the new sections and de-referenced the removed stubs

**Plan-before-approval ordering made explicit** (`build-fast/SKILL.md`):
- §1.2 now states the planner has already written and registered the artifact (`artifact_registered --step plan`) before the plan review gate, so the user sees the proposed plan in the Arcade while deciding
- §OUTPUT's registration is clarified as the build-completion re-registration under `--step build`, not the initial one

`catalog/agents.yaml` checksums regenerated alongside.

## Notes

- Prompt/template-only change — no state machine, phase transition, or feature-mode behavior changes
- Feature-mode `_sections/implementation-summary.md` and `_sections/verification.md` templates are untouched

🤖 Generated using: 🎮 [rp1.run](https://rp1.run)