### PR TITLE
fix(web-ui): resolve central storage roots in Arcade artifact browser

### DIFF
--- a/cli/web-ui/src/__tests__/server/project-paths.test.ts
+++ b/cli/web-ui/src/__tests__/server/project-paths.test.ts
@@ -1,10 +1,12 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
-import { mkdir, mkdtemp, rm } from "node:fs/promises";
-import { tmpdir } from "node:os";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
+import { resetContainerDetectionCache } from "../../../../shared/storage-mode.js";
 import {
 	findArtifactByRequestedPath,
 	getRunDirectories,
+	listProjectSectionRoots,
 	type ProjectDirectories,
 	parseProjectSectionPath,
 	resolveArtifactAbsolutePath,
@@ -270,6 +272,102 @@ describe("project-paths", () => {
 		} finally {
 			await rm(defaultProjectDir, { recursive: true, force: true });
 		}
+	});
+
+	describe("central storage resolution", () => {
+		let centralTmpDir: string;
+		const testProjectId = "test-central-id-12345";
+
+		beforeAll(async () => {
+			resetContainerDetectionCache();
+			centralTmpDir = await mkdtemp(
+				join(tmpdir(), "rp1-project-paths-central-"),
+			);
+			await mkdir(join(centralTmpDir, ".rp1"), { recursive: true });
+			await writeFile(join(centralTmpDir, ".rp1", "project_id"), testProjectId);
+			await writeFile(
+				join(centralTmpDir, ".rp1", "settings.toml"),
+				'[storage]\nmode = "central"\n',
+			);
+		});
+
+		afterAll(async () => {
+			resetContainerDetectionCache();
+			if (centralTmpDir) {
+				await rm(centralTmpDir, { recursive: true, force: true });
+			}
+		});
+
+		test("resolveProjectDirectories returns central paths when storage mode is central", () => {
+			const resolved = resolveProjectDirectories(centralTmpDir);
+			const expectedBase = join(homedir(), ".rp1", "projects", testProjectId);
+
+			expect(resolved.projectRoot).toBe(centralTmpDir);
+			expect(resolved.kbRoot).toBe(join(expectedBase, "context"));
+			expect(resolved.workRoot).toBe(join(expectedBase, "work"));
+		});
+
+		test("listProjectSectionRoots returns absolute central paths with canonical display paths", () => {
+			const resolved = resolveProjectDirectories(centralTmpDir);
+			const roots = listProjectSectionRoots(resolved);
+			const expectedBase = join(homedir(), ".rp1", "projects", testProjectId);
+
+			expect(roots[0].section).toBe("work");
+			expect(roots[0].absolutePath).toBe(join(expectedBase, "work"));
+			expect(roots[0].displayPath).toBe(".rp1/work");
+
+			expect(roots[1].section).toBe("kb");
+			expect(roots[1].absolutePath).toBe(join(expectedBase, "context"));
+			expect(roots[1].displayPath).toBe(".rp1/context");
+		});
+
+		test("resolveProjectDirectories returns local paths when storage mode is local", async () => {
+			const localTmpDir = await mkdtemp(
+				join(tmpdir(), "rp1-project-paths-local-"),
+			);
+
+			try {
+				await mkdir(join(localTmpDir, ".rp1"), { recursive: true });
+				await writeFile(
+					join(localTmpDir, ".rp1", "project_id"),
+					"local-test-id",
+				);
+				await writeFile(
+					join(localTmpDir, ".rp1", "settings.toml"),
+					'[storage]\nmode = "local"\n',
+				);
+
+				const resolved = resolveProjectDirectories(localTmpDir);
+
+				expect(resolved.projectRoot).toBe(localTmpDir);
+				expect(resolved.kbRoot).toBe(join(localTmpDir, ".rp1", "context"));
+				expect(resolved.workRoot).toBe(join(localTmpDir, ".rp1", "work"));
+			} finally {
+				await rm(localTmpDir, { recursive: true, force: true });
+			}
+		});
+
+		test("resolveProjectDirectories defaults to local when no project_id exists", async () => {
+			const noIdTmpDir = await mkdtemp(
+				join(tmpdir(), "rp1-project-paths-noid-"),
+			);
+
+			try {
+				await mkdir(join(noIdTmpDir, ".rp1"), { recursive: true });
+				await writeFile(
+					join(noIdTmpDir, ".rp1", "settings.toml"),
+					'[storage]\nmode = "central"\n',
+				);
+
+				const resolved = resolveProjectDirectories(noIdTmpDir);
+
+				expect(resolved.projectRoot).toBe(noIdTmpDir);
+				expect(resolved.kbRoot).toBe(join(noIdTmpDir, ".rp1", "context"));
+				expect(resolved.workRoot).toBe(join(noIdTmpDir, ".rp1", "work"));
+			} finally {
+				await rm(noIdTmpDir, { recursive: true, force: true });
+			}
+		});
 	});
 
 	describe("parseProjectSectionPath backward compatibility", () => {

--- a/cli/web-ui/src/server/project-paths.ts
+++ b/cli/web-ui/src/server/project-paths.ts
@@ -1,5 +1,11 @@
 import { isAbsolute, join, relative, resolve } from "node:path";
 import type { RunRecord } from "../../../shared/events.js";
+import { readProjectId } from "../../../shared/project-id.js";
+import {
+	computeDirectoryPaths,
+	isContainerEnvironment,
+	readStorageMode,
+} from "../../../shared/storage-mode.js";
 import type { ArtifactRecord } from "../../../src/agent-tools/emit/database.js";
 
 export interface ProjectDirectories {
@@ -36,11 +42,19 @@ const LEGACY_SECTION_PREFIXES: Record<ProjectSection, readonly string[]> = {
 
 const deriveProjectDirectories = (projectPath: string): ProjectDirectories => {
 	const projectRoot = resolve(projectPath);
-	const rp1DotDir = join(projectRoot, ".rp1");
+	const projectId = readProjectId(projectRoot);
+	const mode = isContainerEnvironment()
+		? "local"
+		: readStorageMode(projectRoot);
+	const { kbRoot, workRoot } = computeDirectoryPaths(
+		projectRoot,
+		projectId,
+		mode,
+	);
 	return {
 		projectRoot,
-		kbRoot: join(rp1DotDir, "context"),
-		workRoot: join(rp1DotDir, "work"),
+		kbRoot,
+		workRoot,
 	};
 };
 


### PR DESCRIPTION
## Summary

The Arcade artifact browser always resolved project directories to project-local `.rp1/context` and `.rp1/work` paths, ignoring the `[storage] mode = "central"` setting. Projects using central storage (`~/.rp1/projects/{projectId}/`) showed empty file trees in the browser.

This makes `resolveProjectDirectories()` in `cli/web-ui/src/server/project-paths.ts` storage-mode-aware: it reads the project ID from `.rp1/project_id`, resolves the effective storage mode from `settings.toml` (with container-environment override), and derives roots via the shared `computeDirectoryPaths()` — the same resolution used by `rp1 agent-tools rp1-root-dir` and `directory-resolution.ts`.

Because the file tree endpoint, content viewer, and file watcher all funnel through `resolveProjectDirectories`, this single change makes all three respect central storage — users can now browse centrally-stored work and context artifacts in the Arcade.

## Changes

- `cli/web-ui/src/server/project-paths.ts`: replace hardcoded local-path derivation in `deriveProjectDirectories` with storage-mode-aware resolution (`readProjectId`, `readStorageMode`, `isContainerEnvironment`, `computeDirectoryPaths`)
- `cli/web-ui/src/__tests__/server/project-paths.test.ts`: 4 new tests — central-mode resolution to `~/.rp1/projects/{id}/`, `listProjectSectionRoots` with central paths keeping canonical display paths, explicit local mode unchanged, missing `project_id` fallback

## Testing

- `project-paths` suite: 23/23 pass
- Full server-side suite: 278/278 pass
- Format and lint clean

🤖 Generated using: 🎮 [rp1.run](https://rp1.run)