### PR TITLE
feat(validate-hypothesis): support ad-hoc test scenarios without a feature artifact

### DIFF
--- a/catalog/agents.yaml
+++ b/catalog/agents.yaml
@@ -154,7 +154,7 @@ agents:
   - name: rp1-dev:hypothesis-tester
     description: "Validates design hypotheses through code experiments, codebase analysis, and external research"
     plugin: dev
-    last_checksum: d9c7896079bc6eb5000d36fa3e4e1d6b1f088da44bc6f4f3d4aa1631645576cf
+    last_checksum: 83941a408ff58660cb9a10d3466c670088c403666d100ac94a841138c9a2c681
   - name: rp1-dev:phase-planner
     description: "Decomposes a planning source into a source-adjacent phase-plan artifact and refreshes source backlinks."
     plugin: dev

--- a/catalog/agents.yaml
+++ b/catalog/agents.yaml
@@ -154,7 +154,7 @@ agents:
   - name: rp1-dev:hypothesis-tester
     description: "Validates design hypotheses through code experiments, codebase analysis, and external research"
     plugin: dev
-    last_checksum: 112a037ce2077c9b41ba2a08bd4066331b06c471d753ef508e770a7afa32ad5c
+    last_checksum: d9c7896079bc6eb5000d36fa3e4e1d6b1f088da44bc6f4f3d4aa1631645576cf
   - name: rp1-dev:phase-planner
     description: "Decomposes a planning source into a source-adjacent phase-plan artifact and refreshes source backlinks."
     plugin: dev

--- a/catalog/agents.yaml
+++ b/catalog/agents.yaml
@@ -154,7 +154,7 @@ agents:
   - name: rp1-dev:hypothesis-tester
     description: "Validates design hypotheses through code experiments, codebase analysis, and external research"
     plugin: dev
-    last_checksum: 87adb391c9948fae8b0e60b671cfa7cb68212ab686ddbeee12756cef70ad72bc
+    last_checksum: 112a037ce2077c9b41ba2a08bd4066331b06c471d753ef508e770a7afa32ad5c
   - name: rp1-dev:phase-planner
     description: "Decomposes a planning source into a source-adjacent phase-plan artifact and refreshes source backlinks."
     plugin: dev

--- a/plugins/base/skills/artifact-templates/SKILL.md
+++ b/plugins/base/skills/artifact-templates/SKILL.md
@@ -36,6 +36,7 @@ Active `/build` artifacts are producer-owned: the agent that writes the artifact
 | build-verify-aggregator | build-readiness.md | document | workRoot | features/{FEATURE_ID}/build-readiness.md | templates/build-verify-aggregator/build-readiness.md |
 | feature-editor | edit-marker | section | workRoot | features/{FEATURE_ID}/requirements.md (append) | templates/_sections/edit-marker.md |
 | hypothesis-tester | hypothesis-document.md | document | workRoot | features/{FEATURE_ID}/hypotheses.md | templates/hypothesis-tester/hypothesis-document.md |
+| hypothesis-tester | hypothesis-document-adhoc.md | document | workRoot | hypotheses/{YYYY-MM-DD}-{SLUG}.md | templates/hypothesis-tester/hypothesis-document-adhoc.md |
 | research-reporter | research-report.md | document | workRoot | research/{YYYY-MM-DD}-{TOPIC_SLUG}.md | templates/research-reporter/research-report.md |
 | project-documenter | birds-eye-view.md | document | workRoot | birds-eye/{YYYY-MM-DD}-{PROJECT_SLUG}.md | templates/project-documenter/birds-eye-view.md |
 | security-validator | security-report.md | document | workRoot | security/{REPORT_ID}/report.md | templates/security-validator/security-report.md |

--- a/plugins/base/skills/artifact-templates/SKILL.md
+++ b/plugins/base/skills/artifact-templates/SKILL.md
@@ -36,7 +36,7 @@ Active `/build` artifacts are producer-owned: the agent that writes the artifact
 | build-verify-aggregator | build-readiness.md | document | workRoot | features/{FEATURE_ID}/build-readiness.md | templates/build-verify-aggregator/build-readiness.md |
 | feature-editor | edit-marker | section | workRoot | features/{FEATURE_ID}/requirements.md (append) | templates/_sections/edit-marker.md |
 | hypothesis-tester | hypothesis-document.md | document | workRoot | features/{FEATURE_ID}/hypotheses.md | templates/hypothesis-tester/hypothesis-document.md |
-| hypothesis-tester | hypothesis-document-adhoc.md | document | workRoot | hypotheses/{YYYY-MM-DD}-{SLUG}.md | templates/hypothesis-tester/hypothesis-document-adhoc.md |
+| hypothesis-tester | hypothesis-document-adhoc.md | document | workRoot | hypotheses/{YYYY-MM-DD}-{SLUG}[-{N}].md | templates/hypothesis-tester/hypothesis-document-adhoc.md |
 | research-reporter | research-report.md | document | workRoot | research/{YYYY-MM-DD}-{TOPIC_SLUG}.md | templates/research-reporter/research-report.md |
 | project-documenter | birds-eye-view.md | document | workRoot | birds-eye/{YYYY-MM-DD}-{PROJECT_SLUG}.md | templates/project-documenter/birds-eye-view.md |
 | security-validator | security-report.md | document | workRoot | security/{REPORT_ID}/report.md | templates/security-validator/security-report.md |

--- a/plugins/base/skills/artifact-templates/templates/hypothesis-tester/hypothesis-document-adhoc.md
+++ b/plugins/base/skills/artifact-templates/templates/hypothesis-tester/hypothesis-document-adhoc.md
@@ -1,17 +1,18 @@
 ---
 scope: workRoot
-path_pattern: "hypotheses/{YYYY-MM-DD}-{SLUG}.md"
+path_pattern: "hypotheses/{YYYY-MM-DD}-{SLUG}[-{N}].md"
 producer: hypothesis-tester
 type: document
-description: "Ad-hoc hypothesis document for validating standalone scenarios without a feature context. Created and updated by hypothesis-tester in ad-hoc mode."
+description: "Ad-hoc hypothesis document for validating standalone scenarios without a feature context. Created and updated by hypothesis-tester in ad-hoc mode. Optional [-{N}] suffix resolves same-day slug collisions."
 strictness: strict
 emit_hint: |
+  # Skip if WORKFLOW is empty (standalone invocation).
   rp1 agent-tools emit \
     --workflow {WORKFLOW} \
     --type artifact_registered \
     --run-id {RUN_ID} \
     --step hypothesis-tester:testing \
-    --data '{"path": "hypotheses/{YYYY-MM-DD}-{SLUG}.md", "storageRoot": "work_dir"}'
+    --data '{"path": "hypotheses/{RESOLVED_FILENAME}", "storageRoot": "work_dir"}'
 ---
 
 # Hypothesis Document: {SLUG}

--- a/plugins/base/skills/artifact-templates/templates/hypothesis-tester/hypothesis-document-adhoc.md
+++ b/plugins/base/skills/artifact-templates/templates/hypothesis-tester/hypothesis-document-adhoc.md
@@ -1,0 +1,58 @@
+---
+scope: workRoot
+path_pattern: "hypotheses/{YYYY-MM-DD}-{SLUG}.md"
+producer: hypothesis-tester
+type: document
+description: "Ad-hoc hypothesis document for validating standalone scenarios without a feature context. Created and updated by hypothesis-tester in ad-hoc mode."
+strictness: strict
+emit_hint: |
+  rp1 agent-tools emit \
+    --workflow {WORKFLOW} \
+    --type artifact_registered \
+    --run-id {RUN_ID} \
+    --step hypothesis-tester:testing \
+    --data '{"path": "hypotheses/{YYYY-MM-DD}-{SLUG}.md", "storageRoot": "work_dir"}'
+---
+
+# Hypothesis Document: {SLUG}
+**Version**: 1.0.0 | **Created**: {timestamp} | **Status**: PENDING
+
+## Scenario
+{HYPOTHESIS description}
+
+## Hypotheses
+
+### HYP-001: {Title derived from HYPOTHESIS}
+**Risk Level**: MEDIUM
+**Status**: PENDING
+**Statement**: {assumption to validate}
+**Context**: Ad-hoc validation
+**Validation Criteria**:
+- CONFIRM if: {criteria}
+- REJECT if: {criteria}
+**Suggested Method**: CODE_EXPERIMENT|CODEBASE_ANALYSIS|EXTERNAL_RESEARCH
+
+## Validation Findings
+
+### HYP-001 Findings
+**Validated**: {ISO timestamp}
+**Method**: {method}
+**Result**: CONFIRMED|REJECTED
+**Refutation Coverage**: complete|minor-gaps|partial|contradicted
+**Safety Flags Resolved**: {list, or None}
+**Safety Flags Unresolved**: {list, or None}
+
+**Evidence**:
+{detailed evidence}
+
+**Sources**:
+- {file:line or URLs}
+
+**Implications**:
+{implications}
+
+## Summary
+
+| Hypothesis | Risk | Result | Implication |
+|------------|------|--------|-------------|
+| HYP-001 | {MEDIUM} | {CONFIRMED} | {brief} |

--- a/plugins/dev/agents/hypothesis-tester.md
+++ b/plugins/dev/agents/hypothesis-tester.md
@@ -8,8 +8,12 @@ author: cloud-on-prem/rp1
 arguments:
   - name: FEATURE_ID
     type: string
-    required: true
-    description: "Feature ID"
+    required: false
+    description: "Feature ID. Required for feature-bound mode."
+  - name: HYPOTHESIS
+    type: string
+    required: false
+    description: "Free-form hypothesis or scenario description for ad-hoc validation."
   - name: KB_ROOT
     type: string
     required: true
@@ -45,7 +49,9 @@ You are HypothesisTester-GPT. Validate technical assumptions via code experiment
 <work_root>{{WORK_ROOT from prompt}}</work_root>
 <code_root>{{CODE_ROOT from prompt}}</code_root>
 
-**Doc Path**: `{WORK_ROOT}/features/{FEATURE_ID}/hypotheses.md`
+**Doc Path**:
+- Feature-bound (FEATURE_ID provided): `{WORK_ROOT}/features/{FEATURE_ID}/hypotheses.md`
+- Ad-hoc (HYPOTHESIS provided, no FEATURE_ID): `{WORK_ROOT}/hypotheses/{YYYY-MM-DD}-{slug}.md`
 
 ## Code Root Directive
 
@@ -62,12 +68,30 @@ DO:
 - Flag diagnosability gaps when prod failures would be silent or hard to trace.
 - Mark uncertainty; prefer no finding over low-confidence speculation.
 
+## §MODE: Mode Detection
+
+Determine operating mode before any workflow steps:
+
+- **Feature-bound mode**: FEATURE_ID is provided. Read and update the existing `{WORK_ROOT}/features/{FEATURE_ID}/hypotheses.md` (created by feature-architect).
+- **Ad-hoc mode**: HYPOTHESIS is provided without FEATURE_ID. Generate a kebab-case slug from the HYPOTHESIS description (lowercase, strip non-alphanumeric, truncate to 50 chars). Create a new hypothesis document at `{WORK_ROOT}/hypotheses/{YYYY-MM-DD}-{slug}.md` using the ad-hoc template format.
+
+If neither FEATURE_ID nor HYPOTHESIS is provided, exit with error:
+```
+ERROR: No FEATURE_ID or HYPOTHESIS provided. Cannot determine validation mode.
+```
+
 ## §FMT: Document Format Reference
 
+**Feature-bound mode**:
 1. Read the template at `plugins/base/skills/artifact-templates/templates/hypothesis-tester/hypothesis-document.md` for format reference (fall back to `rp1-base:artifact-templates` SKILL.md index if the direct path fails).
 2. When updating the document, maintain the template's structure. Append findings to the `## Validation Findings` section.
+3. This mode reads and updates existing documents -- it does not create them. The initial document is created by feature-architect.
 
-This agent reads and updates existing documents -- it does not create them. The initial document is created by feature-architect.
+**Ad-hoc mode**:
+1. Read the template at `plugins/base/skills/artifact-templates/templates/hypothesis-tester/hypothesis-document-adhoc.md` for format reference.
+2. Create the hypothesis document from scratch: synthesize HYP-001 from the HYPOTHESIS description, set Risk Level to MEDIUM (default), derive validation criteria and method from the scenario.
+3. Ensure `{WORK_ROOT}/hypotheses/` directory exists (`mkdir -p`).
+4. Write the document, then run the experiment and append findings to it.
 
 ## §KB: Load Knowledge Base
 
@@ -78,11 +102,26 @@ Additional files:
 
 ## §PROC: Validation Workflow
 
-### 1. Load Hypothesis Doc
-Read `{WORK_ROOT}/features/{FEATURE_ID}/hypotheses.md`
+### 1. Load or Create Hypothesis Doc
+
+**Feature-bound mode**: Read `{WORK_ROOT}/features/{FEATURE_ID}/hypotheses.md`
+
+If missing:
+```
+ERROR: No hypotheses.md found at {path}
+This file should have been created by the feature-architect during the design phase.
+Re-run the design phase with /build {FEATURE_ID} or create the file manually following the format above.
+```
+
+**Ad-hoc mode**: Create the hypothesis document:
+1. Generate slug: lowercase the HYPOTHESIS description, replace non-alphanumeric with hyphens, collapse consecutive hyphens, trim leading/trailing hyphens, truncate to 50 chars.
+2. Set date: `YYYY-MM-DD` (today).
+3. `mkdir -p {WORK_ROOT}/hypotheses/`
+4. Create `{WORK_ROOT}/hypotheses/{YYYY-MM-DD}-{slug}.md` using the ad-hoc template format from §FMT.
+5. Synthesize HYP-001: derive statement, validation criteria, and method from the HYPOTHESIS description.
 
 Transition to `testing` state per STATE-MACHINE section (skip if WORKFLOW is empty).
-Report once per experiment using `--task hypothesis-{N}` where N is the sequential experiment number (e.g., `hypothesis-1`, `hypothesis-2`):
+Report once per experiment using `--unit hypothesis-{N}` where N is the sequential experiment number (e.g., `hypothesis-1`, `hypothesis-2`):
 
 ```bash
 rp1 agent-tools emit \
@@ -92,13 +131,6 @@ rp1 agent-tools emit \
   --step hypothesis-tester:testing \
   --unit hypothesis-{N} \
   --data '{"status": "running", "feature": "{FEATURE_ID}"}'
-```
-
-If missing:
-```
-ERROR: No hypotheses.md found at {path}
-This file should have been created by the feature-architect during the design phase.
-Re-run the design phase with /build {FEATURE_ID} or create the file manually following the format above.
 ```
 
 ### 2. Parse Hypotheses
@@ -188,7 +220,7 @@ Update status: PENDING -> CONFIRMED|REJECTED
 
 ### 4.5. Return Rejected for Caller
 
-If any REJECTED, output JSON block:
+**Feature-bound mode only**: If any REJECTED, output JSON block:
 
 ```json
 {
@@ -211,6 +243,8 @@ If any REJECTED, output JSON block:
 Caller handles user confirmation -> may update to CONFIRMED_BY_USER.
 
 Skip JSON if no rejections.
+
+**Ad-hoc mode**: Skip rejected-hypothesis JSON output. Findings are self-contained in the hypothesis document.
 
 ### 5. Update Summary Table
 
@@ -241,12 +275,15 @@ rp1 agent-tools emit \
 ### 6. Cleanup
 
 ```bash
-rm -rf /tmp/hypothesis-{feature-id}/
-ls /tmp/ | grep hypothesis-{feature-id}  # verify empty
+rm -rf /tmp/hypothesis-{feature-id-or-slug}/
+ls /tmp/ | grep hypothesis-{feature-id-or-slug}  # verify empty
 ```
+
+Use FEATURE_ID in feature-bound mode, slug in ad-hoc mode.
 
 ### 7. Report Summary
 
+**Feature-bound mode**:
 ```
 ## Hypothesis Validation Complete
 **Feature**: {feature-id}
@@ -261,6 +298,19 @@ ls /tmp/ | grep hypothesis-{feature-id}  # verify empty
 ```
 
 CONFIRMED_BY_USER = valid for design (user domain knowledge).
+
+**Ad-hoc mode**:
+```
+## Hypothesis Validation Complete
+**Scenario**: {HYPOTHESIS description, truncated to 80 chars}
+**Hypotheses Validated**: X
+**Results**: CONFIRMED: X | REJECTED: X
+
+**Key Findings**:
+- HYP-001: {one-line}
+
+**Document Created**: {path}
+```
 
 ## STATE-MACHINE
 

--- a/plugins/dev/agents/hypothesis-tester.md
+++ b/plugins/dev/agents/hypothesis-tester.md
@@ -88,10 +88,19 @@ ERROR: No FEATURE_ID or HYPOTHESIS provided. Cannot determine validation mode.
 3. This mode reads and updates existing documents -- it does not create them. The initial document is created by feature-architect.
 
 **Ad-hoc mode**:
-1. Read the template at `plugins/base/skills/artifact-templates/templates/hypothesis-tester/hypothesis-document-adhoc.md` for format reference.
+1. Read the template at `plugins/base/skills/artifact-templates/templates/hypothesis-tester/hypothesis-document-adhoc.md` for format reference (fall back to `rp1-base:artifact-templates` SKILL.md index if the direct path fails).
 2. Create the hypothesis document from scratch: synthesize HYP-001 from the HYPOTHESIS description, set Risk Level to MEDIUM (default), derive validation criteria and method from the scenario.
 3. Ensure `{WORK_ROOT}/hypotheses/` directory exists (`mkdir -p`).
-4. Write the document, then run the experiment and append findings to it.
+4. Write the document using exclusive-create semantics (see §PROC step 1 for collision resolution).
+5. Register the artifact after creation (skip if WORKFLOW is empty):
+   ```bash
+   rp1 agent-tools emit \
+     --workflow {WORKFLOW} \
+     --type artifact_registered \
+     --run-id {RUN_ID} \
+     --step hypothesis-tester:testing \
+     --data '{"path": "hypotheses/{resolved-filename}", "storageRoot": "work_dir"}'
+   ```
 
 ## §KB: Load Knowledge Base
 
@@ -114,11 +123,13 @@ Re-run the design phase with /build {FEATURE_ID} or create the file manually fol
 ```
 
 **Ad-hoc mode**: Create the hypothesis document:
-1. Generate slug: lowercase the HYPOTHESIS description, replace non-alphanumeric with hyphens, collapse consecutive hyphens, trim leading/trailing hyphens, truncate to 50 chars.
+1. Generate slug: lowercase the HYPOTHESIS description, replace non-alphanumeric with hyphens, collapse consecutive hyphens, trim leading/trailing hyphens, truncate to 50 chars. If the result is empty, use `adhoc-hypothesis` as the slug.
 2. Set date: `YYYY-MM-DD` (today).
-3. `mkdir -p {WORK_ROOT}/hypotheses/`
-4. Create `{WORK_ROOT}/hypotheses/{YYYY-MM-DD}-{slug}.md` using the ad-hoc template format from §FMT.
-5. Synthesize HYP-001: derive statement, validation criteria, and method from the HYPOTHESIS description.
+3. Set `EXPERIMENT_ID` = the generated slug (used for both setup and cleanup).
+4. `mkdir -p {WORK_ROOT}/hypotheses/`
+5. Resolve target path with exclusive-create semantics: start with `{WORK_ROOT}/hypotheses/{YYYY-MM-DD}-{slug}.md`. If the file exists, try `{YYYY-MM-DD}-{slug}-2.md`, then `-3`, etc. until a free path is found.
+6. Create the document at the resolved path using the ad-hoc template format from §FMT.
+7. Synthesize HYP-001: derive statement, validation criteria, and method from the HYPOTHESIS description.
 
 Transition to `testing` state per STATE-MACHINE section (skip if WORKFLOW is empty).
 Report once per experiment using `--unit hypothesis-{N}` where N is the sequential experiment number (e.g., `hypothesis-1`, `hypothesis-2`):
@@ -157,8 +168,10 @@ Do planning in `<validation_planning>` thinking block:
 #### CODE_EXPERIMENT
 For runtime/API behavior testing.
 
+Set `EXPERIMENT_ID` per mode: FEATURE_ID (feature-bound) or slug (ad-hoc, from §PROC step 1.3).
+
 ```bash
-mkdir -p /tmp/hypothesis-{feature-id}
+mkdir -p /tmp/hypothesis-{EXPERIMENT_ID}
 ```
 - Match project lang (check package.json/Cargo.toml/pyproject.toml/go.mod)
 - Write + execute experimental code
@@ -275,11 +288,11 @@ rp1 agent-tools emit \
 ### 6. Cleanup
 
 ```bash
-rm -rf /tmp/hypothesis-{feature-id-or-slug}/
-ls /tmp/ | grep hypothesis-{feature-id-or-slug}  # verify empty
+rm -rf /tmp/hypothesis-{EXPERIMENT_ID}/
+ls /tmp/ | grep hypothesis-{EXPERIMENT_ID}  # verify empty
 ```
 
-Use FEATURE_ID in feature-bound mode, slug in ad-hoc mode.
+`EXPERIMENT_ID` resolved per mode: FEATURE_ID (feature-bound) or slug (ad-hoc, set in §PROC step 1 ad-hoc sub-step 3).
 
 ### 7. Report Summary
 

--- a/plugins/dev/agents/hypothesis-tester.md
+++ b/plugins/dev/agents/hypothesis-tester.md
@@ -127,8 +127,8 @@ Re-run the design phase with /build {FEATURE_ID} or create the file manually fol
 2. Set date: `YYYY-MM-DD` (today).
 3. Set `EXPERIMENT_ID` = the generated slug (used for both setup and cleanup).
 4. `mkdir -p {WORK_ROOT}/hypotheses/`
-5. Resolve target path with exclusive-create semantics: start with `{WORK_ROOT}/hypotheses/{YYYY-MM-DD}-{slug}.md`. If the file exists, try `{YYYY-MM-DD}-{slug}-2.md`, then `-3`, etc. until a free path is found.
-6. Create the document at the resolved path using the ad-hoc template format from §FMT.
+5. Allocate a collision-free path atomically via no-clobber creation. Attempt `(set -C; > "{WORK_ROOT}/hypotheses/{YYYY-MM-DD}-{slug}.md") 2>/dev/null`; if it fails (file already exists), retry with suffix `-2`, then `-3`, etc. Only a successful no-clobber redirect establishes the path -- never check existence separately.
+6. Write the document content into the allocated file using the ad-hoc template format from §FMT.
 7. Synthesize HYP-001: derive statement, validation criteria, and method from the HYPOTHESIS description.
 
 Transition to `testing` state per STATE-MACHINE section (skip if WORKFLOW is empty).

--- a/plugins/dev/skills/validate-hypothesis/SKILL.md
+++ b/plugins/dev/skills/validate-hypothesis/SKILL.md
@@ -39,10 +39,22 @@ Supports two modes:
 At least one of FEATURE_ID or HYPOTHESIS must be provided. If neither is set:
 
 ```
-ERROR: Provide either FEATURE_ID (for feature-bound validation) or HYPOTHESIS (for ad-hoc validation).
+ERROR: Provide either FEATURE_ID (for feature-bound validation) or --hypothesis "text" (for ad-hoc validation).
 ```
 
 If both are provided, prefer feature-bound mode (FEATURE_ID takes precedence).
+
+### Mode Disambiguation
+
+When FEATURE_ID is resolved but HYPOTHESIS is empty, check before dispatching feature-bound mode:
+
+1. If `{workRoot}/features/{FEATURE_ID}/` exists -> feature-bound mode (proceed).
+2. Otherwise, if the resolved FEATURE_ID value contains whitespace (indicates free-form prose was bound positionally) -> treat the entire resolved value as HYPOTHESIS, clear FEATURE_ID, and dispatch ad-hoc mode instead.
+3. Otherwise (single-token FEATURE_ID, no matching feature dir) -> error:
+   ```
+   ERROR: Feature directory not found: {workRoot}/features/{FEATURE_ID}/
+   For ad-hoc validation, use: --hypothesis "your scenario description"
+   ```
 
 ## Execution
 

--- a/plugins/dev/skills/validate-hypothesis/SKILL.md
+++ b/plugins/dev/skills/validate-hypothesis/SKILL.md
@@ -21,6 +21,7 @@ metadata:
     - name: HYPOTHESIS
       type: string
       required: false
+      variadic: true
       description: "Free-form hypothesis or scenario description to validate ad-hoc, without a feature context."
   sub_agents:
     - "rp1-dev:hypothesis-tester"
@@ -42,19 +43,19 @@ At least one of FEATURE_ID or HYPOTHESIS must be provided. If neither is set:
 ERROR: Provide either FEATURE_ID (for feature-bound validation) or --hypothesis "text" (for ad-hoc validation).
 ```
 
-If both are provided, prefer feature-bound mode (FEATURE_ID takes precedence).
+### Mode Selection
 
-### Mode Disambiguation
+Mode is determined by feature-directory existence, not argument precedence:
 
-When FEATURE_ID is resolved but HYPOTHESIS is empty, check before dispatching feature-bound mode:
-
-1. If `{workRoot}/features/{FEATURE_ID}/` exists -> feature-bound mode (proceed).
-2. Otherwise, if the resolved FEATURE_ID value contains whitespace (indicates free-form prose was bound positionally) -> treat the entire resolved value as HYPOTHESIS, clear FEATURE_ID, and dispatch ad-hoc mode instead.
-3. Otherwise (single-token FEATURE_ID, no matching feature dir) -> error:
-   ```
-   ERROR: Feature directory not found: {workRoot}/features/{FEATURE_ID}/
-   For ad-hoc validation, use: --hypothesis "your scenario description"
-   ```
+1. If FEATURE_ID is set AND `{workRoot}/features/{FEATURE_ID}/` exists -> **feature-bound mode**.
+2. If FEATURE_ID is set AND `{workRoot}/features/{FEATURE_ID}/` does NOT exist:
+   - If HYPOTHESIS is also populated -> combine as `HYPOTHESIS = "{FEATURE_ID} {HYPOTHESIS}"`, clear FEATURE_ID -> **ad-hoc mode**.
+   - If HYPOTHESIS is empty (lone token, no matching directory) -> error:
+     ```
+     ERROR: Feature directory not found: {workRoot}/features/{FEATURE_ID}/
+     For ad-hoc validation, use: --hypothesis "your scenario description"
+     ```
+3. If only HYPOTHESIS is set (no FEATURE_ID) -> **ad-hoc mode**.
 
 ## Execution
 

--- a/plugins/dev/skills/validate-hypothesis/SKILL.md
+++ b/plugins/dev/skills/validate-hypothesis/SKILL.md
@@ -16,8 +16,12 @@ metadata:
   arguments:
     - name: FEATURE_ID
       type: string
-      required: true
-      description: "Feature identifier whose hypotheses to validate (kebab-case)"
+      required: false
+      description: "Feature identifier whose hypotheses to validate (kebab-case). Required for feature-bound mode."
+    - name: HYPOTHESIS
+      type: string
+      required: false
+      description: "Free-form hypothesis or scenario description to validate ad-hoc, without a feature context."
   sub_agents:
     - "rp1-dev:hypothesis-tester"
 ---
@@ -26,13 +30,29 @@ metadata:
 
 Invokes **hypothesis-tester** agent to validate design assumptions.
 
-## Prerequisites
-- `{workRoot}/features/{FEATURE_ID}/hypotheses.md` MUST exist
-- Created by the feature-architect agent during the design phase when high-risk assumptions are identified
+Supports two modes:
+- **Feature-bound** (FEATURE_ID provided): validates hypotheses from an existing `hypotheses.md` artifact
+- **Ad-hoc** (HYPOTHESIS provided, no FEATURE_ID): validates a free-form hypothesis without feature context
+
+## Input Validation
+
+At least one of FEATURE_ID or HYPOTHESIS must be provided. If neither is set:
+
+```
+ERROR: Provide either FEATURE_ID (for feature-bound validation) or HYPOTHESIS (for ad-hoc validation).
+```
+
+If both are provided, prefer feature-bound mode (FEATURE_ID takes precedence).
 
 ## Execution
 
-### Step 1: Invoke Agent
+### Feature-bound Mode (FEATURE_ID provided)
+
+#### Prerequisites
+- `{workRoot}/features/{FEATURE_ID}/hypotheses.md` MUST exist
+- Created by the feature-architect agent during the design phase when high-risk assumptions are identified
+
+#### Step 1: Invoke Agent
 
 {% dispatch_agent "rp1-dev:hypothesis-tester" %}
 FEATURE_ID: {FEATURE_ID}
@@ -41,7 +61,7 @@ Validate all PENDING hypotheses for this feature.
 
 Agent actions: load hypotheses.md -> parse PENDING -> validate via experiment/analysis/research -> document findings w/ evidence -> update status CONFIRMED|REJECTED -> cleanup temp artifacts -> report summary
 
-### Step 2: Handle Rejected Hypotheses
+#### Step 2: Handle Rejected Hypotheses
 
 Parse agent output. If JSON block w/ `type: "rejected_hypotheses"`:
 
@@ -64,6 +84,19 @@ For each rejected:
 
 **If "Accept rejection"**: No change (status remains REJECTED)
 
-### Step 3: Report Result
+### Ad-hoc Mode (HYPOTHESIS provided, no FEATURE_ID)
 
-Display validation summary. Note any user overrides.
+#### Step 1: Invoke Agent
+
+{% dispatch_agent "rp1-dev:hypothesis-tester" %}
+HYPOTHESIS: {HYPOTHESIS}
+Validate this ad-hoc hypothesis. Create a hypothesis document, run the experiment, and persist findings.
+{% enddispatch_agent %}
+
+Agent actions: generate slug -> create hypothesis document at `{workRoot}/hypotheses/{date}-{slug}.md` -> synthesize HYP-001 -> validate via experiment/analysis/research -> document findings -> report summary
+
+No rejected-hypothesis gating for ad-hoc mode (no feature design to gate).
+
+### Report Result
+
+Display validation summary. Note any user overrides (feature-bound mode only).


### PR DESCRIPTION
## Summary

The `validate-hypothesis` workflow only accepted `FEATURE_ID` and required an existing `features/{FEATURE_ID}/hypotheses.md` artifact. Ad-hoc probes like "run a small contained test to see if TypeScript can parse this DOT" had their free-form description jammed into `FEATURE_ID`, forcing the workflow into improvised fallback behavior.

This adds ad-hoc scenarios as a first-class mode:

- **`HYPOTHESIS` argument** (string, optional) on both the skill and the `hypothesis-tester` agent; `FEATURE_ID` becomes optional, with validation that at least one is provided.
- **Dual-mode dispatch** in the skill: `FEATURE_ID` present → existing feature-bound path, unchanged and backwards-compatible; only `HYPOTHESIS` present → ad-hoc dispatch with no prerequisite artifact check.
- **Ad-hoc agent mode**: synthesizes HYP-001 from the free-form description, generates a kebab-case slug, runs the contained experiment, and persists findings to `{WORK_ROOT}/hypotheses/{YYYY-MM-DD}-{slug}.md`.
- **Template registry**: new `hypothesis-document-adhoc.md` template with its own index row and path pattern.

## Changes

- `plugins/dev/skills/validate-hypothesis/SKILL.md`: `HYPOTHESIS` arg, optional `FEATURE_ID`, input validation, conditional dispatch
- `plugins/dev/agents/hypothesis-tester.md`: mode detection, dual-mode doc path, ad-hoc document creation workflow, conditional report/cleanup
- `plugins/base/skills/artifact-templates/SKILL.md`: ad-hoc hypothesis-document row in the template index
- `plugins/base/skills/artifact-templates/templates/hypothesis-tester/hypothesis-document-adhoc.md`: new ad-hoc template
- `catalog/agents.yaml`: regenerated checksums (same commit as prompt edits)

## Testing

- Catalog check passed; plugin builds pass (base: 16 agents/20 skills, dev: 36 agents/24 skills)
- Pre-push hooks green (typecheck CLI + web-ui, catalog, no-artifactory)
- No TypeScript changes — prompt/template/catalog files only

🤖 Generated using: 🎮 [rp1.run](https://rp1.run)