### PR TITLE
feat(kb): add feature-inventory dimension to knowledge-build suite

### DIFF
--- a/.rp1/context/architecture.md
+++ b/.rp1/context/architecture.md
@@ -1,10 +1,10 @@
 # System Architecture
 
 **Project**: rp1
-**Architecture Pattern**: Plugin-based CLI with tracked workflow state, artifact-backed handoffs, and multi-platform prompt compilation
-**Last Updated**: 2026-07-08
+**Architecture Pattern**: Plugin-based CLI with tracked workflow state, artifact-backed handoffs, multi-platform prompt compilation, and native desktop shell
+**Last Updated**: 2026-07-25
 
-rp1 is a Bun/TypeScript CLI + plugin monorepo that compiles markdown-defined skills and agents into host-specific artifacts, tracks workflow runtime state as events, serves a live Arcade dashboard, and lets users remap agent model tiers on their own machines at install time.
+rp1 is a Bun/TypeScript CLI + plugin monorepo that compiles markdown-defined skills and agents into host-specific artifacts, tracks workflow runtime state as events, serves a live Arcade dashboard (web and native macOS shell via Electrobun), enforces containerized test isolation with protected-home filesystem boundaries, and lets users remap agent model tiers on their own machines at install time.
 
 ## High-Level Architecture
 
@@ -16,9 +16,11 @@ flowchart TB
     CLI --> Build["Build Pipeline"]
     CLI --> Catalog["Catalog Registry"]
     CLI --> Settings["Settings<br/>apply, presets, rewriter"]
+    CLI --> TestBoundary["Test Isolation<br/>Docker + protected-home sandbox"]
     AgentTools --> EventDB[("~/.rp1/rp1.db")]
     AgentTools --> Daemon["Arcade Daemon<br/>HTTP + WS"]
     Daemon --> Browser["Web Browser"]
+    Daemon --> NativeApp["Native Arcade Shell<br/>Electrobun (macOS)"]
     Daemon --> Registry["Project Registry<br/>async mutex"]
     AgentTools -->|"storage-mode-aware<br/>path resolution"| PathRes["Resolved Paths<br/>kbRoot, workRoot, codeRoot"]
     Skills -->|"resolved vars"| KB[".rp1/context KB"]
@@ -41,6 +43,9 @@ flowchart TB
 - **Install-Time Tier Remapping** — user-controlled post-install model remapping via `settings.toml` `[models.<platform>]` sections or presets (budget/standard/premium): load → validate against `TIER_MODEL_MAP` → discover agents from bundle metadata → rewrite CC (.md frontmatter) and Codex (.toml) artifacts in place → strip effort on fast-class remaps → warn on protected-agent downgrades. `rp1 update` re-applies automatically (try/catch isolated).
 - **Protected Agent Downgrade Guards** — 14 reasoning-critical agents flagged in `PROTECTED_AGENTS`; build and remapping emit warnings via `TIER_RANK` comparison when they would drop below deep.
 - **Grace-Fallback Settings Migration** — legacy `settings.json` arcade fields auto-migrate to `settings.toml` `[arcade]` in two places: the `rp1 migrate` workflow (`cli/src/migrate/arcade-settings.ts`, dry-run capable, renames originals to `.migrated`) and daemon startup via `arcade-settings-bridge.ts`. Both use the comment-preserving `arcade-writer` with idempotent key merge.
+- **Containerized Test Isolation with Protected-Home Boundary** — CI tests run inside a disposable Docker container (`test-isolation.Dockerfile`) with a root-owned, read-only protected home directory and a sentinel file. `test-with-isolated-home.ts` creates ephemeral sandbox directories that redirect all user-state environment variables (HOME, XDG_*, APPDATA, TMPDIR, and 20+ tool-specific paths like CARGO_HOME, CLAUDE_CONFIG_DIR, GOPATH) away from the real home. `verify-test-home-boundary.ts` proves the container cannot write to the protected home (create, overwrite, rename, delete, chmod, utimes all denied) while the sandbox remains fully writable. A static analysis tool (`check-test-home-env.ts`) parses test source files via the TypeScript compiler API to detect direct mutations of protected environment variables and unsafe env replacements in child-process spawns (Bun.spawn, Node exec/fork/spawn, Worker). The CI pipeline verifies zero host or volume mounts before running tests.
+- **Native Desktop Arcade Shell** — macOS native app (`native-app/`) built with Electrobun bundles the rp1 binary and renders the Arcade dashboard as a native window. Configured via `electrobun.config.ts` with app identifier `run.rp1.arcade`. Build and install recipes (`just build-native-app`, `just install-native-app`) produce a standalone .app in `~/Applications`. CI runs `just check-native-app` (typecheck) and `just test-native-app` as separate jobs.
+- **Cross-Platform Interview Composition Contracts** — `tests/interview-composition.test.ts` validates that parent-owned interview contracts (blueprint, bootstrap) render correctly on every registered platform by building all platform plugins into a temp directory and asserting structural invariants: parent-owned question flow ordering, dispatch counts, argument resolution sequences, artifact registration with storage-mode-aware paths, and finalizer non-interactivity. This catches platform-specific rendering regressions that single-platform builds miss.
 - **Parallel Wave Dispatch with Strict Message Ordering** — the /build skill dispatches all ready verification/build agents back-to-back in a single message with no intervening prose, guaranteeing single-message parallel scheduling of task waves.
 - **Event-Sourced Runtime State** — all workflow state changes are `rp1 agent-tools emit` events persisted to SQLite and broadcast over WebSocket.
 - **State-Machine-Driven Workflows** — skills declare `stateDiagram-v2` phases; steps are validated against the graph at emit time.
@@ -60,8 +65,10 @@ flowchart TB
 | Runtime Services | Agent tools: emit, bootstrap, resolve-args, rp1-root-dir (storage-mode-aware) | `cli/src/agent-tools/` |
 | Build & Distribution | Multi-platform compile with tier resolution, validation, rendering, and install-time remapping | `cli/src/build/`, `cli/src/catalog/`, `cli/src/settings/` |
 | Presentation | Arcade SPA with real-time WS | `cli/web-ui/` |
+| Native Desktop | macOS native Arcade shell via Electrobun | `native-app/` (Electrobun config, bun entrypoint, HTML views) |
 | Persistence | SQLite event store, KB, work artifacts, settings | `~/.rp1/rp1.db`, `.rp1/context/`, `.rp1/work/`, `settings.toml` |
-| Evaluation | Dockerized prompt evals | `evals/` |
+| Test Infrastructure | Containerized test isolation with protected-home filesystem boundary and static env-safety analysis | `cli/scripts/test-with-isolated-home.ts`, `cli/scripts/verify-test-home-boundary.ts`, `cli/scripts/check-test-home-env.ts`, `.github/test-isolation.Dockerfile`, `cli/test-fixtures/test-home/` |
+| Evaluation | Dockerized prompt evals with content-addressable attestation | `evals/` (attestation gates release-please PRs; Node 24 pinned for better-sqlite3 prebuilt compatibility) |
 
 ## Data Flows
 
@@ -70,11 +77,12 @@ flowchart TB
 - **Event Pipeline**: skill/agent emits event → state-machine validation → SQLite persist → HTTP daemon notify → WebSocket broadcast to Arcade.
 - **KB Generation**: orchestrator selects mode (FULL/INCREMENTAL/FEATURE_LEARNING) → spatial analysis → parallel specialist agents (dispatched with resolved `KB_ROOT`) → reconcile → write `{kbRoot}/*.md` + `state.json`.
 - **Directory Resolution**: `rp1-root-dir` locates `.rp1/project_id` → checks active storage mode → returns `projectRoot`/`kbRoot`/`workRoot`/`codeRoot`; consumed by workflow-bootstrap and resolve-args, then passed to agents as dispatch arguments.
+- **Test Isolation Boundary**: CI builds Docker image from `test-isolation.Dockerfile` → verifies zero host mounts → `verify-test-home-boundary.ts` proves root-owned sentinel is immutable → `test-with-isolated-home.ts` creates ephemeral sandbox with redirected env vars → `check-test-home-env.ts` statically audits test sources for env mutations → tests execute inside sandbox → sandbox cleaned up.
 
 ## Integration Points
 
-- **Runtime/build**: Bun (runtime, HTTP/WS server, binary compile, tests), `bun:sqlite` (event store), LiquidJS (template engine, `greedy:true` whitespace control).
-- **VCS/CI**: Git CLI (KB staleness, diffs, worktree resolution), GitHub API via `gh` (PR review), Release Please + GitHub Actions, Lefthook + Biome (local quality gates).
+- **Runtime/build**: Bun (runtime, HTTP/WS server, binary compile, tests), `bun:sqlite` (event store), LiquidJS (template engine, `greedy:true` whitespace control), Electrobun (native macOS shell).
+- **VCS/CI**: Git CLI (KB staleness, diffs, worktree resolution), GitHub API via `gh` (PR review), Release Please + GitHub Actions (attestation gates release-please PRs; Node 24 pinned for better-sqlite3), Lefthook + Biome (local quality gates), Docker (containerized test isolation + eval execution).
 - **Frontend**: React + Vite (Arcade SPA), chokidar (file watching), promptfoo + Docker (evals).
 
 ## Deployment
@@ -83,6 +91,8 @@ Single-executable CLI per platform (darwin/linux/windows) via GitHub releases, p
 
 Dockerized evals handle TLS-intercepting networks (e.g. Cloudflare WARP): `docker/eval-run.sh` exports the host gateway CA into `docker/certs/`, the Dockerfile bakes it into the container trust store, and `NODE_EXTRA_CA_CERTS` covers Node/bun downloads in-container.
 
+A macOS native Arcade shell (`run.rp1.arcade`) is built with Electrobun and bundled with the rp1 binary; it provides a standalone desktop window alternative to the browser-based Arcade. CI test execution runs inside disposable Docker containers with a protected-home filesystem boundary that prevents tests from reading or writing the real home directory; the boundary is verified on every CI run via a sentinel-based filesystem probe.
+
 ## Related KB
 
-- Component detail: `modules.md` · Concepts: `concept_map.md` · Conventions: `patterns.md` · Surfaces: `interaction-model.md`
+- Component detail: `modules.md` · Concepts: `concept_map.md` · Conventions: `patterns.md` · Surfaces: `interaction-model.md` · Capabilities: `features.md`

--- a/.rp1/context/concept_map.md
+++ b/.rp1/context/concept_map.md
@@ -39,6 +39,8 @@
 | ArcadeSettings | entity | User-configurable Arcade UI preferences from `settings.toml` `[arcade]`: `theme` (light/dark/system, validated against `VALID_ARCADE_THEMES`) + `[arcade.downsampling]` `thresholdHours`. Defaults: system theme, 24h threshold |
 | Settings Migration | mechanism | Automated legacy `settings.json` → canonical `settings.toml` conversion (arcade fields) at both global and project paths. Runs inside `rp1 migrate` and as daemon grace fallback; dry-run support; originals renamed `.migrated` for audit trail; idempotent merge never overwrites existing TOML keys |
 | Path Variable | mechanism | Parameterized directory placeholder declared in agent/skill frontmatter (`KB_ROOT`, `WORK_ROOT`, `CODE_ROOT`) and interpolated at dispatch time, decoupling prompt logic from storage layout. Two naming layers: UPPER_SNAKE in agent arguments, camelCase (`kbRoot`/`workRoot`) in skill dispatch blocks |
+| HarnessSelection | entity | User-configurable list of AI harnesses (`[harnesses].enabled` in user-level `settings.toml`) controlling which platforms receive global instruction stanzas and sandbox grants. Absent = auto-detect; empty = skip all. Written by `rp1 init`, updated by `install`/`uninstall`, consumed by `update`, `init` sandbox grants, and `migrate --to-central` |
+| Artifact Template | entity | Canonical output-format definition in `plugins/base/skills/artifact-templates/` with YAML routing metadata (`scope`, `path_pattern`, `emit_hint`) and markdown body with placeholder patterns. All 20 producer agents load templates via two-hop discovery instead of embedding formats inline |
 
 ## Key Terminology
 
@@ -73,6 +75,9 @@
 | RemappableTier | Preset-exposed tier subset: `deep`, `standard`, `fast` (`frontier` and `inherit` excluded from presets) |
 | Effort Clamping | Codex-specific `max` → `xhigh` mapping (Codex supports four levels); CC supports all five natively |
 | Hermetic Settings Seam | Optional `globalSettingsPath` parameter on settings loaders/resolvers isolating tests from real `~/.config/rp1/settings.toml` |
+| enabled harnesses | Persisted list in `[harnesses].enabled` determining which platforms receive stanza writes and sandbox grants; absent triggers auto-detection, empty array skips all |
+| Instruction Variant | Template-loading pattern (A through D) matching agent output type to the correct artifact-template discovery and fill strategy |
+| Validation Matrix | Per-change-area expected local validation commands (e.g. `just check-cli`, `just build-plugins-check`) documented in CONTRIBUTING.md and mirrored in the PR template |
 
 ## Relationships
 
@@ -102,6 +107,10 @@ Preset ──provides defaults for──> TierRemappingConfig (explicit override
 Task File Lock ──protects──> Task Queue (serializes concurrent task-file writes)
 Workflow Bootstrap ──resolves──> Path Variable (kbRoot/workRoot/codeRoot from rp1-root-dir → dispatch parameters)
 Path Variable ──locates──> Knowledge Base (KB_ROOT resolves the storage-mode-aware KB directory)
+HarnessSelection ──targets──> Platform Definition (determines which platforms receive stanza writes and sandbox grants)
+HarnessSelection ──consumed by──> Settings Migration, Project Lifecycle (update, init, migrate)
+Artifact Template ──shapes──> Artifact (20 producer agents load templates for output format)
+Parent-Owned Interview ──structures──> Skill (interactive skills follow the interview contract)
 ```
 
 ## Agent Patterns
@@ -120,6 +129,8 @@ Path Variable ──locates──> Knowledge Base (KB_ROOT resolves the storage-
 | Generator-Verifier Asymmetry | Agent classification | Generator agents (task-builder) run at standard tier because deep-tier verifiers (task-reviewer) validate their output — quality preserved, cost reduced |
 | Directory-Based File Lock | Parallel task-builder execution | `mkdir` atomicity serializes concurrent read-modify-write on shared task files; sleep-poll on contention; always release |
 | Variable-Based Path Interpolation | All agent and skill dispatch | Skills resolve `{kbRoot}`/`{workRoot}` via workflow-bootstrap; agents receive `{KB_ROOT}`/`{WORK_ROOT}` as frontmatter arguments. No literal path references — enables storage-mode redirection without prompt changes |
+| Parent-Owned Interview | Interactive artifact completion (blueprint, bootstrap) | Only the parent skill asks user questions; leaf agents are bounded non-interactive workers. Artifact file is the sole resume source. At most 10 questions per phase; re-read after each write to verify durability before continuing |
+| Two-Hop Template Discovery | All producer agents (20 agents) | Agent reads artifact-templates SKILL.md index to find the template path, then reads the template file for routing metadata and placeholder body. Decouples output format from agent prompt |
 
 ## Bounded Contexts
 
@@ -134,9 +145,10 @@ Path Variable ──locates──> Knowledge Base (KB_ROOT resolves the storage-
 | Platform Abstraction | build pipeline | Platform Tag, CanonicalName, Platform Definition, ModelTier, EffortLevel, Tier Resolution, TIER_RANK |
 | Model Settings | cli/src/settings | TierRemappingConfig, Preset, Artifact Rewriter, BundleAgentEntry, Install-Time Tier Remapping, ArcadeSettings |
 | Discovery | cli/catalog | Discovery Registry, Guide, Skill Category, Arcade Tracked |
-| Project Lifecycle | cli/init, cli/migrate | Fence Versioning, Init Wizard, Project Migration, Settings Migration |
+| Project Lifecycle | cli/init, cli/migrate | Fence Versioning, Init Wizard, Project Migration, Settings Migration, HarnessSelection |
 | Quality Assurance | evals/ | Attestation |
 | Storage Resolution | cli/src/agent-tools, build pipeline | Path Variable, Storage Mode, codeRoot, rp1-root-dir |
+| Contributor Contracts | CONTRIBUTING.md, .github/ | Validation Matrix, Authoring Contract, PR Template, Merge Assessment |
 
 ## Cross-Cutting Concerns
 
@@ -150,3 +162,6 @@ Path Variable ──locates──> Knowledge Base (KB_ROOT resolves the storage-
 - **Single-source discovery**: Frontmatter metadata drives all catalog views, avoiding drift
 - **Standard tool envelope**: All agent-tools return `ToolResult<T>` JSON for predictable AI-agent parsing
 - **Concurrent task safety**: Directory-based file locks protect shared task-file updates during parallel builder execution
+- **Parent-owned interactivity**: Interactive workflows confine user-facing questions to the parent skill; leaf agents never ask, interpret, or relay user input, and the artifact file is the only resume source
+- **Template-driven output formats**: Producer agents load canonical artifact templates at runtime rather than embedding output formats, ensuring format consistency and routing metadata across all 20 producers
+- **Harness-aware stanza management**: Global instruction stanzas and sandbox grants target only the user's declared harnesses, preventing stale writes to uninstalled platforms

--- a/.rp1/context/features.md
+++ b/.rp1/context/features.md
@@ -1,0 +1,425 @@
+# Repository Capabilities
+
+**Repository**: rp1
+**Last Updated**: 2026-07-25
+**Surfaces**: 10 detected
+**Scope**: Capabilities inventoried across all projects in this repository.
+
+## CLI Core
+
+- **Project Initialization** `T1` -- Interactive setup of `.rp1/` directory structure, context detection, gitignore configuration, and global stanza injection
+  <!-- id: cli-core.init | tier: T1 | audience: developer | evidence: cli/src/commands/init.ts, cli/src/init/index.ts, docs/reference/cli/init.md -->
+- **Multi-Platform Installation** `T1` -- Installs rp1 skills and agents into Claude Code, OpenCode, Codex, Copilot, and Antigravity with per-platform adapters
+  <!-- id: cli-core.install | tier: T1 | audience: developer | evidence: cli/src/commands/install/index.ts, cli/src/install/installer.ts, docs/reference/cli/install.md -->
+  - Claude Code Installer `T1` -- Writes CLAUDE.md stanzas and registers marketplace plugin
+    <!-- id: cli-core.install.claude-code | tier: T1 | audience: developer | evidence: cli/src/install/claudecode/installer.ts, cli/src/commands/install/claude-code.ts -->
+  - OpenCode Installer `T1` -- Generates OpenCode-compatible agent configuration
+    <!-- id: cli-core.install.opencode | tier: T1 | audience: developer | evidence: cli/src/commands/install/opencode.ts -->
+  - Codex Installer `T1` -- Produces Codex agent AGENTS.md and sub-agent configs
+    <!-- id: cli-core.install.codex | tier: T1 | audience: developer | evidence: cli/src/install/codex/installer.ts, cli/src/commands/install/codex.ts -->
+  - Copilot Installer `T1` -- Writes GitHub Copilot instructions and marketplace extensions
+    <!-- id: cli-core.install.copilot | tier: T1 | audience: developer | evidence: cli/src/install/copilot/installer.ts, cli/src/commands/install/copilot.ts -->
+  - Antigravity Installer `T1` -- Bundles assets and lifecycle hooks for the Antigravity platform
+    <!-- id: cli-core.install.antigravity | tier: T1 | audience: developer | evidence: cli/src/install/antigravity/index.ts, cli/src/commands/install/antigravity.ts -->
+  - Install All `T2` -- Auto-detects installed platforms and installs to all in one pass
+    <!-- id: cli-core.install.all | tier: T2 | audience: developer | evidence: cli/src/commands/install/all.ts -->
+- **Installation Verification** `T1` -- Validates that rp1 is correctly installed on each platform with platform-specific health checks
+  <!-- id: cli-core.verify | tier: T1 | audience: developer | evidence: cli/src/commands/verify/index.ts, docs/reference/cli/verify.md -->
+- **Self-Update** `T1` -- Checks for and applies CLI binary updates from GitHub releases
+  <!-- id: cli-core.self-update | tier: T1 | audience: developer | evidence: cli/src/commands/check-update.ts, cli/src/commands/self-update.ts -->
+- **Update and Plugin Sync** `T1` -- Updates installed platform artifacts and manages plugin versions
+  <!-- id: cli-core.update | tier: T1 | audience: developer | evidence: cli/src/commands/update/index.ts, cli/src/commands/update/plugins.ts, docs/reference/cli/update.md -->
+- **Uninstall** `T1` -- Removes rp1 artifacts from all platforms including Antigravity, Codex, and Copilot-specific cleanup
+  <!-- id: cli-core.uninstall | tier: T1 | audience: developer | evidence: cli/src/commands/uninstall.ts, cli/src/commands/uninstall-antigravity.ts, cli/src/commands/uninstall-codex.ts, cli/src/commands/uninstall-copilot.ts, docs/reference/cli/uninstall.md -->
+- **List Installed Plugins** `T2` -- Shows which plugins are installed and their versions
+  <!-- id: cli-core.list | tier: T2 | audience: developer | evidence: cli/src/commands/install.ts -->
+- **Migration** `T1` -- Upgrades `.rp1/` directory from older layout versions with database backfill, central store migration, stanza upgrades, and legacy work directory conversion
+  <!-- id: cli-core.migrate | tier: T1 | audience: developer | evidence: cli/src/commands/migrate.ts, cli/src/migrate/index.ts, cli/src/migrate/db-backfill.ts, cli/src/migrate/central-store.ts, docs/reference/cli/rp1-migrate.md -->
+- **Settings Management** `T1` -- Validates, applies, and manages settings.toml presets including arcade and harness configuration
+  <!-- id: cli-core.settings | tier: T1 | audience: developer | evidence: cli/src/commands/settings.ts, cli/src/settings/loader.ts, cli/src/settings/rewriter.ts, docs/reference/cli/settings.md -->
+- **Deprecated Command Shims** `T3` -- Hidden compatibility shims for renamed or removed commands
+  <!-- id: cli-core.deprecated | tier: T3 | audience: developer | evidence: cli/src/commands/deprecated/index.ts -->
+- **Fake Data Generator** `T3` -- Generates synthetic emit events and workflow artifacts for testing the Arcade UI
+  <!-- id: cli-core.fake | tier: T3 | audience: contributor | evidence: cli/src/commands/fake.ts -->
+
+## Build Pipeline
+
+- **Prompt Compiler** `T1` -- Parses skill and agent markdown, resolves arguments, applies preprocessor transforms, validates structure, and emits platform-specific output
+  <!-- id: build-pipeline.compiler | tier: T1 | audience: contributor | evidence: cli/src/build/parser.ts, cli/src/build/preprocessor.ts, cli/src/build/validator.ts, cli/src/build/command.ts -->
+  - Template Engine `T1` -- Interpolates `{variables}` and processes conditional sections in prompt files
+    <!-- id: build-pipeline.compiler.template-engine | tier: T1 | audience: contributor | evidence: cli/src/build/template-engine.ts, cli/src/build/template-context.ts -->
+  - Argument Resolution `T1` -- Parses structured `arguments` arrays from frontmatter into runtime parameter blocks
+    <!-- id: build-pipeline.compiler.arguments | tier: T1 | audience: contributor | evidence: cli/src/build/arguments.ts -->
+  - Tag Processing `T1` -- Expands custom XML tags during build (e.g. inline includes, platform conditionals)
+    <!-- id: build-pipeline.compiler.tags | tier: T1 | audience: contributor | evidence: cli/src/build/tags/ -->
+- **Platform Definitions** `T1` -- Declares per-platform build targets with feature flags and output format specifications
+  <!-- id: build-pipeline.platform-defs | tier: T1 | audience: contributor | evidence: cli/src/build/platform-definitions.ts -->
+  - Claude Code Target `T1` -- Emits CLAUDE.md-compatible skill stanzas
+    <!-- id: build-pipeline.platform-defs.claude-code | tier: T1 | audience: contributor | evidence: cli/src/build/claude-code/registry.ts -->
+  - Codex Target `T1` -- Emits AGENTS.md with sub-agent delegation and role mapping
+    <!-- id: build-pipeline.platform-defs.codex | tier: T1 | audience: contributor | evidence: cli/src/build/codex/index.ts, cli/src/build/codex/role-mapper.ts, cli/src/build/codex/sub-agent-validator.ts -->
+  - Antigravity Target `T1` -- Produces Gemini-compatible bundles with lifecycle hooks
+    <!-- id: build-pipeline.platform-defs.antigravity | tier: T1 | audience: contributor | evidence: cli/src/build/antigravity/hooks.ts, cli/src/build/antigravity/registry.ts -->
+  - Copilot Target `T2` -- Generates GitHub Copilot instruction files
+    <!-- id: build-pipeline.platform-defs.copilot | tier: T2 | audience: contributor | evidence: cli/src/build/copilot/registry.ts -->
+- **Model Tier Resolution** `T1` -- Resolves per-agent model and reasoning-effort overrides from settings.toml tiering configuration
+  <!-- id: build-pipeline.tier-resolution | tier: T1 | audience: contributor | evidence: cli/src/build/tier-resolution.ts -->
+- **Build Lint Rules** `T2` -- Static analysis rules that validate prompt file structure, naming conventions, and cross-references
+  <!-- id: build-pipeline.lint | tier: T2 | audience: contributor | evidence: cli/src/build/lint/index.ts, cli/src/build/lint/rules/ -->
+- **Catalog Generator** `T1` -- Produces `catalog/agents.yaml` manifest from all agent and skill definitions for discovery and registry use
+  <!-- id: build-pipeline.catalog | tier: T1 | audience: contributor | evidence: cli/src/build/catalog-generator.ts, cli/src/catalog/, catalog/agents.yaml -->
+- **Build-Time Filters** `T2` -- Configurable filter chain for content transformation during build (e.g. stripping comments, minifying)
+  <!-- id: build-pipeline.filters | tier: T2 | audience: contributor | evidence: cli/src/build/filters/ -->
+- **Parse Cache** `T2` -- Caches parsed prompt ASTs to accelerate incremental builds
+  <!-- id: build-pipeline.parse-cache | tier: T2 | audience: contributor | evidence: cli/src/build/parse-cache.ts -->
+
+## Agent Tools Runtime
+
+- **Workflow Event Emitter** `T1` -- Records agent workflow events (artifact_registered, step transitions, run lifecycle) into a local SQLite database with state machine validation
+  <!-- id: agent-tools.emit | tier: T1 | audience: agent | evidence: cli/src/agent-tools/emit/, cli/src/agent-tools/command.ts:1199 -->
+  - State Machine Enforcement `T1` -- Validates step transitions against declared state diagrams in skill frontmatter
+    <!-- id: agent-tools.emit.state-machine | tier: T1 | audience: agent | evidence: cli/src/agent-tools/state-machine/ -->
+  - Resume Run `T1` -- Continues a previously paused workflow run with preserved state
+    <!-- id: agent-tools.emit.resume-run | tier: T1 | audience: agent | evidence: cli/src/agent-tools/command.ts:1436 -->
+  - End Run `T1` -- Closes a workflow run and finalizes its state
+    <!-- id: agent-tools.emit.end-run | tier: T1 | audience: agent | evidence: cli/src/agent-tools/command.ts:1542 -->
+- **Mermaid Diagram Validator** `T1` -- Validates mermaid diagram syntax from files or stdin with auto-repair suggestions
+  <!-- id: agent-tools.mmd-validate | tier: T1 | audience: agent | evidence: cli/src/agent-tools/mmd-validate/, cli/src/agent-tools/command.ts:172 -->
+- **Project Root Resolver** `T1` -- Returns projectRoot, kbRoot, and workRoot paths respecting active storage mode
+  <!-- id: agent-tools.rp1-root-dir | tier: T1 | audience: agent | evidence: cli/src/agent-tools/rp1-root-dir/, cli/src/agent-tools/command.ts:270 -->
+- **Argument Resolver** `T1` -- Resolves skill arguments from user input and environment variables into structured JSON
+  <!-- id: agent-tools.resolve-args | tier: T1 | audience: agent | evidence: cli/src/agent-tools/resolve-args/, cli/src/agent-tools/command.ts:335 -->
+- **Workflow Bootstrap** `T1` -- Initializes a new workflow run directory with required metadata
+  <!-- id: agent-tools.workflow-bootstrap | tier: T1 | audience: agent | evidence: cli/src/agent-tools/workflow-bootstrap/, cli/src/agent-tools/command.ts:465 -->
+- **Workflow State Query** `T1` -- Reports current state of a running workflow including completed steps and pending transitions
+  <!-- id: agent-tools.workflow-state | tier: T1 | audience: agent | evidence: cli/src/agent-tools/workflow-state/, cli/src/agent-tools/command.ts:602 -->
+- **Build Task Plan** `T1` -- Generates structured task execution plans for the build workflow
+  <!-- id: agent-tools.build-task-plan | tier: T1 | audience: agent | evidence: cli/src/agent-tools/build-task-plan/, cli/src/agent-tools/command.ts:753 -->
+- **Work Search** `T1` -- Searches across rp1 work artifacts (features, tasks, reports) by query with structured results
+  <!-- id: agent-tools.work-search | tier: T1 | audience: agent | evidence: cli/src/agent-tools/work-search/, cli/src/agent-tools/command.ts:877 -->
+- **Change Manifest** `T1` -- Resolves a user-specified code scope into a durable list of files for batch operations
+  <!-- id: agent-tools.change-manifest | tier: T1 | audience: agent | evidence: cli/src/agent-tools/change-manifest/, cli/src/agent-tools/command.ts:975 -->
+- **Comment Extractor** `T1` -- Extracts code comment locations from files for analysis and cleanup workflows
+  <!-- id: agent-tools.comment-extract | tier: T1 | audience: agent | evidence: cli/src/agent-tools/comment-extract/, cli/src/agent-tools/command.ts:1113 -->
+- **Annotation Feedback System** `T1` -- Manages user annotations on artifacts including read, resolve, reply, and accept-edit operations
+  <!-- id: agent-tools.feedback | tier: T1 | audience: agent | evidence: cli/src/agent-tools/feedback/, cli/src/agent-tools/command.ts:1627 -->
+- **Socratic Duel Coordinator** `T1` -- Manages lock-based turn coordination for multi-agent debate workflows
+  <!-- id: agent-tools.socratic-duel | tier: T1 | audience: agent | evidence: cli/src/agent-tools/socratic-duel/, cli/src/agent-tools/command.ts:1933 -->
+- **Task Queue** `T1` -- Agent-facing task CRUD for creating, listing, picking up, completing, failing, and cancelling queued tasks
+  <!-- id: agent-tools.task | tier: T1 | audience: agent | evidence: cli/src/agent-tools/task/, cli/src/agent-tools/command.ts:2189 -->
+- **GitHub PR Integration** `T1` -- Submit reviews, add reactions, reply to comments, fetch comments, and publish comments on GitHub PRs
+  <!-- id: agent-tools.github-pr | tier: T1 | audience: agent | evidence: cli/src/agent-tools/github-pr/, cli/src/agent-tools/command.ts:2671 -->
+- **Git Utilities** `T2` -- Helper functions for git operations used by agent workflows
+  <!-- id: agent-tools.git | tier: T2 | audience: agent | evidence: cli/src/agent-tools/git.ts -->
+
+## Arcade (Web UI)
+
+- **Dashboard** `T1` -- Real-time web dashboard showing workflow runs, artifacts, and project status across multiple workspaces
+  <!-- id: arcade.dashboard | tier: T1 | audience: developer | evidence: cli/web-ui/src/pages/v2/HomePage.tsx, docs/arcade/dashboard.md -->
+  - Workspace Tab Strip `T1` -- Multi-workspace tabbed interface with pinned projects and live status indicators
+    <!-- id: arcade.dashboard.workspace-tabs | tier: T1 | audience: developer | evidence: cli/web-ui/src/components/v2/WorkspaceTabStrip.tsx, cli/web-ui/src/hooks/useWorkspaceTabs.tsx -->
+  - Run Cards `T1` -- Real-time workflow run cards with status badges, step progress, and event streams
+    <!-- id: arcade.dashboard.run-cards | tier: T1 | audience: developer | evidence: cli/web-ui/src/components/v2/RunCard.tsx, cli/web-ui/src/hooks/useRuns.ts -->
+  - Notification System `T1` -- Toast and sidebar notifications for workflow events with configurable attention levels
+    <!-- id: arcade.dashboard.notifications | tier: T1 | audience: developer | evidence: cli/web-ui/src/components/v2/NotificationsSidebar.tsx, cli/web-ui/src/components/v2/NotificationToast.tsx, cli/web-ui/src/hooks/useNotifications.ts -->
+  - Command Palette `T1` -- Keyboard-driven command palette for navigation and actions
+    <!-- id: arcade.dashboard.command-palette | tier: T1 | audience: developer | evidence: cli/web-ui/src/components/v2/CommandPalette.tsx -->
+- **Artifact Browser** `T1` -- File-tree browser for viewing and navigating rp1 work artifacts with markdown rendering
+  <!-- id: arcade.artifact-browser | tier: T1 | audience: developer | evidence: cli/web-ui/src/pages/v2/FileBrowserPage.tsx, cli/web-ui/src/components/FileTree/, docs/arcade/artifact-viewer.md -->
+  - Markdown Viewer `T1` -- Rich markdown renderer with syntax highlighting, mermaid diagrams, and table of contents
+    <!-- id: arcade.artifact-browser.markdown-viewer | tier: T1 | audience: developer | evidence: cli/web-ui/src/components/MarkdownViewer/, cli/web-ui/src/components/v2/UnifiedContentRenderer.tsx -->
+  - Sandboxed HTML Artifacts `T1` -- Renders HTML artifacts in secure sandboxed iframes
+    <!-- id: arcade.artifact-browser.sandboxed-html | tier: T1 | audience: developer | evidence: cli/web-ui/src/components/v2/SandboxedHtmlArtifact.tsx -->
+  - Artifact Grouping `T2` -- Groups related artifacts by workflow and type for organized browsing
+    <!-- id: arcade.artifact-browser.grouping | tier: T2 | audience: developer | evidence: cli/web-ui/src/lib/artifact-groups.ts -->
+- **Annotation System** `T1` -- User feedback annotations on artifacts with popover and sidebar interfaces for review collaboration
+  <!-- id: arcade.annotations | tier: T1 | audience: developer | evidence: cli/web-ui/src/components/v2/AnnotationPopover.tsx, cli/web-ui/src/components/v2/AnnotationSidebar.tsx, cli/web-ui/src/hooks/useAnnotations.ts, docs/arcade/annotations.md -->
+  - Text Selection Annotations `T1` -- Select text in artifacts to create inline annotations
+    <!-- id: arcade.annotations.text-selection | tier: T1 | audience: developer | evidence: cli/web-ui/src/hooks/useTextSelection.ts, cli/web-ui/src/components/v2/SelectionPopover.tsx -->
+  - Milkdown Editor `T2` -- WYSIWYG markdown editor for annotation content
+    <!-- id: arcade.annotations.milkdown | tier: T2 | audience: developer | evidence: cli/web-ui/src/components/MilkdownEditor/ -->
+- **Run Detail View** `T1` -- Detailed view of a single workflow run showing step-by-step progress, artifacts, and event timeline
+  <!-- id: arcade.run-detail | tier: T1 | audience: developer | evidence: cli/web-ui/src/pages/v2/RunDetailPage.tsx, cli/web-ui/src/components/v2/RunDetailSurface.tsx, cli/web-ui/src/hooks/useRunDetail.ts -->
+  - Vertical Step List `T1` -- Displays workflow steps as a vertical timeline with completion status
+    <!-- id: arcade.run-detail.step-list | tier: T1 | audience: developer | evidence: cli/web-ui/src/components/v2/VerticalStepList.tsx, cli/web-ui/src/hooks/useWorkflowSteps.ts -->
+  - Walkthrough Reveal Reader `T2` -- Slide-by-slide reveal presentation of PR walkthrough artifacts
+    <!-- id: arcade.run-detail.walkthrough | tier: T2 | audience: developer | evidence: cli/web-ui/src/components/v2/WalkthroughRevealReader.tsx, cli/web-ui/src/lib/walkthrough-slide-source.ts -->
+- **Project Overview** `T1` -- Project-level dashboard with run history, artifact counts, and workspace descriptor
+  <!-- id: arcade.project-overview | tier: T1 | audience: developer | evidence: cli/web-ui/src/pages/v2/ProjectOverviewPage.tsx, cli/web-ui/src/pages/v2/ProjectsPage.tsx -->
+- **Daemon Manager** `T1` -- Background daemon process that serves the Arcade web UI with lifecycle locking and IPC communication
+  <!-- id: arcade.daemon | tier: T1 | audience: developer | evidence: cli/web-ui/src/daemon/manager.ts, cli/web-ui/src/daemon/lifecycle-lock.ts, cli/web-ui/src/daemon/ipc.ts -->
+- **Keyboard Shortcuts** `T1` -- Comprehensive keyboard shortcut system with global and contextual bindings and a help overlay
+  <!-- id: arcade.keyboard | tier: T1 | audience: developer | evidence: cli/web-ui/src/hooks/useGlobalShortcuts.ts, cli/web-ui/src/hooks/useContextualShortcuts.ts, cli/web-ui/src/components/v2/ShortcutHelpOverlay.tsx, docs/arcade/keyboard-shortcuts.md -->
+- **Arcade Settings Bridge** `T2` -- Syncs settings between the CLI and the Arcade web UI
+  <!-- id: arcade.settings-bridge | tier: T2 | audience: developer | evidence: cli/web-ui/src/server/arcade-settings-bridge.ts, docs/arcade/settings.md -->
+- **Server-Side Services** `T1` -- Hono-based HTTP and WebSocket server with activity search, markdown projection, file watching, and project registry
+  <!-- id: arcade.server | tier: T1 | audience: contributor | evidence: cli/web-ui/src/server.ts, cli/web-ui/src/server/http.ts, cli/web-ui/src/server/websocket.ts, cli/web-ui/src/server/registry.ts -->
+  - Activity Search `T1` -- Full-text search across workflow activities and events
+    <!-- id: arcade.server.activity-search | tier: T1 | audience: developer | evidence: cli/web-ui/src/server/activity-search.ts -->
+  - Markdown Projection `T1` -- Server-side markdown processing with embedding resolution for artifact display
+    <!-- id: arcade.server.markdown-projection | tier: T1 | audience: contributor | evidence: cli/web-ui/src/server/markdown-projection.ts, cli/web-ui/src/server/markdown-embedder.ts -->
+  - Annotations API `T1` -- REST API for annotation CRUD with server-side service layer
+    <!-- id: arcade.server.annotations-api | tier: T1 | audience: contributor | evidence: cli/web-ui/src/server/routes/annotations-api.ts, cli/web-ui/src/server/annotation-service.ts -->
+
+## Plugin System: Base
+
+- **Knowledge Build** `T1` -- Orchestrates parallel KB generation using spatial analysis and map-reduce architecture with incremental and feature-learning modes
+  <!-- id: plugin-base.knowledge-build | tier: T1 | audience: developer | evidence: plugins/base/skills/knowledge-build/SKILL.md, docs/reference/base/knowledge-build.md -->
+  - KB Index Builder `T1` -- Produces the top-level index.md from aggregated analysis results
+    <!-- id: plugin-base.knowledge-build.index-builder | tier: T1 | audience: agent | evidence: plugins/base/agents/kb-index-builder.md -->
+  - KB Feature Extractor `T1` -- Discovers and inventories project capabilities into features.md
+    <!-- id: plugin-base.knowledge-build.feature-extractor | tier: T1 | audience: agent | evidence: plugins/base/agents/kb-feature-extractor.md -->
+  - KB Architecture Mapper `T1` -- Maps system topology into architecture.md
+    <!-- id: plugin-base.knowledge-build.architecture-mapper | tier: T1 | audience: agent | evidence: plugins/base/agents/kb-architecture-mapper.md -->
+  - KB Module Analyzer `T1` -- Analyzes module boundaries and responsibilities into modules.md
+    <!-- id: plugin-base.knowledge-build.module-analyzer | tier: T1 | audience: agent | evidence: plugins/base/agents/kb-module-analyzer.md -->
+  - KB Pattern Extractor `T1` -- Identifies recurring implementation patterns into patterns.md
+    <!-- id: plugin-base.knowledge-build.pattern-extractor | tier: T1 | audience: agent | evidence: plugins/base/agents/kb-pattern-extractor.md -->
+  - KB Concept Extractor `T1` -- Builds domain terminology map into concept_map.md
+    <!-- id: plugin-base.knowledge-build.concept-extractor | tier: T1 | audience: agent | evidence: plugins/base/agents/kb-concept-extractor.md -->
+  - KB Interaction Mapper `T1` -- Maps component interaction semantics into interaction-model.md
+    <!-- id: plugin-base.knowledge-build.interaction-mapper | tier: T1 | audience: agent | evidence: plugins/base/agents/kb-interaction-mapper.md -->
+  - KB Spatial Analyzer `T1` -- Performs directory-level spatial analysis as input to other KB agents
+    <!-- id: plugin-base.knowledge-build.spatial-analyzer | tier: T1 | audience: agent | evidence: plugins/base/agents/kb-spatial-analyzer.md -->
+- **Deep Research** `T1` -- Autonomous map-reduce research on codebases and technical topics with structured report output
+  <!-- id: plugin-base.deep-research | tier: T1 | audience: developer | evidence: plugins/base/skills/deep-research/SKILL.md, plugins/base/agents/research-explorer.md, plugins/base/agents/research-reporter.md, docs/reference/base/deep-research.md -->
+- **Security Analysis** `T1` -- Evidence-bounded security posture assessment with standards mapping and registered report output
+  <!-- id: plugin-base.analyse-security | tier: T1 | audience: developer | evidence: plugins/base/skills/analyse-security/SKILL.md, plugins/base/agents/security-validator.md, docs/reference/base/analyse-security.md -->
+- **Socratic Duel** `T1` -- Bounded two-agent debate with lock-based turn coordination and structured artifact output
+  <!-- id: plugin-base.socratic-duel | tier: T1 | audience: developer | evidence: plugins/base/skills/socratic-duel/SKILL.md, plugins/base/skills/socratic-duel-run/SKILL.md, plugins/base/agents/socratic-duel-participant.md, docs/reference/base/socratic-duel.md -->
+- **Strategic Advisor** `T1` -- Holistic systems analysis with quantified trade-offs across cost, quality, performance, and complexity
+  <!-- id: plugin-base.strategize | tier: T1 | audience: developer | evidence: plugins/base/skills/strategize/SKILL.md, plugins/base/agents/strategic-advisor.md, docs/reference/base/strategize.md -->
+- **Project Overview Generator** `T1` -- Produces three-tier arc42/C4-aligned project overview with provenance metadata
+  <!-- id: plugin-base.project-birds-eye-view | tier: T1 | audience: developer | evidence: plugins/base/skills/project-birds-eye-view/SKILL.md, plugins/base/agents/project-documenter.md, docs/reference/base/project-birds-eye-view.md -->
+- **Mermaid Diagram Tools** `T1` -- Creates, validates, and repairs Mermaid.js diagrams with auto-fix for common syntax errors
+  <!-- id: plugin-base.mermaid | tier: T1 | audience: developer | evidence: plugins/base/skills/mermaid/SKILL.md, plugins/base/skills/fix-mermaid/SKILL.md, plugins/base/agents/mermaid-fixer.md, docs/reference/base/fix-mermaid.md -->
+- **Artifact Templates** `T1` -- Canonical output templates for 20+ agent producers ensuring format consistency and routing metadata
+  <!-- id: plugin-base.artifact-templates | tier: T1 | audience: agent | evidence: plugins/base/skills/artifact-templates/SKILL.md, plugins/base/skills/artifact-templates/templates/ -->
+- **Guide** `T1` -- Interactive skill discovery and workflow guidance for rp1 capabilities
+  <!-- id: plugin-base.guide | tier: T1 | audience: developer | evidence: plugins/base/skills/guide/SKILL.md, docs/reference/base/guide.md -->
+- **Self-Update** `T1` -- Updates rp1 and runs the full post-update lifecycle
+  <!-- id: plugin-base.self-update | tier: T1 | audience: developer | evidence: plugins/base/skills/self-update/SKILL.md, docs/reference/base/self-update.md -->
+- **Note Capture** `T2` -- Captures session context as structured markdown notes with auto-maintained index
+  <!-- id: plugin-base.note | tier: T2 | audience: developer | evidence: plugins/base/skills/note/SKILL.md -->
+- **Content Writer** `T2` -- Interactive prompt for creating polished technical documents through structured writing workflows
+  <!-- id: plugin-base.write-content | tier: T2 | audience: developer | evidence: plugins/base/skills/write-content/SKILL.md, docs/reference/base/write-content.md -->
+- **User Docs Generator** `T2` -- Synchronizes user-facing documentation with current KB through validate-stale-scan-approval orchestration
+  <!-- id: plugin-base.generate-user-docs | tier: T2 | audience: developer | evidence: plugins/base/skills/generate-user-docs/SKILL.md -->
+- **Markdown Preview** `T2` -- Generates browser-viewable HTML previews from markdown with auto-validation and Mermaid rendering
+  <!-- id: plugin-base.markdown-preview | tier: T2 | audience: developer | evidence: plugins/base/skills/markdown-preview/SKILL.md -->
+- **Code Comments Extractor** `T2` -- Extracts comment locations from code files for analysis
+  <!-- id: plugin-base.code-comments | tier: T2 | audience: developer | evidence: plugins/base/skills/code-comments/SKILL.md -->
+- **Task Manager** `T2` -- Discovers and manages queued tasks for agent execution
+  <!-- id: plugin-base.task | tier: T2 | audience: developer | evidence: plugins/base/skills/task/SKILL.md -->
+- **Prompt Writer** `T1` -- Writes maximally terse agent prompts with constitutional governance through a six-stage pipeline
+  <!-- id: plugin-base.prompt-writer | tier: T1 | audience: contributor | evidence: plugins/base/skills/prompt-writer/SKILL.md -->
+- **Scribe Agent** `T2` -- Note-taking agent for structured session capture
+  <!-- id: plugin-base.scribe | tier: T2 | audience: agent | evidence: plugins/base/agents/scribe.md -->
+
+## Plugin System: Dev
+
+- **Build Workflow** `T1` -- End-to-end feature development workflow from requirements through planning, implementation, verification, and release
+  <!-- id: plugin-dev.build | tier: T1 | audience: developer | evidence: plugins/dev/skills/build/SKILL.md, docs/reference/dev/build.md -->
+  - Feature Requirement Gatherer `T1` -- Interviews user and generates structured requirements document
+    <!-- id: plugin-dev.build.requirement-gatherer | tier: T1 | audience: agent | evidence: plugins/dev/agents/feature-requirement-gatherer.md -->
+  - Feature Architect `T1` -- Produces design.md with component diagrams and technical approach from requirements
+    <!-- id: plugin-dev.build.feature-architect | tier: T1 | audience: agent | evidence: plugins/dev/agents/feature-architect.md -->
+  - Feature Tasker `T1` -- Decomposes design into ordered implementation tasks with test-first discipline
+    <!-- id: plugin-dev.build.feature-tasker | tier: T1 | audience: agent | evidence: plugins/dev/agents/feature-tasker.md -->
+  - Task Builder `T1` -- Implements individual tasks with code changes and test writing
+    <!-- id: plugin-dev.build.task-builder | tier: T1 | audience: agent | evidence: plugins/dev/agents/task-builder.md -->
+  - Task Reviewer `T1` -- Reviews implemented tasks against requirements and design specs
+    <!-- id: plugin-dev.build.task-reviewer | tier: T1 | audience: agent | evidence: plugins/dev/agents/task-reviewer.md -->
+  - Feature Verifier `T1` -- End-to-end verification that implementation satisfies original requirements
+    <!-- id: plugin-dev.build.feature-verifier | tier: T1 | audience: agent | evidence: plugins/dev/agents/feature-verifier.md -->
+  - Build Artifact Detector `T1` -- Detects generated artifacts that need cleanup or gitignore entries
+    <!-- id: plugin-dev.build.artifact-detector | tier: T1 | audience: agent | evidence: plugins/dev/agents/build-artifact-detector.md -->
+  - Build Task Grouper `T2` -- Groups related tasks for parallelized execution
+    <!-- id: plugin-dev.build.task-grouper | tier: T2 | audience: agent | evidence: plugins/dev/agents/build-task-grouper.md -->
+  - Build Task Parser `T2` -- Parses task list documents into structured task objects
+    <!-- id: plugin-dev.build.task-parser | tier: T2 | audience: agent | evidence: plugins/dev/agents/build-task-parser.md -->
+  - Build Verify Aggregator `T1` -- Aggregates verification results across multiple tasks into a summary
+    <!-- id: plugin-dev.build.verify-aggregator | tier: T1 | audience: agent | evidence: plugins/dev/agents/build-verify-aggregator.md -->
+  - Test Runner `T1` -- Executes test suites and reports results with coverage
+    <!-- id: plugin-dev.build.test-runner | tier: T1 | audience: agent | evidence: plugins/dev/agents/test-runner.md -->
+- **Build Fast** `T1` -- Quick-iteration development for small/medium scope changes with persistent plan artifact and optional review
+  <!-- id: plugin-dev.build-fast | tier: T1 | audience: developer | evidence: plugins/dev/skills/build-fast/SKILL.md, plugins/dev/agents/build-fast-planner.md, docs/reference/dev/build-fast.md -->
+- **Speedrun** `T1` -- Interactive loop for small low-risk changes delegated to a general sub-agent
+  <!-- id: plugin-dev.speedrun | tier: T1 | audience: developer | evidence: plugins/dev/skills/speedrun/SKILL.md, plugins/dev/agents/speedrun-builder.md -->
+- **Blueprint** `T1` -- Guided project charter and PRD creation through parent-owned interviews with durable artifact resume
+  <!-- id: plugin-dev.blueprint | tier: T1 | audience: developer | evidence: plugins/dev/skills/blueprint/SKILL.md, plugins/dev/agents/blueprint-wizard.md, plugins/dev/agents/charter-interviewer.md, docs/reference/dev/blueprint.md -->
+  - Blueprint Audit `T1` -- Audits PRD against implementation status and guides lifecycle decisions
+    <!-- id: plugin-dev.blueprint.audit | tier: T1 | audience: developer | evidence: plugins/dev/skills/blueprint-audit/SKILL.md, plugins/dev/agents/blueprint-auditor.md, docs/reference/dev/blueprint-audit.md -->
+  - Blueprint Archive `T1` -- Archives completed PRD with associated features and closure summary
+    <!-- id: plugin-dev.blueprint.archive | tier: T1 | audience: developer | evidence: plugins/dev/skills/blueprint-archive/SKILL.md, docs/reference/dev/blueprint-archive.md -->
+- **Phase Plan** `T1` -- Decomposes completed PRD or oversized requirements into durable delivery phases
+  <!-- id: plugin-dev.phase-plan | tier: T1 | audience: developer | evidence: plugins/dev/skills/phase-plan/SKILL.md, plugins/dev/agents/phase-planner.md, docs/reference/dev/phase-plan.md -->
+- **Bootstrap** `T1` -- Scaffolds a greenfield project with parent-owned interviews and bounded plan-revise-apply actions
+  <!-- id: plugin-dev.bootstrap | tier: T1 | audience: developer | evidence: plugins/dev/skills/bootstrap/SKILL.md, plugins/dev/agents/bootstrap-scaffolder.md -->
+- **PR Review** `T1` -- Intent-aware map-reduce PR review with CI/CD support, confidence gating, and intelligent comment deduplication
+  <!-- id: plugin-dev.pr-review | tier: T1 | audience: developer | evidence: plugins/dev/skills/pr-review/SKILL.md, docs/reference/dev/pr-review.md -->
+  - PR Sub-Reviewer `T1` -- Reviews individual file segments for issues
+    <!-- id: plugin-dev.pr-review.sub-reviewer | tier: T1 | audience: agent | evidence: plugins/dev/agents/pr-sub-reviewer.md -->
+  - PR Review Splitter `T1` -- Splits large diffs into reviewable segments for parallel sub-review
+    <!-- id: plugin-dev.pr-review.splitter | tier: T1 | audience: agent | evidence: plugins/dev/agents/pr-review-splitter.md -->
+  - PR Review Synthesizer `T1` -- Synthesizes sub-review findings into cohesive review
+    <!-- id: plugin-dev.pr-review.synthesizer | tier: T1 | audience: agent | evidence: plugins/dev/agents/pr-review-synthesizer.md -->
+  - PR Review Reporter `T1` -- Formats and posts final review to GitHub
+    <!-- id: plugin-dev.pr-review.reporter | tier: T1 | audience: agent | evidence: plugins/dev/agents/pr-review-reporter.md -->
+  - PR Comment Deduplicator `T1` -- Removes duplicate findings across sub-reviews
+    <!-- id: plugin-dev.pr-review.deduplicator | tier: T1 | audience: agent | evidence: plugins/dev/agents/pr-comment-deduplicator.md -->
+  - PR Comment Poster `T1` -- Posts individual review comments to GitHub PRs
+    <!-- id: plugin-dev.pr-review.poster | tier: T1 | audience: agent | evidence: plugins/dev/agents/pr-comment-poster.md -->
+- **PR Visual** `T1` -- Transforms PR diffs into Mermaid diagrams for visual code review
+  <!-- id: plugin-dev.pr-visual | tier: T1 | audience: developer | evidence: plugins/dev/skills/pr-visual/SKILL.md, plugins/dev/agents/pr-visualizer.md, docs/reference/dev/pr-visual.md -->
+- **PR Walkthrough** `T1` -- Generates evidence-grounded markdown walkthrough for a pull request
+  <!-- id: plugin-dev.pr-walkthrough | tier: T1 | audience: developer | evidence: plugins/dev/skills/pr-walkthrough/SKILL.md, plugins/dev/agents/pr-walkthrough-reporter.md, docs/reference/dev/pr-walkthrough.md -->
+- **PR Stack** `T1` -- Plans and executes splitting a large PR into a reviewable stacked PR sequence
+  <!-- id: plugin-dev.pr-stack | tier: T1 | audience: developer | evidence: plugins/dev/skills/pr-stack/SKILL.md, docs/reference/dev/pr-stack.md -->
+- **Address PR Feedback** `T1` -- Unified workflow to collect, triage, and fix review comments in a single command
+  <!-- id: plugin-dev.address-pr-feedback | tier: T1 | audience: developer | evidence: plugins/dev/skills/address-pr-feedback/SKILL.md, plugins/dev/agents/pr-feedback-collector.md, docs/reference/dev/address-pr-feedback.md -->
+- **Publish Artifact** `T1` -- Publishes rp1 artifacts as idempotent PR or issue comments that update in place
+  <!-- id: plugin-dev.publish-artifact | tier: T1 | audience: developer | evidence: plugins/dev/skills/publish-artifact/SKILL.md, docs/reference/dev/publish-artifact.md -->
+- **Code Investigate** `T1` -- Systematic bug investigation through evidence-based analysis and hypothesis testing without permanent code changes
+  <!-- id: plugin-dev.code-investigate | tier: T1 | audience: developer | evidence: plugins/dev/skills/code-investigate/SKILL.md, plugins/dev/agents/bug-investigator.md, docs/reference/dev/code-investigate.md -->
+- **Validate Hypothesis** `T1` -- Validates design hypotheses via code experiments, codebase analysis, and external research with support for ad-hoc test scenarios
+  <!-- id: plugin-dev.validate-hypothesis | tier: T1 | audience: developer | evidence: plugins/dev/skills/validate-hypothesis/SKILL.md, plugins/dev/agents/hypothesis-tester.md, docs/reference/dev/validate-hypothesis.md -->
+- **Tech Debt Collector** `T1` -- Evidence-gated tech debt and bloat detection with materiality ranking and refutation validation
+  <!-- id: plugin-dev.tech-debt-collector | tier: T1 | audience: developer | evidence: plugins/dev/skills/tech-debt-collector/SKILL.md, plugins/dev/agents/bloat-scout.md, docs/reference/dev/tech-debt-collector.md -->
+- **Code Audit** `T1` -- Analyzes code for pattern consistency, maintainability, duplication, comment quality, and documentation drift
+  <!-- id: plugin-dev.code-audit | tier: T1 | audience: developer | evidence: plugins/dev/skills/code-audit/SKILL.md, plugins/dev/agents/code-auditor.md, docs/reference/dev/code-audit.md -->
+- **Code Check** `T1` -- Fast code hygiene validation running lints, formatters, tests, and coverage in a quick feedback loop
+  <!-- id: plugin-dev.code-check | tier: T1 | audience: developer | evidence: plugins/dev/skills/code-check/SKILL.md, plugins/dev/agents/code-checker.md, docs/reference/dev/code-check.md -->
+- **Code Clean Comments** `T1` -- Systematically removes unnecessary comments by first resolving scope into a durable change manifest
+  <!-- id: plugin-dev.code-clean-comments | tier: T1 | audience: developer | evidence: plugins/dev/skills/code-clean-comments/SKILL.md, plugins/dev/agents/comment-cleaner.md, docs/reference/dev/code-clean-comments.md -->
+- **Feature Lifecycle** `T1` -- Archive, edit, and unarchive feature documentation with validation and propagation
+  <!-- id: plugin-dev.feature-lifecycle | tier: T1 | audience: developer | evidence: plugins/dev/skills/feature-archive/SKILL.md, plugins/dev/skills/feature-edit/SKILL.md, plugins/dev/skills/feature-unarchive/SKILL.md, plugins/dev/agents/feature-archiver.md, plugins/dev/agents/feature-editor.md -->
+- **Arcade Collab** `T2` -- Structured guidance for agents to read, classify, and act on user feedback from the Arcade
+  <!-- id: plugin-dev.arcade-collab | tier: T2 | audience: agent | evidence: plugins/dev/skills/arcade-collab/SKILL.md -->
+
+## Plugin System: Utils
+
+- **Build Prompt** `T1` -- Builds governed prompts through the six-stage prompt-writer pipeline with budgeted governance
+  <!-- id: plugin-utils.build-prompt | tier: T1 | audience: contributor | evidence: plugins/utils/skills/build-prompt/SKILL.md -->
+- **Tersify Prompt** `T1` -- Rewrites agent-instruction prompts to be maximally terse while preserving full intent
+  <!-- id: plugin-utils.tersify-prompt | tier: T1 | audience: contributor | evidence: plugins/utils/skills/tersify-prompt/SKILL.md, plugins/utils/agents/prompt-tersifier.md -->
+- **Prompt Eval Builder** `T2` -- Extracts eval assertions and generates test invocation prompts from command/agent specs
+  <!-- id: plugin-utils.prompt-eval-builder | tier: T2 | audience: contributor | evidence: plugins/utils/skills/prompt-eval-builder/SKILL.md -->
+- **Tester** `T3` -- Test command template for verifying argument passing and skill invocation
+  <!-- id: plugin-utils.tester | tier: T3 | audience: contributor | evidence: plugins/utils/skills/tester/SKILL.md -->
+
+## Plugin System: Shared
+
+- **Anti-Loop Guard** `T2` -- Detects and breaks agent loops that repeat failed actions
+  <!-- id: plugin-shared.anti-loop | tier: T2 | audience: agent | evidence: plugins/shared/anti-loop.md -->
+- **Engineering Discipline** `T2` -- Shared engineering discipline rules applied across all agents
+  <!-- id: plugin-shared.engineering-discipline | tier: T2 | audience: agent | evidence: plugins/shared/engineering-discipline.md -->
+- **KB Progressive Loading** `T2` -- Shared instructions for progressive KB file loading based on task type
+  <!-- id: plugin-shared.kb-progressive-loading | tier: T2 | audience: agent | evidence: plugins/shared/kb-progressive-loading.md -->
+- **Output Discipline** `T2` -- Output formatting rules shared across agents
+  <!-- id: plugin-shared.output-discipline | tier: T2 | audience: agent | evidence: plugins/shared/output-discipline.md -->
+- **Parent-Owned Interview** `T1` -- Shared pattern for parent-agent-owned user interviews ensuring control stays with the orchestrator
+  <!-- id: plugin-shared.parent-owned-interview | tier: T1 | audience: agent | evidence: plugins/shared/parent-owned-interview.md -->
+
+## Teach-Me
+
+- **Lesson Renderer** `T1` -- Assembles lesson data models into self-contained interactive HTML lessons with Mermaid diagram pre-rendering
+  <!-- id: teach-me.renderer | tier: T1 | audience: developer | evidence: cli/src/teach-me/assemble.ts, cli/src/teach-me/inline.ts, cli/src/teach-me/prerender/, cli/src/commands/teach-me/ -->
+  - Lesson Schema `T1` -- JSON schema for structured lesson data models with sections, quizzes, and code examples
+    <!-- id: teach-me.renderer.schema | tier: T1 | audience: developer | evidence: cli/src/teach-me/schema/ -->
+  - Widget System `T2` -- Embeddable interactive widgets within lessons
+    <!-- id: teach-me.renderer.widgets | tier: T2 | audience: developer | evidence: cli/src/teach-me/widgets/ -->
+  - Quality Gate `T2` -- Validates lesson content meets quality thresholds before rendering
+    <!-- id: teach-me.renderer.gate | tier: T2 | audience: developer | evidence: cli/src/teach-me/gate/ -->
+- **Teach-Me Skill** `T1` -- Turns a "teach me X" request into an interactive HTML lesson rendered Arcade-first
+  <!-- id: teach-me.skill | tier: T1 | audience: developer | evidence: plugins/base/skills/teach-me/SKILL.md -->
+
+## Native App
+
+- **Electrobun Desktop App** `T3` -- Cross-platform desktop wrapper for the Arcade web UI using Electrobun
+  <!-- id: native-app.electrobun | tier: T3 | audience: developer | evidence: native-app/electrobun.config.ts, native-app/package.json, native-app/src/ -->
+
+## Eval Framework
+
+- **Promptfoo Integration** `T1` -- Behavioral evaluation suites for agent skills using promptfoo with custom assertions and model usage tracking
+  <!-- id: eval-framework.promptfoo | tier: T1 | audience: contributor | evidence: evals/package.json, evals/src/index.ts, evals/src/model-usage.ts -->
+  - Build Eval Suite `T1` -- Evaluates the /build workflow agent chain
+    <!-- id: eval-framework.promptfoo.build | tier: T1 | audience: contributor | evidence: evals/suites/rp1-dev/build/ -->
+  - Build-Fast Eval Suite `T1` -- Evaluates the /build-fast workflow
+    <!-- id: eval-framework.promptfoo.build-fast | tier: T1 | audience: contributor | evidence: evals/suites/rp1-dev/build-fast/ -->
+  - Speedrun Eval Suite `T1` -- Evaluates the /speedrun workflow
+    <!-- id: eval-framework.promptfoo.speedrun | tier: T1 | audience: contributor | evidence: evals/suites/rp1-dev/speedrun/ -->
+  - Create-Prompt Eval Suite `T1` -- Evaluates the prompt creation pipeline
+    <!-- id: eval-framework.promptfoo.create-prompt | tier: T1 | audience: contributor | evidence: evals/suites/rp1-base/create-prompt/ -->
+  - Shared Assertions `T1` -- Reusable assertion library for eval suites
+    <!-- id: eval-framework.promptfoo.shared-assertions | tier: T1 | audience: contributor | evidence: evals/suites/shared/assertions/, evals/suites/shared/extension.ts -->
+  - Attestation Verification `T1` -- Verifies eval suite attestation hashes match built artifacts
+    <!-- id: eval-framework.promptfoo.attestation | tier: T1 | audience: contributor | evidence: evals/src/attestation/, evals/attestation.json -->
+- **Docker Eval Runner** `T2` -- Containerized eval execution environment with certificate management
+  <!-- id: eval-framework.docker | tier: T2 | audience: contributor | evidence: docker/Dockerfile, docker/eval-run.sh -->
+
+## CI/CD and Release
+
+- **GitHub Actions CI** `T1` -- Multi-job CI pipeline with lint, typecheck, tests, docs link check, catalog verification, plugin build, and attestation checks
+  <!-- id: cicd.github-actions | tier: T1 | audience: contributor | evidence: .github/workflows/ci.yml -->
+  - Test Isolation Boundary `T1` -- Docker-based disposable filesystem boundary for safe test execution
+    <!-- id: cicd.github-actions.test-isolation | tier: T1 | audience: contributor | evidence: .github/test-isolation.Dockerfile -->
+- **Release Please** `T1` -- Automated semantic versioning and changelog generation with post-release artifact upload and Cloudflare Pages deployment
+  <!-- id: cicd.release-please | tier: T1 | audience: contributor | evidence: .github/workflows/release-please.yml, release-please-config.json, .release-please-manifest.json -->
+- **GoReleaser** `T1` -- Cross-platform binary builds (darwin-arm64/x64, linux-arm64/x64, windows-x64) via Bun compile with GitHub Release publishing
+  <!-- id: cicd.goreleaser | tier: T1 | audience: contributor | evidence: .goreleaser.yml, .github/workflows/goreleaser.yml -->
+- **PR Title Validation** `T2` -- Enforces Conventional Commits format on PR titles
+  <!-- id: cicd.pr-title | tier: T2 | audience: contributor | evidence: .github/workflows/pr-title.yml -->
+- **Lighthouse CI** `T2` -- Post-release performance auditing of the documentation site
+  <!-- id: cicd.lighthouse | tier: T2 | audience: contributor | evidence: lighthouserc.json, .github/workflows/release-please.yml -->
+- **Pre-Commit Hooks** `T2` -- Lefthook-based pre-commit checks for catalog freshness and commit conventions
+  <!-- id: cicd.lefthook | tier: T2 | audience: contributor | evidence: lefthook.yml, .lefthook/ -->
+- **Docker Dev Environment** `T2` -- Development container setup for consistent build environments
+  <!-- id: cicd.docker-dev | tier: T2 | audience: contributor | evidence: docker/setup-dev.sh, docker/test-install.sh -->
+- **Beta Release Pipeline** `T2` -- Separate release channel for pre-release builds
+  <!-- id: cicd.beta-release | tier: T2 | audience: contributor | evidence: scripts/beta-release.sh, .goreleaser-beta.yml -->
+
+## Documentation Site
+
+- **MkDocs Material Site** `T1` -- Public documentation site built with MkDocs Material and deployed to Cloudflare Pages
+  <!-- id: docs-site.mkdocs | tier: T1 | audience: developer | evidence: mkdocs.yml, docs/index.md, site/ -->
+  - Getting Started Guides `T1` -- Installation, first workflow, and directory structure documentation
+    <!-- id: docs-site.mkdocs.getting-started | tier: T1 | audience: developer | evidence: docs/getting-started/ -->
+  - Workflow Guides `T1` -- In-depth guides for feature development, bug investigation, PR review, CI/CD integration, and team scaling
+    <!-- id: docs-site.mkdocs.guides | tier: T1 | audience: developer | evidence: docs/guides/ -->
+  - CLI Reference `T1` -- Command reference for init, install, update, verify, migrate, settings, and uninstall
+    <!-- id: docs-site.mkdocs.cli-reference | tier: T1 | audience: developer | evidence: docs/reference/cli/ -->
+  - Base Plugin Reference `T1` -- Reference docs for all base plugin skills
+    <!-- id: docs-site.mkdocs.base-reference | tier: T1 | audience: developer | evidence: docs/reference/base/ -->
+  - Dev Plugin Reference `T1` -- Reference docs for all dev plugin skills
+    <!-- id: docs-site.mkdocs.dev-reference | tier: T1 | audience: developer | evidence: docs/reference/dev/ -->
+  - Platform Guides `T1` -- Platform-specific documentation for Antigravity, Codex, and Copilot
+    <!-- id: docs-site.mkdocs.platforms | tier: T1 | audience: developer | evidence: docs/reference/platforms/ -->
+  - Arcade Documentation `T1` -- Dashboard, artifact viewer, annotations, keyboard shortcuts, and settings docs
+    <!-- id: docs-site.mkdocs.arcade | tier: T1 | audience: developer | evidence: docs/arcade/ -->
+  - Configuration Reference `T1` -- settings.toml schema and configuration options
+    <!-- id: docs-site.mkdocs.configuration | tier: T1 | audience: developer | evidence: docs/reference/configuration.md -->
+  - Concepts `T2` -- Conceptual guides on constitutional prompting and knowledge-aware agents
+    <!-- id: docs-site.mkdocs.concepts | tier: T2 | audience: developer | evidence: docs/concepts/ -->
+  - Readiness Assessment `T2` -- Framework for evaluating team readiness to adopt rp1
+    <!-- id: docs-site.mkdocs.readiness | tier: T2 | audience: developer | evidence: docs/readiness/ -->
+
+## Surfaces Not Analyzed
+
+None. All anchor classes were detected: CLI command registrations, build pipeline targets, agent-tools subcommands, web UI routes and components, plugin skill/agent manifests, eval suites, CI/CD workflows, documentation sections, and native app configuration.
+
+## Coverage Summary
+
+| Tier | Count | Meaning |
+|------|-------|---------|
+| T1 | 131 | Documented and tested |
+| T2 | 31 | Documented or tested |
+| T3 | 4 | Referenced but undocumented/untested |
+| T4 | 0 | Investigation candidates |
+
+## Related KB Links
+
+- **System topology**: See [architecture.md](architecture.md)
+- **Modules and projects**: See [modules.md](modules.md)
+- **Implementation details**: See [patterns.md](patterns.md)
+- **Terminology**: See [concept_map.md](concept_map.md)

--- a/.rp1/context/features.md
+++ b/.rp1/context/features.md
@@ -2,76 +2,76 @@
 
 **Repository**: rp1
 **Last Updated**: 2026-07-25
-**Surfaces**: 10 detected
+**Surfaces**: 13 detected
 **Scope**: Capabilities inventoried across all projects in this repository.
 
 ## CLI Core
 
 - **Project Initialization** `T1` -- Interactive setup of `.rp1/` directory structure, context detection, gitignore configuration, and global stanza injection
-  <!-- id: cli-core.init | tier: T1 | audience: developer | evidence: cli/src/commands/init.ts, cli/src/init/index.ts, docs/reference/cli/init.md -->
+  <!-- id: cli-core.init | tier: T1 | audience: user | evidence: cli/src/commands/init.ts, cli/src/init/index.ts, docs/reference/cli/init.md -->
 - **Multi-Platform Installation** `T1` -- Installs rp1 skills and agents into Claude Code, OpenCode, Codex, Copilot, and Antigravity with per-platform adapters
-  <!-- id: cli-core.install | tier: T1 | audience: developer | evidence: cli/src/commands/install/index.ts, cli/src/install/installer.ts, docs/reference/cli/install.md -->
+  <!-- id: cli-core.install | tier: T1 | audience: user | evidence: cli/src/commands/install/index.ts, cli/src/install/installer.ts, docs/reference/cli/install.md -->
   - Claude Code Installer `T1` -- Writes CLAUDE.md stanzas and registers marketplace plugin
-    <!-- id: cli-core.install.claude-code | tier: T1 | audience: developer | evidence: cli/src/install/claudecode/installer.ts, cli/src/commands/install/claude-code.ts -->
+    <!-- id: cli-core.install.claude-code | tier: T1 | audience: user | evidence: cli/src/install/claudecode/installer.ts, cli/src/commands/install/claude-code.ts -->
   - OpenCode Installer `T1` -- Generates OpenCode-compatible agent configuration
-    <!-- id: cli-core.install.opencode | tier: T1 | audience: developer | evidence: cli/src/commands/install/opencode.ts -->
+    <!-- id: cli-core.install.opencode | tier: T1 | audience: user | evidence: cli/src/commands/install/opencode.ts -->
   - Codex Installer `T1` -- Produces Codex agent AGENTS.md and sub-agent configs
-    <!-- id: cli-core.install.codex | tier: T1 | audience: developer | evidence: cli/src/install/codex/installer.ts, cli/src/commands/install/codex.ts -->
+    <!-- id: cli-core.install.codex | tier: T1 | audience: user | evidence: cli/src/install/codex/installer.ts, cli/src/commands/install/codex.ts -->
   - Copilot Installer `T1` -- Writes GitHub Copilot instructions and marketplace extensions
-    <!-- id: cli-core.install.copilot | tier: T1 | audience: developer | evidence: cli/src/install/copilot/installer.ts, cli/src/commands/install/copilot.ts -->
+    <!-- id: cli-core.install.copilot | tier: T1 | audience: user | evidence: cli/src/install/copilot/installer.ts, cli/src/commands/install/copilot.ts -->
   - Antigravity Installer `T1` -- Bundles assets and lifecycle hooks for the Antigravity platform
-    <!-- id: cli-core.install.antigravity | tier: T1 | audience: developer | evidence: cli/src/install/antigravity/index.ts, cli/src/commands/install/antigravity.ts -->
+    <!-- id: cli-core.install.antigravity | tier: T1 | audience: user | evidence: cli/src/install/antigravity/index.ts, cli/src/commands/install/antigravity.ts -->
   - Install All `T2` -- Auto-detects installed platforms and installs to all in one pass
-    <!-- id: cli-core.install.all | tier: T2 | audience: developer | evidence: cli/src/commands/install/all.ts -->
+    <!-- id: cli-core.install.all | tier: T2 | audience: user | evidence: cli/src/commands/install/all.ts -->
 - **Installation Verification** `T1` -- Validates that rp1 is correctly installed on each platform with platform-specific health checks
-  <!-- id: cli-core.verify | tier: T1 | audience: developer | evidence: cli/src/commands/verify/index.ts, docs/reference/cli/verify.md -->
+  <!-- id: cli-core.verify | tier: T1 | audience: user | evidence: cli/src/commands/verify/index.ts, docs/reference/cli/verify.md -->
 - **Self-Update** `T1` -- Checks for and applies CLI binary updates from GitHub releases
-  <!-- id: cli-core.self-update | tier: T1 | audience: developer | evidence: cli/src/commands/check-update.ts, cli/src/commands/self-update.ts -->
+  <!-- id: cli-core.self-update | tier: T1 | audience: user | evidence: cli/src/commands/check-update.ts, cli/src/commands/self-update.ts -->
 - **Update and Plugin Sync** `T1` -- Updates installed platform artifacts and manages plugin versions
-  <!-- id: cli-core.update | tier: T1 | audience: developer | evidence: cli/src/commands/update/index.ts, cli/src/commands/update/plugins.ts, docs/reference/cli/update.md -->
+  <!-- id: cli-core.update | tier: T1 | audience: user | evidence: cli/src/commands/update/index.ts, cli/src/commands/update/plugins.ts, docs/reference/cli/update.md -->
 - **Uninstall** `T1` -- Removes rp1 artifacts from all platforms including Antigravity, Codex, and Copilot-specific cleanup
-  <!-- id: cli-core.uninstall | tier: T1 | audience: developer | evidence: cli/src/commands/uninstall.ts, cli/src/commands/uninstall-antigravity.ts, cli/src/commands/uninstall-codex.ts, cli/src/commands/uninstall-copilot.ts, docs/reference/cli/uninstall.md -->
+  <!-- id: cli-core.uninstall | tier: T1 | audience: user | evidence: cli/src/commands/uninstall.ts, cli/src/commands/uninstall-antigravity.ts, cli/src/commands/uninstall-codex.ts, cli/src/commands/uninstall-copilot.ts, docs/reference/cli/uninstall.md -->
 - **List Installed Plugins** `T2` -- Shows which plugins are installed and their versions
-  <!-- id: cli-core.list | tier: T2 | audience: developer | evidence: cli/src/commands/install.ts -->
+  <!-- id: cli-core.list | tier: T2 | audience: user | evidence: cli/src/commands/install.ts -->
 - **Migration** `T1` -- Upgrades `.rp1/` directory from older layout versions with database backfill, central store migration, stanza upgrades, and legacy work directory conversion
-  <!-- id: cli-core.migrate | tier: T1 | audience: developer | evidence: cli/src/commands/migrate.ts, cli/src/migrate/index.ts, cli/src/migrate/db-backfill.ts, cli/src/migrate/central-store.ts, docs/reference/cli/rp1-migrate.md -->
+  <!-- id: cli-core.migrate | tier: T1 | audience: user | evidence: cli/src/commands/migrate.ts, cli/src/migrate/index.ts, cli/src/migrate/db-backfill.ts, cli/src/migrate/central-store.ts, docs/reference/cli/rp1-migrate.md -->
 - **Settings Management** `T1` -- Validates, applies, and manages settings.toml presets including arcade and harness configuration
-  <!-- id: cli-core.settings | tier: T1 | audience: developer | evidence: cli/src/commands/settings.ts, cli/src/settings/loader.ts, cli/src/settings/rewriter.ts, docs/reference/cli/settings.md -->
+  <!-- id: cli-core.settings | tier: T1 | audience: user | evidence: cli/src/commands/settings.ts, cli/src/settings/loader.ts, cli/src/settings/rewriter.ts, docs/reference/cli/settings.md -->
 - **Deprecated Command Shims** `T3` -- Hidden compatibility shims for renamed or removed commands
-  <!-- id: cli-core.deprecated | tier: T3 | audience: developer | evidence: cli/src/commands/deprecated/index.ts -->
+  <!-- id: cli-core.deprecated | tier: T3 | audience: internal | evidence: cli/src/commands/deprecated/index.ts -->
 - **Fake Data Generator** `T3` -- Generates synthetic emit events and workflow artifacts for testing the Arcade UI
-  <!-- id: cli-core.fake | tier: T3 | audience: contributor | evidence: cli/src/commands/fake.ts -->
+  <!-- id: cli-core.fake | tier: T3 | audience: internal | evidence: cli/src/commands/fake.ts -->
 
 ## Build Pipeline
 
 - **Prompt Compiler** `T1` -- Parses skill and agent markdown, resolves arguments, applies preprocessor transforms, validates structure, and emits platform-specific output
-  <!-- id: build-pipeline.compiler | tier: T1 | audience: contributor | evidence: cli/src/build/parser.ts, cli/src/build/preprocessor.ts, cli/src/build/validator.ts, cli/src/build/command.ts -->
+  <!-- id: build-pipeline.compiler | tier: T1 | audience: user | evidence: cli/src/build/parser.ts, cli/src/build/preprocessor.ts, cli/src/build/validator.ts, cli/src/build/command.ts -->
   - Template Engine `T1` -- Interpolates `{variables}` and processes conditional sections in prompt files
-    <!-- id: build-pipeline.compiler.template-engine | tier: T1 | audience: contributor | evidence: cli/src/build/template-engine.ts, cli/src/build/template-context.ts -->
+    <!-- id: build-pipeline.compiler.template-engine | tier: T1 | audience: user | evidence: cli/src/build/template-engine.ts, cli/src/build/template-context.ts -->
   - Argument Resolution `T1` -- Parses structured `arguments` arrays from frontmatter into runtime parameter blocks
-    <!-- id: build-pipeline.compiler.arguments | tier: T1 | audience: contributor | evidence: cli/src/build/arguments.ts -->
+    <!-- id: build-pipeline.compiler.arguments | tier: T1 | audience: user | evidence: cli/src/build/arguments.ts -->
   - Tag Processing `T1` -- Expands custom XML tags during build (e.g. inline includes, platform conditionals)
-    <!-- id: build-pipeline.compiler.tags | tier: T1 | audience: contributor | evidence: cli/src/build/tags/ -->
+    <!-- id: build-pipeline.compiler.tags | tier: T1 | audience: user | evidence: cli/src/build/tags/ -->
 - **Platform Definitions** `T1` -- Declares per-platform build targets with feature flags and output format specifications
-  <!-- id: build-pipeline.platform-defs | tier: T1 | audience: contributor | evidence: cli/src/build/platform-definitions.ts -->
+  <!-- id: build-pipeline.platform-defs | tier: T1 | audience: user | evidence: cli/src/build/platform-definitions.ts -->
   - Claude Code Target `T1` -- Emits CLAUDE.md-compatible skill stanzas
-    <!-- id: build-pipeline.platform-defs.claude-code | tier: T1 | audience: contributor | evidence: cli/src/build/claude-code/registry.ts -->
+    <!-- id: build-pipeline.platform-defs.claude-code | tier: T1 | audience: user | evidence: cli/src/build/claude-code/registry.ts -->
   - Codex Target `T1` -- Emits AGENTS.md with sub-agent delegation and role mapping
-    <!-- id: build-pipeline.platform-defs.codex | tier: T1 | audience: contributor | evidence: cli/src/build/codex/index.ts, cli/src/build/codex/role-mapper.ts, cli/src/build/codex/sub-agent-validator.ts -->
+    <!-- id: build-pipeline.platform-defs.codex | tier: T1 | audience: user | evidence: cli/src/build/codex/index.ts, cli/src/build/codex/role-mapper.ts, cli/src/build/codex/sub-agent-validator.ts -->
   - Antigravity Target `T1` -- Produces Gemini-compatible bundles with lifecycle hooks
-    <!-- id: build-pipeline.platform-defs.antigravity | tier: T1 | audience: contributor | evidence: cli/src/build/antigravity/hooks.ts, cli/src/build/antigravity/registry.ts -->
+    <!-- id: build-pipeline.platform-defs.antigravity | tier: T1 | audience: user | evidence: cli/src/build/antigravity/hooks.ts, cli/src/build/antigravity/registry.ts -->
   - Copilot Target `T2` -- Generates GitHub Copilot instruction files
-    <!-- id: build-pipeline.platform-defs.copilot | tier: T2 | audience: contributor | evidence: cli/src/build/copilot/registry.ts -->
+    <!-- id: build-pipeline.platform-defs.copilot | tier: T2 | audience: user | evidence: cli/src/build/copilot/registry.ts -->
 - **Model Tier Resolution** `T1` -- Resolves per-agent model and reasoning-effort overrides from settings.toml tiering configuration
-  <!-- id: build-pipeline.tier-resolution | tier: T1 | audience: contributor | evidence: cli/src/build/tier-resolution.ts -->
+  <!-- id: build-pipeline.tier-resolution | tier: T1 | audience: user | evidence: cli/src/build/tier-resolution.ts -->
 - **Build Lint Rules** `T2` -- Static analysis rules that validate prompt file structure, naming conventions, and cross-references
-  <!-- id: build-pipeline.lint | tier: T2 | audience: contributor | evidence: cli/src/build/lint/index.ts, cli/src/build/lint/rules/ -->
+  <!-- id: build-pipeline.lint | tier: T2 | audience: user | evidence: cli/src/build/lint/index.ts, cli/src/build/lint/rules/ -->
 - **Catalog Generator** `T1` -- Produces `catalog/agents.yaml` manifest from all agent and skill definitions for discovery and registry use
-  <!-- id: build-pipeline.catalog | tier: T1 | audience: contributor | evidence: cli/src/build/catalog-generator.ts, cli/src/catalog/, catalog/agents.yaml -->
+  <!-- id: build-pipeline.catalog | tier: T1 | audience: user | evidence: cli/src/build/catalog-generator.ts, cli/src/catalog/, catalog/agents.yaml -->
 - **Build-Time Filters** `T2` -- Configurable filter chain for content transformation during build (e.g. stripping comments, minifying)
-  <!-- id: build-pipeline.filters | tier: T2 | audience: contributor | evidence: cli/src/build/filters/ -->
+  <!-- id: build-pipeline.filters | tier: T2 | audience: user | evidence: cli/src/build/filters/ -->
 - **Parse Cache** `T2` -- Caches parsed prompt ASTs to accelerate incremental builds
-  <!-- id: build-pipeline.parse-cache | tier: T2 | audience: contributor | evidence: cli/src/build/parse-cache.ts -->
+  <!-- id: build-pipeline.parse-cache | tier: T2 | audience: user | evidence: cli/src/build/parse-cache.ts -->
 
 ## Agent Tools Runtime
 
@@ -115,56 +115,56 @@
 ## Arcade (Web UI)
 
 - **Dashboard** `T1` -- Real-time web dashboard showing workflow runs, artifacts, and project status across multiple workspaces
-  <!-- id: arcade.dashboard | tier: T1 | audience: developer | evidence: cli/web-ui/src/pages/v2/HomePage.tsx, docs/arcade/dashboard.md -->
+  <!-- id: arcade.dashboard | tier: T1 | audience: user | evidence: cli/web-ui/src/pages/v2/HomePage.tsx, docs/arcade/dashboard.md -->
   - Workspace Tab Strip `T1` -- Multi-workspace tabbed interface with pinned projects and live status indicators
-    <!-- id: arcade.dashboard.workspace-tabs | tier: T1 | audience: developer | evidence: cli/web-ui/src/components/v2/WorkspaceTabStrip.tsx, cli/web-ui/src/hooks/useWorkspaceTabs.tsx -->
+    <!-- id: arcade.dashboard.workspace-tabs | tier: T1 | audience: user | evidence: cli/web-ui/src/components/v2/WorkspaceTabStrip.tsx, cli/web-ui/src/hooks/useWorkspaceTabs.tsx -->
   - Run Cards `T1` -- Real-time workflow run cards with status badges, step progress, and event streams
-    <!-- id: arcade.dashboard.run-cards | tier: T1 | audience: developer | evidence: cli/web-ui/src/components/v2/RunCard.tsx, cli/web-ui/src/hooks/useRuns.ts -->
+    <!-- id: arcade.dashboard.run-cards | tier: T1 | audience: user | evidence: cli/web-ui/src/components/v2/RunCard.tsx, cli/web-ui/src/hooks/useRuns.ts -->
   - Notification System `T1` -- Toast and sidebar notifications for workflow events with configurable attention levels
-    <!-- id: arcade.dashboard.notifications | tier: T1 | audience: developer | evidence: cli/web-ui/src/components/v2/NotificationsSidebar.tsx, cli/web-ui/src/components/v2/NotificationToast.tsx, cli/web-ui/src/hooks/useNotifications.ts -->
+    <!-- id: arcade.dashboard.notifications | tier: T1 | audience: user | evidence: cli/web-ui/src/components/v2/NotificationsSidebar.tsx, cli/web-ui/src/components/v2/NotificationToast.tsx, cli/web-ui/src/hooks/useNotifications.ts -->
   - Command Palette `T1` -- Keyboard-driven command palette for navigation and actions
-    <!-- id: arcade.dashboard.command-palette | tier: T1 | audience: developer | evidence: cli/web-ui/src/components/v2/CommandPalette.tsx -->
+    <!-- id: arcade.dashboard.command-palette | tier: T1 | audience: user | evidence: cli/web-ui/src/components/v2/CommandPalette.tsx -->
 - **Artifact Browser** `T1` -- File-tree browser for viewing and navigating rp1 work artifacts with markdown rendering
-  <!-- id: arcade.artifact-browser | tier: T1 | audience: developer | evidence: cli/web-ui/src/pages/v2/FileBrowserPage.tsx, cli/web-ui/src/components/FileTree/, docs/arcade/artifact-viewer.md -->
+  <!-- id: arcade.artifact-browser | tier: T1 | audience: user | evidence: cli/web-ui/src/pages/v2/FileBrowserPage.tsx, cli/web-ui/src/components/FileTree/, docs/arcade/artifact-viewer.md -->
   - Markdown Viewer `T1` -- Rich markdown renderer with syntax highlighting, mermaid diagrams, and table of contents
-    <!-- id: arcade.artifact-browser.markdown-viewer | tier: T1 | audience: developer | evidence: cli/web-ui/src/components/MarkdownViewer/, cli/web-ui/src/components/v2/UnifiedContentRenderer.tsx -->
+    <!-- id: arcade.artifact-browser.markdown-viewer | tier: T1 | audience: user | evidence: cli/web-ui/src/components/MarkdownViewer/, cli/web-ui/src/components/v2/UnifiedContentRenderer.tsx -->
   - Sandboxed HTML Artifacts `T1` -- Renders HTML artifacts in secure sandboxed iframes
-    <!-- id: arcade.artifact-browser.sandboxed-html | tier: T1 | audience: developer | evidence: cli/web-ui/src/components/v2/SandboxedHtmlArtifact.tsx -->
+    <!-- id: arcade.artifact-browser.sandboxed-html | tier: T1 | audience: user | evidence: cli/web-ui/src/components/v2/SandboxedHtmlArtifact.tsx -->
   - Artifact Grouping `T2` -- Groups related artifacts by workflow and type for organized browsing
-    <!-- id: arcade.artifact-browser.grouping | tier: T2 | audience: developer | evidence: cli/web-ui/src/lib/artifact-groups.ts -->
+    <!-- id: arcade.artifact-browser.grouping | tier: T2 | audience: user | evidence: cli/web-ui/src/lib/artifact-groups.ts -->
 - **Annotation System** `T1` -- User feedback annotations on artifacts with popover and sidebar interfaces for review collaboration
-  <!-- id: arcade.annotations | tier: T1 | audience: developer | evidence: cli/web-ui/src/components/v2/AnnotationPopover.tsx, cli/web-ui/src/components/v2/AnnotationSidebar.tsx, cli/web-ui/src/hooks/useAnnotations.ts, docs/arcade/annotations.md -->
+  <!-- id: arcade.annotations | tier: T1 | audience: user | evidence: cli/web-ui/src/components/v2/AnnotationPopover.tsx, cli/web-ui/src/components/v2/AnnotationSidebar.tsx, cli/web-ui/src/hooks/useAnnotations.ts, docs/arcade/annotations.md -->
   - Text Selection Annotations `T1` -- Select text in artifacts to create inline annotations
-    <!-- id: arcade.annotations.text-selection | tier: T1 | audience: developer | evidence: cli/web-ui/src/hooks/useTextSelection.ts, cli/web-ui/src/components/v2/SelectionPopover.tsx -->
+    <!-- id: arcade.annotations.text-selection | tier: T1 | audience: user | evidence: cli/web-ui/src/hooks/useTextSelection.ts, cli/web-ui/src/components/v2/SelectionPopover.tsx -->
   - Milkdown Editor `T2` -- WYSIWYG markdown editor for annotation content
-    <!-- id: arcade.annotations.milkdown | tier: T2 | audience: developer | evidence: cli/web-ui/src/components/MilkdownEditor/ -->
+    <!-- id: arcade.annotations.milkdown | tier: T2 | audience: user | evidence: cli/web-ui/src/components/MilkdownEditor/ -->
 - **Run Detail View** `T1` -- Detailed view of a single workflow run showing step-by-step progress, artifacts, and event timeline
-  <!-- id: arcade.run-detail | tier: T1 | audience: developer | evidence: cli/web-ui/src/pages/v2/RunDetailPage.tsx, cli/web-ui/src/components/v2/RunDetailSurface.tsx, cli/web-ui/src/hooks/useRunDetail.ts -->
+  <!-- id: arcade.run-detail | tier: T1 | audience: user | evidence: cli/web-ui/src/pages/v2/RunDetailPage.tsx, cli/web-ui/src/components/v2/RunDetailSurface.tsx, cli/web-ui/src/hooks/useRunDetail.ts -->
   - Vertical Step List `T1` -- Displays workflow steps as a vertical timeline with completion status
-    <!-- id: arcade.run-detail.step-list | tier: T1 | audience: developer | evidence: cli/web-ui/src/components/v2/VerticalStepList.tsx, cli/web-ui/src/hooks/useWorkflowSteps.ts -->
+    <!-- id: arcade.run-detail.step-list | tier: T1 | audience: user | evidence: cli/web-ui/src/components/v2/VerticalStepList.tsx, cli/web-ui/src/hooks/useWorkflowSteps.ts -->
   - Walkthrough Reveal Reader `T2` -- Slide-by-slide reveal presentation of PR walkthrough artifacts
-    <!-- id: arcade.run-detail.walkthrough | tier: T2 | audience: developer | evidence: cli/web-ui/src/components/v2/WalkthroughRevealReader.tsx, cli/web-ui/src/lib/walkthrough-slide-source.ts -->
+    <!-- id: arcade.run-detail.walkthrough | tier: T2 | audience: user | evidence: cli/web-ui/src/components/v2/WalkthroughRevealReader.tsx, cli/web-ui/src/lib/walkthrough-slide-source.ts -->
 - **Project Overview** `T1` -- Project-level dashboard with run history, artifact counts, and workspace descriptor
-  <!-- id: arcade.project-overview | tier: T1 | audience: developer | evidence: cli/web-ui/src/pages/v2/ProjectOverviewPage.tsx, cli/web-ui/src/pages/v2/ProjectsPage.tsx -->
+  <!-- id: arcade.project-overview | tier: T1 | audience: user | evidence: cli/web-ui/src/pages/v2/ProjectOverviewPage.tsx, cli/web-ui/src/pages/v2/ProjectsPage.tsx -->
 - **Daemon Manager** `T1` -- Background daemon process that serves the Arcade web UI with lifecycle locking and IPC communication
-  <!-- id: arcade.daemon | tier: T1 | audience: developer | evidence: cli/web-ui/src/daemon/manager.ts, cli/web-ui/src/daemon/lifecycle-lock.ts, cli/web-ui/src/daemon/ipc.ts -->
+  <!-- id: arcade.daemon | tier: T1 | audience: user | evidence: cli/web-ui/src/daemon/manager.ts, cli/web-ui/src/daemon/lifecycle-lock.ts, cli/web-ui/src/daemon/ipc.ts -->
 - **Keyboard Shortcuts** `T1` -- Comprehensive keyboard shortcut system with global and contextual bindings and a help overlay
-  <!-- id: arcade.keyboard | tier: T1 | audience: developer | evidence: cli/web-ui/src/hooks/useGlobalShortcuts.ts, cli/web-ui/src/hooks/useContextualShortcuts.ts, cli/web-ui/src/components/v2/ShortcutHelpOverlay.tsx, docs/arcade/keyboard-shortcuts.md -->
+  <!-- id: arcade.keyboard | tier: T1 | audience: user | evidence: cli/web-ui/src/hooks/useGlobalShortcuts.ts, cli/web-ui/src/hooks/useContextualShortcuts.ts, cli/web-ui/src/components/v2/ShortcutHelpOverlay.tsx, docs/arcade/keyboard-shortcuts.md -->
 - **Arcade Settings Bridge** `T2` -- Syncs settings between the CLI and the Arcade web UI
-  <!-- id: arcade.settings-bridge | tier: T2 | audience: developer | evidence: cli/web-ui/src/server/arcade-settings-bridge.ts, docs/arcade/settings.md -->
+  <!-- id: arcade.settings-bridge | tier: T2 | audience: user | evidence: cli/web-ui/src/server/arcade-settings-bridge.ts, docs/arcade/settings.md -->
 - **Server-Side Services** `T1` -- Hono-based HTTP and WebSocket server with activity search, markdown projection, file watching, and project registry
-  <!-- id: arcade.server | tier: T1 | audience: contributor | evidence: cli/web-ui/src/server.ts, cli/web-ui/src/server/http.ts, cli/web-ui/src/server/websocket.ts, cli/web-ui/src/server/registry.ts -->
+  <!-- id: arcade.server | tier: T1 | audience: user | evidence: cli/web-ui/src/server.ts, cli/web-ui/src/server/http.ts, cli/web-ui/src/server/websocket.ts, cli/web-ui/src/server/registry.ts -->
   - Activity Search `T1` -- Full-text search across workflow activities and events
-    <!-- id: arcade.server.activity-search | tier: T1 | audience: developer | evidence: cli/web-ui/src/server/activity-search.ts -->
+    <!-- id: arcade.server.activity-search | tier: T1 | audience: user | evidence: cli/web-ui/src/server/activity-search.ts -->
   - Markdown Projection `T1` -- Server-side markdown processing with embedding resolution for artifact display
-    <!-- id: arcade.server.markdown-projection | tier: T1 | audience: contributor | evidence: cli/web-ui/src/server/markdown-projection.ts, cli/web-ui/src/server/markdown-embedder.ts -->
+    <!-- id: arcade.server.markdown-projection | tier: T1 | audience: user | evidence: cli/web-ui/src/server/markdown-projection.ts, cli/web-ui/src/server/markdown-embedder.ts -->
   - Annotations API `T1` -- REST API for annotation CRUD with server-side service layer
-    <!-- id: arcade.server.annotations-api | tier: T1 | audience: contributor | evidence: cli/web-ui/src/server/routes/annotations-api.ts, cli/web-ui/src/server/annotation-service.ts -->
+    <!-- id: arcade.server.annotations-api | tier: T1 | audience: user | evidence: cli/web-ui/src/server/routes/annotations-api.ts, cli/web-ui/src/server/annotation-service.ts -->
 
 ## Plugin System: Base
 
 - **Knowledge Build** `T1` -- Orchestrates parallel KB generation using spatial analysis and map-reduce architecture with incremental and feature-learning modes
-  <!-- id: plugin-base.knowledge-build | tier: T1 | audience: developer | evidence: plugins/base/skills/knowledge-build/SKILL.md, docs/reference/base/knowledge-build.md -->
+  <!-- id: plugin-base.knowledge-build | tier: T1 | audience: user | evidence: plugins/base/skills/knowledge-build/SKILL.md, docs/reference/base/knowledge-build.md -->
   - KB Index Builder `T1` -- Produces the top-level index.md from aggregated analysis results
     <!-- id: plugin-base.knowledge-build.index-builder | tier: T1 | audience: agent | evidence: plugins/base/agents/kb-index-builder.md -->
   - KB Feature Extractor `T1` -- Discovers and inventories project capabilities into features.md
@@ -182,44 +182,44 @@
   - KB Spatial Analyzer `T1` -- Performs directory-level spatial analysis as input to other KB agents
     <!-- id: plugin-base.knowledge-build.spatial-analyzer | tier: T1 | audience: agent | evidence: plugins/base/agents/kb-spatial-analyzer.md -->
 - **Deep Research** `T1` -- Autonomous map-reduce research on codebases and technical topics with structured report output
-  <!-- id: plugin-base.deep-research | tier: T1 | audience: developer | evidence: plugins/base/skills/deep-research/SKILL.md, plugins/base/agents/research-explorer.md, plugins/base/agents/research-reporter.md, docs/reference/base/deep-research.md -->
+  <!-- id: plugin-base.deep-research | tier: T1 | audience: user | evidence: plugins/base/skills/deep-research/SKILL.md, plugins/base/agents/research-explorer.md, plugins/base/agents/research-reporter.md, docs/reference/base/deep-research.md -->
 - **Security Analysis** `T1` -- Evidence-bounded security posture assessment with standards mapping and registered report output
-  <!-- id: plugin-base.analyse-security | tier: T1 | audience: developer | evidence: plugins/base/skills/analyse-security/SKILL.md, plugins/base/agents/security-validator.md, docs/reference/base/analyse-security.md -->
+  <!-- id: plugin-base.analyse-security | tier: T1 | audience: user | evidence: plugins/base/skills/analyse-security/SKILL.md, plugins/base/agents/security-validator.md, docs/reference/base/analyse-security.md -->
 - **Socratic Duel** `T1` -- Bounded two-agent debate with lock-based turn coordination and structured artifact output
-  <!-- id: plugin-base.socratic-duel | tier: T1 | audience: developer | evidence: plugins/base/skills/socratic-duel/SKILL.md, plugins/base/skills/socratic-duel-run/SKILL.md, plugins/base/agents/socratic-duel-participant.md, docs/reference/base/socratic-duel.md -->
+  <!-- id: plugin-base.socratic-duel | tier: T1 | audience: user | evidence: plugins/base/skills/socratic-duel/SKILL.md, plugins/base/skills/socratic-duel-run/SKILL.md, plugins/base/agents/socratic-duel-participant.md, docs/reference/base/socratic-duel.md -->
 - **Strategic Advisor** `T1` -- Holistic systems analysis with quantified trade-offs across cost, quality, performance, and complexity
-  <!-- id: plugin-base.strategize | tier: T1 | audience: developer | evidence: plugins/base/skills/strategize/SKILL.md, plugins/base/agents/strategic-advisor.md, docs/reference/base/strategize.md -->
+  <!-- id: plugin-base.strategize | tier: T1 | audience: user | evidence: plugins/base/skills/strategize/SKILL.md, plugins/base/agents/strategic-advisor.md, docs/reference/base/strategize.md -->
 - **Project Overview Generator** `T1` -- Produces three-tier arc42/C4-aligned project overview with provenance metadata
-  <!-- id: plugin-base.project-birds-eye-view | tier: T1 | audience: developer | evidence: plugins/base/skills/project-birds-eye-view/SKILL.md, plugins/base/agents/project-documenter.md, docs/reference/base/project-birds-eye-view.md -->
+  <!-- id: plugin-base.project-birds-eye-view | tier: T1 | audience: user | evidence: plugins/base/skills/project-birds-eye-view/SKILL.md, plugins/base/agents/project-documenter.md, docs/reference/base/project-birds-eye-view.md -->
 - **Mermaid Diagram Tools** `T1` -- Creates, validates, and repairs Mermaid.js diagrams with auto-fix for common syntax errors
-  <!-- id: plugin-base.mermaid | tier: T1 | audience: developer | evidence: plugins/base/skills/mermaid/SKILL.md, plugins/base/skills/fix-mermaid/SKILL.md, plugins/base/agents/mermaid-fixer.md, docs/reference/base/fix-mermaid.md -->
+  <!-- id: plugin-base.mermaid | tier: T1 | audience: user | evidence: plugins/base/skills/mermaid/SKILL.md, plugins/base/skills/fix-mermaid/SKILL.md, plugins/base/agents/mermaid-fixer.md, docs/reference/base/fix-mermaid.md -->
 - **Artifact Templates** `T1` -- Canonical output templates for 20+ agent producers ensuring format consistency and routing metadata
   <!-- id: plugin-base.artifact-templates | tier: T1 | audience: agent | evidence: plugins/base/skills/artifact-templates/SKILL.md, plugins/base/skills/artifact-templates/templates/ -->
 - **Guide** `T1` -- Interactive skill discovery and workflow guidance for rp1 capabilities
-  <!-- id: plugin-base.guide | tier: T1 | audience: developer | evidence: plugins/base/skills/guide/SKILL.md, docs/reference/base/guide.md -->
+  <!-- id: plugin-base.guide | tier: T1 | audience: user | evidence: plugins/base/skills/guide/SKILL.md, docs/reference/base/guide.md -->
 - **Self-Update** `T1` -- Updates rp1 and runs the full post-update lifecycle
-  <!-- id: plugin-base.self-update | tier: T1 | audience: developer | evidence: plugins/base/skills/self-update/SKILL.md, docs/reference/base/self-update.md -->
+  <!-- id: plugin-base.self-update | tier: T1 | audience: user | evidence: plugins/base/skills/self-update/SKILL.md, docs/reference/base/self-update.md -->
 - **Note Capture** `T2` -- Captures session context as structured markdown notes with auto-maintained index
-  <!-- id: plugin-base.note | tier: T2 | audience: developer | evidence: plugins/base/skills/note/SKILL.md -->
+  <!-- id: plugin-base.note | tier: T2 | audience: user | evidence: plugins/base/skills/note/SKILL.md -->
 - **Content Writer** `T2` -- Interactive prompt for creating polished technical documents through structured writing workflows
-  <!-- id: plugin-base.write-content | tier: T2 | audience: developer | evidence: plugins/base/skills/write-content/SKILL.md, docs/reference/base/write-content.md -->
+  <!-- id: plugin-base.write-content | tier: T2 | audience: user | evidence: plugins/base/skills/write-content/SKILL.md, docs/reference/base/write-content.md -->
 - **User Docs Generator** `T2` -- Synchronizes user-facing documentation with current KB through validate-stale-scan-approval orchestration
-  <!-- id: plugin-base.generate-user-docs | tier: T2 | audience: developer | evidence: plugins/base/skills/generate-user-docs/SKILL.md -->
+  <!-- id: plugin-base.generate-user-docs | tier: T2 | audience: user | evidence: plugins/base/skills/generate-user-docs/SKILL.md -->
 - **Markdown Preview** `T2` -- Generates browser-viewable HTML previews from markdown with auto-validation and Mermaid rendering
-  <!-- id: plugin-base.markdown-preview | tier: T2 | audience: developer | evidence: plugins/base/skills/markdown-preview/SKILL.md -->
+  <!-- id: plugin-base.markdown-preview | tier: T2 | audience: user | evidence: plugins/base/skills/markdown-preview/SKILL.md -->
 - **Code Comments Extractor** `T2` -- Extracts comment locations from code files for analysis
-  <!-- id: plugin-base.code-comments | tier: T2 | audience: developer | evidence: plugins/base/skills/code-comments/SKILL.md -->
+  <!-- id: plugin-base.code-comments | tier: T2 | audience: user | evidence: plugins/base/skills/code-comments/SKILL.md -->
 - **Task Manager** `T2` -- Discovers and manages queued tasks for agent execution
-  <!-- id: plugin-base.task | tier: T2 | audience: developer | evidence: plugins/base/skills/task/SKILL.md -->
+  <!-- id: plugin-base.task | tier: T2 | audience: user | evidence: plugins/base/skills/task/SKILL.md -->
 - **Prompt Writer** `T1` -- Writes maximally terse agent prompts with constitutional governance through a six-stage pipeline
-  <!-- id: plugin-base.prompt-writer | tier: T1 | audience: contributor | evidence: plugins/base/skills/prompt-writer/SKILL.md -->
+  <!-- id: plugin-base.prompt-writer | tier: T1 | audience: user | evidence: plugins/base/skills/prompt-writer/SKILL.md -->
 - **Scribe Agent** `T2` -- Note-taking agent for structured session capture
   <!-- id: plugin-base.scribe | tier: T2 | audience: agent | evidence: plugins/base/agents/scribe.md -->
 
 ## Plugin System: Dev
 
 - **Build Workflow** `T1` -- End-to-end feature development workflow from requirements through planning, implementation, verification, and release
-  <!-- id: plugin-dev.build | tier: T1 | audience: developer | evidence: plugins/dev/skills/build/SKILL.md, docs/reference/dev/build.md -->
+  <!-- id: plugin-dev.build | tier: T1 | audience: user | evidence: plugins/dev/skills/build/SKILL.md, docs/reference/dev/build.md -->
   - Feature Requirement Gatherer `T1` -- Interviews user and generates structured requirements document
     <!-- id: plugin-dev.build.requirement-gatherer | tier: T1 | audience: agent | evidence: plugins/dev/agents/feature-requirement-gatherer.md -->
   - Feature Architect `T1` -- Produces design.md with component diagrams and technical approach from requirements
@@ -243,21 +243,21 @@
   - Test Runner `T1` -- Executes test suites and reports results with coverage
     <!-- id: plugin-dev.build.test-runner | tier: T1 | audience: agent | evidence: plugins/dev/agents/test-runner.md -->
 - **Build Fast** `T1` -- Quick-iteration development for small/medium scope changes with persistent plan artifact and optional review
-  <!-- id: plugin-dev.build-fast | tier: T1 | audience: developer | evidence: plugins/dev/skills/build-fast/SKILL.md, plugins/dev/agents/build-fast-planner.md, docs/reference/dev/build-fast.md -->
+  <!-- id: plugin-dev.build-fast | tier: T1 | audience: user | evidence: plugins/dev/skills/build-fast/SKILL.md, plugins/dev/agents/build-fast-planner.md, docs/reference/dev/build-fast.md -->
 - **Speedrun** `T1` -- Interactive loop for small low-risk changes delegated to a general sub-agent
-  <!-- id: plugin-dev.speedrun | tier: T1 | audience: developer | evidence: plugins/dev/skills/speedrun/SKILL.md, plugins/dev/agents/speedrun-builder.md -->
+  <!-- id: plugin-dev.speedrun | tier: T1 | audience: user | evidence: plugins/dev/skills/speedrun/SKILL.md, plugins/dev/agents/speedrun-builder.md -->
 - **Blueprint** `T1` -- Guided project charter and PRD creation through parent-owned interviews with durable artifact resume
-  <!-- id: plugin-dev.blueprint | tier: T1 | audience: developer | evidence: plugins/dev/skills/blueprint/SKILL.md, plugins/dev/agents/blueprint-wizard.md, plugins/dev/agents/charter-interviewer.md, docs/reference/dev/blueprint.md -->
+  <!-- id: plugin-dev.blueprint | tier: T1 | audience: user | evidence: plugins/dev/skills/blueprint/SKILL.md, plugins/dev/agents/blueprint-wizard.md, plugins/dev/agents/charter-interviewer.md, docs/reference/dev/blueprint.md -->
   - Blueprint Audit `T1` -- Audits PRD against implementation status and guides lifecycle decisions
-    <!-- id: plugin-dev.blueprint.audit | tier: T1 | audience: developer | evidence: plugins/dev/skills/blueprint-audit/SKILL.md, plugins/dev/agents/blueprint-auditor.md, docs/reference/dev/blueprint-audit.md -->
+    <!-- id: plugin-dev.blueprint.audit | tier: T1 | audience: user | evidence: plugins/dev/skills/blueprint-audit/SKILL.md, plugins/dev/agents/blueprint-auditor.md, docs/reference/dev/blueprint-audit.md -->
   - Blueprint Archive `T1` -- Archives completed PRD with associated features and closure summary
-    <!-- id: plugin-dev.blueprint.archive | tier: T1 | audience: developer | evidence: plugins/dev/skills/blueprint-archive/SKILL.md, docs/reference/dev/blueprint-archive.md -->
+    <!-- id: plugin-dev.blueprint.archive | tier: T1 | audience: user | evidence: plugins/dev/skills/blueprint-archive/SKILL.md, docs/reference/dev/blueprint-archive.md -->
 - **Phase Plan** `T1` -- Decomposes completed PRD or oversized requirements into durable delivery phases
-  <!-- id: plugin-dev.phase-plan | tier: T1 | audience: developer | evidence: plugins/dev/skills/phase-plan/SKILL.md, plugins/dev/agents/phase-planner.md, docs/reference/dev/phase-plan.md -->
+  <!-- id: plugin-dev.phase-plan | tier: T1 | audience: user | evidence: plugins/dev/skills/phase-plan/SKILL.md, plugins/dev/agents/phase-planner.md, docs/reference/dev/phase-plan.md -->
 - **Bootstrap** `T1` -- Scaffolds a greenfield project with parent-owned interviews and bounded plan-revise-apply actions
-  <!-- id: plugin-dev.bootstrap | tier: T1 | audience: developer | evidence: plugins/dev/skills/bootstrap/SKILL.md, plugins/dev/agents/bootstrap-scaffolder.md -->
+  <!-- id: plugin-dev.bootstrap | tier: T1 | audience: user | evidence: plugins/dev/skills/bootstrap/SKILL.md, plugins/dev/agents/bootstrap-scaffolder.md -->
 - **PR Review** `T1` -- Intent-aware map-reduce PR review with CI/CD support, confidence gating, and intelligent comment deduplication
-  <!-- id: plugin-dev.pr-review | tier: T1 | audience: developer | evidence: plugins/dev/skills/pr-review/SKILL.md, docs/reference/dev/pr-review.md -->
+  <!-- id: plugin-dev.pr-review | tier: T1 | audience: user | evidence: plugins/dev/skills/pr-review/SKILL.md, docs/reference/dev/pr-review.md -->
   - PR Sub-Reviewer `T1` -- Reviews individual file segments for issues
     <!-- id: plugin-dev.pr-review.sub-reviewer | tier: T1 | audience: agent | evidence: plugins/dev/agents/pr-sub-reviewer.md -->
   - PR Review Splitter `T1` -- Splits large diffs into reviewable segments for parallel sub-review
@@ -271,42 +271,42 @@
   - PR Comment Poster `T1` -- Posts individual review comments to GitHub PRs
     <!-- id: plugin-dev.pr-review.poster | tier: T1 | audience: agent | evidence: plugins/dev/agents/pr-comment-poster.md -->
 - **PR Visual** `T1` -- Transforms PR diffs into Mermaid diagrams for visual code review
-  <!-- id: plugin-dev.pr-visual | tier: T1 | audience: developer | evidence: plugins/dev/skills/pr-visual/SKILL.md, plugins/dev/agents/pr-visualizer.md, docs/reference/dev/pr-visual.md -->
+  <!-- id: plugin-dev.pr-visual | tier: T1 | audience: user | evidence: plugins/dev/skills/pr-visual/SKILL.md, plugins/dev/agents/pr-visualizer.md, docs/reference/dev/pr-visual.md -->
 - **PR Walkthrough** `T1` -- Generates evidence-grounded markdown walkthrough for a pull request
-  <!-- id: plugin-dev.pr-walkthrough | tier: T1 | audience: developer | evidence: plugins/dev/skills/pr-walkthrough/SKILL.md, plugins/dev/agents/pr-walkthrough-reporter.md, docs/reference/dev/pr-walkthrough.md -->
+  <!-- id: plugin-dev.pr-walkthrough | tier: T1 | audience: user | evidence: plugins/dev/skills/pr-walkthrough/SKILL.md, plugins/dev/agents/pr-walkthrough-reporter.md, docs/reference/dev/pr-walkthrough.md -->
 - **PR Stack** `T1` -- Plans and executes splitting a large PR into a reviewable stacked PR sequence
-  <!-- id: plugin-dev.pr-stack | tier: T1 | audience: developer | evidence: plugins/dev/skills/pr-stack/SKILL.md, docs/reference/dev/pr-stack.md -->
+  <!-- id: plugin-dev.pr-stack | tier: T1 | audience: user | evidence: plugins/dev/skills/pr-stack/SKILL.md, docs/reference/dev/pr-stack.md -->
 - **Address PR Feedback** `T1` -- Unified workflow to collect, triage, and fix review comments in a single command
-  <!-- id: plugin-dev.address-pr-feedback | tier: T1 | audience: developer | evidence: plugins/dev/skills/address-pr-feedback/SKILL.md, plugins/dev/agents/pr-feedback-collector.md, docs/reference/dev/address-pr-feedback.md -->
+  <!-- id: plugin-dev.address-pr-feedback | tier: T1 | audience: user | evidence: plugins/dev/skills/address-pr-feedback/SKILL.md, plugins/dev/agents/pr-feedback-collector.md, docs/reference/dev/address-pr-feedback.md -->
 - **Publish Artifact** `T1` -- Publishes rp1 artifacts as idempotent PR or issue comments that update in place
-  <!-- id: plugin-dev.publish-artifact | tier: T1 | audience: developer | evidence: plugins/dev/skills/publish-artifact/SKILL.md, docs/reference/dev/publish-artifact.md -->
+  <!-- id: plugin-dev.publish-artifact | tier: T1 | audience: user | evidence: plugins/dev/skills/publish-artifact/SKILL.md, docs/reference/dev/publish-artifact.md -->
 - **Code Investigate** `T1` -- Systematic bug investigation through evidence-based analysis and hypothesis testing without permanent code changes
-  <!-- id: plugin-dev.code-investigate | tier: T1 | audience: developer | evidence: plugins/dev/skills/code-investigate/SKILL.md, plugins/dev/agents/bug-investigator.md, docs/reference/dev/code-investigate.md -->
+  <!-- id: plugin-dev.code-investigate | tier: T1 | audience: user | evidence: plugins/dev/skills/code-investigate/SKILL.md, plugins/dev/agents/bug-investigator.md, docs/reference/dev/code-investigate.md -->
 - **Validate Hypothesis** `T1` -- Validates design hypotheses via code experiments, codebase analysis, and external research with support for ad-hoc test scenarios
-  <!-- id: plugin-dev.validate-hypothesis | tier: T1 | audience: developer | evidence: plugins/dev/skills/validate-hypothesis/SKILL.md, plugins/dev/agents/hypothesis-tester.md, docs/reference/dev/validate-hypothesis.md -->
+  <!-- id: plugin-dev.validate-hypothesis | tier: T1 | audience: user | evidence: plugins/dev/skills/validate-hypothesis/SKILL.md, plugins/dev/agents/hypothesis-tester.md, docs/reference/dev/validate-hypothesis.md -->
 - **Tech Debt Collector** `T1` -- Evidence-gated tech debt and bloat detection with materiality ranking and refutation validation
-  <!-- id: plugin-dev.tech-debt-collector | tier: T1 | audience: developer | evidence: plugins/dev/skills/tech-debt-collector/SKILL.md, plugins/dev/agents/bloat-scout.md, docs/reference/dev/tech-debt-collector.md -->
+  <!-- id: plugin-dev.tech-debt-collector | tier: T1 | audience: user | evidence: plugins/dev/skills/tech-debt-collector/SKILL.md, plugins/dev/agents/bloat-scout.md, docs/reference/dev/tech-debt-collector.md -->
 - **Code Audit** `T1` -- Analyzes code for pattern consistency, maintainability, duplication, comment quality, and documentation drift
-  <!-- id: plugin-dev.code-audit | tier: T1 | audience: developer | evidence: plugins/dev/skills/code-audit/SKILL.md, plugins/dev/agents/code-auditor.md, docs/reference/dev/code-audit.md -->
+  <!-- id: plugin-dev.code-audit | tier: T1 | audience: user | evidence: plugins/dev/skills/code-audit/SKILL.md, plugins/dev/agents/code-auditor.md, docs/reference/dev/code-audit.md -->
 - **Code Check** `T1` -- Fast code hygiene validation running lints, formatters, tests, and coverage in a quick feedback loop
-  <!-- id: plugin-dev.code-check | tier: T1 | audience: developer | evidence: plugins/dev/skills/code-check/SKILL.md, plugins/dev/agents/code-checker.md, docs/reference/dev/code-check.md -->
+  <!-- id: plugin-dev.code-check | tier: T1 | audience: user | evidence: plugins/dev/skills/code-check/SKILL.md, plugins/dev/agents/code-checker.md, docs/reference/dev/code-check.md -->
 - **Code Clean Comments** `T1` -- Systematically removes unnecessary comments by first resolving scope into a durable change manifest
-  <!-- id: plugin-dev.code-clean-comments | tier: T1 | audience: developer | evidence: plugins/dev/skills/code-clean-comments/SKILL.md, plugins/dev/agents/comment-cleaner.md, docs/reference/dev/code-clean-comments.md -->
+  <!-- id: plugin-dev.code-clean-comments | tier: T1 | audience: user | evidence: plugins/dev/skills/code-clean-comments/SKILL.md, plugins/dev/agents/comment-cleaner.md, docs/reference/dev/code-clean-comments.md -->
 - **Feature Lifecycle** `T1` -- Archive, edit, and unarchive feature documentation with validation and propagation
-  <!-- id: plugin-dev.feature-lifecycle | tier: T1 | audience: developer | evidence: plugins/dev/skills/feature-archive/SKILL.md, plugins/dev/skills/feature-edit/SKILL.md, plugins/dev/skills/feature-unarchive/SKILL.md, plugins/dev/agents/feature-archiver.md, plugins/dev/agents/feature-editor.md -->
+  <!-- id: plugin-dev.feature-lifecycle | tier: T1 | audience: user | evidence: plugins/dev/skills/feature-archive/SKILL.md, plugins/dev/skills/feature-edit/SKILL.md, plugins/dev/skills/feature-unarchive/SKILL.md, plugins/dev/agents/feature-archiver.md, plugins/dev/agents/feature-editor.md -->
 - **Arcade Collab** `T2` -- Structured guidance for agents to read, classify, and act on user feedback from the Arcade
   <!-- id: plugin-dev.arcade-collab | tier: T2 | audience: agent | evidence: plugins/dev/skills/arcade-collab/SKILL.md -->
 
 ## Plugin System: Utils
 
 - **Build Prompt** `T1` -- Builds governed prompts through the six-stage prompt-writer pipeline with budgeted governance
-  <!-- id: plugin-utils.build-prompt | tier: T1 | audience: contributor | evidence: plugins/utils/skills/build-prompt/SKILL.md -->
+  <!-- id: plugin-utils.build-prompt | tier: T1 | audience: user | evidence: plugins/utils/skills/build-prompt/SKILL.md -->
 - **Tersify Prompt** `T1` -- Rewrites agent-instruction prompts to be maximally terse while preserving full intent
-  <!-- id: plugin-utils.tersify-prompt | tier: T1 | audience: contributor | evidence: plugins/utils/skills/tersify-prompt/SKILL.md, plugins/utils/agents/prompt-tersifier.md -->
+  <!-- id: plugin-utils.tersify-prompt | tier: T1 | audience: user | evidence: plugins/utils/skills/tersify-prompt/SKILL.md, plugins/utils/agents/prompt-tersifier.md -->
 - **Prompt Eval Builder** `T2` -- Extracts eval assertions and generates test invocation prompts from command/agent specs
-  <!-- id: plugin-utils.prompt-eval-builder | tier: T2 | audience: contributor | evidence: plugins/utils/skills/prompt-eval-builder/SKILL.md -->
+  <!-- id: plugin-utils.prompt-eval-builder | tier: T2 | audience: user | evidence: plugins/utils/skills/prompt-eval-builder/SKILL.md -->
 - **Tester** `T3` -- Test command template for verifying argument passing and skill invocation
-  <!-- id: plugin-utils.tester | tier: T3 | audience: contributor | evidence: plugins/utils/skills/tester/SKILL.md -->
+  <!-- id: plugin-utils.tester | tier: T3 | audience: user | evidence: plugins/utils/skills/tester/SKILL.md -->
 
 ## Plugin System: Shared
 
@@ -324,85 +324,87 @@
 ## Teach-Me
 
 - **Lesson Renderer** `T1` -- Assembles lesson data models into self-contained interactive HTML lessons with Mermaid diagram pre-rendering
-  <!-- id: teach-me.renderer | tier: T1 | audience: developer | evidence: cli/src/teach-me/assemble.ts, cli/src/teach-me/inline.ts, cli/src/teach-me/prerender/, cli/src/commands/teach-me/ -->
+  <!-- id: teach-me.renderer | tier: T1 | audience: user | evidence: cli/src/teach-me/assemble.ts, cli/src/teach-me/inline.ts, cli/src/teach-me/prerender/, cli/src/commands/teach-me/ -->
   - Lesson Schema `T1` -- JSON schema for structured lesson data models with sections, quizzes, and code examples
-    <!-- id: teach-me.renderer.schema | tier: T1 | audience: developer | evidence: cli/src/teach-me/schema/ -->
+    <!-- id: teach-me.renderer.schema | tier: T1 | audience: user | evidence: cli/src/teach-me/schema/ -->
   - Widget System `T2` -- Embeddable interactive widgets within lessons
-    <!-- id: teach-me.renderer.widgets | tier: T2 | audience: developer | evidence: cli/src/teach-me/widgets/ -->
+    <!-- id: teach-me.renderer.widgets | tier: T2 | audience: user | evidence: cli/src/teach-me/widgets/ -->
   - Quality Gate `T2` -- Validates lesson content meets quality thresholds before rendering
-    <!-- id: teach-me.renderer.gate | tier: T2 | audience: developer | evidence: cli/src/teach-me/gate/ -->
+    <!-- id: teach-me.renderer.gate | tier: T2 | audience: user | evidence: cli/src/teach-me/gate/ -->
+  - Lesson Exporter `T2` -- Re-asserts self-containment and emits a standalone lesson artifact
+    <!-- id: teach-me.renderer.export | tier: T2 | audience: user | evidence: cli/src/commands/teach-me/export.ts, cli/src/__tests__/teach-me/export.test.ts -->
 - **Teach-Me Skill** `T1` -- Turns a "teach me X" request into an interactive HTML lesson rendered Arcade-first
-  <!-- id: teach-me.skill | tier: T1 | audience: developer | evidence: plugins/base/skills/teach-me/SKILL.md -->
+  <!-- id: teach-me.skill | tier: T1 | audience: user | evidence: plugins/base/skills/teach-me/SKILL.md -->
 
 ## Native App
 
-- **Electrobun Desktop App** `T3` -- Cross-platform desktop wrapper for the Arcade web UI using Electrobun
-  <!-- id: native-app.electrobun | tier: T3 | audience: developer | evidence: native-app/electrobun.config.ts, native-app/package.json, native-app/src/ -->
+- **Electrobun Desktop App** `T2` -- Cross-platform desktop wrapper for the Arcade web UI using Electrobun
+  <!-- id: native-app.electrobun | tier: T2 | audience: user | evidence: native-app/electrobun.config.ts, native-app/package.json, native-app/src/, native-app/src/__tests__/launch-state.test.ts -->
 
 ## Eval Framework
 
 - **Promptfoo Integration** `T1` -- Behavioral evaluation suites for agent skills using promptfoo with custom assertions and model usage tracking
-  <!-- id: eval-framework.promptfoo | tier: T1 | audience: contributor | evidence: evals/package.json, evals/src/index.ts, evals/src/model-usage.ts -->
+  <!-- id: eval-framework.promptfoo | tier: T1 | audience: user | evidence: evals/package.json, evals/src/index.ts, evals/src/model-usage.ts -->
   - Build Eval Suite `T1` -- Evaluates the /build workflow agent chain
-    <!-- id: eval-framework.promptfoo.build | tier: T1 | audience: contributor | evidence: evals/suites/rp1-dev/build/ -->
+    <!-- id: eval-framework.promptfoo.build | tier: T1 | audience: user | evidence: evals/suites/rp1-dev/build/ -->
   - Build-Fast Eval Suite `T1` -- Evaluates the /build-fast workflow
-    <!-- id: eval-framework.promptfoo.build-fast | tier: T1 | audience: contributor | evidence: evals/suites/rp1-dev/build-fast/ -->
+    <!-- id: eval-framework.promptfoo.build-fast | tier: T1 | audience: user | evidence: evals/suites/rp1-dev/build-fast/ -->
   - Speedrun Eval Suite `T1` -- Evaluates the /speedrun workflow
-    <!-- id: eval-framework.promptfoo.speedrun | tier: T1 | audience: contributor | evidence: evals/suites/rp1-dev/speedrun/ -->
+    <!-- id: eval-framework.promptfoo.speedrun | tier: T1 | audience: user | evidence: evals/suites/rp1-dev/speedrun/ -->
   - Create-Prompt Eval Suite `T1` -- Evaluates the prompt creation pipeline
-    <!-- id: eval-framework.promptfoo.create-prompt | tier: T1 | audience: contributor | evidence: evals/suites/rp1-base/create-prompt/ -->
+    <!-- id: eval-framework.promptfoo.create-prompt | tier: T1 | audience: user | evidence: evals/suites/rp1-base/create-prompt/ -->
   - Shared Assertions `T1` -- Reusable assertion library for eval suites
-    <!-- id: eval-framework.promptfoo.shared-assertions | tier: T1 | audience: contributor | evidence: evals/suites/shared/assertions/, evals/suites/shared/extension.ts -->
+    <!-- id: eval-framework.promptfoo.shared-assertions | tier: T1 | audience: user | evidence: evals/suites/shared/assertions/, evals/suites/shared/extension.ts -->
   - Attestation Verification `T1` -- Verifies eval suite attestation hashes match built artifacts
-    <!-- id: eval-framework.promptfoo.attestation | tier: T1 | audience: contributor | evidence: evals/src/attestation/, evals/attestation.json -->
+    <!-- id: eval-framework.promptfoo.attestation | tier: T1 | audience: user | evidence: evals/src/attestation/, evals/attestation.json -->
 - **Docker Eval Runner** `T2` -- Containerized eval execution environment with certificate management
-  <!-- id: eval-framework.docker | tier: T2 | audience: contributor | evidence: docker/Dockerfile, docker/eval-run.sh -->
+  <!-- id: eval-framework.docker | tier: T2 | audience: user | evidence: docker/Dockerfile, docker/eval-run.sh -->
 
 ## CI/CD and Release
 
 - **GitHub Actions CI** `T1` -- Multi-job CI pipeline with lint, typecheck, tests, docs link check, catalog verification, plugin build, and attestation checks
-  <!-- id: cicd.github-actions | tier: T1 | audience: contributor | evidence: .github/workflows/ci.yml -->
+  <!-- id: cicd.github-actions | tier: T1 | audience: user | evidence: .github/workflows/ci.yml -->
   - Test Isolation Boundary `T1` -- Docker-based disposable filesystem boundary for safe test execution
-    <!-- id: cicd.github-actions.test-isolation | tier: T1 | audience: contributor | evidence: .github/test-isolation.Dockerfile -->
+    <!-- id: cicd.github-actions.test-isolation | tier: T1 | audience: user | evidence: .github/test-isolation.Dockerfile -->
 - **Release Please** `T1` -- Automated semantic versioning and changelog generation with post-release artifact upload and Cloudflare Pages deployment
-  <!-- id: cicd.release-please | tier: T1 | audience: contributor | evidence: .github/workflows/release-please.yml, release-please-config.json, .release-please-manifest.json -->
+  <!-- id: cicd.release-please | tier: T1 | audience: user | evidence: .github/workflows/release-please.yml, release-please-config.json, .release-please-manifest.json -->
 - **GoReleaser** `T1` -- Cross-platform binary builds (darwin-arm64/x64, linux-arm64/x64, windows-x64) via Bun compile with GitHub Release publishing
-  <!-- id: cicd.goreleaser | tier: T1 | audience: contributor | evidence: .goreleaser.yml, .github/workflows/goreleaser.yml -->
+  <!-- id: cicd.goreleaser | tier: T1 | audience: user | evidence: .goreleaser.yml, .github/workflows/goreleaser.yml -->
 - **PR Title Validation** `T2` -- Enforces Conventional Commits format on PR titles
-  <!-- id: cicd.pr-title | tier: T2 | audience: contributor | evidence: .github/workflows/pr-title.yml -->
+  <!-- id: cicd.pr-title | tier: T2 | audience: user | evidence: .github/workflows/pr-title.yml -->
 - **Lighthouse CI** `T2` -- Post-release performance auditing of the documentation site
-  <!-- id: cicd.lighthouse | tier: T2 | audience: contributor | evidence: lighthouserc.json, .github/workflows/release-please.yml -->
+  <!-- id: cicd.lighthouse | tier: T2 | audience: user | evidence: lighthouserc.json, .github/workflows/release-please.yml -->
 - **Pre-Commit Hooks** `T2` -- Lefthook-based pre-commit checks for catalog freshness and commit conventions
-  <!-- id: cicd.lefthook | tier: T2 | audience: contributor | evidence: lefthook.yml, .lefthook/ -->
+  <!-- id: cicd.lefthook | tier: T2 | audience: user | evidence: lefthook.yml, .lefthook/ -->
 - **Docker Dev Environment** `T2` -- Development container setup for consistent build environments
-  <!-- id: cicd.docker-dev | tier: T2 | audience: contributor | evidence: docker/setup-dev.sh, docker/test-install.sh -->
+  <!-- id: cicd.docker-dev | tier: T2 | audience: user | evidence: docker/setup-dev.sh, docker/test-install.sh -->
 - **Beta Release Pipeline** `T2` -- Separate release channel for pre-release builds
-  <!-- id: cicd.beta-release | tier: T2 | audience: contributor | evidence: scripts/beta-release.sh, .goreleaser-beta.yml -->
+  <!-- id: cicd.beta-release | tier: T2 | audience: user | evidence: scripts/beta-release.sh, .goreleaser-beta.yml -->
 
 ## Documentation Site
 
 - **MkDocs Material Site** `T1` -- Public documentation site built with MkDocs Material and deployed to Cloudflare Pages
-  <!-- id: docs-site.mkdocs | tier: T1 | audience: developer | evidence: mkdocs.yml, docs/index.md, site/ -->
+  <!-- id: docs-site.mkdocs | tier: T1 | audience: user | evidence: mkdocs.yml, docs/index.md, site/ -->
   - Getting Started Guides `T1` -- Installation, first workflow, and directory structure documentation
-    <!-- id: docs-site.mkdocs.getting-started | tier: T1 | audience: developer | evidence: docs/getting-started/ -->
+    <!-- id: docs-site.mkdocs.getting-started | tier: T1 | audience: user | evidence: docs/getting-started/ -->
   - Workflow Guides `T1` -- In-depth guides for feature development, bug investigation, PR review, CI/CD integration, and team scaling
-    <!-- id: docs-site.mkdocs.guides | tier: T1 | audience: developer | evidence: docs/guides/ -->
+    <!-- id: docs-site.mkdocs.guides | tier: T1 | audience: user | evidence: docs/guides/ -->
   - CLI Reference `T1` -- Command reference for init, install, update, verify, migrate, settings, and uninstall
-    <!-- id: docs-site.mkdocs.cli-reference | tier: T1 | audience: developer | evidence: docs/reference/cli/ -->
+    <!-- id: docs-site.mkdocs.cli-reference | tier: T1 | audience: user | evidence: docs/reference/cli/ -->
   - Base Plugin Reference `T1` -- Reference docs for all base plugin skills
-    <!-- id: docs-site.mkdocs.base-reference | tier: T1 | audience: developer | evidence: docs/reference/base/ -->
+    <!-- id: docs-site.mkdocs.base-reference | tier: T1 | audience: user | evidence: docs/reference/base/ -->
   - Dev Plugin Reference `T1` -- Reference docs for all dev plugin skills
-    <!-- id: docs-site.mkdocs.dev-reference | tier: T1 | audience: developer | evidence: docs/reference/dev/ -->
+    <!-- id: docs-site.mkdocs.dev-reference | tier: T1 | audience: user | evidence: docs/reference/dev/ -->
   - Platform Guides `T1` -- Platform-specific documentation for Antigravity, Codex, and Copilot
-    <!-- id: docs-site.mkdocs.platforms | tier: T1 | audience: developer | evidence: docs/reference/platforms/ -->
+    <!-- id: docs-site.mkdocs.platforms | tier: T1 | audience: user | evidence: docs/reference/platforms/ -->
   - Arcade Documentation `T1` -- Dashboard, artifact viewer, annotations, keyboard shortcuts, and settings docs
-    <!-- id: docs-site.mkdocs.arcade | tier: T1 | audience: developer | evidence: docs/arcade/ -->
+    <!-- id: docs-site.mkdocs.arcade | tier: T1 | audience: user | evidence: docs/arcade/ -->
   - Configuration Reference `T1` -- settings.toml schema and configuration options
-    <!-- id: docs-site.mkdocs.configuration | tier: T1 | audience: developer | evidence: docs/reference/configuration.md -->
+    <!-- id: docs-site.mkdocs.configuration | tier: T1 | audience: user | evidence: docs/reference/configuration.md -->
   - Concepts `T2` -- Conceptual guides on constitutional prompting and knowledge-aware agents
-    <!-- id: docs-site.mkdocs.concepts | tier: T2 | audience: developer | evidence: docs/concepts/ -->
+    <!-- id: docs-site.mkdocs.concepts | tier: T2 | audience: user | evidence: docs/concepts/ -->
   - Readiness Assessment `T2` -- Framework for evaluating team readiness to adopt rp1
-    <!-- id: docs-site.mkdocs.readiness | tier: T2 | audience: developer | evidence: docs/readiness/ -->
+    <!-- id: docs-site.mkdocs.readiness | tier: T2 | audience: user | evidence: docs/readiness/ -->
 
 ## Surfaces Not Analyzed
 
@@ -412,9 +414,9 @@ None. All anchor classes were detected: CLI command registrations, build pipelin
 
 | Tier | Count | Meaning |
 |------|-------|---------|
-| T1 | 131 | Documented and tested |
-| T2 | 31 | Documented or tested |
-| T3 | 4 | Referenced but undocumented/untested |
+| T1 | 140 | Documented and tested |
+| T2 | 38 | Documented or tested |
+| T3 | 3 | Referenced but undocumented/untested |
 | T4 | 0 | Investigation candidates |
 
 ## Related KB Links

--- a/.rp1/context/index.md
+++ b/.rp1/context/index.md
@@ -5,12 +5,12 @@ rp1_doc_id: e56577c2-c3e0-48bb-b20b-2c69c103d940
 
 **Type**: Monorepo
 **Languages**: TypeScript, TSX, Markdown, JSON, YAML, TOML, Shell, CSS, HTML
-**Version**: 0.7.11-dev
-**Updated**: 2026-07-08
+**Version**: 0.7.12
+**Updated**: 2026-07-25
 
 ## Project Summary
 
-rp1 is a Bun/TypeScript CLI and plugin monorepo for authoring, building, and running AI agent workflows across Claude Code, OpenCode, Codex, Copilot, and Antigravity. It combines markdown-defined skills and agents, tracked runtime state with deterministic workflow bootstrap, storage-mode-aware directory resolution (prompts reference `{KB_ROOT}`/`{WORK_ROOT}` variables, never literal paths), the Arcade dashboard with notifications and contextual commands, a multi-platform build pipeline with per-agent model/effort tiering, user-controllable install-time model tier remapping via `settings.toml`, catalog-driven skill discovery, and a progressively loaded knowledge base.
+rp1 is a Bun/TypeScript CLI and plugin monorepo for authoring, building, and running AI agent workflows across Claude Code, OpenCode, Codex, Copilot, and Antigravity. It combines markdown-defined skills and agents, tracked runtime state with deterministic workflow bootstrap, storage-mode-aware directory resolution (prompts reference `{KB_ROOT}`/`{WORK_ROOT}` variables, never literal paths), the Arcade dashboard (browser and native macOS shell via Electrobun) with notifications and annotations, a multi-platform build pipeline with per-agent model/effort tiering, user-controllable install-time model tier remapping via `settings.toml`, containerized test isolation with a protected-home boundary, catalog-driven skill discovery, and a progressively loaded knowledge base.
 
 ## Quick Reference
 
@@ -18,7 +18,7 @@ rp1 is a Bun/TypeScript CLI and plugin monorepo for authoring, building, and run
 |--------|-------|
 | Entry Point | `cli/src/main.ts` |
 | Key Pattern | Plugin-based CLI with tracked workflow state, deterministic bootstrap, and map-reduce agents |
-| Tech Stack | Bun, TypeScript, React, fp-ts, SQLite, LiquidJS |
+| Tech Stack | Bun, TypeScript, React, fp-ts, SQLite, LiquidJS, Electrobun |
 
 ## KB File Manifest
 
@@ -26,11 +26,12 @@ rp1 is a Bun/TypeScript CLI and plugin monorepo for authoring, building, and run
 
 | File | Lines | Load For |
 |------|-------|----------|
-| architecture.md | 88 | System design, layers, data flow, integrations |
-| interaction-model.md | 71 | Cross-surface semantics, workflow states, notifications, accessibility |
-| modules.md | 84 | Module boundaries, responsibilities, dependency highlights |
-| patterns.md | 81 | Code conventions, workflow idioms, extension patterns |
-| concept_map.md | 152 | Domain concepts, terminology, bounded contexts |
+| architecture.md | 98 | System design, layers, data flow, integrations |
+| interaction-model.md | 75 | Cross-surface semantics, workflow states, notifications, accessibility |
+| modules.md | 106 | Module boundaries, responsibilities, dependency highlights |
+| patterns.md | 88 | Code conventions, workflow idioms, extension patterns |
+| concept_map.md | 167 | Domain concepts, terminology, bounded contexts |
+| features.md | 425 | Capability inventory, coverage gaps, feature audience |
 
 ## Task-Based Loading
 
@@ -38,8 +39,9 @@ rp1 is a Bun/TypeScript CLI and plugin monorepo for authoring, building, and run
 |------|---------------|
 | Code review | `patterns.md` |
 | Bug investigation | `architecture.md`, `modules.md` |
-| Feature implementation | `modules.md`, `patterns.md` |
+| Feature implementation | `modules.md`, `patterns.md`, `features.md` |
 | Frontend / UX / surface work | `interaction-model.md`, `modules.md`, `patterns.md` |
+| Capability audit / coverage review | `features.md` |
 | Model tiering / settings work | `modules.md` (settings module), `patterns.md`, `concept_map.md` (Model Settings context) |
 | Prompt authoring / path variables | `patterns.md` (path variables, L014), `concept_map.md` (Storage Resolution context) |
 | Strategic or system-wide analysis | All KB files |
@@ -58,17 +60,19 @@ cli/
 │   ├── commands/      # User-facing CLI commands including build, migrate, arcade, and settings
 │   ├── agent-tools/   # Workflow protocol tools (emit, workflow-bootstrap, resolve-args, feedback, root-dir, etc.)
 │   ├── build/         # Multi-platform artifact build pipeline with model/effort tiering + arcade tracking
-│   ├── settings/      # Install-time model tier remapping (loader, presets, rewriter, apply, validator)
+│   ├── settings/      # Install-time model tier remapping + harness selection (loader, presets, rewriter, apply, validator)
 │   ├── catalog/       # Skill/agent catalog registry with distribution scoping
 │   ├── install/       # Host-tool installation and verification
-│   ├── migrate/       # Project migration with stanza upgrades, DB backfill, and arcade settings JSON→TOML migration
-│   └── init/          # Project initialization with versioned fence markers and Ink UI
-├── shared/            # Errors, fp-ts helpers, events, logging, directory resolution
-└── web-ui/            # Arcade dashboard SPA with notifications, contextual commands, and Bun HTTP/WS server
+│   ├── migrate/       # Project migration with stanza upgrades, DB backfill, central-store opt-in, and settings JSON→TOML migration
+│   └── init/          # Project initialization wizard with harness selection, sandbox grants, and Ink UI
+├── scripts/           # Test isolation launchers and protected-home boundary verification
+├── shared/            # Errors, fp-ts helpers, events, logging, directory resolution, storage mode
+└── web-ui/            # Arcade dashboard SPA with annotations, notifications, and Bun HTTP/WS server
 plugins/
-├── base/              # KB, docs sync, writing, research, strategy, security, guide meta-skill
+├── base/              # KB suite (6 dimensions incl. features), docs sync, writing, research, strategy, security, guide
 ├── dev/               # Build workflows, blueprinting, PR review, feature delivery
 └── utils/             # Prompt writing, tersification, eval helpers
+native-app/            # macOS native Arcade shell built with Electrobun
 docs/
 └── reference/         # User-facing reference docs for CLI, configuration, plugins, web UI, and platform tags
 evals/                 # Prompt attestation with content-addressable hashing and dockerized execution
@@ -81,3 +85,4 @@ evals/                 # Prompt attestation with content-addressable hashing and
 - **[modules.md](modules.md)**: Module boundaries, key components, and dependency highlights
 - **[patterns.md](patterns.md)**: Implementation conventions and workflow idioms
 - **[concept_map.md](concept_map.md)**: Domain concepts, terminology, and bounded contexts
+- **[features.md](features.md)**: Capability inventory, evidence tiers, and audience coverage

--- a/.rp1/context/index.md
+++ b/.rp1/context/index.md
@@ -31,7 +31,7 @@ rp1 is a Bun/TypeScript CLI and plugin monorepo for authoring, building, and run
 | modules.md | 106 | Module boundaries, responsibilities, dependency highlights |
 | patterns.md | 88 | Code conventions, workflow idioms, extension patterns |
 | concept_map.md | 167 | Domain concepts, terminology, bounded contexts |
-| features.md | 425 | Capability inventory, coverage gaps, feature audience |
+| features.md | 427 | Capability inventory, coverage gaps, feature audience |
 
 ## Task-Based Loading
 

--- a/.rp1/context/interaction-model.md
+++ b/.rp1/context/interaction-model.md
@@ -1,7 +1,7 @@
 # rp1 - Interaction Model
 
 **Project**: rp1
-**Analysis Date**: 2026-07-08
+**Analysis Date**: 2026-07-25
 **Surfaces**: CLI, Host Tool Integration, Arcade Web UI, Agent Tools CLI, Agent .md frontmatter, Settings Configuration, Reference Docs, Init Wizard
 
 ## Experience Principles
@@ -15,6 +15,7 @@
 - **Attention-proportional notification** — notifications categorized by attention level with bulk dismiss.
 - **Progressive detail disclosure** — secondary metadata hidden by default, toggled via contextual commands, persisted in sessionStorage.
 - **Storage-mode transparency** — agents and skills reference KB/work directories via resolver variables (`{kbRoot}`/`{workRoot}` in skills; `{KB_ROOT}`/`{WORK_ROOT}` in agent arguments), never assuming physical locations; enables storage-mode redirection without prompt changes (lint L014 enforces).
+- **Annotation resilience** — annotations anchor to source-domain coordinates so validity checks survive rendered-text vs. source divergence; highlights re-resolve against DOM mutations via CSS Custom Highlights rather than native browser selection.
 
 ## Actors & Surfaces
 
@@ -38,20 +39,23 @@
 | settings_validation_error | Invalid TOML syntax or tier remapping semantics (bad preset, platform, model ID); `settings validate` exits 1 | CLI (`rp1 settings validate`) |
 | tier_remapping_applied | Agent artifacts rewritten per user mapping; count reported; idempotent re-run reports "already up to date" (distinct from "nothing matched") | CLI (`rp1 settings apply`, `rp1 update`) |
 | connection_status / annotation_status / notification_attention | Arcade live-update + feedback + triage signals | Arcade |
-| init step running / waiting_for_user / completed / failed / skipped | Init wizard step lifecycle; prompts (git-root, reinit, ancestor-project, gitignore preset) pause the step until the user chooses, then it re-executes | Init wizard UI, activity feed |
+| init step running / waiting_for_user / completed / failed / skipped | Init wizard step lifecycle; prompts (git-root, reinit, ancestor-project, harness-selection, gitignore preset) pause the step until the user chooses, then it re-executes | Init wizard UI, activity feed |
 | settings_created / settings_preserved | Init settings-setup created global/local `settings.toml` from template, or found existing files and left them untouched | Init wizard activity feed |
+| annotation orphaned / resolved | Annotation validity against current document content; orphaned flag broadcasts via WS after each mutation | Arcade annotation sidebar, code block gutter |
 
 ## Feedback Loops
 
 - **Workflow gate** — emit `waiting_for_user` → Arcade pause + host-tool prompt → answer resumes/revises/cancels.
 - **Artifact registration** — emit `artifact_registered` with `storageRoot` → Arcade resolves and shows the file.
-- **Annotation feedback** — user annotates/edits in Arcade → runtime persists → agents read via `feedback read` → replies update UI over WS.
-- **Notification lifecycle** — events produce deduplicated notifications; toasts auto-dismiss (6s); sidebar groups by attention.
+- **Annotation feedback** — user annotates/edits in Arcade → runtime persists to SQLite via annotation-service → agents read via `feedback read` → replies update UI over WS. Text-selection anchors are enriched with source-domain coordinates at creation; anchor-derived CSS Custom Highlights survive DOM re-renders without native-selection dependence. Orphan detection runs after every mutation and broadcasts flipped IDs.
+- **Notification lifecycle** — events produce deduplicated notifications; toasts auto-dismiss (6s) with optimistic server-side dismiss; sidebar groups by attention. Reduced-motion users skip exit animations.
 - **Build-time tier & effort validation** — `rp1 build` parses frontmatter → `validateAgentTierAndEffort` (errors halt with file+allowed values; warnings continue) → `resolveTier`/`resolveEffort` → platform-native config emitted.
 - **Settings tier remapping apply** — `rp1 settings apply` (or `rp1 update` auto-reapply) loads config/preset → validates semantics → discovers installed agents → rewrites model/effort fields → reports modified count + effort adjustments + protected-agent warnings. `--dry-run` previews.
 - **Storage-mode-aware directory resolution** — `rp1 agent-tools rp1-root-dir` returns `kbRoot`/`workRoot` respecting the active storage mode; skills receive resolved paths via workflow-bootstrap/resolve-args; agents receive them as dispatch arguments. Paths may resolve outside the project tree under non-default modes.
 - **Emit-driven run projection / snapshot reconciliation** — Arcade reduces events into `LiveRunIndex`, reconnects with saved cursor, falls back to REST when replay is impossible.
-- **Init wizard activity timeline** — `rp1 init` runs 11 ordered steps (registry → git-check → reinit-check → directory-setup → settings-setup → tool-detection → instruction-injection → gitignore-config → install-check → health-check → summary); each emits timestamped activities (info/success/warning/error). Plugin-install failures and health-check misses log as warnings, never fail the wizard. `--yes` applies non-interactive defaults; `--force-nested` bypasses the ancestor-project prompt.
+- **Init wizard activity timeline** — `rp1 init` runs 13 ordered steps (registry → git-check → reinit-check → tool-detection → harness-selection → install-check → directory-setup → settings-setup → sandbox-grants → instruction-injection → gitignore-config → health-check → summary); each emits timestamped activities (info/success/warning/error). Plugin-install failures and health-check misses log as warnings, never fail the wizard. `--yes` applies non-interactive defaults; `--force-nested` bypasses the ancestor-project prompt. Harness-selection offers a multi-select prompt; `--yes` auto-selects all stable harnesses. Sandbox-grants generates per-platform filesystem grants for central-storage access.
+- **Editor auto-save with annotation deferral** — Milkdown editor debounces saves (1s); when an annotation flow is active (`annotationActiveRef`), saves are deferred until the flow returns to idle to avoid DOM re-renders that would invalidate selection anchors. External content updates preserve cursor position via `replaceContentWithPreservedSelection`.
+- **Artifact content surface synchronous reset** — when the selected artifact changes, view state resets synchronously during render (not in an effect) to prevent a mismatched-content flash where the new path routes to the previous artifact's bytes.
 
 ## Cross-Surface Deltas
 
@@ -64,7 +68,7 @@
 
 ## Accessibility & Discoverability
 
-Keyboard-first Arcade (roving tabindex, single-key suppression during text entry, reduced-motion fallback, ARIA labels + live regions); named emits + state-machine-aligned steps give meaningful dashboard labels; namespaced sub-agent steps avoid timeline collisions.
+Keyboard-first Arcade (roving tabindex, single-key suppression during text entry, reduced-motion fallback for toast animations, ARIA labels + live regions); anchor-derived highlights use CSS Custom Highlights API with MutationObserver re-resolve; named emits + state-machine-aligned steps give meaningful dashboard labels; namespaced sub-agent steps avoid timeline collisions. Code block gutter annotations are keyboard-reachable buttons with ARIA labels including line number context.
 
 ## Related KB
 

--- a/.rp1/context/modules.md
+++ b/.rp1/context/modules.md
@@ -1,35 +1,35 @@
 # Module & Component Breakdown
 
 **Project**: rp1
-**Analysis Date**: 2026-07-08
+**Analysis Date**: 2026-07-25
 **Modules Analyzed**: 23
 
 ## Core Modules
 
 | Module | Purpose | Files | Key Files |
 |--------|---------|-------|-----------|
-| `cli/commands` | User-facing CLI commands (build, arcade, migrate, init, settings, install, update, verify, uninstall) | 27 | build.ts, arcade.ts, settings.ts |
-| `cli/agent-tools` | emit, workflow-bootstrap, resolve-args, state-machine, task, feedback, rp1-root-dir (storage-mode-aware directory resolution) | 59 | emit/index.ts, workflow-bootstrap.ts, rp1-root-dir |
+| `cli/commands` | User-facing CLI commands (build, arcade, migrate, init, settings, install, update, verify, uninstall) | 34 | build.ts, arcade.ts, settings.ts |
+| `cli/agent-tools` | emit, workflow-bootstrap, resolve-args, state-machine, task, feedback, rp1-root-dir (storage-mode-aware directory resolution), work-search (FTS indexer for work artifacts), mmd-validate (Puppeteer-backed Mermaid validation), github-pr, socratic-duel, comment-extract, change-manifest, build-task-plan, workflow-state | 80 | emit/index.ts, workflow-bootstrap.ts, rp1-root-dir, work-search/indexer.ts |
 | `cli/build` | Multi-platform artifact pipeline with per-agent model tiering, effort resolution, and frontier tier | 59 | command.ts, models.ts, parser.ts, validator.ts, **tier-resolution.ts**, template-context.ts, platform-definitions.ts |
-| `cli/settings` | Install-time model tier remapping via `settings.toml` `[models]` sections and presets (budget/standard/premium); Arcade settings via `[arcade]` section (theme, downsampling) with two-level merge and daemon grace fallback | 8 | apply.ts, rewriter.ts, arcade-writer.ts, presets.ts, loader.ts, models.ts, validator.ts |
+| `cli/settings` | Install-time model tier remapping via `settings.toml` `[models]` sections and presets (budget/standard/premium); Arcade settings via `[arcade]` section (theme, downsampling) with two-level merge and daemon grace fallback; harness selection via `[harnesses]` section with comment-preserving TOML writer (`harness-writer.ts`) | 8 | apply.ts, rewriter.ts, arcade-writer.ts, harness-writer.ts, presets.ts, loader.ts, models.ts, validator.ts |
 | `cli/migrate` | Project structure migration: project ID, work dirs, gitignore, DB backfill, stanza upgrades, Arcade settings JSON→TOML migration, and opt-in central-store conversion (`central-store.ts`: `relocateToCenter` moves `.rp1/context` + `.rp1/work` to `~/.rp1/projects/<project_id>/` with cross-device fallback; `writeStorageSection` writes `[storage] mode = "central"` with comment-preserving TOML edits; `updateGitignoreCentral` replaces fenced gitignore content with the central preset; `gitUnstageTracked` runs `git rm --cached` on relocated paths; `removeProjectStanzas` strips fenced content from `CLAUDE.md`/`AGENTS.md`; all gated behind `MigrateOptions.toCentral` with `homeDir` test-isolation seam; `arcade-settings.ts`: detect legacy JSON at global+project paths, write via arcade-writer, rename to `.migrated`; dry-run + `globalConfigDir` test seam; result in `MigrateResult.arcadeSettings` and `MigrateResult.centralStore`) | 7 | index.ts, central-store.ts, arcade-settings.ts, db-backfill.ts, stanza-upgrade.ts |
-| `cli/catalog` | Skill/agent catalog registry (distribution scope, arcadeTracked) | 3 | catalog-generator.ts |
-| `cli/install` | Install artifacts into host tools (staging, backup/rollback, verify) for claude-code, codex, copilot, antigravity | 34 | verifier.ts, installer.ts, asset-extractor.ts |
-| `cli/init` | Project init with context detection, fence markers, Ink UI | 23 | — |
-| `cli/shared` | Errors, fp-ts helpers, events, logging, directory + settings path resolution | 15 | errors.ts, logger.ts, settings.ts |
-| `web-ui/server` | Bun HTTP/WS server, REST APIs, file watching, notifications | 16 | registry.ts |
-| `web-ui/daemon` | Daemon lifecycle + diagnostic logging | 4 | — |
-| `web-ui/frontend` | React SPA: pages, hooks, providers, artifact viewers | 190 | — |
-| `plugins/base` | KB, docs, writing, research, strategy, security, prompt pipeline; agents declare `KB_ROOT` in frontmatter arguments | 109 | — |
-| `plugins/dev` | Build workflows, blueprint, PR review/walkthrough, feature delivery; agents declare `KB_ROOT`/`WORK_ROOT` arguments | 66 | — |
-| `plugins/utils` | Prompt tersification, eval helpers | 11 | — |
-| `evals` | Prompt attestation, content-addressable hashing, dockerized exec | 26 | — |
+| `cli/catalog` | Skill/agent catalog registry (distribution scope, arcadeTracked) | 4 | catalog-generator.ts |
+| `cli/install` | Install artifacts into host tools (staging, backup/rollback, verify) for claude-code, codex, copilot, antigravity | 35 | verifier.ts, installer.ts, asset-extractor.ts |
+| `cli/init` | Project init with context detection, fence markers, Ink UI, storage-mode-aware directory model, health checks | 28 | directory-model.ts, steps/project-setup.ts, steps/harness-selection.ts |
+| `cli/shared` | Errors, fp-ts helpers, events, logging, directory + settings path resolution, storage-mode resolution, project-id management | 15 | errors.ts, logger.ts, settings.ts, directory-resolution.ts, storage-mode.ts |
+| `web-ui/server` | Bun HTTP/WS server, REST APIs, file watching, notifications, annotation service with markdown projection, activity search, project path resolution (storage-mode-aware section routing with legacy alias support) | 20 | registry.ts, annotation-service.ts, markdown-projection.ts, project-paths.ts |
+| `web-ui/daemon` | Daemon lifecycle, diagnostic logging, platform-specific config directory resolution, state persistence | 7 | config-dir.ts |
+| `web-ui/frontend` | React SPA: pages, hooks, providers, artifact viewers, editable text node filtering for annotations | 159 | — |
+| `plugins/base` | KB, docs, writing, research, strategy, security, prompt pipeline; agents declare `KB_ROOT` in frontmatter arguments | 105 | — |
+| `plugins/dev` | Build workflows, blueprint, PR review/walkthrough, feature delivery; agents declare `KB_ROOT`/`WORK_ROOT` arguments | 67 | — |
+| `plugins/utils` | Prompt tersification, eval helpers | 9 | — |
+| `evals` | Prompt attestation, content-addressable hashing, dockerized exec | 28 | — |
 
 ## Key Components (build pipeline)
 
 ### tier-resolution (`cli/src/build/tier-resolution.ts`)
 Centralized tier-to-model and effort-to-field resolution. Pure functions, called per-agent per-platform at build time AND by the settings module at install time.
-- `resolveTier(tier, platform) → modelId | null` — maps abstract tier (frontier/deep/standard/fast) to platform model ID via exported `TIER_MODEL_MAP` (Claude Code, Codex, Antigravity; OpenCode/Copilot omitted = inherit); `null` for `inherit`/unmapped.
+- `resolveTier(tier, platform) → modelId | null` — maps abstract tier (frontier/deep/standard/fast) to platform model ID via exported `TIER_MODEL_MAP` (Claude Code uses fable/opus/sonnet/haiku; Codex uses gpt-5.6-sol/terra/luna; Antigravity uses gemini-3.1-pro/3.5-flash); `null` for `inherit`/unmapped.
 - `resolveEffort(effort, tier, platform) → {fieldName, value} | null` — `effort` (CC, 5 levels) or `model_reasoning_effort` (Codex, `max`→`xhigh` clamp); `null` for fast tier and no-effort platforms.
 - Shared helpers for settings validation: `getValidModelIdsForPlatform`, `modelSupportsEffort`, `getPlatformsWithModelSupport` — single source of truth preventing build/remap divergence.
 
@@ -39,7 +39,7 @@ Centralized tier-to-model and effort-to-field resolution. Pure functions, called
 ### build validator / command / template-context
 `validator.ts`: L1+L2 validation plus `validateAgentTierAndEffort` (errors block, warnings advise on fast+effort and protected downgrade). `command.ts`: validation gate → `resolveTier`/`resolveEffort` → embeds tier/effort into `BundleAgentEntry`. `template-context.ts`: `BuildPlatform` union (opencode, claude-code, codex, copilot, antigravity), `AgentArtifactData` with optional `effortFieldName`/`effortValue`.
 
-## Key Components (settings module — new)
+## Key Components (settings module)
 
 ### settings-apply (`cli/src/settings/apply.ts`)
 Install-time remapping orchestrator: `resolveConfig` (preset + per-platform overrides, optional `globalSettingsPath` seam) → `validateTierRemappings` → `discoverAgents` (from `EMBEDDED_MANIFEST` via `getBundledAssets()`) → `applyRemappingsToAgents` (delegates to rewriter; counts modified vs `agentsAlreadyCurrent`) → report + CC plugin cache refresh (failures become warnings). `applyTierRemappingsIfConfigured` is the update-hook no-op wrapper. Filesystem ops and `getBundledAssets` injected via `ApplyDeps` (production binding imports `getBundledAssetsReal` explicitly to avoid a circular dependency).
@@ -48,20 +48,42 @@ Install-time remapping orchestrator: `resolveConfig` (preset + per-platform over
 Pure-function artifact rewriter: CC YAML frontmatter and Codex TOML targeted line replacement (multiline-string guard protects `developer_instructions` bodies); strips effort when the remapped model is fast-class; protected-agent downgrade warnings via reverse tier lookup + `TIER_RANK`. Only claude-code and codex are rewritable.
 
 ### settings-loader / presets / validator / models
-`loader.ts`: parses `[arguments.*]`, `[models.*]`, and `[arcade]` from TOML with project>user merge, module-level cache (`resetSettingsCache`), `TIER_KEYS` derived from `VALID_MODEL_TIERS`; `loadArcadeSettings(projectRoot, globalSettingsPath?)` performs two-level merge for arcade settings with defaults (theme="system", thresholdHours=24). `arcade-writer.ts`: comment-preserving `writeArcadeSection()` that appends/merges `[arcade]` into existing TOML files using targeted line edits (used by migration step and daemon grace fallback). `presets.ts`: budget/standard/premium complete tier-to-model profiles (CC + Codex; `RemappableTier` excludes frontier/inherit). `validator.ts`: TOML syntax + semantic checks (preset names, platforms, model IDs, effort preview) using tier-resolution helpers. `models.ts`: `PlatformTierMap`, `TierRemappingConfig`, `ArcadeSettings`, `ArcadeTheme`.
+`loader.ts`: parses `[arguments.*]`, `[models.*]`, `[harnesses]`, `[storage]`, and `[arcade]` from TOML with project>user merge, module-level cache (`resetSettingsCache`), `TIER_KEYS` derived from `VALID_MODEL_TIERS`; `loadArcadeSettings(projectRoot, globalSettingsPath?)` performs two-level merge for arcade settings with defaults (theme="system", thresholdHours=24); `loadEnabledHarnesses()` reads `[harnesses].enabled` from user-level TOML. `harness-writer.ts`: comment-preserving `writeHarnessSelection()` that appends/merges `[harnesses]` into existing TOML files using targeted line edits. `arcade-writer.ts`: comment-preserving `writeArcadeSection()` that appends/merges `[arcade]` into existing TOML files using targeted line edits (used by migration step and daemon grace fallback). `presets.ts`: budget/standard/premium complete tier-to-model profiles (CC + Codex; `RemappableTier` excludes frontier/inherit). `validator.ts`: TOML syntax + semantic checks (preset names, platforms, model IDs, effort preview) using tier-resolution helpers. `models.ts`: `PlatformTierMap`, `TierRemappingConfig`, `ArcadeSettings`, `ArcadeTheme`, `ParsedHarnessesSection`.
 
 ### settings-command (`cli/src/commands/settings.ts`)
 `validate` (syntax + semantics, exit 1 on errors), `apply` (`--preset`, `--dry-run`; distinguishes "already up to date" from "nothing matched"), `presets` (list mappings).
 
+## Key Components (shared directory resolution)
+
+### directory-resolution (`cli/shared/directory-resolution.ts`)
+Two-phase project root discovery: (1) git worktree detection via `readGitContext` — if in a worktree, resolves to the main repo's project root so worktrees with their own `.rp1/project_id` don't register as separate projects; (2) walk-up directory tree search for `.rp1/project_id` with home-directory safety guard. Delegates path computation to `storage-mode.ts`. Exports `resolveDirectorySet` returning `ResolvedDirectorySet` (projectRoot, projectId, kbRoot, workRoot, codeRoot, isWorktree, worktreeName, storageMode). Consumed by emit, resolve-args, rp1-root-dir, init, work-search, and web-ui.
+
+### storage-mode (`cli/shared/storage-mode.ts`)
+Storage mode resolution: `computeDirectoryPaths(projectRoot, projectId, mode)` returns kbRoot/workRoot based on mode — local mode uses `.rp1/context` and `.rp1/work` under projectRoot; central mode redirects to `~/.rp1/projects/<projectId>/context|work`. `readStorageMode` reads `[storage].mode` from project-level then user-level TOML. `isContainerEnvironment()` forces local mode in Docker/Codespaces (with `RP1_TEST_HOME_BOUNDARY` escape hatch for test isolation).
+
+## Key Components (emit / event system)
+
+### emit database (`cli/src/agent-tools/emit/database.ts`)
+SQLite database layer (schema v19) with 10 tables: runs, events, artifacts, annotations, tasks, notifications, projects, project_registry_meta, activity_search_runs, socratic_duels + socratic_duel_participants. Provides CRUD operations, run status derivation, skipped-step detection, inactivity reaper, artifact location deduplication (`dedupeArtifactLocations` — merges duplicate file-artifact rows by keeping the doc_id with the most recent artifact_registered event), and 19 schema migrations. WAL journal mode with 5s busy timeout.
+
+### doc-id (`cli/src/agent-tools/emit/doc-id.ts`)
+Stable document identity utility: `generateDocId` (UUID), `parseFrontmatter`/`injectFrontmatter` for markdown doc_id management, `readFrontmatterDocId` (read-only identity probe — never writes before the registration transaction picks the winner), `overwriteDocIdFrontmatter` (stamps the winning identity after transaction settles).
+
+### emit index (`cli/src/agent-tools/emit/index.ts`)
+Unified event recording pipeline handling all 6 event types: flow-mismatch check → run auto-create → step validation against state machine → skipped-step detection with predecessor auto-completion → artifact registration (file or URL with `locationKind` discriminator, link doc_id derivation via SHA-256) → annotation upsert → event insert → run status derivation → daemon notification (bounded by `NOTIFY_DEADLINE_MS` = 500ms) → structured result. Also provides `executeBatchEmit` for strict-order multi-event batches and `executeEndRun` for manual run termination.
+
 ## Module Dependencies (highlights)
 
 - `cli/build/command` → `cli/build/tier-resolution` (per-agent resolution) → `cli/build/models`, `cli/build/template-context`.
-- `cli/settings/apply` → `settings/{loader,rewriter,arcade-writer,validator,presets}`, `cli/assets/reader` (embedded manifest), `cli/install/claudecode/marketplace`.
+- `cli/settings/apply` → `settings/{loader,rewriter,arcade-writer,harness-writer,validator,presets}`, `cli/assets/reader` (embedded manifest), `cli/install/claudecode/marketplace`.
 - `cli/settings/{rewriter,validator}` → `cli/build/tier-resolution` (canonical `TIER_MODEL_MAP` + helpers) and `cli/build/models` (`PROTECTED_AGENTS`, `TIER_RANK`).
 - `cli/commands/update` → `cli/settings/apply` (auto re-apply after plugin update, try/catch isolated).
 - `cli/web-ui/server` → `cli/src/settings/{loader,arcade-writer}` (cross-package import via `arcade-settings-bridge.ts` — narrow interface: `loadArcadeSettings`, `writeArcadeSection`, `resetSettingsCache`).
+- `cli/web-ui/server/project-paths` → `cli/shared/{storage-mode,project-id}` (storage-mode-aware artifact path resolution with section routing and legacy alias matching).
+- `cli/web-ui/server/annotation-service` → `cli/web-ui/server/{markdown-projection,project-paths}` → `cli/src/agent-tools/emit/database` (annotation and artifact persistence).
 - `cli/scripts/generate-asset-imports.ts` → propagates `BundleAgentEntry.tier/effort` into `EMBEDDED_MANIFEST` (`if (import.meta.main)` guarded); `cli/assets/reader.ts` `AssetEntry` widened with optional tier/effort.
 - `cli/agent-tools/emit` → `state-machine`, `web-ui/daemon` (lazy); `plugins/*` → `cli/agent-tools`; `plugins/dev` → `plugins/base` (runtime).
+- `cli/shared/directory-resolution` → `cli/shared/{storage-mode,project-id}` — consumed by emit, resolve-args, rp1-root-dir, init/directory-model, work-search/indexer, and web-ui/server/project-paths.
 - `plugins/*/skills` → `cli/agent-tools/rp1-root-dir` (runtime, via workflow-bootstrap/resolve-args): skills receive `{kbRoot}`/`{workRoot}` and pass them to agents as `KB_ROOT`/`WORK_ROOT` dispatch arguments — 30 agents declare `KB_ROOT`, 21 declare `WORK_ROOT`.
 - External: fp-ts, liquidjs, commander, yaml, bun:sqlite, chalk.
 
@@ -70,14 +92,14 @@ Pure-function artifact rewriter: CC YAML frontmatter and Codex TOML targeted lin
 | Module | Files | LOC (approx) | Components |
 |--------|-------|--------------|------------|
 | `cli/build` | 59 | ~9,562 | 6 |
-| `cli/settings` | 8 | ~2,100 | 8 |
-| `cli/migrate` | 6 | ~640 | 5 |
-| `cli/install` | 34 | ~10,981 | 4 |
-| `cli/catalog` | 3 | ~1,173 | 1 |
+| `cli/settings` | 8 | ~2,160 | 9 |
+| `cli/migrate` | 7 | ~2,917 | 6 |
+| `cli/install` | 35 | ~11,193 | 4 |
+| `cli/catalog` | 4 | ~1,173 | 1 |
 
 ## Cross-Module Patterns
 
-Skill-Agent Delegation · Tracked Workflow Bootstrap · **Variable-Based Path Interpolation** (skills resolve `{kbRoot}`/`{workRoot}` via bootstrap, agents receive `KB_ROOT`/`WORK_ROOT` arguments; no literal `.rp1/` paths in prompts — prerequisite for `[storage]` mode redirection) · State-Machine + Emit Discipline · Async-Mutex Registry · Notification Auto-Generation · Catalog Registry (body-content checksums) · Multi-Platform Build (5 targets) · **Abstract Tier Resolution** (one `TIER_MODEL_MAP` update propagates everywhere) · **Build-to-Install Tier Metadata Chain** (`BundleAgentEntry` → embedded manifest → apply) · **Settings Two-Level Merge** (project > user for `[arguments]`, `[models]`, `[arcade]`) · **Update Hook Auto-Reapply** (tier preferences survive plugin updates) · **Daemon Grace Fallback** (legacy JSON auto-migrated to TOML on daemon start) · **Migrate-Integrated Settings Migration** (`rp1 migrate` runs the same JSON→TOML arcade migration explicitly, with `.migrated` audit trail).
+Skill-Agent Delegation · Tracked Workflow Bootstrap · **Variable-Based Path Interpolation** (skills resolve `{kbRoot}`/`{workRoot}` via bootstrap, agents receive `KB_ROOT`/`WORK_ROOT` arguments; no literal `.rp1/` paths in prompts — prerequisite for `[storage]` mode redirection) · **Two-Phase Directory Resolution** (`directory-resolution.ts` handles worktree detection + walk-up discovery; delegates to `storage-mode.ts` for local/central path computation — single entry point consumed by 6 modules) · State-Machine + Emit Discipline · **Transactional Doc-Id Resolution** (read-only frontmatter probe before transaction; winner stamped after settlement; prevents concurrent registration races) · Async-Mutex Registry · Notification Auto-Generation · Catalog Registry (body-content checksums) · Multi-Platform Build (5 targets) · **Abstract Tier Resolution** (one `TIER_MODEL_MAP` update propagates everywhere) · **Build-to-Install Tier Metadata Chain** (`BundleAgentEntry` → embedded manifest → apply) · **Settings Two-Level Merge** (project > user for `[arguments]`, `[models]`, `[harnesses]`, `[storage]`, `[arcade]`) · **Comment-Preserving TOML Writers** (arcade-writer + harness-writer use targeted line edits, not full serialization) · **Update Hook Auto-Reapply** (tier preferences survive plugin updates) · **Daemon Grace Fallback** (legacy JSON auto-migrated to TOML on daemon start) · **Migrate-Integrated Settings Migration** (`rp1 migrate` runs the same JSON→TOML arcade migration explicitly, with `.migrated` audit trail) · **Markdown Projection Pipeline** (mdast-to-plaintext with per-character offset map for precise annotation source anchoring) · **Artifact Location Deduplication** (DB migration v19 merges duplicate file-artifact rows by event-recency, re-points annotations).
 
 ## Related KB
 

--- a/.rp1/context/patterns.md
+++ b/.rp1/context/patterns.md
@@ -1,7 +1,7 @@
 # Implementation Patterns
 
 **Project**: rp1
-**Last Updated**: 2026-07-08
+**Last Updated**: 2026-07-25
 
 ## Naming & Organization
 
@@ -12,8 +12,8 @@
 
 ## Type & Data Modeling
 
-- **Enum tables**: string-literal unions with parallel `VALID_*` arrays for build-time validation — `ModelTier`/`VALID_MODEL_TIERS`, `EffortLevel`/`VALID_EFFORT_LEVELS`, `SkillCategory`, `WorkflowRunPolicy`, `Status`, `EventType`.
-- Discriminated unions: `_tag` on `CLIError`, `type` on `EventPayload`.
+- **Enum tables**: string-literal unions with parallel `VALID_*` arrays for build-time validation — `ModelTier`/`VALID_MODEL_TIERS`, `EffortLevel`/`VALID_EFFORT_LEVELS`, `SkillCategory`, `WorkflowRunPolicy`, `Status`, `EventType`, `StorageMode`/`VALID_STORAGE_MODES`, `ArcadeTheme`/`VALID_ARCADE_THEMES`, `PresetName`/`VALID_PRESET_NAMES`.
+- Discriminated unions: `_tag` on `CLIError` and `AnnotationServiceError`, `type` on `EventPayload`.
 - `readonly` + `Readonly<Record<...>>` + `as const` throughout; persisted artifacts are source-of-truth snapshots.
 - **Tier abstraction**: abstract tier aliases (frontier/deep/standard/fast/inherit) decoupled from vendor model IDs via the centralized `TIER_MODEL_MAP` — single update point on vendor model releases. `PROTECTED_AGENTS` + `TIER_RANK` guard reasoning-critical agents from accidental downgrade. Compile-time safety: `Exclude<ModelTier, "inherit">` keys on `TIER_MODEL_MAP` and `TIER_RANK` force compile errors if a tier is added without mappings.
 - **Build-to-install metadata chain**: `BundleAgentEntry` extends `BundleAssetEntry` with optional `tier`/`effort`, preserved through bundle manifests → `generate-asset-imports.ts` → `EMBEDDED_MANIFEST`, so install-time remapping works from the compiled binary without source frontmatter.
@@ -24,7 +24,7 @@
 - Parent skills gate on hard failures; batch workflows tolerate partial success. L1 (syntax) then L2 (schema) validation staging.
 - **Warnings vs errors**: `validateAgentTierAndEffort` and `validateTierRemappings` return `{errors[], warnings[]}` — errors halt processing, warnings emit advisories (fast-tier effort, protected-agent downgrade, unsupported platform).
 - **Non-blocking degradation**: optional post-update steps (tier remapping re-apply, plugin cache refresh) wrap in try/catch, surface warnings, and never abort the parent lifecycle.
-- **Comment-preserving TOML writes**: `rewriter.ts` (model tier remapping) and `arcade-writer.ts` (arcade settings migration) use targeted line edits with regex-based section boundary detection to append/merge TOML sections without disturbing existing comments or formatting; full-file serialization is avoided because `smol-toml` is parse-only.
+- **Comment-preserving TOML writes**: `rewriter.ts`, `arcade-writer.ts`, and `harness-writer.ts` use targeted line edits with regex-based section boundary detection (`findSectionRange` over `ANY_TABLE_HEADER_RE`) to append/merge TOML sections without disturbing existing comments or formatting; full-file serialization is avoided because `smol-toml` is parse-only.
 
 ## Validation & Boundaries
 
@@ -39,8 +39,7 @@
 - **Install-time tier remapping (late binding)**: user `settings.toml` `[models]`/`[models.<platform>]` sections (or presets budget/standard/premium) drive `rp1 settings apply`: load → validate → discover agents from the embedded manifest → rewrite installed artifacts (CC YAML frontmatter, Codex TOML targeted line replacement) → report modified/already-current counts. `rp1 update` re-applies automatically. Idempotent: rewriter reports `modified=false` when target equals current.
 - **LiquidJS whitespace control (CRITICAL)**: production engine (`template-engine.ts`) uses `greedy:true`. Golden-file tests MUST replicate the identical config — config drift lets whitespace bugs ship undetected. Use `{%- endif %}` (no trailing dash) when a newline separator must survive. Gate optional fields on `model != "inherit"` / `effortValue` so opt-out output is byte-identical to legacy.
 - **Script entrypoint guard**: `cli/scripts/` executables wrap top-level execution in `if (import.meta.main)` so test imports of exported functions are side-effect-free.
-- **Migrate-integrated settings migration**: `migrateArcadeSettings` runs inside `executeMigrate()` (cli/src/migrate): detect legacy `settings.json` (global + project) → parse arcade fields with `VALID_ARCADE_THEMES` validation → write `[arcade]` via comment-preserving writer (idempotent, never overwrites existing keys) → rename source to `.migrated`. Dry-run detects without writing.
-- **Central-store migration pattern** (`cli/src/migrate/central-store.ts`): opt-in flag gating — all central-conversion steps are gated behind `MigrateOptions.toCentral === true`; bare `rp1 migrate` never converts or recommends. Test-isolation seams via `homeDir` (overrides `os.homedir()` for relocation target) and `globalSettingsPath` (overrides global settings path for harness resolution) — both optional parameters on `MigrateOptions` with production defaults. Comment-preserving TOML section writes for `[storage]` use the same regex-based section boundary detection pattern as `arcade-writer.ts` (find header, scan to next `[table]`, replace or append keys in place). Fenced-content management reuses `hasFencedContent`/`removeFencedContent` from `comment-fence.ts` for project stanzas and `replaceShellFencedContent` from `shell-fence.ts` for gitignore preset replacement. Cross-device-safe file relocation via `rename()` with `EXDEV` fallback to copy-then-delete. Step ordering ensures consistency: relocation before mode write (the commit point), cleanup steps after.
+- **Migrate-integrated settings migration**: `migrateArcadeSettings` runs inside `executeMigrate()`. Central-store migration (`central-store.ts`) is opt-in flag gated — `MigrateOptions.toCentral === true`; bare `rp1 migrate` never converts. Test-isolation seams via `homeDir`/`globalSettingsPath` optional parameters. Cross-device-safe file relocation via `rename()` with `EXDEV` fallback to copy-then-delete. Step ordering ensures consistency: relocation before mode write (the commit point).
 - **Catalog checksums cover body content**: `catalog/agents.yaml` checksums hash agent body text, not just frontmatter — every prompt edit (even body-only) requires `just catalog-generate` with the regenerated catalog in the same commit.
 - **fp-ts pipeline**: `pipe(loadConfig, TE.fromEither, TE.chain(...))`; prefer clear `map`/`flatMap`/`isLeft` over abstractions.
 
@@ -52,7 +51,7 @@
 
 - Tests under `cli/src/__tests__/` mirror feature areas with shared helpers (temp dirs, env save/restore, Either/TaskEither unwrap).
 - **Golden-file tests** validate rendered template output; the test Liquid engine config MUST match production (`greedy:true`) or whitespace bugs ship undetected.
-- **Hermetic settings tests**: any code path reading `~/.config/rp1/settings.toml` accepts an optional `globalSettingsPath` injection seam (`loadAllArgumentDefaults`, `loadTierRemappings`, `resolveConfig`); tests point it at an isolated nonexistent path so real developer config never leaks into assertions. Contract tests guard shape parity between `BundleAgentEntry` and the embedded manifest generator.
+- **Hermetic settings tests**: any code path reading `~/.config/rp1/settings.toml` accepts an optional `globalSettingsPath` injection seam (`loadAllArgumentDefaults`, `loadTierRemappings`, `resolveConfig`, `loadArcadeSettings`, `loadStorageMode`, `loadEnabledHarnesses`, `writeHarnessSelection`); tests point it at an isolated nonexistent path so real developer config never leaks into assertions. Contract tests guard shape parity between `BundleAgentEntry` and the embedded manifest generator.
 - Evals share assertions under `evals/suites/shared/`.
 
 ## I/O & Integration
@@ -60,7 +59,8 @@
 - SQLite via `bun:sqlite` (runs, events, artifacts, annotations, notifications); upsert + source dedup.
 - Atomic writes via temp-file + rename (registry); PID file mode `0o600`.
 - `rp1 agent-tools emit` persists canonical events; daemon relays project-scoped WS envelopes. File artifacts keep `path`+`storageRoot`; URL artifacts register as `type: link` with deterministic identity (only curated run-output links).
-- **Directory-scoped I/O**: code edits resolve against `codeRoot` (worktree-aware); work/KB reads use `workRoot`/`kbRoot` via `rp1-root-dir`, which respects the active storage mode — these paths may resolve outside the project tree when a non-default mode is configured.
+- **Directory-scoped I/O**: code edits resolve against `codeRoot` (worktree-aware); work/KB reads use `workRoot`/`kbRoot` via `rp1-root-dir`, which respects the active storage mode — these paths may resolve outside the project tree when central mode is configured. `isContainerEnvironment()` forces local mode in Docker/Codespaces (cached after first check, with `resetContainerDetectionCache()` for test isolation).
+- **Annotation persistence**: `annotation-service.ts` stores annotations in SQLite keyed by `doc_id` (FK to artifacts). `markdown-projection.ts` maps rendered-DOM text selections back to source-file offsets via an mdast-walk offset map, enabling anchored annotations on markdown artifacts.
 
 ## Concurrency & Async
 
@@ -71,11 +71,17 @@
 ## Dependency Injection & Configuration
 
 - **Optional-parameter seams**: `ApplyDeps` interface injects `readFile`/`writeFile`/`fileExists`/`refreshClaudeCodePlugins`/`getBundledAssets` with `DEFAULT_DEPS` production binding (imports `getBundledAssetsReal` explicitly to avoid a circular dependency); `globalSettingsPath` threads through loader/apply/migrate for isolation; `globalConfigDir` on `migrateArcadeSettings` isolates migration tests.
-- **TOML settings, two-level merge**: project `.rp1/settings.toml` > user `~/.config/rp1/settings.toml`, per key for `[arguments.*]`, `[models.*]`, and `[arcade]` sections; loader normalizes lower-kebab → UPPER_SNAKE for arguments. `[arcade]` section supports `theme` ("light"/"dark"/"system", default "system") and `[arcade.downsampling]` sub-table (`thresholdHours`, default 24); `loadArcadeSettings()` merges project over user with per-key granularity and returns typed `ArcadeSettings`. Blessed presets (`presets.ts`) provide complete tier-to-model profiles that explicit overrides supersede.
+- **TOML settings, two-level merge**: project `.rp1/settings.toml` > user `~/.config/rp1/settings.toml`, per key for `[arguments.*]`, `[models.*]`, `[arcade]`, and `[storage]` sections; loader normalizes lower-kebab → UPPER_SNAKE for arguments. `[arcade]` section supports `theme` ("light"/"dark"/"system", default "system") and `[arcade.downsampling]` sub-table (`thresholdHours`, default 24); `loadArcadeSettings()` merges project over user with per-key granularity and returns typed `ArcadeSettings`. `[harnesses]` is user-level only (per-machine, not per-project); `loadEnabledHarnesses()` reads only from global settings and returns `undefined` when absent (callers fall back to all-detected-stable). Blessed presets (`presets.ts`) provide complete tier-to-model profiles (budget/standard/premium) that explicit overrides supersede.
+- **Argument resolution (5-layer merge)**: `resolveArgs` merges arguments in precedence order: user input → project settings → user settings → ENV var (`source.env`) → schema default. Positional parsing uses greedy capture when exactly one required non-variadic string arg exists with no variadic peer; otherwise the required scalar takes a single token and the variadic captures the rest. Implies chains resolve via fixed-point iteration. `kbInitialized` flag (checks `index.md` presence, not bare directory) surfaces `kbNextStepHint` when the KB is empty.
 
 ## Extension Mechanisms
 
 - Commands via `program.addCommand` in `main.ts`; agent tools via `registerTool()`; build templates per-platform under `templates/<platform>/` with registered lint rules + filters; state machines via `stateDiagram-v2` with auto-skip/auto-complete.
+
+## Agent & Workflow Patterns
+
+- **Parent-owned interview**: only the top-level skill asks user-facing questions; leaf agents are bounded non-interactive workers. At most 10 parent questions per artifact phase. Loop: read artifact → scan declared required sections for gaps → ask one focused question → reconstruct and write full artifact → re-read and verify → repeat or exit. Resume always starts from the artifact read, not from workflow events or checkpoint files.
+- **Artifact template indirection**: 20 producer agents read canonical templates from `rp1-base:artifact-templates` via a two-hop discovery flow (index table → template file with routing metadata) rather than embedding output formats inline. Four instruction variants (A: single-doc, B: multi-doc, C: section-append, D: format-reference) match the agent's output type.
 
 ## Related KB
 

--- a/catalog/agents.yaml
+++ b/catalog/agents.yaml
@@ -18,7 +18,7 @@ agents:
   - name: rp1-base:kb-feature-extractor
     description: "Extracts project capabilities and feature inventory for features.md from pre-filtered anchor-class files"
     plugin: base
-    last_checksum: d78ed5a00c4f1cc064af692a6a589a6fa4bc93d2fcf733d096520095ec8006e5
+    last_checksum: 605a01ab8fdf247b56e53b1461b28497c676711cffb1072f7c854d90350117f8
   - name: rp1-base:kb-index-builder
     description: "[DEPRECATED] Generates project overview data for index.md from pre-filtered files"
     plugin: base

--- a/catalog/agents.yaml
+++ b/catalog/agents.yaml
@@ -18,7 +18,7 @@ agents:
   - name: rp1-base:kb-feature-extractor
     description: "Extracts project capabilities and feature inventory for features.md from pre-filtered anchor-class files"
     plugin: base
-    last_checksum: e439f2a09b21c6b747e7641d5fbb863a2094586eb9271bd594fb3770a50618d5
+    last_checksum: 63ebbb39c380813c29185ac3312f64d8624707bcb814c37b3e2696a2679ff8c6
   - name: rp1-base:kb-index-builder
     description: "[DEPRECATED] Generates project overview data for index.md from pre-filtered files"
     plugin: base
@@ -38,7 +38,7 @@ agents:
   - name: rp1-base:kb-spatial-analyzer
     description: "Scans repository files, ranks by importance (0-5), and categorizes them by KB section for parallel analysis"
     plugin: base
-    last_checksum: 53bf61f724b8d2b97a483e8267a8f185a38f5573004e67511506da6773d42d81
+    last_checksum: 7f923e22e795f7e5cbf22a4fd4e706ea68b34e36262191447eb764e546d237b1
   - name: rp1-base:mermaid-fixer
     description: "Validates and repairs mermaid diagrams in markdown files. Scans for mermaid blocks, validates each diagram, attempts automatic repair (up to 3 iterations), and inserts placeholders for unfixable diagrams."
     plugin: base

--- a/catalog/agents.yaml
+++ b/catalog/agents.yaml
@@ -18,7 +18,7 @@ agents:
   - name: rp1-base:kb-feature-extractor
     description: "Extracts project capabilities and feature inventory for features.md from pre-filtered anchor-class files"
     plugin: base
-    last_checksum: 63ebbb39c380813c29185ac3312f64d8624707bcb814c37b3e2696a2679ff8c6
+    last_checksum: 81a4a2f225ad1c13288377574f87fd38a3216ae4946fee04103d17a907d63ab0
   - name: rp1-base:kb-index-builder
     description: "[DEPRECATED] Generates project overview data for index.md from pre-filtered files"
     plugin: base

--- a/catalog/agents.yaml
+++ b/catalog/agents.yaml
@@ -18,7 +18,7 @@ agents:
   - name: rp1-base:kb-feature-extractor
     description: "Extracts project capabilities and feature inventory for features.md from pre-filtered anchor-class files"
     plugin: base
-    last_checksum: 605a01ab8fdf247b56e53b1461b28497c676711cffb1072f7c854d90350117f8
+    last_checksum: e439f2a09b21c6b747e7641d5fbb863a2094586eb9271bd594fb3770a50618d5
   - name: rp1-base:kb-index-builder
     description: "[DEPRECATED] Generates project overview data for index.md from pre-filtered files"
     plugin: base

--- a/catalog/agents.yaml
+++ b/catalog/agents.yaml
@@ -15,6 +15,10 @@ agents:
     description: "Extracts domain concepts and terminology for concept_map.md from pre-filtered files"
     plugin: base
     last_checksum: 86dd178b5ca9dcb3f006a2790d52a20e7194a78531de2de3b35d6b326ec14c96
+  - name: rp1-base:kb-feature-extractor
+    description: "Extracts project capabilities and feature inventory for features.md from pre-filtered anchor-class files"
+    plugin: base
+    last_checksum: d78ed5a00c4f1cc064af692a6a589a6fa4bc93d2fcf733d096520095ec8006e5
   - name: rp1-base:kb-index-builder
     description: "[DEPRECATED] Generates project overview data for index.md from pre-filtered files"
     plugin: base
@@ -34,7 +38,7 @@ agents:
   - name: rp1-base:kb-spatial-analyzer
     description: "Scans repository files, ranks by importance (0-5), and categorizes them by KB section for parallel analysis"
     plugin: base
-    last_checksum: ef1e6d7f770f4d441277a26f189c1993c6a58d459708a235d239a6529d362682
+    last_checksum: 53bf61f724b8d2b97a483e8267a8f185a38f5573004e67511506da6773d42d81
   - name: rp1-base:mermaid-fixer
     description: "Validates and repairs mermaid diagrams in markdown files. Scans for mermaid blocks, validates each diagram, attempts automatic repair (up to 3 iterations), and inserts placeholders for unfixable diagrams."
     plugin: base

--- a/plugins/base/agents/kb-feature-extractor.md
+++ b/plugins/base/agents/kb-feature-extractor.md
@@ -1,0 +1,303 @@
+---
+name: kb-feature-extractor
+description: Extracts project capabilities and feature inventory for features.md from pre-filtered anchor-class files
+tools: Read, Grep, Glob
+model: standard
+effort: medium
+arguments:
+  - name: CODEBASE_ROOT
+    type: string
+    required: false
+    default: "."
+    description: "Repository root"
+  - name: FEATURE_FILES_JSON
+    type: string
+    required: true
+    description: "JSON array of {path, score} for feature inventory analysis"
+  - name: REPO_TYPE
+    type: string
+    required: false
+    default: "single-project"
+    description: "Type of repository"
+  - name: MODE
+    type: enum
+    required: false
+    default: "FULL"
+    description: "Analysis mode"
+    enum_values:
+      - "FULL"
+      - "INCREMENTAL"
+      - "FEATURE_LEARNING"
+  - name: FILE_DIFFS
+    type: string
+    required: false
+    default: ""
+    description: "Diff information for incremental updates"
+  - name: FEATURE_CONTEXT
+    type: string
+    required: false
+    default: ""
+    description: "Feature context JSON for FEATURE_LEARNING mode"
+  - name: KB_ROOT
+    type: string
+    required: true
+    description: "Knowledge base root directory"
+---
+
+# KB Feature Extractor - Capability Inventory
+
+You are FeatureExtractor-GPT, a specialized agent that builds a deterministic capability inventory from mechanically enumerable registration points in codebases. You receive pre-filtered anchor-class files and produce a two-level surface-to-capability tree with stable IDs, evidence tiers, and audience tags.
+
+**CRITICAL**: You do NOT scan files. You receive a curated list of capability-registration files and focus on enumerating concrete features from anchor-class registration points. Use ultrathink or extend thinking time as needed to ensure deep analysis.
+
+<codebase_root>
+$1
+</codebase_root>
+
+<feature_files_json>
+$2
+</feature_files_json>
+
+<repo_type>
+$3
+</repo_type>
+
+<mode>
+$4
+</mode>
+
+<file_diffs>
+$5
+</file_diffs>
+
+<feature_context>
+$6
+</feature_context>
+
+## 1. Load Existing KB Context (If Available)
+
+**Check for existing features.md**:
+- Check if `{KB_ROOT}/features.md` exists
+- If exists, read and parse:
+  - Surface headings and their capabilities
+  - Stable node IDs from HTML-comment metadata trailers
+  - Tier assignments, audience tags, evidence paths
+- Use as baseline for Bayesian reconciliation
+
+**Benefits**:
+- Preserve stable IDs across regenerations
+- Maintain curated capability descriptions
+- Prevent unnecessary churn in well-established nodes
+
+## §BAYES
+
+Existing `features.md` = prior. New files/diffs/feature notes = evidence. Output = posterior.
+Bayesian update includes revising old hypotheses and creating new ones when evidence does not fit the old map.
+
+- Revise; do not rewrite.
+- Keep prior claims that still fit the evidence.
+- Tighten when evidence sharpens.
+- Rewrite/remove only on contradiction.
+- Add only with strong evidence.
+- Silence in changed files != deletion signal.
+- Local evidence -> local edits. Broad rewrites need broad evidence.
+
+Anti-bias:
+- Read the prior first, but treat it as hypotheses, not truth.
+- For each major claim: `confirmed | refined | contradicted | untested`.
+- Seek disconfirming evidence before preserving a major claim.
+- Preserve `untested` claims unless evidence disproves them.
+
+MUST NOT:
+- keep a claim only because it already exists
+- delete a claim only because new evidence is silent
+- replace a specific prior claim with weaker generic wording
+
+Preserve knowledge mass. Correct it; do not reset it.
+
+## §DISCOVERY
+
+The prior is incomplete.
+
+- Do not limit exploration to capabilities already named in the prior.
+- Actively search for new commands, routes, surfaces, skills, exports, and documentation references.
+- Treat the prior as a starting map, not a closed set.
+- If evidence points to a material capability the prior does not model: investigate it, then add it if supported.
+- Missing prior coverage != unimportant.
+- After reconciling existing claims, perform one explicit novelty scan for material capabilities absent from the prior.
+
+## 2. Parse Input Files
+
+Extract file list from FEATURE_FILES_JSON:
+- Parse JSON array
+- Extract paths for files with score >= 3
+- Limit to top 150 files by score for efficiency
+
+**Check MODE**:
+- **FULL mode**: Analyze all assigned files completely. If `FILE_DIFFS` is non-empty, start from that changed-file frontier, then widen.
+- **INCREMENTAL mode**: Use `FILE_DIFFS` to focus on changed capability registrations. Widen only locally when needed.
+- **FEATURE_LEARNING mode**: Focus on capabilities introduced or modified by the completed feature. Use FEATURE_CONTEXT to understand what was built and which registration points were added or changed.
+
+**FEATURE_LEARNING mode specific**:
+- Parse FEATURE_CONTEXT JSON to extract:
+  - New commands, routes, or skills added
+  - Capabilities modified or renamed
+  - Registration points introduced
+- Focus on files listed in `feature_context.files_modified`
+- Identify new capabilities and update existing ones
+- Merge with existing features.md structure
+
+**CRITICAL - Context Size Discipline**:
+- Only add capabilities that are **distinct, registered features** (not internal helper functions)
+- Prefer updating existing capability descriptions over adding new entries
+- One-line descriptions per capability; multi-sentence only for top-level surfaces
+- If a capability already exists, update tier/evidence minimally
+- Ask: "Is this a user-invocable or agent-invocable registration point?" If no, omit
+
+## 3. Anchor-Class Detection
+
+Classify each input file into anchor classes based on path patterns and content. A file may belong to multiple classes.
+
+| Anchor Class | Detection Heuristics |
+|---|---|
+| CLI command registrations | Files in `commands/`, `cmd/`, `cli/` with command-builder patterns (Commander `.command()`, yargs `.command()`, clap `#[command]`, cobra `&cobra.Command`, argparse `add_parser`) |
+| Web/API route definitions | Files in `routes/`, `handlers/`, `controllers/`, `pages/`, `api/`; OpenAPI/Swagger specs; gRPC `.proto` service defs; Express `router.get/post`, FastAPI `@app.get`, Rails `resources :` |
+| UI entry surfaces | Files in `pages/`, `screens/`, `views/`; SPA route configs (React Router `<Route>`, Next.js `page.tsx`); navigation menu definitions |
+| Extension/plugin manifests | `SKILL.md` files, `plugin.json`, `*.plugin.*`, `manifest.yaml`, hook/extension registration files, package.json `contributes` or `exports` |
+| Public API surface | Index/barrel files (`index.ts`, `__init__.py`, `mod.rs`); explicitly exported functions/classes; `@public` or `@api` markers |
+| Docs-tree cross-references | Files in `docs/`, `documentation/`; README files referencing capabilities; user-facing reference pages |
+
+**Track unanalyzed classes**: If the input file set contains no files matching a particular anchor class, record that class as "not detected" for the unanalyzed report.
+
+## 4. Surface Derivation
+
+Group detected anchor classes into surface categories:
+- Each anchor class with at least one detected file becomes a candidate surface
+- Merge related anchor classes into named surfaces (e.g., CLI commands + CLI docs = "CLI" surface)
+- Omit surfaces with no detected files entirely
+- Order surfaces by capability count descending
+
+**Surface naming**: Derive surface names from the detected anchor classes, not from a hardcoded list. Use descriptive names reflecting the project's actual capability groupings.
+
+## 5. Capability Enumeration
+
+Within each surface, enumerate individual capabilities from registration points:
+- One capability per CLI command, route endpoint, skill definition, exported API, or documented feature
+- Create sub-features only when a capability has distinct sub-commands, sub-routes, or documented sub-operations
+- Cap at 30 capabilities per surface; use representative sampling if the surface has more
+
+**Naming**: Derive capability names from the registration point (command name, route path, skill name, export name). Normalize to human-readable form.
+
+## 6. Stable ID Generation
+
+Generate node IDs deterministically:
+- Format: `{surface}.{capability}[.{sub-feature}]`
+- Normalize all segments to lowercase kebab-case
+- Derive from source registration names, not LLM-chosen labels
+- Examples: `cli.build`, `web-ui.artifact-browser`, `plugin-skills.knowledge-build`
+
+**ID stability rules**:
+- If the prior features.md contains a node with matching registration point, reuse its ID
+- If a capability is renamed in source, retire the old ID and create a new one
+- Never silently reuse an old ID for a different capability
+
+## 7. Evidence-Tier Scoring
+
+Score each node using static signals only. No LLM judgment or usage claims.
+
+For each capability, check:
+1. **Docs reference**: Search `docs/`, documentation directories, and README files for mentions of the capability name or path
+2. **Test coverage**: Search test directories (`__tests__/`, `test/`, `tests/`, `spec/`, `*_test.*`, `*.test.*`, `*.spec.*`) for test files covering the capability
+3. **External references**: Other source files that import, reference, or invoke the capability
+
+Scoring:
+- **T1**: Docs reference present AND test coverage present
+- **T2**: Docs reference present OR test coverage present (not both)
+- **T3**: External references present but no docs and no tests
+- **T4**: No docs, no tests, no external references -- label as "investigation candidate" (NEVER "prune candidate")
+
+## 8. Audience Tagging
+
+Tag each node using generic heuristics applicable to any target project:
+
+- **user**: Capability appears in the project's user-facing documentation tree (docs/, README, user guides)
+- **agent**: Capability belongs to a detected agent-facing tool surface (only when the project has such a surface -- e.g., `agent-tools/` directory, MCP server tools, API tools for agents). If no agent-facing surface is detected in the project, NEVER apply the `agent` tag
+- **internal**: Capability has hidden flags (`hidden: true`), `@internal`/`@hidden` JSDoc markers, test-harness-only registration, or naming conventions indicating internal use (leading underscore, `_internal` suffix)
+
+**Precedence**: When a capability matches multiple heuristics, the most visible tag wins: `user > agent > internal`.
+
+## 9. Emit Steps
+
+Namespaced workflow steps for orchestrator tracking:
+- `kb-feature-extractor:extracting` -- emitted when analysis begins
+- `kb-feature-extractor:completed` -- emitted on successful JSON output
+- `kb-feature-extractor:failed` -- emitted on fatal error before stopping
+
+These step names are namespaced to avoid collision with parent knowledge-build state machine states.
+
+## 10. Template Loading
+
+Load the features.md artifact template via two-hop discovery:
+
+1. Read `plugins/base/skills/artifact-templates/SKILL.md` -- find the features.md entry in the Template Index
+2. Read the template file at the path listed in the index for the matching REPO_TYPE variant
+
+Use the template structure to format your JSON output fields consistently. The orchestrator renders the final markdown from your JSON.
+
+## 11. JSON Output Contract
+
+```json
+{
+  "section": "features",
+  "data": {
+    "surfaces": [
+      {
+        "name": "Surface Name",
+        "anchor_class": "anchor_class_id",
+        "capabilities": [
+          {
+            "name": "capability-name",
+            "id": "surface.capability-name",
+            "description": "One-line description of what this capability does",
+            "tier": "T1",
+            "audience": "user",
+            "evidence": {
+              "docs": ["docs/reference/file.md"],
+              "tests": ["src/__tests__/capability.test.ts"],
+              "refs": ["src/commands/capability.ts"]
+            },
+            "sub_features": [
+              {
+                "name": "sub-feature-name",
+                "id": "surface.capability-name.sub-feature-name",
+                "description": "One-line description",
+                "tier": "T2",
+                "audience": "user",
+                "evidence": {
+                  "docs": [],
+                  "tests": ["src/__tests__/sub.test.ts"],
+                  "refs": ["src/commands/sub.ts"]
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "unanalyzed_classes": ["List of anchor classes not detected in this project"]
+  },
+  "processing": {
+    "files_analyzed": 0,
+    "surfaces_detected": 0,
+    "nodes_total": 0,
+    "tier_distribution": {"T1": 0, "T2": 0, "T3": 0, "T4": 0}
+  }
+}
+```
+
+{% include_shared "anti-loop.md" %}
+
+**Target Completion**: 10-12 minutes
+
+{% include_shared "output-discipline.md" %}
+- Parent orchestrator handles user communication

--- a/plugins/base/agents/kb-feature-extractor.md
+++ b/plugins/base/agents/kb-feature-extractor.md
@@ -194,7 +194,7 @@ Generate node IDs deterministically:
 - Format: `{surface}.{capability}[.{sub-feature}]`
 - Normalize all segments to lowercase kebab-case
 - Derive from source registration names, not LLM-chosen labels
-- Examples: `cli.build`, `web-ui.artifact-browser`, `plugin-skills.knowledge-build`
+- Examples: `cli.serve`, `web-ui.dashboard`, `plugins.auth-provider`
 
 **ID stability rules**:
 - If the prior features.md contains a node with matching registration point, reuse its ID

--- a/plugins/base/agents/kb-feature-extractor.md
+++ b/plugins/base/agents/kb-feature-extractor.md
@@ -224,6 +224,8 @@ Tag each node using generic heuristics applicable to any target project:
 - **agent**: Capability belongs to a detected agent-facing tool surface (only when the project has such a surface -- e.g., `agent-tools/` directory, MCP server tools, API tools for agents). If no agent-facing surface is detected in the project, NEVER apply the `agent` tag
 - **internal**: Capability has hidden flags (`hidden: true`), `@internal`/`@hidden` JSDoc markers, test-harness-only registration, or naming conventions indicating internal use (leading underscore, `_internal` suffix)
 
+The audience vocabulary is CLOSED: every node's `audience` value MUST be exactly one of `user`, `agent`, or `internal`. Never emit any other label (e.g., `developer`, `contributor`, `maintainer`) -- when a project's end users are developers, they are still `user`.
+
 **Precedence**: When a capability matches multiple heuristics, the most visible tag wins: `user > agent > internal`.
 
 ## 9. Emit Steps

--- a/plugins/base/agents/kb-feature-extractor.md
+++ b/plugins/base/agents/kb-feature-extractor.md
@@ -48,7 +48,7 @@ arguments:
 
 You are FeatureExtractor-GPT, a specialized agent that builds a deterministic capability inventory from mechanically enumerable registration points in codebases. You receive pre-filtered anchor-class files and produce a two-level surface-to-capability tree with stable IDs, evidence tiers, and audience tags.
 
-**CRITICAL**: You do NOT scan files. You receive a curated list of capability-registration files and focus on enumerating concrete features from anchor-class registration points. Use ultrathink or extend thinking time as needed to ensure deep analysis.
+**CRITICAL**: You do NOT scan the repository to discover input files -- your input scope is the curated FEATURE_FILES_JSON list of capability-registration files. Targeted Grep/Glob lookups required by later sections (evidence-tier scoring in section 7, the single §DISCOVERY novelty scan) are permitted and expected; unbounded repository crawling is not. Use ultrathink or extend thinking time as needed to ensure deep analysis.
 
 <codebase_root>
 $1
@@ -184,7 +184,7 @@ Group detected anchor classes into surface categories:
 Within each surface, enumerate individual capabilities from registration points:
 - One capability per CLI command, route endpoint, skill definition, exported API, or documented feature
 - Create sub-features only when a capability has distinct sub-commands, sub-routes, or documented sub-operations
-- Cap at 30 capabilities per surface; use representative sampling if the surface has more
+- Cap at 30 capabilities per surface. If a surface exceeds the cap, select deterministically: higher evidence tier first (T1 > T2 > T3 > T4), then alphabetical by registration name. Report the surface's full pre-cap count in `total_capabilities` so omissions stay visible
 
 **Naming**: Derive capability names from the registration point (command name, route path, skill name, export name). Normalize to human-readable form.
 
@@ -200,6 +200,7 @@ Generate node IDs deterministically:
 - If the prior features.md contains a node with matching registration point, reuse its ID
 - If a capability is renamed in source, retire the old ID and create a new one
 - Never silently reuse an old ID for a different capability
+- If two distinct capabilities in the same surface normalize to the same ID, keep the first unsuffixed and append `-2`, `-3`, ... to the rest, ordered lexicographically by first evidence file path
 
 ## 7. Evidence-Tier Scoring
 
@@ -227,6 +228,8 @@ Tag each node using generic heuristics applicable to any target project:
 The audience vocabulary is CLOSED: every node's `audience` value MUST be exactly one of `user`, `agent`, or `internal`. Never emit any other label (e.g., `developer`, `contributor`, `maintainer`) -- when a project's end users are developers, they are still `user`.
 
 **Precedence**: When a capability matches multiple heuristics, the most visible tag wins: `user > agent > internal`.
+
+**Fallback**: When a capability matches none of the three heuristics (an ordinary undocumented public capability), tag it `user` -- a publicly registered capability is assumed user-facing until evidence indicates otherwise. Every node carries exactly one audience tag.
 
 ## 9. Emit Steps
 
@@ -256,6 +259,7 @@ Use the template structure to format your JSON output fields consistently. The o
       {
         "name": "Surface Name",
         "anchor_class": "anchor_class_id",
+        "total_capabilities": 0,
         "capabilities": [
           {
             "name": "capability-name",

--- a/plugins/base/agents/kb-feature-extractor.md
+++ b/plugins/base/agents/kb-feature-extractor.md
@@ -131,7 +131,8 @@ The prior is incomplete.
 Extract file list from FEATURE_FILES_JSON:
 - Parse JSON array
 - Extract paths for files with score >= 3
-- Limit to top 150 files by score for efficiency
+- Sort by score descending, then path ascending; take the first 150
+- Record the pre-cap count in the processing block's `files_received` so any capping stays visible
 
 **Check MODE**:
 - **FULL mode**: Analyze all assigned files completely. If `FILE_DIFFS` is non-empty, start from that changed-file frontier, then widen.
@@ -200,7 +201,7 @@ Generate node IDs deterministically:
 - If the prior features.md contains a node with matching registration point, reuse its ID
 - If a capability is renamed in source, retire the old ID and create a new one
 - Never silently reuse an old ID for a different capability
-- If two distinct capabilities in the same surface normalize to the same ID, keep the first unsuffixed and append `-2`, `-3`, ... to the rest, ordered lexicographically by first evidence file path
+- Same-surface ID collisions: first reserve every ID reused from the prior (a new collider never displaces a prior ID); then order the remaining new colliders by the total key (first evidence file path, then registration name, both lexicographic ascending) and assign each the next free suffix (`-2`, `-3`, ...)
 
 ## 7. Evidence-Tier Scoring
 
@@ -293,6 +294,7 @@ Use the template structure to format your JSON output fields consistently. The o
     "unanalyzed_classes": ["List of anchor classes not detected in this project"]
   },
   "processing": {
+    "files_received": 0,
     "files_analyzed": 0,
     "surfaces_detected": 0,
     "nodes_total": 0,

--- a/plugins/base/agents/kb-spatial-analyzer.md
+++ b/plugins/base/agents/kb-spatial-analyzer.md
@@ -287,6 +287,7 @@ Categorize each file into one or more KB sections:
 - A file can appear in multiple categories if relevant (e.g., `models/user.py` in both concept_files and module_files)
 - Prioritize categories by relevance: Entry point → index_files, Domain model → concept_files + module_files
 - Include score with each file for downstream filtering
+- Files categorized into feature_files receive a minimum importance score of 3 -- they were mechanically identified as capability-anchor registration points and must survive downstream score filtering
 - When CHANGED_FILES is provided, relevant changed files are mandatory inclusions in their categories
 
 ## 5. Metadata Extraction

--- a/plugins/base/agents/kb-spatial-analyzer.md
+++ b/plugins/base/agents/kb-spatial-analyzer.md
@@ -275,6 +275,14 @@ Categorize each file into one or more KB sections:
 - Components: UI components, reusable modules
 - Tests: `tests/`, `__tests__/`, `*.test.*`
 
+**feature_files** (for features.md - capability inventory):
+- CLI command registrations: files in `commands/`, `cmd/`, `cli/` directories containing command-builder patterns (Commander, yargs, oclif, clap, cobra, argparse)
+- Web/API route definitions: files in `routes/`, `handlers/`, `controllers/`, `pages/`, `api/` directories; OpenAPI specs (`openapi.yaml`, `swagger.*`); gRPC service definitions (`*.proto`)
+- UI entry surfaces: files in `pages/`, `screens/`, `views/` directories; SPA route configuration files
+- Extension/plugin manifests: `SKILL.md`, `plugin.json`, `*.plugin.*`, hook registration files, extension manifests
+- Public API surface: index/barrel files exporting public interfaces (`index.ts`, `mod.rs`, `__init__.py` at module boundaries)
+- Documentation tree: files in `docs/` that reference project capabilities
+
 **Categorization Rules**:
 - A file can appear in multiple categories if relevant (e.g., `models/user.py` in both concept_files and module_files)
 - Prioritize categories by relevance: Entry point → index_files, Domain model → concept_files + module_files
@@ -309,6 +317,7 @@ Return structured JSON with these fields:
   "arch_files": [{"path": <path>, "score": <0-5>}, ...],
   "interaction_files": [{"path": <path>, "score": <0-5>}, ...],
   "module_files": [{"path": <path>, "score": <0-5>}, ...],
+  "feature_files": [{"path": <path>, "score": <0-5>}, ...],
   "local_meta": {
     "repo_root": "/absolute/path",
     "current_project_path": "project/ | ."

--- a/plugins/base/skills/artifact-templates/SKILL.md
+++ b/plugins/base/skills/artifact-templates/SKILL.md
@@ -99,8 +99,8 @@ Each template file contains YAML frontmatter with these fields:
 
 Templates under `templates/knowledge-base/` are organized by project type:
 
-- **`single-project/`**: Standard single-project KB documentation (index, concept_map, architecture, interaction-model, modules, patterns)
-- **`monorepo/`**: Multi-project KB documentation (adds dependencies, technology-matrix)
+- **`single-project/`**: Standard single-project KB documentation (index, concept_map, architecture, interaction-model, modules, patterns, features)
+- **`monorepo/`**: Multi-project KB documentation (adds dependencies, technology-matrix, features)
 - **`state.json`**: KB metadata tracking template
 - **`meta.json`**: Local-only values template (not committed)
 
@@ -135,9 +135,7 @@ templates/
 |   +-- meta.json
 |   +-- state.json
 |   +-- monorepo/
-|   |   +-- features.md
 |   +-- single-project/
-|   |   +-- features.md
 +-- note/
 |   +-- note.md
 +-- phase-planner/

--- a/plugins/base/skills/artifact-templates/SKILL.md
+++ b/plugins/base/skills/artifact-templates/SKILL.md
@@ -62,6 +62,7 @@ Active `/build` artifacts are producer-owned: the agent that writes the artifact
 | knowledge-base | interaction-model.md | document | kbRoot | interaction-model.md | templates/knowledge-base/single-project/interaction-model.md |
 | knowledge-base | modules.md | document | kbRoot | modules.md | templates/knowledge-base/single-project/modules.md |
 | knowledge-base | patterns.md | document | kbRoot | patterns.md | templates/knowledge-base/single-project/patterns.md |
+| knowledge-base | features.md | document | kbRoot | features.md | templates/knowledge-base/single-project/features.md |
 | knowledge-base | index.md (monorepo) | document | kbRoot | index.md | templates/knowledge-base/monorepo/index.md |
 | knowledge-base | concept_map.md (monorepo) | document | kbRoot | concept_map.md | templates/knowledge-base/monorepo/concept_map.md |
 | knowledge-base | architecture.md (monorepo) | document | kbRoot | architecture.md | templates/knowledge-base/monorepo/architecture.md |
@@ -70,6 +71,7 @@ Active `/build` artifacts are producer-owned: the agent that writes the artifact
 | knowledge-base | patterns.md (monorepo) | document | kbRoot | patterns.md | templates/knowledge-base/monorepo/patterns.md |
 | knowledge-base | dependencies.md (monorepo) | document | kbRoot | dependencies.md | templates/knowledge-base/monorepo/dependencies.md |
 | knowledge-base | technology-matrix.md (monorepo) | document | kbRoot | technology-matrix.md | templates/knowledge-base/monorepo/technology-matrix.md |
+| knowledge-base | features.md (monorepo) | document | kbRoot | features.md | templates/knowledge-base/monorepo/features.md |
 | knowledge-base | state.json | data | kbRoot | state.json | templates/knowledge-base/state.json |
 | knowledge-base | meta.json | data | kbRoot | meta.json | templates/knowledge-base/meta.json |
 | note | note.md | document | workRoot | notes/{yyyy-mm-dd}-{title-slug}.md | templates/note/note.md |
@@ -133,7 +135,9 @@ templates/
 |   +-- meta.json
 |   +-- state.json
 |   +-- monorepo/
+|   |   +-- features.md
 |   +-- single-project/
+|   |   +-- features.md
 +-- note/
 |   +-- note.md
 +-- phase-planner/

--- a/plugins/base/skills/artifact-templates/templates/knowledge-base/monorepo/features.md
+++ b/plugins/base/skills/artifact-templates/templates/knowledge-base/monorepo/features.md
@@ -1,0 +1,49 @@
+---
+scope: kbRoot
+path_pattern: "features.md"
+producer: knowledge-base
+type: document
+description: "Capability inventory with two-level surface-to-feature tree, evidence-tier badges, audience tags, and stable node IDs for a monorepo codebase."
+emit_hint: |
+  rp1 agent-tools emit \
+    --workflow knowledge-build \
+    --type artifact_registered \
+    --step kb-feature-extractor:completed \
+    --data '{"path": ".rp1/context/features.md", "storageRoot": "project"}'
+strictness: strict
+---
+# Repository Capabilities
+
+**Repository**: [Repository Name]
+**Last Updated**: [Date]
+**Surfaces**: [N detected]
+**Scope**: Capabilities inventoried across all projects in this repository.
+
+## [Surface Name]
+
+- **[Capability Name]** `T{N}` -- [One-line description]
+  <!-- id: {surface}.{capability} | tier: T{N} | audience: {tag} | evidence: {comma-separated paths} -->
+  - [Sub-feature Name] `T{N}` -- [One-line description]
+    <!-- id: {surface}.{capability}.{sub-feature} | tier: T{N} | audience: {tag} | evidence: {comma-separated paths} -->
+
+## Surfaces Not Analyzed
+
+[List of anchor classes that could not be mechanically detected in this repository, or "None" if all anchor classes were detected.]
+
+## Coverage Summary
+
+| Tier | Count | Meaning |
+|------|-------|---------|
+| T1 | [N] | Documented and tested |
+| T2 | [N] | Documented or tested |
+| T3 | [N] | Referenced but undocumented/untested |
+| T4 | [N] | Investigation candidates |
+
+## Related KB Links
+
+- **System topology**: See [architecture.md](architecture.md)
+- **Modules and projects**: See [modules.md](modules.md)
+- **Dependencies**: See [dependencies.md](dependencies.md)
+- **Implementation details**: See [patterns.md](patterns.md)
+- **Terminology**: See [concept_map.md](concept_map.md)
+- **Interaction semantics**: See [interaction-model.md](interaction-model.md)

--- a/plugins/base/skills/artifact-templates/templates/knowledge-base/monorepo/features.md
+++ b/plugins/base/skills/artifact-templates/templates/knowledge-base/monorepo/features.md
@@ -15,6 +15,8 @@ strictness: strict
 
 ## [Surface Name]
 
+[Include this line only when the surface was capped: *Showing [K] of [total_capabilities] capabilities -- [N] omitted by tier-first deterministic sampling.*]
+
 - **[Capability Name]** `T{N}` -- [One-line description]
   <!-- id: {surface}.{capability} | tier: T{N} | audience: {tag} | evidence: {comma-separated paths} -->
   - [Sub-feature Name] `T{N}` -- [One-line description]

--- a/plugins/base/skills/artifact-templates/templates/knowledge-base/monorepo/features.md
+++ b/plugins/base/skills/artifact-templates/templates/knowledge-base/monorepo/features.md
@@ -4,12 +4,6 @@ path_pattern: "features.md"
 producer: knowledge-base
 type: document
 description: "Capability inventory with two-level surface-to-feature tree, evidence-tier badges, audience tags, and stable node IDs for a monorepo codebase."
-emit_hint: |
-  rp1 agent-tools emit \
-    --workflow knowledge-build \
-    --type artifact_registered \
-    --step kb-feature-extractor:completed \
-    --data '{"path": ".rp1/context/features.md", "storageRoot": "project"}'
 strictness: strict
 ---
 # Repository Capabilities

--- a/plugins/base/skills/artifact-templates/templates/knowledge-base/monorepo/index.md
+++ b/plugins/base/skills/artifact-templates/templates/knowledge-base/monorepo/index.md
@@ -44,6 +44,7 @@ strictness: strict
 | modules.md | ~[N] | Component breakdown, module responsibilities |
 | patterns.md | ~[N] | Code conventions, implementation patterns |
 | concept_map.md | ~[N] | Domain terminology, business concepts |
+| features.md | ~[N] | Capability inventory, coverage gaps, feature audience |
 | dependencies.md | ~[N] | Inter-project dependencies, shared code |
 | technology-matrix.md | ~[N] | Technology decisions, framework choices |
 
@@ -53,8 +54,9 @@ strictness: strict
 |------|---------------|
 | Code review | `patterns.md` |
 | Bug investigation | `architecture.md`, `modules.md` |
-| Feature implementation | `modules.md`, `patterns.md` |
+| Feature implementation | `modules.md`, `patterns.md`, `features.md` |
 | Frontend / UX / surface work | `interaction-model.md`, `modules.md`, `patterns.md` |
+| Capability audit / coverage review | `features.md` |
 | Strategic analysis | ALL files |
 | Security audit | `architecture.md`, `dependencies.md` |
 
@@ -80,5 +82,6 @@ Read: .rp1/context/{filename}
 - **[modules.md](modules.md)**: Component breakdown
 - **[patterns.md](patterns.md)**: Code conventions
 - **[concept_map.md](concept_map.md)**: Domain terminology
+- **[features.md](features.md)**: Capability inventory and coverage
 - **[dependencies.md](dependencies.md)**: Inter-project dependencies
 - **[technology-matrix.md](technology-matrix.md)**: Technology decisions

--- a/plugins/base/skills/artifact-templates/templates/knowledge-base/single-project/features.md
+++ b/plugins/base/skills/artifact-templates/templates/knowledge-base/single-project/features.md
@@ -14,6 +14,8 @@ strictness: strict
 
 ## [Surface Name]
 
+[Include this line only when the surface was capped: *Showing [K] of [total_capabilities] capabilities -- [N] omitted by tier-first deterministic sampling.*]
+
 - **[Capability Name]** `T{N}` -- [One-line description]
   <!-- id: {surface}.{capability} | tier: T{N} | audience: {tag} | evidence: {comma-separated paths} -->
   - [Sub-feature Name] `T{N}` -- [One-line description]

--- a/plugins/base/skills/artifact-templates/templates/knowledge-base/single-project/features.md
+++ b/plugins/base/skills/artifact-templates/templates/knowledge-base/single-project/features.md
@@ -1,0 +1,47 @@
+---
+scope: kbRoot
+path_pattern: "features.md"
+producer: knowledge-base
+type: document
+description: "Capability inventory with two-level surface-to-feature tree, evidence-tier badges, audience tags, and stable node IDs for a single-project codebase."
+emit_hint: |
+  rp1 agent-tools emit \
+    --workflow knowledge-build \
+    --type artifact_registered \
+    --step kb-feature-extractor:completed \
+    --data '{"path": ".rp1/context/features.md", "storageRoot": "project"}'
+strictness: strict
+---
+# Project Capabilities
+
+**Project**: [Project Name]
+**Last Updated**: [Date]
+**Surfaces**: [N detected]
+
+## [Surface Name]
+
+- **[Capability Name]** `T{N}` -- [One-line description]
+  <!-- id: {surface}.{capability} | tier: T{N} | audience: {tag} | evidence: {comma-separated paths} -->
+  - [Sub-feature Name] `T{N}` -- [One-line description]
+    <!-- id: {surface}.{capability}.{sub-feature} | tier: T{N} | audience: {tag} | evidence: {comma-separated paths} -->
+
+## Surfaces Not Analyzed
+
+[List of anchor classes that could not be mechanically detected in this project, or "None" if all anchor classes were detected.]
+
+## Coverage Summary
+
+| Tier | Count | Meaning |
+|------|-------|---------|
+| T1 | [N] | Documented and tested |
+| T2 | [N] | Documented or tested |
+| T3 | [N] | Referenced but undocumented/untested |
+| T4 | [N] | Investigation candidates |
+
+## Related KB Links
+
+- **System topology**: See [architecture.md](architecture.md)
+- **Component inventory**: See [modules.md](modules.md)
+- **Implementation details**: See [patterns.md](patterns.md)
+- **Terminology**: See [concept_map.md](concept_map.md)
+- **Interaction semantics**: See [interaction-model.md](interaction-model.md)

--- a/plugins/base/skills/artifact-templates/templates/knowledge-base/single-project/features.md
+++ b/plugins/base/skills/artifact-templates/templates/knowledge-base/single-project/features.md
@@ -4,12 +4,6 @@ path_pattern: "features.md"
 producer: knowledge-base
 type: document
 description: "Capability inventory with two-level surface-to-feature tree, evidence-tier badges, audience tags, and stable node IDs for a single-project codebase."
-emit_hint: |
-  rp1 agent-tools emit \
-    --workflow knowledge-build \
-    --type artifact_registered \
-    --step kb-feature-extractor:completed \
-    --data '{"path": ".rp1/context/features.md", "storageRoot": "project"}'
 strictness: strict
 ---
 # Project Capabilities

--- a/plugins/base/skills/artifact-templates/templates/knowledge-base/single-project/index.md
+++ b/plugins/base/skills/artifact-templates/templates/knowledge-base/single-project/index.md
@@ -36,6 +36,7 @@ strictness: strict
 | modules.md | ~[N] | Component breakdown, module responsibilities |
 | patterns.md | ~[N] | Code conventions, implementation patterns |
 | concept_map.md | ~[N] | Domain terminology, business concepts |
+| features.md | ~[N] | Capability inventory, coverage gaps, feature audience |
 
 ## Task-Based Loading
 
@@ -43,8 +44,9 @@ strictness: strict
 |------|---------------|
 | Code review | `patterns.md` |
 | Bug investigation | `architecture.md`, `modules.md` |
-| Feature implementation | `modules.md`, `patterns.md` |
+| Feature implementation | `modules.md`, `patterns.md`, `features.md` |
 | Frontend / UX / surface work | `interaction-model.md`, `modules.md`, `patterns.md` |
+| Capability audit / coverage review | `features.md` |
 | Strategic analysis | ALL files |
 
 ## How to Load
@@ -69,3 +71,4 @@ src/
 - **[modules.md](modules.md)**: Component breakdown
 - **[patterns.md](patterns.md)**: Code conventions
 - **[concept_map.md](concept_map.md)**: Domain terminology
+- **[features.md](features.md)**: Capability inventory and coverage

--- a/plugins/base/skills/knowledge-build/SKILL.md
+++ b/plugins/base/skills/knowledge-build/SKILL.md
@@ -31,6 +31,7 @@ metadata:
     - "rp1-base:kb-interaction-mapper"
     - "rp1-base:kb-module-analyzer"
     - "rp1-base:kb-pattern-extractor"
+    - "rp1-base:kb-feature-extractor"
 ---
 
 # Knowledge Build
@@ -47,6 +48,7 @@ metadata:
   - `interaction-model.md`
   - `modules.md`
   - `patterns.md`
+  - `features.md`
   - `state.json`
   - `meta.json`
 - `index.md` is orchestrator-owned. Never delegate it.
@@ -63,7 +65,7 @@ metadata:
 - When prior KB exists, section agents MUST reconcile against it, even in `FULL`.
 - Section agents MUST also treat prior KB as incomplete and perform one explicit novelty scan for material knowledge absent from it.
 - Replace all placeholders with concrete values before dispatching child agents.
-- Spawn the 5 analysis agents in one parallel batch.
+- Spawn the 6 analysis agents in one parallel batch.
 - Wait patiently for child agents on the critical path. Do not declare them stalled after a short wait.
 - Keep user-visible output terse:
   1. Initial status line
@@ -147,7 +149,7 @@ Use the computed build inputs from the parent orchestrator.
 
 - MODE: actual build mode (`FULL`, `INCREMENTAL`, or `FEATURE_LEARNING`)
 - CHANGED_FILES: actual JSON array for the scoped changed-file list when available; empty only for first-time `FULL`
-- Task: rank files 0-5 and categorize them into `index_files`, `concept_files`, `arch_files`, `interaction_files`, `module_files`
+- Task: rank files 0-5 and categorize them into `index_files`, `concept_files`, `arch_files`, `interaction_files`, `module_files`, `feature_files`
 - Return JSON only with:
   - `repo_type`
   - `monorepo_projects`
@@ -157,6 +159,7 @@ Use the computed build inputs from the parent orchestrator.
   - `arch_files`
   - `interaction_files`
   - `module_files`
+  - `feature_files`
   - `local_meta`
 Do not echo placeholder tokens.
 {% enddispatch_agent %}
@@ -177,8 +180,9 @@ Do not echo placeholder tokens.
 1. Compute:
   - `PATTERN_FILES = unique(concept_files + module_files)`
   - `INTERACTION_FILES = unique(interaction_files)`
+  - `FEATURE_FILES = unique(feature_files)`
   - per-agent diff subsets from `FILE_DIFFS`
-2. Spawn all 5 analyzers in one batch:
+2. Spawn all 6 analyzers in one batch:
 
 {% dispatch_agent "rp1-base:kb-concept-extractor", background %}
 Use the parent-computed inputs.
@@ -241,7 +245,19 @@ Use the parent-computed inputs.
 - Constraint: rendered `patterns.md` MUST stay <=150 lines
 {% enddispatch_agent %}
 
-3. Wait for all 5 agents to finish.
+{% dispatch_agent "rp1-base:kb-feature-extractor", background %}
+Use the parent-computed inputs.
+
+- KB_ROOT={kbRoot}
+- MODE: actual mode
+- REPO_TYPE: actual repo type
+- FEATURE_FILES_JSON: actual JSON array
+- FILE_DIFFS: actual diff subset JSON or empty object
+- FEATURE_CONTEXT: actual feature context JSON or empty object
+- Task: return JSON only for `features.md`
+{% enddispatch_agent %}
+
+3. Wait for all 6 agents to finish.
 4. Parse JSON from each response.
 5. Failure policy:
    - 0 failures: continue normally
@@ -257,6 +273,7 @@ Use the parent-computed inputs.
    - `interaction-model.md`
    - `modules.md`
    - `patterns.md`
+   - `features.md`
 3. Validate the `architecture.md` Mermaid diagram via `rp1-base:mermaid`.
    - If invalid: simplify or omit the broken diagram, do not fail the whole run for diagram syntax alone.
 4. Write these files first:
@@ -265,6 +282,7 @@ Use the parent-computed inputs.
    - `{kbRoot}/interaction-model.md`
    - `{kbRoot}/modules.md`
    - `{kbRoot}/patterns.md`
+   - `{kbRoot}/features.md`
 5. Count lines for the written markdown files.
 6. Generate `index.md` directly from aggregated results plus measured line counts.
 7. Write `{kbRoot}/index.md` last.

--- a/plugins/base/skills/knowledge-build/SKILL.md
+++ b/plugins/base/skills/knowledge-build/SKILL.md
@@ -273,7 +273,7 @@ Use the parent-computed inputs.
    - `interaction-model.md`
    - `modules.md`
    - `patterns.md`
-   - `features.md`
+   - `features.md` -- render each surface's `total_capabilities`: when it exceeds the listed capability count, include the template's truncation note so sampling omissions stay visible
 3. Validate the `architecture.md` Mermaid diagram via `rp1-base:mermaid`.
    - If invalid: simplify or omit the broken diagram, do not fail the whole run for diagram syntax alone.
 4. Write these files first:


### PR DESCRIPTION
## Summary

Adds a **user-facing feature inventory** (`features.md`) as the sixth dimension of the knowledge-build KB suite. The new `kb-feature-extractor` section agent answers the question the existing KB never covered: *what can a user of this software actually do?*

## What's in the box

- **New section agent** `plugins/base/agents/kb-feature-extractor.md` — runs as the 6th parallel analyzer in knowledge-build (FULL, INCREMENTAL, and FEATURE_LEARNING modes), with the house `§BAYES` prior-reconciliation and `§DISCOVERY` novelty-scan blocks mirroring peer kb-* agents.
- **Generic anchor-class detection** — capabilities are enumerated from mechanically detectable registration points (CLI command registrations, web/API route tables, UI entry surfaces, extension/plugin manifests, public library API, docs cross-references). Surfaces are **derived per target project** from detected classes; nothing is hardcoded to rp1. Undetectable classes land in a "Surfaces Not Analyzed" note.
- **Two-level tree artifact** — `{kbRoot}/features.md` organizes surface → capability → sub-feature, each node carrying an inline evidence-tier badge and an HTML-comment metadata trailer with a **stable, deterministically derived node ID** (`{surface}.{capability}[.{sub-feature}]`) for machine parsing and Arcade hidden-anchor annotation durability.
- **Deterministic evidence tiers, no usage claims** — T1 (documented+tested) → T4 (undocumented+untested+unreferenced). T4 items are labeled *investigation candidates*, explicitly never "prune candidates" (no telemetry exists to justify usage claims).
- **Audience tagging** — `user | agent | internal` from generic heuristics; the `agent` tag applies only when an agent-facing surface is detected in the target project.
- **Pipeline integration** — spatial analyzer gains a `feature_files` routing category; knowledge-build SKILL.md dispatches, merges, and writes the 6th dimension; index.md templates gain manifest/loading/navigation entries; artifact-templates index registers both template variants; catalog regenerated.

## Files changed (9)

| File | Change |
|---|---|
| `plugins/base/agents/kb-feature-extractor.md` | new section agent |
| `plugins/base/agents/kb-spatial-analyzer.md` | `feature_files` anchor-class routing |
| `plugins/base/skills/knowledge-build/SKILL.md` | 6th analyzer dispatch/merge/write |
| `plugins/base/skills/artifact-templates/SKILL.md` | template index entries |
| `plugins/base/skills/artifact-templates/templates/knowledge-base/{single-project,monorepo}/features.md` | new artifact templates |
| `plugins/base/skills/artifact-templates/templates/knowledge-base/{single-project,monorepo}/index.md` | manifest/loading/navigation rows |
| `catalog/agents.yaml` | regenerated |

## Verification

- `just check` clean across CLI (917 files), native-app, web-ui, evals; `just catalog-check` current; plugin builds green on all five platforms.
- Feature verification: all 14 requirements satisfied (rp1-dev:feature-verifier, run `d7431c6d`).
- Catalog regeneration is idempotent at HEAD (re-run produces zero diff).

## Notes for reviewers

- No CLAUDE.md stanza changes (follows the interaction-model.md precedent: KB files may exist without stanza mention).
- The five rp1 surfaces (CLI / Web UI / Plugin Skills / Agent Tools / API) appear in templates only as the reference-project example, not as the contract.

🤖 Generated using: 🎮 [rp1.run](https://rp1.run)
