### PR TITLE
fix(build): emit agent tool allowlists for Claude Code

### DIFF
--- a/cli/src/__tests__/build/filters/agent-tools.test.ts
+++ b/cli/src/__tests__/build/filters/agent-tools.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Unit tests for the agent_tools Liquid filter.
+ * Scoped specifiers collapse to bare tool names, duplicates are removed,
+ * and declaration order is preserved.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { agentTools } from "../../../build/filters/agent-tools.js";
+
+describe("agentTools", () => {
+	test("passes through bare tool names in declaration order", () => {
+		expect(agentTools(["Read", "Grep", "Glob", "Bash"])).toBe(
+			"Read, Grep, Glob, Bash",
+		);
+	});
+
+	test("collapses a scoped Bash specifier to the bare tool name", () => {
+		expect(agentTools(["Read", "Write", "Glob", "Bash(rp1 *)"])).toBe(
+			"Read, Write, Glob, Bash",
+		);
+	});
+
+	test("de-duplicates when a scoped entry collapses onto an existing tool", () => {
+		expect(
+			agentTools([
+				"Read",
+				"Write",
+				"Edit",
+				"Bash",
+				"Glob",
+				"Grep",
+				"Bash(rp1 *)",
+			]),
+		).toBe("Read, Write, Edit, Bash, Glob, Grep");
+	});
+
+	test("collapses several scoped specifiers for the same tool to one entry", () => {
+		expect(
+			agentTools([
+				"Read",
+				"Bash(git log *)",
+				"Bash(git show *)",
+				"Bash(gh pr view *)",
+			]),
+		).toBe("Read, Bash");
+	});
+
+	test("returns an empty string for an empty list", () => {
+		expect(agentTools([])).toBe("");
+	});
+
+	test("ignores blank entries and trims surrounding whitespace", () => {
+		expect(agentTools([" Read ", "", "  ", "Glob"])).toBe("Read, Glob");
+	});
+
+	test("preserves the Skill tool name", () => {
+		expect(agentTools(["Read", "Edit", "Grep", "Bash", "Skill"])).toBe(
+			"Read, Edit, Grep, Bash, Skill",
+		);
+	});
+});

--- a/cli/src/__tests__/build/filters/agent-tools.test.ts
+++ b/cli/src/__tests__/build/filters/agent-tools.test.ts
@@ -1,7 +1,7 @@
 /**
  * Unit tests for the agent_tools Liquid filter.
- * Scoped specifiers collapse to bare tool names, duplicates are removed,
- * and declaration order is preserved.
+ * Scoped specifiers survive verbatim, exact duplicates are removed, and
+ * declaration order is preserved.
  */
 
 import { describe, expect, test } from "bun:test";
@@ -14,13 +14,24 @@ describe("agentTools", () => {
 		);
 	});
 
-	test("collapses a scoped Bash specifier to the bare tool name", () => {
+	test("preserves a scoped Bash specifier instead of widening it to bare Bash", () => {
 		expect(agentTools(["Read", "Write", "Glob", "Bash(rp1 *)"])).toBe(
-			"Read, Write, Glob, Bash",
+			"Read, Write, Glob, Bash(rp1 *)",
 		);
 	});
 
-	test("de-duplicates when a scoped entry collapses onto an existing tool", () => {
+	test("preserves several distinct scoped specifiers for the same tool", () => {
+		expect(
+			agentTools([
+				"Read",
+				"Bash(git log *)",
+				"Bash(git show *)",
+				"Bash(gh pr view *)",
+			]),
+		).toBe("Read, Bash(git log *), Bash(git show *), Bash(gh pr view *)");
+	});
+
+	test("keeps a bare tool and a scoped entry for that tool as declared", () => {
 		expect(
 			agentTools([
 				"Read",
@@ -31,18 +42,13 @@ describe("agentTools", () => {
 				"Grep",
 				"Bash(rp1 *)",
 			]),
-		).toBe("Read, Write, Edit, Bash, Glob, Grep");
+		).toBe("Read, Write, Edit, Bash, Glob, Grep, Bash(rp1 *)");
 	});
 
-	test("collapses several scoped specifiers for the same tool to one entry", () => {
-		expect(
-			agentTools([
-				"Read",
-				"Bash(git log *)",
-				"Bash(git show *)",
-				"Bash(gh pr view *)",
-			]),
-		).toBe("Read, Bash");
+	test("removes exact duplicates", () => {
+		expect(agentTools(["Read", "Bash(rp1 *)", "Read", "Bash(rp1 *)"])).toBe(
+			"Read, Bash(rp1 *)",
+		);
 	});
 
 	test("returns an empty string for an empty list", () => {

--- a/cli/src/__tests__/build/templates/golden/cc-agent-model-effort.md
+++ b/cli/src/__tests__/build/templates/golden/cc-agent-model-effort.md
@@ -1,6 +1,7 @@
 ---
 model: opus
 effort: high
+tools: Bash, Read
 ---
 
 ## Host Context

--- a/cli/src/__tests__/build/templates/golden/cc-agent-model-only.md
+++ b/cli/src/__tests__/build/templates/golden/cc-agent-model-only.md
@@ -1,5 +1,6 @@
 ---
 model: haiku
+tools: Bash
 ---
 
 ## Host Context

--- a/cli/src/__tests__/build/templates/template-rendering.test.ts
+++ b/cli/src/__tests__/build/templates/template-rendering.test.ts
@@ -16,6 +16,7 @@ import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { agentTools } from "../../../build/filters/agent-tools.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const GOLDEN_DIR = join(__dirname, "golden");
@@ -105,6 +106,10 @@ const createTestEngine = () => {
 			}
 			return content;
 		},
+	);
+
+	engine.registerFilter("agent_tools", (tools: readonly string[]) =>
+		agentTools(tools),
 	);
 
 	engine.registerFilter("allowed_tools", (value: string, platform: string) => {
@@ -1324,6 +1329,73 @@ describeWithLiquid("template rendering", () => {
 			});
 			expect(result).not.toContain("---");
 			expect(result).not.toContain("model:");
+		});
+
+		test("emits the declared tool allowlist so restrictions survive compilation", async () => {
+			const engine = createTestEngine();
+			const result = await engine.renderFile("claude-code/agent", {
+				platform: "claude-code",
+				artifact: {
+					type: "agent",
+					name: "test-agent",
+					description: "Test agent",
+					model: "sonnet",
+					tools: ["Read", "Grep", "Glob"],
+					content: "Agent content.",
+				},
+			});
+			expect(result).toContain("tools: Read, Grep, Glob");
+		});
+
+		test("collapses scoped Bash specifiers in the emitted allowlist", async () => {
+			const engine = createTestEngine();
+			const result = await engine.renderFile("claude-code/agent", {
+				platform: "claude-code",
+				artifact: {
+					type: "agent",
+					name: "test-agent",
+					description: "Test agent",
+					model: "sonnet",
+					tools: ["Read", "Write", "Glob", "Bash(rp1 *)"],
+					content: "Agent content.",
+				},
+			});
+			expect(result).toContain("tools: Read, Write, Glob, Bash");
+			expect(result).not.toContain("Bash(rp1 *)");
+		});
+
+		test("emits frontmatter for tools alone when model is inherit and effort absent", async () => {
+			const engine = createTestEngine();
+			const result = await engine.renderFile("claude-code/agent", {
+				platform: "claude-code",
+				artifact: {
+					type: "agent",
+					name: "test-agent",
+					description: "Test agent",
+					model: "inherit",
+					tools: ["Read"],
+					content: "Agent content.",
+				},
+			});
+			expect(result).toContain("tools: Read");
+			expect(result).not.toContain("model:");
+		});
+
+		test("omits tools when the declared list is empty so the agent inherits", async () => {
+			const engine = createTestEngine();
+			const result = await engine.renderFile("claude-code/agent", {
+				platform: "claude-code",
+				artifact: {
+					type: "agent",
+					name: "test-agent",
+					description: "Test agent",
+					model: "sonnet",
+					tools: [],
+					content: "Agent content.",
+				},
+			});
+			expect(result).toContain("model: sonnet");
+			expect(result).not.toContain("tools:");
 		});
 
 		test("golden: model + effort produces frontmatter with both fields", async () => {

--- a/cli/src/__tests__/build/templates/template-rendering.test.ts
+++ b/cli/src/__tests__/build/templates/template-rendering.test.ts
@@ -1347,7 +1347,7 @@ describeWithLiquid("template rendering", () => {
 			expect(result).toContain("tools: Read, Grep, Glob");
 		});
 
-		test("collapses scoped Bash specifiers in the emitted allowlist", async () => {
+		test("preserves scoped Bash specifiers in the emitted allowlist", async () => {
 			const engine = createTestEngine();
 			const result = await engine.renderFile("claude-code/agent", {
 				platform: "claude-code",
@@ -1360,8 +1360,9 @@ describeWithLiquid("template rendering", () => {
 					content: "Agent content.",
 				},
 			});
-			expect(result).toContain("tools: Read, Write, Glob, Bash");
-			expect(result).not.toContain("Bash(rp1 *)");
+			// Collapsing the specifier to a bare `Bash` would grant every shell
+			// command, which is the restriction this allowlist exists to impose.
+			expect(result).toContain("tools: Read, Write, Glob, Bash(rp1 *)");
 		});
 
 		test("emits frontmatter for tools alone when model is inherit and effort absent", async () => {

--- a/cli/src/build/filters/agent-tools.ts
+++ b/cli/src/build/filters/agent-tools.ts
@@ -1,0 +1,40 @@
+/**
+ * Liquid filter: agent_tools
+ *
+ * Renders an agent's declared tool allowlist for platforms whose agent
+ * frontmatter takes bare tool names (Claude Code).
+ *
+ * Claude Code's agent `tools` field is an allowlist of tool names, not a
+ * permission-grant mechanism: scoped specifiers such as `Bash(rp1 *)` belong in
+ * a skill's `allowed-tools` or in `permissions.allow`. Scoped entries therefore
+ * collapse to their base tool name, and the duplicates that collapsing can
+ * produce (`Bash` plus `Bash(rp1 *)`) are removed while preserving order.
+ */
+
+const SCOPED_TOOL_PATTERN = /^([A-Za-z][\w-]*)\(.*\)$/;
+
+/**
+ * Collapse scoped tool entries to bare tool names and de-duplicate.
+ */
+export const agentTools = (tools: readonly string[]): string => {
+	const seen = new Set<string>();
+	const names: string[] = [];
+
+	for (const entry of tools) {
+		const trimmed = entry.trim();
+		if (!trimmed) {
+			continue;
+		}
+
+		const scoped = trimmed.match(SCOPED_TOOL_PATTERN);
+		const name = scoped ? scoped[1] : trimmed;
+
+		if (seen.has(name)) {
+			continue;
+		}
+		seen.add(name);
+		names.push(name);
+	}
+
+	return names.join(", ");
+};

--- a/cli/src/build/filters/agent-tools.ts
+++ b/cli/src/build/filters/agent-tools.ts
@@ -1,40 +1,31 @@
 /**
  * Liquid filter: agent_tools
  *
- * Renders an agent's declared tool allowlist for platforms whose agent
- * frontmatter takes bare tool names (Claude Code).
+ * Renders an agent's declared tool allowlist into the comma-separated form
+ * Claude Code expects in agent frontmatter.
  *
- * Claude Code's agent `tools` field is an allowlist of tool names, not a
- * permission-grant mechanism: scoped specifiers such as `Bash(rp1 *)` belong in
- * a skill's `allowed-tools` or in `permissions.allow`. Scoped entries therefore
- * collapse to their base tool name, and the duplicates that collapsing can
- * produce (`Bash` plus `Bash(rp1 *)`) are removed while preserving order.
+ * A subagent's `tools` field accepts the same `ToolName(specifier)` rule format
+ * as `permissions.allow`, so scoped entries such as `Bash(rp1 *)` are preserved
+ * verbatim: collapsing them to a bare `Bash` would widen the grant to every
+ * shell command and defeat the restriction the agent declared. Only exact
+ * duplicates are removed, and declaration order is preserved.
  */
 
-const SCOPED_TOOL_PATTERN = /^([A-Za-z][\w-]*)\(.*\)$/;
-
 /**
- * Collapse scoped tool entries to bare tool names and de-duplicate.
+ * Join declared tool entries, dropping blanks and exact duplicates.
  */
 export const agentTools = (tools: readonly string[]): string => {
 	const seen = new Set<string>();
-	const names: string[] = [];
+	const entries: string[] = [];
 
 	for (const entry of tools) {
 		const trimmed = entry.trim();
-		if (!trimmed) {
+		if (!trimmed || seen.has(trimmed)) {
 			continue;
 		}
-
-		const scoped = trimmed.match(SCOPED_TOOL_PATTERN);
-		const name = scoped ? scoped[1] : trimmed;
-
-		if (seen.has(name)) {
-			continue;
-		}
-		seen.add(name);
-		names.push(name);
+		seen.add(trimmed);
+		entries.push(trimmed);
 	}
 
-	return names.join(", ");
+	return entries.join(", ");
 };

--- a/cli/src/build/filters/index.ts
+++ b/cli/src/build/filters/index.ts
@@ -13,6 +13,7 @@
 import type { Liquid } from "liquidjs";
 import type { PlatformRegistry } from "../models.js";
 import type { BuildPlatform } from "../template-context.js";
+import { agentTools } from "./agent-tools.js";
 import {
 	allowedToolsFilter,
 	copilotPermissionPatternsFilter,
@@ -30,6 +31,7 @@ import { toolName } from "./tool-name.js";
 import { toolProse } from "./tool-prose.js";
 
 export {
+	agentTools,
 	allowedToolsFilter,
 	copilotPermissionPatternsFilter,
 	escapeJson,
@@ -80,6 +82,10 @@ export function registerFilters(liquid: Liquid): void {
 
 	liquid.registerFilter("copilot_permissions", (allowedTools: string) =>
 		copilotPermissionPatternsFilter(allowedTools),
+	);
+
+	liquid.registerFilter("agent_tools", (tools: readonly string[]) =>
+		agentTools(tools),
 	);
 
 	liquid.registerFilter("escape_yaml", (value: string) => escapeYaml(value));

--- a/cli/src/build/templates/claude-code/agent.liquid
+++ b/cli/src/build/templates/claude-code/agent.liquid
@@ -1,10 +1,14 @@
-{%- if artifact.model != "inherit" or artifact.effortValue -%}
+{%- assign agentToolList = artifact.tools | agent_tools -%}
+{%- if artifact.model != "inherit" or artifact.effortValue or agentToolList != "" -%}
 ---
 {%- if artifact.model != "inherit" %}
 model: {{ artifact.model }}
 {%- endif %}
 {%- if artifact.effortValue %}
 {{ artifact.effortFieldName }}: {{ artifact.effortValue }}
+{%- endif %}
+{%- if agentToolList != "" %}
+tools: {{ agentToolList }}
 {%- endif %}
 ---
 


### PR DESCRIPTION
## Problem

The Claude Code agent template rendered only `model` and `effort`, so the `tools:` restriction declared by every rp1 agent was silently dropped at build time.

Claude Code treats an omitted `tools` field as *inherit every tool available to subagents*, so **all 54 agents ran unrestricted** — the agent registry reported each one as having all tools.

Verified:

- All 54 source agents under `plugins/*/agents/` declare `tools:` (17 base, 36 dev, 1 internal utils); **0** compiled agents under `dist/claude-code/` retained it.
- `git log -p --follow` on the template shows the field was **never** present — a long-standing hole, not a recent regression.
- The parser already captured `tools` (`cli/src/build/parser.ts`), and the antigravity, copilot, and opencode agent templates already emit it. Only claude-code never did.

### How this surfaced

An AFK `/build` run dispatched `feature-requirement-gatherer`, which declares `tools: Read, Write, Glob, Bash(rp1 *)` — no `Edit`, no unrestricted `Bash`. Unrestricted, it implemented an entire feature, ran `git commit`, and opened a PR instead of writing `requirements.md`, silently bypassing every downstream quality gate. Its declared restrictions would have made that impossible.

## Fix

Add an `agent_tools` filter and render the allowlist in the claude-code agent template.

Scoped specifiers are **preserved verbatim**. A subagent's `tools` field accepts the same rule format as permission rules — the [tools reference](https://code.claude.com/docs/en/tools-reference) lists "a subagent's `tools` or `disallowedTools` frontmatter" among the surfaces accepting `ToolName(specifier)`, and documents `Bash(npm run *)` as applying to Bash. Only exact duplicates are dropped; declaration order is preserved.

After rebuilding, **52 of 54** agents carry restrictions with internal utils included (51 of 53 for the distributable base/dev build), and 14 retain scoped specifiers. The 2 without an allowlist are the intentional empty-list declarations described below. The gatherer emits `tools: Read, Write, Glob, Bash(rp1 *)`, so it can no longer run `git commit` or `gh pr create` — the exact escape that motivated this change.

> **Correction:** the first revision of this PR collapsed `Bash(rp1 *)` to a bare `Bash`, on the mistaken assumption that the field takes only tool names. That widened every scoped grant into unrestricted shell access and defeated the restriction this PR exists to enforce. Caught in review and fixed in `7a7a8f53`.

## Safety notes

- **An empty list still emits nothing.** `parser.ts` defaults `tools` to an empty array when the field is absent, so absent and empty declarations are indistinguishable. Emitting an empty list would leave any agent without a declaration with *no* tools. Consequence: the two agents declaring an empty list (`build-task-grouper`, `pr-comment-deduplicator`) keep inheriting rather than being locked down — unchanged from today, never worse.
- **No allowlist consists solely of specifiers.** Every agent declares at least one bare tool, so none risks the documented zero-tools launch failure.
- **Strict improvement, never a tightening regression.** Today every agent has all tools; after this change each has only what it declared. No agent gains access it previously lacked.
- The same declarations are **already enforced** on opencode, copilot, and antigravity, which is good evidence they are accurate rather than stale.

## Residual gap (not addressed here)

`hooks` are ignored for plugin-shipped agents, so per-agent hook-based validation isn't available to rp1's agents. Scoped specifiers cover the cases that motivated this change.

Separately, the build orchestrator validates the requirements phase by parsing the agent's JSON response rather than confirming the `requirements.md` artifact exists. An artifact-existence assertion would have caught the breach independently of tool restrictions.

## Verification

- `just test-unit`: 3512 pass, 24 skip, **0 fail**
- `just check`: clean (biome + tsc across cli, web-ui, evals)
- `just build-claude-code`: succeeds; all build lints pass
- Tests: 8 filter unit tests, 4 template-rendering tests; 2 golden fixtures updated

🤖 Generated using: 🎮 [rp1.run](https://rp1.run)
