### PR TITLE
fix(evals): record real eval provenance instead of silently empty git_commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,16 @@ jobs:
       - name: Run native app tests
         run: just test-native-app
 
+      - name: Install eval dependencies
+        run: cd evals && bun install --frozen-lockfile
+
+      # The eval unit tests cover the attestation provenance contract and the
+      # dockerized launcher scripts (docker stubbed via PATH). Without this
+      # step nothing in CI exercises evals/src or the launcher contract, which
+      # let a stale launcher test sit broken for months unnoticed.
+      - name: Run eval unit tests
+        run: cd evals && bun test
+
       - name: Generate coverage report
         if: ${{ always() && !cancelled() && steps.test_home_boundary.outcome == 'success' }}
         shell: bash

--- a/docker/eval-run.sh
+++ b/docker/eval-run.sh
@@ -220,7 +220,14 @@ else
 fi
 
 if [ "$do_commit" = "true" ] && [ "$attest" = "true" ]; then
-    host_commit_eval_results "$host_commit_outputs_file"
+    # A non-zero container exit includes attestation failure (run-local.sh
+    # exits 1 when any attestation fails), so committing here would ship eval
+    # outputs without their provenance record.
+    if [ "$docker_exit" -eq 0 ]; then
+        host_commit_eval_results "$host_commit_outputs_file"
+    else
+        echo "Skipping eval-results commit: containerized run exited ${docker_exit}"
+    fi
 elif [ "$do_commit" = "true" ]; then
     echo "--commit requested without --attest; skipping commit"
 fi

--- a/docker/eval-run.sh
+++ b/docker/eval-run.sh
@@ -173,7 +173,12 @@ docker_run_args+=(
     rp1-dev
     zsh
     -lc
-    'cd /src/rp1 && just eval-run-local "$@"'
+    # safe.directory: the mounted repo is owned by the host user, not rp1user,
+    # so git otherwise fails with "dubious ownership" and the --attest step
+    # cannot record which commit the eval ran against. setup-dev.sh also sets
+    # this, but that script is baked into the image -- repeating it here makes
+    # the fix effective on images built before it existed.
+    'git config --global --add safe.directory "*" && cd /src/rp1 && just eval-run-local "$@"'
     --
     "${container_args[@]}"
 )

--- a/docker/setup-dev.sh
+++ b/docker/setup-dev.sh
@@ -31,6 +31,16 @@ echo ""
 echo "━━━ rp1 dev container setup ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 echo ""
 
+# The mounted repo is owned by the host user while this container runs as
+# rp1user, so git refuses every command with "detected dubious ownership"
+# (exit 128). That silently broke the dev-SHA embed below and wrote empty
+# git_commit provenance into eval attestations. Trust all mounted paths:
+# the repo lands at /src/rp1, and worktree runs additionally mount the git
+# common dir at its arbitrary host path, so a fixed path list cannot cover it.
+# This is an ephemeral single-purpose container; the multi-user attack that
+# safe.directory guards against does not apply.
+git config --global --add safe.directory '*'
+
 ensure_writable_dir() {
     local dir="$1"
     mkdir -p "$dir"

--- a/evals/src/attestation/__tests__/commands.test.ts
+++ b/evals/src/attestation/__tests__/commands.test.ts
@@ -5,12 +5,14 @@
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import * as E from "fp-ts/Either";
 import {
 	attestFromOutput,
 	detectPassRate,
 	extractSuiteFromFilename,
+	getGitCommit,
 } from "../commands.js";
 
 const evalRoot = join(import.meta.dirname, "..", "..", "..");
@@ -393,5 +395,79 @@ describe("detectPassRate", () => {
 			},
 		};
 		expect(detectPassRate(output)).toBe(false);
+	});
+});
+
+describe("getGitCommit", () => {
+	// Must live outside the rp1 checkout: git walks parent directories, so a
+	// temp dir inside the repo resolves to the repo's own HEAD.
+	let tempDir: string;
+
+	beforeEach(async () => {
+		tempDir = join(
+			tmpdir(),
+			`rp1-git-commit-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+		);
+		await mkdir(tempDir, { recursive: true });
+	});
+
+	afterEach(async () => {
+		await rm(tempDir, { recursive: true, force: true });
+	});
+
+	const run = (args: string[]): Promise<number> => {
+		const proc = Bun.spawn(["git", ...args], {
+			stdout: "ignore",
+			stderr: "ignore",
+		});
+		return proc.exited;
+	};
+
+	test("returns the short SHA of HEAD in a git repository", async () => {
+		expect(await run(["-C", tempDir, "init", "-q"])).toBe(0);
+		expect(
+			await run([
+				"-C",
+				tempDir,
+				"-c",
+				"user.email=test@example.com",
+				"-c",
+				"user.name=Test",
+				"commit",
+				"--allow-empty",
+				"-q",
+				"-m",
+				"initial",
+			]),
+		).toBe(0);
+
+		const sha = await getGitCommit(tempDir);
+		expect(sha).toMatch(/^[0-9a-f]{4,40}$/);
+	});
+
+	test("rejects a zero-exit run that produces no SHA", async () => {
+		// Practically unreachable with real git, but the guard is part of the
+		// contract: provenance is never recorded as an empty string. Stub
+		// Bun.spawn for this one call to simulate exit 0 with empty stdout.
+		const original = Bun.spawn;
+		try {
+			Bun.spawn = (() => ({
+				stdout: new Response("\n").body,
+				stderr: new Response("").body,
+				exited: Promise.resolve(0),
+			})) as unknown as typeof Bun.spawn;
+			await expect(getGitCommit()).rejects.toThrow(/produced no output/);
+		} finally {
+			Bun.spawn = original;
+		}
+	});
+
+	test("throws with the git error instead of returning an empty string outside a repository", async () => {
+		// The regression this guards: a failed `git rev-parse` (e.g. "dubious
+		// ownership" inside the eval container) was written to the attestation
+		// manifest as git_commit: "".
+		await expect(getGitCommit(tempDir)).rejects.toThrow(
+			/git rev-parse --short HEAD exited with 128/,
+		);
 	});
 });

--- a/evals/src/attestation/commands.ts
+++ b/evals/src/attestation/commands.ts
@@ -125,14 +125,38 @@ function suiteToSkillPath(suite: string, platform: EvalPlatform): string {
 
 /**
  * Get current git commit SHA (short form).
+ *
+ * Throws when git fails or produces no SHA. Provenance is part of the
+ * attestation record: a silent empty string here once shipped attestations
+ * that could not be traced to the commit they were evaluated against, because
+ * a non-zero git exit was written to the manifest as valid data. Exported for
+ * tests; `cwd` defaults to the process working directory.
  */
-async function getGitCommit(): Promise<string> {
+export async function getGitCommit(cwd?: string): Promise<string> {
 	const proc = Bun.spawn(["git", "rev-parse", "--short", "HEAD"], {
 		stdout: "pipe",
+		stderr: "pipe",
+		...(cwd ? { cwd } : {}),
 	});
-	const output = await new Response(proc.stdout).text();
-	await proc.exited;
-	return output.trim();
+	const [output, errorOutput, exitCode] = await Promise.all([
+		new Response(proc.stdout).text(),
+		new Response(proc.stderr).text(),
+		proc.exited,
+	]);
+
+	if (exitCode !== 0) {
+		throw new Error(
+			`git rev-parse --short HEAD exited with ${exitCode}: ${errorOutput.trim()}`,
+		);
+	}
+
+	const sha = output.trim();
+	if (!sha) {
+		throw new Error(
+			"git rev-parse --short HEAD produced no output; cannot record eval provenance",
+		);
+	}
+	return sha;
 }
 
 /**

--- a/evals/suites/shared/__tests__/docker-eval-launcher.test.ts
+++ b/evals/suites/shared/__tests__/docker-eval-launcher.test.ts
@@ -155,6 +155,10 @@ kind="$1"
 shift || true
 printf '%s\n' "$@" > "\${DOCKER_STUB_LOG_DIR}/\${kind}-args.txt"
 env | sort > "\${DOCKER_STUB_LOG_DIR}/\${kind}-env.txt"
+# Report the image as absent so the launcher exercises its build path.
+if [ "$kind" = "image" ]; then
+    exit 1
+fi
 `,
 			"utf-8",
 		);
@@ -216,7 +220,9 @@ env | sort > "\${DOCKER_STUB_LOG_DIR}/\${kind}-env.txt"
 		expect(runArgs).toContain("rp1-dev");
 		expect(runArgs).toContain("zsh");
 		expect(runArgs).toContain("-lc");
-		expect(runArgs).toContain('cd /src/rp1 && just eval-run-local "$@"');
+		expect(runArgs).toContain(
+			'git config --global --add safe.directory "*" && cd /src/rp1 && just eval-run-local "$@"',
+		);
 		expect(runArgs).toContain("--");
 		expect(runArgs).toContain("rp1-dev/build-fast");
 		expect(runArgs).toContain("--harness=opencode");
@@ -400,6 +406,81 @@ esac
 			`-C ${REPO_ROOT} add evals/output/rp1-dev-build-fast.json`,
 		);
 		expect(gitLog).toContain(`-C ${REPO_ROOT} commit -m`);
+	});
+
+	test("skips the host commit when the containerized run fails", async () => {
+		// run-local.sh exits non-zero when an eval or its attestation fails, so
+		// a failing container must never reach the host git commit: that would
+		// ship eval outputs without their provenance record.
+		const stubRoot = await createTempDir("rp1-docker-failed-run-");
+		const binDir = join(stubRoot, "bin");
+		const logDir = join(stubRoot, "logs");
+		const dockerStubPath = join(binDir, "docker");
+		const gitStubPath = join(binDir, "git");
+		const gitLogPath = join(logDir, "git.log");
+
+		await mkdir(binDir, { recursive: true });
+		await mkdir(logDir, { recursive: true });
+		await writeFile(
+			dockerStubPath,
+			`#!/usr/bin/env bash
+set -euo pipefail
+kind="$1"
+shift || true
+printf '%s\n' "$@" > "\${DOCKER_STUB_LOG_DIR}/\${kind}-args.txt"
+if [ "$kind" = "run" ]; then
+    exit 1
+fi
+`,
+			"utf-8",
+		);
+		await writeFile(
+			gitStubPath,
+			`#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "\${GIT_STUB_LOG}"
+if [ "$1" = "-C" ]; then
+    shift 2
+fi
+case "$1" in
+    rev-parse)
+        case "$2" in
+            --is-inside-work-tree)
+                echo true
+                ;;
+            --git-dir|--git-common-dir)
+                echo .git
+                ;;
+        esac
+        ;;
+esac
+`,
+			"utf-8",
+		);
+		await chmod(dockerStubPath, 0o755);
+		await chmod(gitStubPath, 0o755);
+		await writeFile(gitLogPath, "", "utf-8");
+
+		const result = await runCommand(
+			"bash",
+			[EVAL_LAUNCHER_PATH, "rp1-dev/build-fast", "--attest", "--commit"],
+			{
+				cwd: REPO_ROOT,
+				env: {
+					...process.env,
+					PATH: `${binDir}:${process.env.PATH ?? ""}`,
+					DOCKER_STUB_LOG_DIR: logDir,
+					GIT_STUB_LOG: gitLogPath,
+				},
+			},
+		);
+
+		expect(result.exitCode).not.toBe(0);
+		expect(result.stdout).toContain("Skipping eval-results commit");
+
+		const gitLog = await readFile(gitLogPath, "utf-8");
+		expect(gitLog).not.toContain("add evals/attestation.json");
+		expect(gitLog).not.toContain("commit -m");
 	});
 
 	test("quarantines corrupt promptfoo database files before reuse", async () => {

--- a/scripts/evals/run-local.sh
+++ b/scripts/evals/run-local.sh
@@ -66,9 +66,6 @@ for config in $configs_list; do
     echo "=== ${suite_path} (harness: ${harness}) ==="
     if cd "${evals_dir}" && bunx promptfoo eval -c "suites/${suite_path}/evals.yaml" --output "${output_file}" $verbose_flag $provider_flag; then
         passed_suites="${passed_suites} ${output_file}"
-        if [ -n "$passed_suites_file" ]; then
-            printf '%s\n' "${output_file}" >> "$passed_suites_file"
-        fi
         cd "${repo_root}"
     else
         echo "FAILED: ${suite_path}"
@@ -77,12 +74,23 @@ for config in $configs_list; do
     fi
 done
 
+attest_failed=0
 if [ "$attest" = "true" ] && [ -n "$passed_suites" ]; then
     echo ""
     echo "=== Attesting passing suites ==="
     for output in $passed_suites; do
         echo "Attesting: $output"
-        bun run evals/src/attestation/cli.ts attest-from-output "evals/${output}" --platform="${platform}" || echo "Attestation failed for ${output}"
+        if bun run evals/src/attestation/cli.ts attest-from-output "evals/${output}" --platform="${platform}"; then
+            # The passed-suites file is the host-commit contract: a suite is
+            # only eligible for commit once it has passed AND attested, so a
+            # failed attestation can never ship its output.
+            if [ -n "$passed_suites_file" ]; then
+                printf '%s\n' "${output}" >> "$passed_suites_file"
+            fi
+        else
+            echo "Attestation FAILED for ${output}"
+            attest_failed=1
+        fi
     done
 fi
 
@@ -91,4 +99,5 @@ if [ "$do_commit" = "true" ]; then
 fi
 
 if [ "$failed" = "1" ]; then echo "Some evals FAILED"; exit 1; fi
+if [ "$attest_failed" = "1" ]; then echo "Some attestations FAILED"; exit 1; fi
 echo "All evals PASSED"


### PR DESCRIPTION
## Summary

Attestations produced by `just eval-run --attest` recorded `git_commit: ""` — provenance that cannot be traced to the commit the eval ran against — and attestation failure could not stop eval outputs from being committed. Two commits:

### `32e83b9b` — record real provenance

**`getGitCommit()` swallowed failure** (`evals/src/attestation/commands.ts`). It never checked the subprocess exit code, so a failed `git rev-parse` was written into `attestation.json` as valid data. It now pipes stderr, checks the exit code, rejects an empty SHA, and throws with the actual git error.

**Git always failed inside the eval container.** Reproduced in the `rp1-dev` image: the repo mount is owned by the host user while the container runs as `rp1user`, so every git command exits 128 with `fatal: detected dubious ownership`. The same failure silently blanked the dev-SHA embed in `setup-dev.sh`. The container now trusts mounted paths via `safe.directory '*'` — in `setup-dev.sh` at entry, and repeated in `eval-run.sh`'s run command because `setup-dev.sh` is baked into the image and stale images would otherwise hard-fail at attest until `--rebuild-image`. Verified in the real image.

### `e48e6a2d` — enforce the guarantee (review round 1 blockers)

Review found the loud failure was still swallowed at the launch boundary: `run-local.sh` wrapped attest in `|| echo` and exited 0, it marked suites commit-eligible at eval-pass time *before* attestation, and `eval-run.sh` committed on the host unconditionally. So `--commit --attest` could ship outputs without provenance.

- `run-local.sh`: attestation failure exits the container non-zero; a suite enters the host-commit eligibility file only after it has both passed **and** attested
- `eval-run.sh`: the host commit is gated on a zero container exit
- New launcher test proves a failing containerized run never reaches `git commit` (verified to fail against the ungated script)

**The launcher contract test was unpassable, and CI never noticed.** Its docker stub answered `image inspect` with exit 0, so once image reuse landed in `eval-run.sh` the launcher skipped the build the test asserts on — and nothing in CI runs the evals test suite, so the breakage sat invisible. The stub now reports the image absent, the run-command literal matches the current launcher, and **the evals unit tests now run in the CI Tests job** so this contract stays enforced. (An earlier revision of this PR described the failure as "local-environment-only" based on the green Tests check — that was wrong; CI simply never ran these tests.)

**Deliberately not done:** no backfill of existing empty `git_commit` entries — their true commits are unknown and a guessed SHA would fabricate provenance. `eval-verify` compares only `deps_hash`, so CI gating is unaffected either way.

## Test plan
- [x] evals suite: **178 pass, 0 fail** — including all 5 launcher tests (was 3 pass / 1 unpassable / 4 total)
- [x] 3 new `getGitCommit` tests (exit-128 rejection verified to fail against the old implementation) + 1 new commit-gate launcher test (verified to fail against the ungated script)
- [x] `bash -n` on all three modified scripts; `just check` clean
- [x] End-to-end reproduction and fix confirmed in the actual `rp1-dev` image
- [x] Adversarial 3-lens verify workflow on commit 1 (bash 3.2 array-comment semantics executed, quoting, stream-deadlock, fp-ts error propagation to exit 1, cwd of every invocation path)

🤖 Generated using: 🎮 [rp1.run](https://rp1.run)
