### PR TITLE
feat(agents): add reuse-first scope discipline

### DIFF
--- a/catalog/agents.yaml
+++ b/catalog/agents.yaml
@@ -206,7 +206,7 @@ agents:
   - name: rp1-dev:speedrun-builder
     description: "Implements a single focused code change from a speedrun request"
     plugin: dev
-    last_checksum: b9a57e3448993006712cedede15014b3e726e250f779cff1130c3a87b4d7a295
+    last_checksum: fe0fd0ebbb1124175a945a239914da9b86634ed19fdc54a015c2ae69ed3fad3b
   - name: rp1-dev:task-builder
     description: "Implements assigned task(s) w/ full context, writes summaries to the resolved task file. Uses extended thinking (or ultrathink)."
     plugin: dev
@@ -214,7 +214,7 @@ agents:
   - name: rp1-dev:task-reviewer
     description: "Verifies builder's work for discipline, accuracy, completeness, and commit quality. Returns SUCCESS or FAILURE with actionable feedback. Uses extended thinking for careful verification."
     plugin: dev
-    last_checksum: ef6c635d3dfccc0df0831c09163eb092513786ea74c4c8bd88cc040fddebb0e5
+    last_checksum: 33227030a7990271e9ccb4c0123c7a59d801f088ed18a85c9dc2119050208fc2
   - name: rp1-dev:test-runner
     description: "Executes comprehensive functional testing of implemented features including automated tests, coverage measurement, acceptance criteria verification, and detailed test reporting"
     plugin: dev

--- a/cli/src/__tests__/build/shared-fragment-contracts.test.ts
+++ b/cli/src/__tests__/build/shared-fragment-contracts.test.ts
@@ -16,6 +16,9 @@ const REPO_ROOT = join(import.meta.dir, "..", "..", "..", "..");
 const readFragment = (name: string): Promise<string> =>
 	readFile(join(REPO_ROOT, "plugins", "shared", name), "utf-8");
 
+const readPrompt = (name: string): Promise<string> =>
+	readFile(join(REPO_ROOT, "plugins", "dev", "agents", name), "utf-8");
+
 describe("shared fragment contracts", () => {
 	test("anti-loop.md pins single-pass execution invariants", async () => {
 		const fragment = await readFragment("anti-loop.md");
@@ -84,15 +87,121 @@ describe("shared fragment contracts", () => {
 		expect(offenders).toEqual([]);
 	});
 
-	test("engineering-discipline.md pins the ten MUST rules", async () => {
+	test("engineering-discipline.md preserves the original ten MUST rules", async () => {
 		const fragment = await readFragment("engineering-discipline.md");
-		const rules = fragment.split("\n").filter((line) => line.startsWith("- "));
-		expect(rules.length).toBe(10);
-		expect(fragment).toContain("Write for the next reader under pressure");
-		expect(fragment).toContain("Fail loud near cause");
-		expect(fragment).toContain("Prefer duplication over wrong abstraction");
-		expect(fragment).toContain("Make effects/boundaries/failures explicit");
-		expect(fragment).toContain("Make change easy, then make easy change");
+		const [discipline] = fragment.split("\n## Reuse-First Scope Discipline\n");
+		const rules = discipline
+			.split("\n")
+			.filter((line) => line.startsWith("- "));
+
+		expect(rules).toEqual([
+			"- Write for the next reader under pressure: names/structure/control flow show intent.",
+			"- Minimize complexity, not lines: simple paths, narrow APIs, deep modules.",
+			"- Model domain invariants; make wrong states hard to express.",
+			"- Fail loud near cause; never hide impossible state, corrupt data, or unexpected errors.",
+			"- Co-locate code that changes together; organize by behavior/ownership.",
+			"- Treat code as liability: no speculative hooks/layers/options/deps/features.",
+			"- Prefer duplication over wrong abstraction.",
+			"- Make effects/boundaries/failures explicit: IO, time, random, concurrency, retries, external deps.",
+			"- Make prod diagnosable: structured errors/logs/metrics/traces/correlation IDs/breadcrumbs.",
+			"- Make change easy, then make easy change: refactor small before behavior when shape fights goal.",
+		]);
+	});
+
+	test("engineering-discipline.md pins reuse-first policy and completion stop", async () => {
+		const fragment = await readFragment("engineering-discipline.md");
+
+		expect(fragment).toContain(
+			"For each gate-approved task, choose the first sufficient option:",
+		);
+		expect(fragment).toContain(
+			"1. Reuse an existing project capability or established project pattern.",
+		);
+		expect(fragment).toContain(
+			"2. Use an available platform or language capability.",
+		);
+		expect(fragment).toContain("3. Use an already-available dependency.");
+		expect(fragment).toContain("4. Create the minimum custom work necessary.");
+		expect(fragment).toContain(
+			"Sufficient means fully meeting approved acceptance criteria and realistically reachable failure needs. Do not proceed to a later option after a sufficient one.",
+		);
+		expect(fragment).toContain(
+			"This policy cannot skip or renegotiate a gate-approved task.",
+		);
+		expect(fragment).toContain("All approved safeguards remain mandatory");
+		expect(fragment).toContain(
+			"After required verification confirms approved acceptance criteria and realistically reachable failure paths, stop.",
+		);
+		expect(fragment).toContain(
+			"Do not start a fresh improvement, hardening, or edge-case discovery sweep.",
+		);
+	});
+
+	test("delivery roles consume engineering discipline through the shared fragment", async () => {
+		const [taskBuilder, taskReviewer, speedrunBuilder] = await Promise.all([
+			readPrompt("task-builder.md"),
+			readPrompt("task-reviewer.md"),
+			readPrompt("speedrun-builder.md"),
+		]);
+
+		for (const prompt of [taskBuilder, taskReviewer, speedrunBuilder]) {
+			expect(
+				prompt.match(/include_shared "engineering-discipline\.md"/g),
+			).toHaveLength(1);
+		}
+	});
+
+	test("task reviewer keeps verdicts stable and evidence bounded", async () => {
+		const reviewer = await readPrompt("task-reviewer.md");
+
+		expect(reviewer).toContain(
+			"Edge cases required by approved requirements, design, acceptance criteria, or realistically reachable failures are addressed",
+		);
+		expect(reviewer).toContain(
+			"Return FAILURE only when uncertainty affects an approved acceptance criterion or realistically reachable production invariant; otherwise record a non-blocking suggestion with clear guidance.",
+		);
+		expect(reviewer).toContain(`### SUCCESS Criteria
+All of these must be true:
+- Discipline: PASS (no scope violations)
+- Accuracy: PASS (implementation matches design)
+- Completeness: PASS (all acceptance criteria met)
+- Quality: PASS (follows patterns) OR PASS with suggestions
+- Testing: PASS (tests are high-value) OR N/A (no tests added)
+- Commit: PASS (valid atomic commit with correct format) OR N/A (GIT_COMMIT=false or no code changes)
+- Comments: PASS (no unnecessary comments) OR N/A (no code files modified)`);
+		expect(reviewer).toContain(`### FAILURE Criteria
+Any of these trigger FAILURE:
+- Discipline: FAIL (scope violations found)
+- Accuracy: FAIL (implementation doesn't match design)
+- Completeness: FAIL (missing acceptance criteria)
+- Quality: FAIL with blocking issues
+- Testing: FAIL (superfluous or low-value tests added)
+- Commit: FAIL (missing commit, wrong format, or unrelated files)
+- Comments: FAIL (unnecessary comments found in modified files)`);
+	});
+
+	test("speedrun builder retains rapid-delivery safeguards", async () => {
+		const speedrunBuilder = await readPrompt("speedrun-builder.md");
+
+		expect(speedrunBuilder).toContain("- Do NOT commit changes");
+		expect(speedrunBuilder).toContain(
+			"- Do NOT modify files unrelated to the request",
+		);
+		expect(speedrunBuilder).toContain(
+			"- If the request is ambiguous, prefer the most conservative interpretation",
+		);
+		expect(speedrunBuilder).toContain(
+			"- Run smallest relevant format/lint/test check identifiable quickly.",
+		);
+		expect(speedrunBuilder).toContain(
+			"- Add/modify tests only for behavior change, bug regression, or risky branch.",
+		);
+		expect(speedrunBuilder).toContain(
+			"- Else report: `Tests: not added (no high-value regression)`.",
+		);
+		expect(speedrunBuilder).toContain(
+			"- If design/broad coverage/scope exceeds gate: STOP -> /build-fast or /build.",
+		);
 	});
 
 	test("output-discipline.md pins silent JSON-only execution", async () => {

--- a/plugins/dev/agents/speedrun-builder.md
+++ b/plugins/dev/agents/speedrun-builder.md
@@ -10,6 +10,8 @@ effort: medium
 
 Implement the requested code change. Keep changes minimal and focused.
 
+{% include_shared "engineering-discipline.md" %}
+
 ## Process
 
 1. Read the relevant source files
@@ -33,7 +35,6 @@ When the dispatch prompt includes a `CODE_ROOT` value:
 - Do NOT commit changes
 - Do NOT modify files unrelated to the request
 - Do NOT load KB files or spawn subagents
-- Keep changes as small as possible while fully addressing the request
 - If the request is ambiguous, prefer the most conservative interpretation
 
 ## Speedrun Gate

--- a/plugins/dev/agents/task-reviewer.md
+++ b/plugins/dev/agents/task-reviewer.md
@@ -55,6 +55,8 @@ You are **TaskReviewer**, an expert code reviewer that verifies the builder's im
 
 **Core Principle**: Signal explicit SUCCESS or FAILURE. No ambiguous states. Failures must include actionable feedback.
 
+{% include_shared "engineering-discipline.md" %}
+
 **Mode Detection**: If QUICK_BUILD_PATH is not empty, operate in quick-build mode. Otherwise, use FEATURE_ID mode.
 
 The orchestrator provides these parameters in the prompt:
@@ -216,7 +218,7 @@ Verify across seven dimensions, using `<thinking>` for detailed analysis:
 - [ ] Implementation follows design.md specifications
 - [ ] Business logic is correct
 - [ ] Error handling matches requirements
-- [ ] Edge cases are addressed
+- [ ] Edge cases required by approved requirements, design, acceptance criteria, or realistically reachable failures are addressed
 
 **Evidence**: Quote design spec, show implementation matches
 
@@ -553,7 +555,7 @@ Skip if WORKFLOW is empty.
 
 {% include_shared "anti-loop.md" %}
 
-Make a definitive judgment based on available evidence. If uncertain, err on the side of FAILURE with clear guidance -- it is better to have one retry than to let a bad implementation through.
+Make a definitive judgment based on available evidence. Return FAILURE only when uncertainty affects an approved acceptance criterion or realistically reachable production invariant; otherwise record a non-blocking suggestion with clear guidance.
 
 ## 8. Confidence Scoring
 

--- a/plugins/shared/engineering-discipline.md
+++ b/plugins/shared/engineering-discipline.md
@@ -11,3 +11,18 @@ MUST:
 - Make effects/boundaries/failures explicit: IO, time, random, concurrency, retries, external deps.
 - Make prod diagnosable: structured errors/logs/metrics/traces/correlation IDs/breadcrumbs.
 - Make change easy, then make easy change: refactor small before behavior when shape fights goal.
+
+## Reuse-First Scope Discipline
+
+For each gate-approved task, choose the first sufficient option:
+
+1. Reuse an existing project capability or established project pattern.
+2. Use an available platform or language capability.
+3. Use an already-available dependency.
+4. Create the minimum custom work necessary.
+
+Sufficient means fully meeting approved acceptance criteria and realistically reachable failure needs. Do not proceed to a later option after a sufficient one.
+
+This policy cannot skip or renegotiate a gate-approved task. All approved safeguards remain mandatory, including safety, accessibility, validation, data protection, operability, and other approved obligations.
+
+After required verification confirms approved acceptance criteria and realistically reachable failure paths, stop. Do not start a fresh improvement, hardening, or edge-case discovery sweep.


### PR DESCRIPTION
## Summary

- add an ordered reuse-first, first-sufficient implementation ladder to the shared engineering discipline
- add an explicit stop once approved acceptance criteria and realistically reachable failure paths are verified
- deliver the shared discipline to task-reviewer and speedrun-builder
- bound reviewer edge-case and uncertainty handling to approved requirements and realistic production invariants
- pin the prompt contracts and regenerate the two affected agent checksums

## Ponytail provenance

This change comes from a comparative review of [DietrichGebert/ponytail](https://github.com/DietrichGebert/ponytail/tree/16f29800fd2681bdf24f3eb4ccffe38be3baec6b), especially its [ordered implementation ladder and explicit completion stop](https://github.com/DietrichGebert/ponytail/blob/16f29800fd2681bdf24f3eb4ccffe38be3baec6b/skills/ponytail/SKILL.md).

rp1 adopts those two ideas in its own governed workflow: the ladder starts at reuse, and it cannot skip or renegotiate a gate-approved task. The Ponytail attribution is also preserved in all four commit bodies.

## Why

rp1 already had strong scope prohibitions, task gates, and bounded review loops, but it did not tell implementing agents where to look first or when verified work was complete. The task reviewer and speedrun builder also did not consume the canonical engineering-discipline fragment.

## Scope

Five files only. No new skill, runtime subsystem, workflow, retry behavior, eval suite, or speculative abstraction.

## Validation

- focused shared-fragment contracts: 16 passed, 0 failed
- lint, formatting, CLI typecheck, repository tests, and 82.37% coverage passed
- cross-platform prompt build passed for all 15 agent/platform outputs with no unresolved includes
- `just catalog-check` passed
- final tracked review and independent Claude review: approve, zero retained findings
- pre-push catalog and CLI/Web UI typechecks passed

## Known draft note

The pre-push eval verification reports three stale Claude Code prompt attestations because the shared fragment dependency hash changed. The hook treats this as non-blocking; this scoped PR intentionally does not add or alter an eval suite.
