### PR TITLE
fix(web-ui): report real file paths in file tree for central storage mode

### DIFF
--- a/cli/web-ui/bun.lock
+++ b/cli/web-ui/bun.lock
@@ -1443,7 +1443,7 @@
 
     "base64id": ["base64id@2.0.0", "", {}, "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog=="],
 
-    "baseline-browser-mapping": ["baseline-browser-mapping@2.8.32", "", { "bin": { "baseline-browser-mapping": "dist/cli.js" } }, "sha512-OPz5aBThlyLFgxyhdwf/s2+8ab3OvT7AdTNvKHBwpXomIYeXqpUUuT8LrdtxZSsWJ4R4CU1un4XGh5Ez3nlTpw=="],
+    "baseline-browser-mapping": ["baseline-browser-mapping@2.10.43", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-AjYpR78kDWAY3Efj+cDTFH9t9SCoL7OoTp1BOb0mQV7S+6CiLwnWM3FyxhJtdPufDFKzmCSFoUncKjWgJEZTCQ=="],
 
     "basic-ftp": ["basic-ftp@5.2.0", "", {}, "sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw=="],
 
@@ -1501,7 +1501,7 @@
 
     "camelcase-css": ["camelcase-css@2.0.1", "", {}, "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA=="],
 
-    "caniuse-lite": ["caniuse-lite@1.0.30001757", "", {}, "sha512-r0nnL/I28Zi/yjk1el6ilj27tKcdjLsNqAOZr0yVjWPrSQyHgKI2INaEWw21bAQSv2LXRt1XuCS/GomNpWOxsQ=="],
+    "caniuse-lite": ["caniuse-lite@1.0.30001805", "", {}, "sha512-52noaS3DubycKSXaU30TwPGIp+POyQSUVa5jBEq3vkRkY0kjyb3LQgvhU6WGyCcyXqVLWO0Cw0Q6BSdD0kUfVA=="],
 
     "ccount": ["ccount@2.0.1", "", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
 

--- a/cli/web-ui/src/__tests__/components/FileTree/FileTreeNode.test.ts
+++ b/cli/web-ui/src/__tests__/components/FileTree/FileTreeNode.test.ts
@@ -2,6 +2,16 @@ import { describe, expect, test } from "bun:test";
 import { getCopyableFilePath } from "../../../components/FileTree/FileTreeNode";
 
 describe("getCopyableFilePath", () => {
+	test("prefers the server-resolved absolute path when the tree provides one", () => {
+		expect(
+			getCopyableFilePath(
+				"/Users/prem/Development/buzz",
+				".rp1/work/notes/stack.md",
+				"/Users/prem/.rp1/projects/8f20b5a0/work/notes/stack.md",
+			),
+		).toBe("/Users/prem/.rp1/projects/8f20b5a0/work/notes/stack.md");
+	});
+
 	test("joins project root with canonical rp1 file paths without duplicating .rp1", () => {
 		expect(
 			getCopyableFilePath(

--- a/cli/web-ui/src/__tests__/server/content-utils.test.ts
+++ b/cli/web-ui/src/__tests__/server/content-utils.test.ts
@@ -53,6 +53,24 @@ describe("content-utils", () => {
 	});
 
 	describe("buildFileTree", () => {
+		test("reports each file's absolute path alongside its display path", async () => {
+			const tempDir = await mkdtemp(join(tmpdir(), "rp1-content-utils-"));
+			const treeRoot = join(tempDir, "central-store", "work");
+
+			try {
+				await mkdir(join(treeRoot, "notes"), { recursive: true });
+				await Bun.write(join(treeRoot, "notes", "stack.md"), "# stack");
+
+				const tree = await buildFileTree(treeRoot, ".rp1/work");
+				const note = tree?.children?.[0]?.children?.[0];
+
+				expect(note?.path).toBe(".rp1/work/notes/stack.md");
+				expect(note?.absolutePath).toBe(join(treeRoot, "notes", "stack.md"));
+			} finally {
+				await rm(tempDir, { recursive: true, force: true });
+			}
+		});
+
 		test("skips nested git worktree directories", async () => {
 			const tempDir = await mkdtemp(join(tmpdir(), "rp1-content-utils-"));
 			const treeRoot = join(tempDir, "tree-root");

--- a/cli/web-ui/src/components/FileTree/FileTreeNode.tsx
+++ b/cli/web-ui/src/components/FileTree/FileTreeNode.tsx
@@ -25,7 +25,12 @@ interface FileTreeNodeProps {
 export const getCopyableFilePath = (
 	projectPath: string | null | undefined,
 	filePath: string,
+	absolutePath?: string | null,
 ): string => {
+	if (absolutePath) {
+		return absolutePath;
+	}
+
 	if (!projectPath) {
 		return filePath;
 	}
@@ -134,10 +139,18 @@ export function FileTreeNode({
 				{!isDirectory ? (
 					<button
 						type="button"
-						title={getCopyableFilePath(projectPath, node.path)}
+						title={getCopyableFilePath(
+							projectPath,
+							node.path,
+							node.absolutePath,
+						)}
 						onClick={(e) => {
 							e.stopPropagation();
-							const fullPath = getCopyableFilePath(projectPath, node.path);
+							const fullPath = getCopyableFilePath(
+								projectPath,
+								node.path,
+								node.absolutePath,
+							);
 							navigator.clipboard.writeText(fullPath).then(() => {
 								setCopied(true);
 								setTimeout(() => setCopied(false), 2000);

--- a/cli/web-ui/src/server/routes/content-utils.ts
+++ b/cli/web-ui/src/server/routes/content-utils.ts
@@ -9,6 +9,7 @@ export interface FileNode {
 	path: string;
 	name: string;
 	type: "file" | "directory";
+	absolutePath?: string;
 	size?: number;
 	modifiedAt?: string;
 	children?: FileNode[];
@@ -131,6 +132,7 @@ export async function buildFileTree(
 					path: entryRelativePath,
 					name: entry.name,
 					type: "file",
+					absolutePath: resolve(entryPath),
 					size: fileStat.size,
 					modifiedAt: fileStat.mtime?.toISOString(),
 				});


### PR DESCRIPTION
## Summary
- The file tree's copy-path button and tooltip joined the project root with the virtual `.rp1/work` display path, which does not exist when a project uses central storage.
- The tree API now returns each file's resolved `absolutePath`, and the client prefers it when present.
- Bumps caniuse-lite browser mappings in the web-ui lockfile.

## Test plan
- [x] `bun test` for FileTreeNode and content-utils (9 pass)
- [ ] CI

🤖 Generated using: 🎮 [rp1.run](https://rp1.run)